### PR TITLE
Match renamed LOR previews by stable identity

### DIFF
--- a/Docs/01_LOR_System/02_Data_Extraction/LOR_Preview_File_Structure_Specification.md
+++ b/Docs/01_LOR_System/02_Data_Extraction/LOR_Preview_File_Structure_Specification.md
@@ -99,6 +99,21 @@ The parser searches the complete XML tree and accepts a `PreviewClass` element a
 
 The parser additionally records the actual `.lorprev` filename as `SourceFilename`; that value comes from the filesystem, not from a PreviewClass attribute.
 
+### Master Musical identity and operator version name
+
+The Master Musical Preview has two intentionally different identity layers:
+
+- `PreviewClass.id` is its stable machine identity and does not change merely
+  because the file is renamed;
+- the Master Musical filename and `PreviewClass.Name` include the LOR version
+  and working date so operators can identify the correct version to use.
+
+When channels, props, Displays, Scenes, or other Master Musical content change,
+the version/date name may be advanced while the stable PreviewID remains the
+same. The parser preserves the exact filename in `SourceFilename`. Compatibility
+checking matches the logical preview by PreviewID and separately reports the
+human-facing version/date filename change for review.
+
 ### Compatibility risks
 
 The parser can be affected if a new LOR release:

--- a/Docs/01_LOR_System/02_Data_Extraction/LOR_Preview_Version_Compatibility_Review.md
+++ b/Docs/01_LOR_System/02_Data_Extraction/LOR_Preview_Version_Compatibility_Review.md
@@ -74,6 +74,12 @@ review while the same logical comprehensive preview is selected automatically.
 Do not rename a version-specific candidate file merely to match the baseline
 filename.
 
+The Master Musical Preview is intentionally versioned in both its filename and
+operator-facing `PreviewClass.Name`. Its LOR version and date tell field and
+sequencing personnel which copy to use. That human-facing change must remain
+visible in the compatibility report even though the unchanged PreviewID proves
+it is the same logical preview.
+
 Any added/removed structure, attribute, value shape, ordering contract, or
 ChannelGrid position is blocking until it is explicitly reviewed. A failed
 report records `parser_modifications_required`. Candidate parser testing may

--- a/Docs/01_LOR_System/02_Data_Extraction/LOR_Preview_Version_Compatibility_Review.md
+++ b/Docs/01_LOR_System/02_Data_Extraction/LOR_Preview_Version_Compatibility_Review.md
@@ -68,6 +68,12 @@ the parser. It scans every `.lorprev` file and compares:
 - raw PreviewClass, Scene, and PropClass ID/count changes in every preview; and
 - focused identity/position review in the selected deep preview.
 
+Preview files are matched across LOR versions by the stable
+`PreviewClass.id`, not by filename. An expected filename change is recorded for
+review while the same logical comprehensive preview is selected automatically.
+Do not rename a version-specific candidate file merely to match the baseline
+filename.
+
 Any added/removed structure, attribute, value shape, ordering contract, or
 ChannelGrid position is blocking until it is explicitly reviewed. A failed
 report records `parser_modifications_required`. Candidate parser testing may

--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/lor_version_checker.py
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/lor_version_checker.py
@@ -23,8 +23,8 @@ from pathlib import Path
 from typing import Any, Iterable
 
 
-CHECKER_VERSION = "V1.1.0"
-MANIFEST_VERSION = 2
+CHECKER_VERSION = "V1.2.0"
+MANIFEST_VERSION = 3
 CRITICAL_ELEMENTS = {"PreviewClass", "Scene", "PropClass"}
 UUID_RE = re.compile(
     r"^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
@@ -288,15 +288,44 @@ def merge_contracts(files: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
-def build_manifest(folder: Path, lor_version: str, deep_preview: str | None) -> dict[str, Any]:
+def preview_identity(contract: dict[str, Any]) -> str:
+    """Return the stable per-preview identity, falling back only when LOR omitted it."""
+    preview_ids = contract.get("ids", {}).get("PreviewClass", [])
+    if len(preview_ids) == 1:
+        return f"PreviewClass:{preview_ids[0].casefold()}"
+    return f"Filename:{contract['filename'].casefold()}"
+
+
+def build_manifest(
+    folder: Path,
+    lor_version: str,
+    deep_preview: str | None,
+    deep_identity: str | None = None,
+) -> dict[str, Any]:
     paths = sorted(folder.glob("*.lorprev"), key=lambda item: item.name.casefold())
     if not paths:
         raise ValueError(f"No .lorprev files found in {folder}")
     file_contracts = [one_file_contract(path) for path in paths]
+    identities = Counter(preview_identity(contract) for contract in file_contracts)
+    duplicates = sorted(identity for identity, count in identities.items() if count > 1)
+    if duplicates:
+        raise ValueError(
+            "Duplicate PreviewClass identity across preview files: " + ", ".join(duplicates)
+        )
     deep_name = deep_preview or max(paths, key=lambda item: item.stat().st_size).name
     deep = next((item for item in file_contracts if item["filename"] == deep_name), None)
+    if deep is None and deep_identity:
+        matches = [
+            item for item in file_contracts if preview_identity(item) == deep_identity
+        ]
+        if len(matches) == 1:
+            deep = matches[0]
+            deep_name = deep["filename"]
     if deep is None:
-        raise ValueError(f"Deep preview is not present in the selected folder: {deep_name}")
+        expected = f" ({deep_identity})" if deep_identity else ""
+        raise ValueError(
+            f"Deep preview is not present in the selected folder: {deep_name}{expected}"
+        )
     manifest = {
         "manifest_version": MANIFEST_VERSION,
         "checker_version": CHECKER_VERSION,
@@ -305,6 +334,7 @@ def build_manifest(folder: Path, lor_version: str, deep_preview: str | None) -> 
         "preview_folder": str(folder.resolve()),
         "file_count": len(file_contracts),
         "deep_preview": deep_name,
+        "deep_preview_identity": preview_identity(deep),
         "files": file_contracts,
         "aggregate": merge_contracts(file_contracts),
         "deep_contract": deep,
@@ -407,17 +437,33 @@ def compare_delimited_fields(
 def compare_file_contracts(baseline: dict[str, Any], candidate: dict[str, Any]) -> list[Finding]:
     """Compare every matching preview, not only the aggregate/deep preview."""
     findings: list[Finding] = []
-    old_files = {item["filename"]: item for item in baseline["files"]}
-    new_files = {item["filename"]: item for item in candidate["files"]}
-    for filename in sorted(set(old_files) | set(new_files), key=str.casefold):
-        if filename not in old_files:
-            findings.append(Finding("REVIEW", "preview set", f"New preview file: {filename}"))
+    old_files = {preview_identity(item): item for item in baseline["files"]}
+    new_files = {preview_identity(item): item for item in candidate["files"]}
+    for identity in sorted(set(old_files) | set(new_files), key=str.casefold):
+        if identity not in old_files:
+            findings.append(Finding(
+                "REVIEW", "preview set",
+                f"New preview identity/file: {new_files[identity]['filename']} ({identity}).",
+            ))
             continue
-        if filename not in new_files:
-            findings.append(Finding("BLOCKING", "preview set", f"Approved preview file removed: {filename}"))
+        if identity not in new_files:
+            findings.append(Finding(
+                "BLOCKING", "preview set",
+                f"Approved preview identity removed: {old_files[identity]['filename']} ({identity}).",
+            ))
             continue
-        old, new = old_files[filename], new_files[filename]
-        prefix = f"{filename}: "
+        old, new = old_files[identity], new_files[identity]
+        old_filename, new_filename = old["filename"], new["filename"]
+        if old_filename != new_filename:
+            findings.append(Finding(
+                "REVIEW", "preview filename",
+                f"Preview filename changed from {old_filename} to {new_filename}; "
+                f"stable identity {identity} was preserved.",
+            ))
+        prefix = (
+            f"{old_filename}: " if old_filename == new_filename
+            else f"{old_filename} -> {new_filename}: "
+        )
         findings.extend(set_difference_findings(
             [old["root_element"]], [new["root_element"]], prefix + "document", "root element"
         ))
@@ -623,9 +669,15 @@ def main(argv: list[str] | None = None) -> int:
             return 0
 
         baseline = json.loads(arguments.baseline.read_text(encoding="utf-8"))
+        baseline_deep_identity = (
+            baseline.get("deep_preview_identity")
+            or preview_identity(baseline["deep_contract"])
+        )
         candidate = build_manifest(
-            arguments.preview_folder, arguments.new_lor_version,
+            arguments.preview_folder,
+            arguments.new_lor_version,
             arguments.deep_preview or baseline.get("deep_preview"),
+            deep_identity=baseline_deep_identity,
         )
         if arguments.candidate_manifest:
             write_json(arguments.candidate_manifest, candidate)

--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/test_lor_version_checker.py
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/test_lor_version_checker.py
@@ -30,11 +30,13 @@ BASELINE_XML = """<?xml version="1.0"?>
 
 
 class CompatibilityCheckerTests(unittest.TestCase):
-    def manifest(self, xml: str, version: str = "6.6.3"):
+    def manifest(
+        self, xml: str, version: str = "6.6.3", filename: str = "test.lorprev"
+    ):
         temporary = tempfile.TemporaryDirectory()
         folder = Path(temporary.name)
-        write_preview(folder, "test.lorprev", xml)
-        manifest = checker.build_manifest(folder, version, "test.lorprev")
+        write_preview(folder, filename, xml)
+        manifest = checker.build_manifest(folder, version, filename)
         return temporary, manifest
 
     def test_identical_xml_contract_passes(self) -> None:
@@ -117,6 +119,52 @@ class CompatibilityCheckerTests(unittest.TestCase):
             and item.area == "PropClass.TraditionalColors"
             for item in findings
         ))
+
+    def test_renamed_preview_matches_by_stable_previewclass_id(self) -> None:
+        old_temp, baseline = self.manifest(
+            BASELINE_XML,
+            filename="Master Musical Preview v6.6.lorprev",
+        )
+        new_temp, candidate = self.manifest(
+            BASELINE_XML,
+            "6.6.10",
+            filename="Master Musical Preview v6.6.10.lorprev",
+        )
+        self.addCleanup(old_temp.cleanup)
+        self.addCleanup(new_temp.cleanup)
+        findings = checker.compare_manifests(baseline, candidate)
+        self.assertTrue(any(
+            item.severity == "REVIEW"
+            and item.area == "preview filename"
+            and "stable identity PreviewClass:11111111" in item.message
+            for item in findings
+        ))
+        self.assertFalse(any(
+            item.severity == "BLOCKING" and item.area == "preview set"
+            for item in findings
+        ))
+
+    def test_deep_preview_rename_resolves_by_stable_identity(self) -> None:
+        old_temp, baseline = self.manifest(
+            BASELINE_XML,
+            filename="Master Musical Preview v6.6.lorprev",
+        )
+        self.addCleanup(old_temp.cleanup)
+        new_temp = tempfile.TemporaryDirectory()
+        self.addCleanup(new_temp.cleanup)
+        new_folder = Path(new_temp.name)
+        new_name = "Master Musical Preview v6.6.10.lorprev"
+        write_preview(new_folder, new_name, BASELINE_XML)
+        candidate = checker.build_manifest(
+            new_folder,
+            "6.6.10",
+            baseline["deep_preview"],
+            deep_identity=baseline["deep_preview_identity"],
+        )
+        self.assertEqual(candidate["deep_preview"], new_name)
+        self.assertEqual(
+            candidate["deep_preview_identity"], baseline["deep_preview_identity"]
+        )
 
     def test_channel_grid_position_change_is_blocking(self) -> None:
         candidate_xml = BASELINE_XML.replace(


### PR DESCRIPTION
## What changed

- match baseline and candidate preview files by stable `PreviewClass.id` instead of requiring identical filenames
- automatically select a renamed comprehensive/deep preview when its stable PreviewID is preserved
- record an expected filename change as a review finding
- continue blocking genuinely removed preview identities
- reject duplicate PreviewClass identities across the preview set
- document that version-specific candidate files must not be renamed to match the baseline

## Why

The approved and candidate Master Musical previews correctly use different version/date filenames:

- `2026 Master Musical Preview v6.6 2026-07-30.lorprev`
- `2026 Master Musical Preview v6.6.10 2026-08-11.lorprev`

Both carry PreviewID `fcf5c29c-8d51-46c5-9ad0-cc47a97c75bd`. The checker must compare them as the same logical preview without hiding the filename change.

## Validation

- 10 checker/runner tests passed
- added regression coverage for renamed preview matching
- added regression coverage for automatic renamed deep-preview selection
- Python compilation and whitespace checks passed

No production files, database schema, parser output, or LOR2DB deployment was changed.