### PR TITLE
Make V7 parser logging safe on Windows

### DIFF
--- a/Docs/01_LOR_System/02_Data_Extraction/LOR_Preview_File_Structure_Specification.md
+++ b/Docs/01_LOR_System/02_Data_Extraction/LOR_Preview_File_Structure_Specification.md
@@ -25,7 +25,7 @@ The current production parser is:
 
 Functional parser baseline:
 
-`V7.0.8`
+`V7.0.9`
 
 Known-good LOR preview baseline:
 

--- a/Docs/01_LOR_System/02_Data_Extraction/LOR_Preview_Parser_Architecture.md
+++ b/Docs/01_LOR_System/02_Data_Extraction/LOR_Preview_Parser_Architecture.md
@@ -4,7 +4,7 @@
 |---|---|
 | Status | CURRENT — engineering architecture |
 | System | LOR Preview Parser / LOR2DB Ingest |
-| Functional baseline | `parse_props_v7_scene_parser.py` V7.0.8 |
+| Functional baseline | `parse_props_v7_scene_parser.py` V7.0.9 |
 | Current revision | 2026-08-13 |
 | Owner | MSB Database Administrator |
 
@@ -20,6 +20,8 @@ The current implementation is:
 
 The initial content was derived from V7.0.7. V7.0.8 adds the website-runner
 contract, atomic publication, full output validation, and complete provenance.
+V7.0.9 makes diagnostics non-fatal when Windows PowerShell redirects parser
+logs through a legacy console encoding.
 Future parser changes must be reviewed against this architecture.
 
 ## System Boundary

--- a/Docs/01_LOR_System/02_Data_Extraction/LOR_SQLite_Output_Database_Structure.md
+++ b/Docs/01_LOR_System/02_Data_Extraction/LOR_SQLite_Output_Database_Structure.md
@@ -5,7 +5,7 @@
 | Status | CURRENT — Engineering Design |
 | System | LOR Preview Parser |
 | Database | `lor_output_v7_scene.db` |
-| Current Parser Baseline | V7.0.8 |
+| Current Parser Baseline | V7.0.9 |
 | Owner | MSB Database Administrator |
 | Initial Release | 2026-08-08 |
 

--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/README.md
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/README.md
@@ -13,6 +13,7 @@ tools for operator convenience but does not own their XML interpretation.
 | `lor_operator_runner.py` | Restricted Windows/G-drive API used by the authenticated LOR2DB website |
 | `test_lor_version_checker.py` | Regression tests for Scene count/structure, unused fields, ChannelGrid, and other delimiter-position changes |
 | `test_lor_operator_runner.py` | Regression tests for version-scoped paths, approved-manifest retention, and approval history |
+| `test_parse_props_console_encoding.py` | Regression test preventing Windows console/log encoding from aborting parser execution |
 
 ## Operating Boundary
 

--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/parse_props_v7_scene_parser.py
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/parse_props_v7_scene_parser.py
@@ -2,7 +2,7 @@
 #
 # Baseline: parse_props_v6.py V6.8.3
 # Initial Release : 2022-01-20  V0.1.0
-# Current Version : 2026-08-13  V7.0.8
+# Current Version : 2026-08-13  V7.0.9
 #
 # Author:
 #   Greg Liebig
@@ -47,6 +47,12 @@
 #
 # Changelog
 # ---------
+## 2026-08-13  V7.0.9  (GAL / OpenAI)
+# • Prevent Windows legacy console/log encodings from aborting a parser run
+#   when an informational message contains a Unicode character.
+# • Preserve the active console encoding and escape only unsupported output
+#   characters so PowerShell redirection remains readable and reliable.
+#
 ## 2026-08-13  V7.0.8  (GAL / OpenAI)
 # • Added explicit command-line arguments for the LOR2DB operator runner while
 #   preserving the no-argument interactive workflow.
@@ -248,6 +254,27 @@ import platform
 import socket
 
 
+def configure_console_output() -> None:
+    """Make diagnostic output non-fatal on legacy Windows code pages.
+
+    Windows PowerShell may give redirected native processes a strict legacy
+    encoding such as cp1252. Parser diagnostics must never be able to abort an
+    otherwise valid database build merely because that encoding cannot render
+    an arrow, dash, or other informational character.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if callable(reconfigure):
+            try:
+                reconfigure(errors="backslashreplace")
+            except (AttributeError, OSError, ValueError):
+                # Embedded/test streams may not support runtime reconfiguration.
+                pass
+
+
+configure_console_output()
+
+
 # GAL 25-10-16: Align parser docs with Core Model v1.0 (no logic changes)
 # - Declares LOR→DB naming map inline for clarity (Comment→DisplayName, Name→ChannelName, etc.)
 # - Attempts to import field lists from lor_core for documentation parity only
@@ -313,7 +340,7 @@ def get_reports_dir() -> str:
 
 
 # ---- Global flags & defaults (must be defined before functions) ----
-PARSER_VERSION = "V7.0.8"  # GAL 2026-08-13: authoritative runtime version
+PARSER_VERSION = "V7.0.9"  # GAL 2026-08-13: authoritative runtime version
 
 DEBUG = False  # Global debug flag
 

--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/test_parse_props_console_encoding.py
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/test_parse_props_console_encoding.py
@@ -1,0 +1,40 @@
+"""Windows console-encoding regression test for the canonical V7 parser."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+PARSER_PATH = Path(__file__).with_name("parse_props_v7_scene_parser.py")
+
+
+class ParserConsoleEncodingTests(unittest.TestCase):
+    def test_ascii_redirect_cannot_abort_unicode_diagnostic(self) -> None:
+        """Import-time configuration must escape characters absent from ASCII."""
+        script = (
+            "import runpy; "
+            f"runpy.run_path({str(PARSER_PATH)!r}, run_name='parser_encoding_test'); "
+            "print('parser output \\u2192 review log')"
+        )
+        environment = os.environ.copy()
+        environment["PYTHONIOENCODING"] = "ascii:strict"
+        completed = subprocess.run(
+            [sys.executable, "-c", script],
+            env=environment,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(
+            completed.returncode,
+            0,
+            completed.stderr.decode(errors="replace"),
+        )
+        self.assertIn(b"parser output \\u2192 review log", completed.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Docs/01_LOR_System/02_Data_Extraction/README.md
+++ b/Docs/01_LOR_System/02_Data_Extraction/README.md
@@ -38,7 +38,7 @@ The parser owns interpretation of Light-O-Rama preview structure. PostgreSQL ing
 ## Current Baseline
 
 The current functional parser is
-`Parser/parse_props_v7_scene_parser.py` V7.0.8. The current approved LOR version
+`Parser/parse_props_v7_scene_parser.py` V7.0.9. The current approved LOR version
 is an operator-controlled record initialized from the known-good 6.6.4 preview
 set; it is not a hard-coded parser assumption.
 

--- a/LOR2DB/01_Ingest/postgres_ingest_from_lor_sqlite_v7.py
+++ b/LOR2DB/01_Ingest/postgres_ingest_from_lor_sqlite_v7.py
@@ -20,7 +20,7 @@
 # - V0.3.1 preserves the exact source .lorprev filename in
 #   lor_snap.previews.source_filename.
 # - V0.3.2 refuses to ingest unless parser_run.Status is COMPLETE.
-# - V0.4.0 requires the exact operator-reviewed SQLite SHA-256 and V7.0.8
+# - V0.4.0 requires the exact operator-reviewed SQLite SHA-256 and a current V7
 #   production/validation provenance before any PostgreSQL write.
 # (GAL)
 #


### PR DESCRIPTION
## What changed

- advance the canonical parser to V7.0.9
- configure stdout and stderr so unsupported characters are escaped instead of raising a fatal UnicodeEncodeError
- preserve the active Windows console encoding rather than assuming UTF-8
- add an ASCII/strict redirected-output regression test
- update parser baseline documentation

## Root cause

The first isolated V6.6.10 parser run reached normal preview processing, then Windows PowerShell redirected output through a legacy strict character encoding. An informational Unicode arrow could not be encoded, so logging aborted the run.

This was not an LOR XML compatibility failure.

## Safety behavior observed

- the temporary build was retained for diagnosis
- no candidate SQLite was published
- any prior published SQLite was preserved
- PostgreSQL ingest was never started

## Validation

- 11 checker/runner/parser tests passed
- the regression test forces `PYTHONIOENCODING=ascii:strict` and proves a Unicode diagnostic no longer aborts execution
- Python compilation and whitespace checks passed