### PR TITLE
Release SQLite snapshots through transient locks

### DIFF
--- a/Docs/01_LOR_System/02_Data_Extraction/LOR_Preview_File_Structure_Specification.md
+++ b/Docs/01_LOR_System/02_Data_Extraction/LOR_Preview_File_Structure_Specification.md
@@ -25,7 +25,7 @@ The current production parser is:
 
 Functional parser baseline:
 
-`V7.0.9`
+`V7.0.10`
 
 Known-good LOR preview baseline:
 

--- a/Docs/01_LOR_System/02_Data_Extraction/LOR_Preview_Parser_Architecture.md
+++ b/Docs/01_LOR_System/02_Data_Extraction/LOR_Preview_Parser_Architecture.md
@@ -4,7 +4,7 @@
 |---|---|
 | Status | CURRENT — engineering architecture |
 | System | LOR Preview Parser / LOR2DB Ingest |
-| Functional baseline | `parse_props_v7_scene_parser.py` V7.0.9 |
+| Functional baseline | `parse_props_v7_scene_parser.py` V7.0.10 |
 | Current revision | 2026-08-13 |
 | Owner | MSB Database Administrator |
 
@@ -21,7 +21,9 @@ The current implementation is:
 The initial content was derived from V7.0.7. V7.0.8 adds the website-runner
 contract, atomic publication, full output validation, and complete provenance.
 V7.0.9 makes diagnostics non-fatal when Windows PowerShell redirects parser
-logs through a legacy console encoding.
+logs through a legacy console encoding. V7.0.10 explicitly releases final
+SQLite connections and retries bounded, transient Windows sharing locks before
+atomic publication, including short-lived Google Drive inspection locks.
 Future parser changes must be reviewed against this architecture.
 
 ## System Boundary

--- a/Docs/01_LOR_System/02_Data_Extraction/LOR_SQLite_Output_Database_Structure.md
+++ b/Docs/01_LOR_System/02_Data_Extraction/LOR_SQLite_Output_Database_Structure.md
@@ -5,7 +5,7 @@
 | Status | CURRENT — Engineering Design |
 | System | LOR Preview Parser |
 | Database | `lor_output_v7_scene.db` |
-| Current Parser Baseline | V7.0.9 |
+| Current Parser Baseline | V7.0.10 |
 | Owner | MSB Database Administrator |
 | Initial Release | 2026-08-08 |
 

--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/README.md
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/README.md
@@ -14,6 +14,7 @@ tools for operator convenience but does not own their XML interpretation.
 | `test_lor_version_checker.py` | Regression tests for Scene count/structure, unused fields, ChannelGrid, and other delimiter-position changes |
 | `test_lor_operator_runner.py` | Regression tests for version-scoped paths, approved-manifest retention, and approval history |
 | `test_parse_props_console_encoding.py` | Regression test preventing Windows console/log encoding from aborting parser execution |
+| `test_parse_props_atomic_publish.py` | Regression tests for transient Windows file-lock retry and fail-closed atomic publication |
 
 ## Operating Boundary
 

--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/parse_props_v7_scene_parser.py
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/parse_props_v7_scene_parser.py
@@ -2,7 +2,7 @@
 #
 # Baseline: parse_props_v6.py V6.8.3
 # Initial Release : 2022-01-20  V0.1.0
-# Current Version : 2026-08-13  V7.0.9
+# Current Version : 2026-08-13  V7.0.10
 #
 # Author:
 #   Greg Liebig
@@ -47,6 +47,14 @@
 #
 # Changelog
 # ---------
+## 2026-08-13  V7.0.10  (GAL / OpenAI)
+# • Explicitly close the final validation and collision-report SQLite
+#   connections before attempting to publish the completed database.
+# • Retry only transient Windows sharing violations during atomic publication,
+#   accommodating short Google Drive/antivirus inspection locks.
+# • Preserve the original parser exception if failed-build retention is also
+#   blocked, and clearly report the exact build file left for diagnosis.
+#
 ## 2026-08-13  V7.0.9  (GAL / OpenAI)
 # • Prevent Windows legacy console/log encodings from aborting a parser run
 #   when an informational message contains a Unicode character.
@@ -252,6 +260,9 @@ import csv
 import getpass
 import platform
 import socket
+import errno
+import time
+from contextlib import closing
 
 
 def configure_console_output() -> None:
@@ -340,7 +351,7 @@ def get_reports_dir() -> str:
 
 
 # ---- Global flags & defaults (must be defined before functions) ----
-PARSER_VERSION = "V7.0.9"  # GAL 2026-08-13: authoritative runtime version
+PARSER_VERSION = "V7.0.10"  # GAL 2026-08-13: authoritative runtime version
 
 DEBUG = False  # Global debug flag
 
@@ -4009,9 +4020,45 @@ def configure_run(arguments: argparse.Namespace) -> None:
     DB_PATH = DB_FILE
 
 
+def _is_transient_file_lock(error: OSError) -> bool:
+    """Return True only for retryable sharing/permission locks."""
+    return (
+        getattr(error, "winerror", None) in (32, 33)
+        or error.errno in (errno.EACCES, errno.EBUSY, errno.EPERM)
+    )
+
+
+def replace_with_lock_retry(
+    source: Path,
+    destination: Path,
+    *,
+    attempts: int = 8,
+    initial_delay_seconds: float = 0.25,
+) -> None:
+    """Atomically replace a file, tolerating only short-lived sharing locks."""
+    if attempts < 1:
+        raise ValueError("attempts must be at least 1")
+
+    for attempt in range(1, attempts + 1):
+        try:
+            os.replace(source, destination)
+            return
+        except OSError as error:
+            if attempt == attempts or not _is_transient_file_lock(error):
+                raise
+            delay = min(initial_delay_seconds * (2 ** (attempt - 1)), 2.0)
+            print(
+                f"[WARN] File handoff is temporarily locked; retrying "
+                f"{attempt}/{attempts - 1} in {delay:.2f}s: {source}"
+            )
+            time.sleep(delay)
+
+
 def validate_output_database(db_file: Path, require_complete: bool = False) -> dict[str, int]:
     """Fail closed unless the entire published SQLite contract is usable."""
-    with sqlite3.connect(db_file) as conn:
+    # sqlite3.Connection.__exit__ commits/rolls back but does not close. The
+    # explicit closing is required before Windows can atomically publish a DB.
+    with closing(sqlite3.connect(db_file)) as conn:
         integrity = conn.execute("PRAGMA integrity_check").fetchone()[0]
         if integrity != "ok":
             raise RuntimeError(f"SQLite integrity_check failed: {integrity}")
@@ -4063,7 +4110,7 @@ def validate_output_database(db_file: Path, require_complete: bool = False) -> d
 
 
 def _write_collision_reports() -> None:
-    with sqlite3.connect(DB_FILE) as conn:
+    with closing(sqlite3.connect(DB_FILE)) as conn:
         cursor = conn.cursor()
         try:
             write_propid_collisions_csv(cursor)
@@ -4102,7 +4149,7 @@ def execute_parser_run(arguments: argparse.Namespace) -> dict[str, object]:
         detail = json.dumps(counts, sort_keys=True, separators=(",", ":"))
         complete_parser_run("COMPLETE", "PASSED", detail)
         validate_output_database(DB_FILE, require_complete=True)
-        os.replace(DB_FILE, OUTPUT_DB_FILE)
+        replace_with_lock_retry(DB_FILE, OUTPUT_DB_FILE)
 
         result = {
             "status": "COMPLETE",
@@ -4138,8 +4185,15 @@ def execute_parser_run(arguments: argparse.Namespace) -> dict[str, object]:
         if Path(DB_FILE).exists():
             timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
             failed_path = REPORTS_DIR / f"{OUTPUT_DB_FILE.stem}.failed-{timestamp}.db"
-            os.replace(DB_FILE, failed_path)
-            print(f"[ERROR] Failed build retained for diagnosis: {failed_path}")
+            try:
+                replace_with_lock_retry(DB_FILE, failed_path)
+            except OSError as retention_error:
+                print(
+                    f"[ERROR] Failed build remains at {DB_FILE}; could not move it "
+                    f"to {failed_path}: {retention_error}"
+                )
+            else:
+                print(f"[ERROR] Failed build retained for diagnosis: {failed_path}")
         print(f"[ERROR] Previous published SQLite snapshot was preserved: {OUTPUT_DB_FILE}")
         raise
 

--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/test_parse_props_atomic_publish.py
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/test_parse_props_atomic_publish.py
@@ -1,0 +1,51 @@
+"""Atomic SQLite publication regression tests for the canonical V7 parser."""
+
+from __future__ import annotations
+
+import errno
+import unittest
+from pathlib import Path
+from unittest.mock import call, patch
+
+import parse_props_v7_scene_parser as parser
+
+
+class ParserAtomicPublishTests(unittest.TestCase):
+    def test_transient_file_lock_is_retried_then_published(self) -> None:
+        source = Path("candidate.db")
+        destination = Path("published.db")
+        locked = PermissionError(errno.EACCES, "temporarily locked")
+
+        with (
+            patch.object(parser.os, "replace", side_effect=[locked, locked, None]) as replace,
+            patch.object(parser.time, "sleep") as sleep,
+        ):
+            parser.replace_with_lock_retry(
+                source,
+                destination,
+                attempts=4,
+                initial_delay_seconds=0.1,
+            )
+
+        self.assertEqual(replace.call_count, 3)
+        replace.assert_has_calls([call(source, destination)] * 3)
+        sleep.assert_has_calls([call(0.1), call(0.2)])
+
+    def test_non_lock_file_error_is_not_retried(self) -> None:
+        source = Path("missing.db")
+        destination = Path("published.db")
+        missing = FileNotFoundError(errno.ENOENT, "missing")
+
+        with (
+            patch.object(parser.os, "replace", side_effect=missing) as replace,
+            patch.object(parser.time, "sleep") as sleep,
+        ):
+            with self.assertRaises(FileNotFoundError):
+                parser.replace_with_lock_retry(source, destination)
+
+        replace.assert_called_once_with(source, destination)
+        sleep.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Docs/01_LOR_System/02_Data_Extraction/README.md
+++ b/Docs/01_LOR_System/02_Data_Extraction/README.md
@@ -38,7 +38,7 @@ The parser owns interpretation of Light-O-Rama preview structure. PostgreSQL ing
 ## Current Baseline
 
 The current functional parser is
-`Parser/parse_props_v7_scene_parser.py` V7.0.9. The current approved LOR version
+`Parser/parse_props_v7_scene_parser.py` V7.0.10. The current approved LOR version
 is an operator-controlled record initialized from the known-good 6.6.4 preview
 set; it is not a hard-coded parser assumption.
 


### PR DESCRIPTION
## What changed

- bumps the canonical parser to V7.0.10
- explicitly closes final SQLite validation and collision-report connections before publication
- retries only transient Windows sharing/permission locks during atomic file handoff
- preserves the original parser exception when failed-build retention is also locked
- documents the new parser baseline and adds atomic-publication regression tests

## Why

The V6.6.10 candidate build completed its database audits but Windows/Google Drive returned WinError 32 during the final `os.replace`. The existing failure handler then attempted the same locked handoff and masked where the completed hidden build remained.

## Operator impact

A short Google Drive or antivirus inspection lock is now retried for a bounded period. Permanent locks still fail closed, preserve any previous published snapshot, and report the exact build path left for diagnosis.

## Validation

- `python -m unittest discover -s "Docs/01_LOR_System/02_Data_Extraction/Parser" -p "test_*.py" -v` (13 tests passed)
- `python -m py_compile` for the parser and new atomic-publication test
- `git diff --check`