### PR TITLE
Gate LOR approval on SQLite output comparison

### DIFF
--- a/Docs/01_LOR_System/02_Data_Extraction/LOR_Preview_Version_Compatibility_Review.md
+++ b/Docs/01_LOR_System/02_Data_Extraction/LOR_Preview_Version_Compatibility_Review.md
@@ -311,8 +311,10 @@ Do not modify parser code during this phase. First establish the complete impact
 
 Only after the raw XML comparison is documented should the current parser be tested against the copied new-version previews.
 
-Use the website's candidate parser action. It runs with `VERSION_CHECK` mode and
-writes a separate test SQLite database under the candidate evidence folder.
+Use the website to build both the approved-version baseline and candidate with
+the same parser in `VERSION_CHECK` mode. Each writes a separate test SQLite
+database under its versioned evidence folder. The runner rejects either source
+folder if it no longer matches the XML manifest used for the review.
 
 Record:
 
@@ -331,7 +333,8 @@ A successful process exit is not sufficient acceptance evidence.
 
 ## Phase 7 — Compare Parser Outputs
 
-Compare the known-good and new-version SQLite results for equivalent previews.
+The website automatically compares the known-good and new-version SQLite
+results by stable identity after the candidate parser passes.
 
 Review at least:
 
@@ -345,6 +348,13 @@ Review at least:
 - parser-run provenance.
 
 Compare both schema and content.
+
+LOR increments `PreviewClass.Revision` when a preview is opened or saved even
+when no meaningful content changes. Revision-only differences must be retained
+as informational evidence but must not, by themselves, block approval. Name,
+SourceFilename, StageID, Brightness, and BackgroundFile changes require review.
+Any difference in props, subProps, DMX channels, raw Scene rows, or positional
+Scene membership is blocking until its cause and downstream effect are resolved.
 
 Expected differences caused only by the LOR version should be distinguishable from unintended parser differences.
 
@@ -414,10 +424,11 @@ The decision record should identify:
 - validation evidence;
 - final approval.
 
-Approval is permitted only when the candidate parser run is `COMPLETE` with
-`ValidationStatus=PASSED` and either the XML report is `PASSED` or every failed
-finding has a recorded engineering resolution tied to that parser version.
-Unresolved findings remain attached to and block the candidate.
+Approval is permitted only when both approved-version and candidate parser runs
+are `COMPLETE` with `ValidationStatus=PASSED`, the automated SQLite comparison
+exists, and both the XML report and SQLite comparison either pass or have a
+recorded engineering resolution tied to that parser version. Unresolved
+findings remain attached to and block the candidate.
 
 ## Standard ChatGPT Compatibility Review Prompt
 

--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/README.md
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/README.md
@@ -10,9 +10,9 @@ tools for operator convenience but does not own their XML interpretation.
 |---|---|
 | `parse_props_v7_scene_parser.py` | Canonical V7 parser; atomically publishes only a fully validated SQLite snapshot |
 | `lor_version_checker.py` | Parser-independent complete XML manifest and Current/New LOR compatibility comparison |
-| `lor_operator_runner.py` | Restricted Windows/G-drive API used by the authenticated LOR2DB website |
+| `lor_operator_runner.py` | Restricted Windows/G-drive API, stale-manifest guard, and same-parser SQLite output comparison used by the authenticated LOR2DB website |
 | `test_lor_version_checker.py` | Regression tests for Scene count/structure, unused fields, ChannelGrid, and other delimiter-position changes |
-| `test_lor_operator_runner.py` | Regression tests for version-scoped paths, approved-manifest retention, and approval history |
+| `test_lor_operator_runner.py` | Regression tests for version-scoped paths, stale manifests, SQLite output comparison, Revision handling, and approval history |
 | `test_parse_props_console_encoding.py` | Regression test preventing Windows console/log encoding from aborting parser execution |
 | `test_parse_props_atomic_publish.py` | Regression tests for transient Windows file-lock retry and fail-closed atomic publication |
 

--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/lor_operator_runner.py
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/lor_operator_runner.py
@@ -10,10 +10,12 @@ callers cannot submit arbitrary executable or output paths.
 from __future__ import annotations
 
 import argparse
+from collections import Counter
 import hmac
 import json
 import os
 import re
+import sqlite3
 import subprocess
 import sys
 import threading
@@ -24,10 +26,26 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
-from lor_version_checker import build_manifest, write_json
+from lor_version_checker import build_manifest, manifest_source_signature, write_json
 
 
-RUNNER_VERSION = "V1.0.0"
+RUNNER_VERSION = "V1.1.0"
+
+AUTHORITATIVE_OUTPUT_TABLES = (
+    "props",
+    "subProps",
+    "dmxChannels",
+    "scenes",
+    "scene_lor_props",
+)
+PREVIEW_METADATA_FIELDS = (
+    "StageID",
+    "Name",
+    "Revision",
+    "Brightness",
+    "BackgroundFile",
+    "SourceFilename",
+)
 
 
 def required_environment(name: str) -> str:
@@ -47,6 +65,298 @@ def path_within(path: Path, root: Path) -> bool:
         return True
     except ValueError:
         return False
+
+
+def _table_contract(connection: sqlite3.Connection, table: str) -> list[tuple[Any, ...]]:
+    return [
+        (row[1], row[2], row[3], row[4], row[5])
+        for row in connection.execute(f'PRAGMA table_info("{table}")')
+    ]
+
+
+def _content_columns(contract: list[tuple[Any, ...]]) -> list[str]:
+    # Exclude only disposable integer primary keys. A prefix-only test would
+    # incorrectly omit authoritative fields such as IndividualChannels.
+    return [
+        str(row[0])
+        for row in contract
+        if not (
+            str(row[0]).startswith("Int")
+            and str(row[1]).upper() == "INTEGER"
+            and int(row[4]) > 0
+        )
+    ]
+
+
+def _quoted(name: str) -> str:
+    return '"' + name.replace('"', '""') + '"'
+
+
+def _rows(
+    connection: sqlite3.Connection,
+    table: str,
+    columns: list[str],
+) -> Counter[tuple[Any, ...]]:
+    selected = ", ".join(_quoted(column) for column in columns)
+    return Counter(connection.execute(f'SELECT {selected} FROM {_quoted(table)}').fetchall())
+
+
+def _write_output_comparison_markdown(path: Path, report: dict[str, Any]) -> None:
+    lines = [
+        "# LOR Parser Output Comparison",
+        "",
+        f"- Current LOR version: {report['current_lor_version']}",
+        f"- New LOR version: {report['new_lor_version']}",
+        f"- Status: **{report['status']}**",
+        f"- Approval blocked: **{'YES' if report['approval_blocked'] else 'NO'}**",
+        f"- Blocking findings: {report['blocking_count']}",
+        f"- Review findings: {report['review_count']}",
+        f"- Informational findings: {report['information_count']}",
+        f"- Parser version: {report['parser_contract']['baseline_version']}",
+        f"- View contracts equal: **{'YES' if report['view_contract']['contracts_equal'] else 'NO'}**",
+        "",
+        "## Authoritative table comparison",
+        "",
+        "| Table | Baseline only | Candidate only | Schema equal |",
+        "|---|---:|---:|---|",
+    ]
+    for table, detail in report["tables"].items():
+        lines.append(
+            f"| {table} | {detail['baseline_only']} | {detail['candidate_only']} | "
+            f"{'YES' if detail['schema_equal'] else 'NO'} |"
+        )
+    lines.extend([
+        "",
+        "## Preview metadata changes",
+        "",
+        "| Field | Changed previews |",
+        "|---|---:|",
+    ])
+    for field, count in report["preview_metadata_change_counts"].items():
+        lines.append(f"| {field} | {count} |")
+    lines.extend([
+        "",
+        "## Findings",
+        "",
+        "| Severity | Area | Finding |",
+        "|---|---|---|",
+    ])
+    if report["findings"]:
+        for finding in report["findings"]:
+            message = str(finding["message"]).replace("|", "\\|")
+            lines.append(f"| {finding['severity']} | {finding['area']} | {message} |")
+    else:
+        lines.append("| — | — | No differences found. |")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def compare_parser_outputs(
+    baseline_db: Path,
+    candidate_db: Path,
+    current_lor_version: str,
+    new_lor_version: str,
+    report_json: Path,
+    report_markdown: Path,
+) -> dict[str, Any]:
+    """Compare same-parser SQLite outputs and fail closed on unexplained content."""
+    for label, path in (("Baseline", baseline_db), ("Candidate", candidate_db)):
+        if not path.is_file():
+            raise ValueError(f"{label} parser database does not exist: {path}")
+
+    baseline = sqlite3.connect(baseline_db)
+    candidate = sqlite3.connect(candidate_db)
+    try:
+        findings: list[dict[str, str]] = []
+        tables: dict[str, dict[str, Any]] = {}
+        for table in ("previews", *AUTHORITATIVE_OUTPUT_TABLES):
+            baseline_contract = _table_contract(baseline, table)
+            candidate_contract = _table_contract(candidate, table)
+            schema_equal = bool(baseline_contract) and baseline_contract == candidate_contract
+            if not schema_equal:
+                findings.append({
+                    "severity": "BLOCKING",
+                    "area": f"{table} schema",
+                    "message": "Baseline and candidate SQLite table contracts differ.",
+                })
+            columns = _content_columns(baseline_contract)
+            if not columns or not schema_equal:
+                baseline_only = candidate_only = 0
+            else:
+                baseline_rows = _rows(baseline, table, columns)
+                candidate_rows = _rows(candidate, table, columns)
+                baseline_only = sum((baseline_rows - candidate_rows).values())
+                candidate_only = sum((candidate_rows - baseline_rows).values())
+            tables[table] = {
+                "schema_equal": schema_equal,
+                "baseline_only": baseline_only,
+                "candidate_only": candidate_only,
+            }
+            if table != "previews" and (baseline_only or candidate_only):
+                findings.append({
+                    "severity": "BLOCKING",
+                    "area": table,
+                    "message": (
+                        f"Authoritative content differs: baseline-only={baseline_only}; "
+                        f"candidate-only={candidate_only}."
+                    ),
+                })
+
+        baseline_parser_contract = _table_contract(baseline, "parser_run")
+        candidate_parser_contract = _table_contract(candidate, "parser_run")
+        if baseline_parser_contract != candidate_parser_contract:
+            findings.append({
+                "severity": "BLOCKING",
+                "area": "parser_run schema",
+                "message": "Baseline and candidate parser provenance contracts differ.",
+            })
+        baseline_parser_rows = baseline.execute(
+            "SELECT ParserVersion, RunMode, ValidationStatus FROM parser_run"
+        ).fetchall()
+        candidate_parser_rows = candidate.execute(
+            "SELECT ParserVersion, RunMode, ValidationStatus FROM parser_run"
+        ).fetchall()
+        baseline_parser_version = baseline_parser_rows[0][0] if len(baseline_parser_rows) == 1 else None
+        candidate_parser_version = candidate_parser_rows[0][0] if len(candidate_parser_rows) == 1 else None
+        if (
+            len(baseline_parser_rows) != 1
+            or len(candidate_parser_rows) != 1
+            or baseline_parser_version != candidate_parser_version
+            or baseline_parser_rows[0][1:] != ("VERSION_CHECK", "PASSED")
+            or candidate_parser_rows[0][1:] != ("VERSION_CHECK", "PASSED")
+        ):
+            findings.append({
+                "severity": "BLOCKING",
+                "area": "parser provenance",
+                "message": "Outputs were not produced by the same passing parser in VERSION_CHECK mode.",
+            })
+
+        baseline_views = {
+            row[0]: row[1]
+            for row in baseline.execute(
+                "SELECT name, sql FROM sqlite_master WHERE type='view' ORDER BY name"
+            )
+        }
+        candidate_views = {
+            row[0]: row[1]
+            for row in candidate.execute(
+                "SELECT name, sql FROM sqlite_master WHERE type='view' ORDER BY name"
+            )
+        }
+        view_names_equal = set(baseline_views) == set(candidate_views)
+        common_views = sorted(set(baseline_views) & set(candidate_views))
+        differing_view_contracts = [
+            name
+            for name in common_views
+            if baseline_views[name] != candidate_views[name]
+            or _table_contract(baseline, name) != _table_contract(candidate, name)
+        ]
+        view_contracts_equal = bool(baseline_views) and view_names_equal and not differing_view_contracts
+        if not view_contracts_equal:
+            findings.append({
+                "severity": "BLOCKING",
+                "area": "SQLite views",
+                "message": (
+                    f"View contracts differ: baseline={len(baseline_views)}; "
+                    f"candidate={len(candidate_views)}; changed={len(differing_view_contracts)}."
+                ),
+            })
+
+        preview_columns = [row[0] for row in _table_contract(baseline, "previews")]
+        if "id" not in preview_columns:
+            raise RuntimeError("previews table does not contain stable id identity")
+        selected = ", ".join(_quoted(column) for column in preview_columns)
+        baseline_previews = {
+            row[preview_columns.index("id")]: dict(zip(preview_columns, row))
+            for row in baseline.execute(f'SELECT {selected} FROM "previews"')
+        }
+        candidate_previews = {
+            row[preview_columns.index("id")]: dict(zip(preview_columns, row))
+            for row in candidate.execute(f'SELECT {selected} FROM "previews"')
+        }
+        missing = sorted(set(baseline_previews) - set(candidate_previews))
+        added = sorted(set(candidate_previews) - set(baseline_previews))
+        if missing or added:
+            findings.append({
+                "severity": "BLOCKING",
+                "area": "preview identity",
+                "message": f"Stable PreviewID sets differ: missing={len(missing)}; added={len(added)}.",
+            })
+
+        changes: list[dict[str, Any]] = []
+        change_counts = {field: 0 for field in PREVIEW_METADATA_FIELDS}
+        for preview_id in sorted(set(baseline_previews) & set(candidate_previews)):
+            before = baseline_previews[preview_id]
+            after = candidate_previews[preview_id]
+            for field in PREVIEW_METADATA_FIELDS:
+                if before.get(field) == after.get(field):
+                    continue
+                change_counts[field] += 1
+                changes.append({
+                    "preview_id": preview_id,
+                    "preview_name": after.get("Name") or before.get("Name"),
+                    "field": field,
+                    "baseline": before.get(field),
+                    "candidate": after.get(field),
+                })
+
+        revision_count = change_counts["Revision"]
+        if revision_count:
+            findings.append({
+                "severity": "INFO",
+                "area": "preview Revision",
+                "message": (
+                    f"LOR changed Revision metadata for {revision_count} preview(s). "
+                    "Revision is recorded but is not treated as proof of a content change."
+                ),
+            })
+        for field in PREVIEW_METADATA_FIELDS:
+            count = change_counts[field]
+            if not count or field == "Revision":
+                continue
+            findings.append({
+                "severity": "REVIEW",
+                "area": f"preview {field}",
+                "message": f"{field} changed for {count} stable PreviewID row(s); operator resolution is required.",
+            })
+
+        blocking_count = sum(item["severity"] == "BLOCKING" for item in findings)
+        review_count = sum(item["severity"] == "REVIEW" for item in findings)
+        information_count = sum(item["severity"] == "INFO" for item in findings)
+        status = "BLOCKED" if blocking_count else "REVIEW_REQUIRED" if review_count else "PASSED"
+        report = {
+            "current_lor_version": current_lor_version,
+            "new_lor_version": new_lor_version,
+            "status": status,
+            "approval_blocked": status != "PASSED",
+            "blocking_count": blocking_count,
+            "review_count": review_count,
+            "information_count": information_count,
+            "tables": tables,
+            "parser_contract": {
+                "schema_equal": baseline_parser_contract == candidate_parser_contract,
+                "baseline_version": baseline_parser_version,
+                "candidate_version": candidate_parser_version,
+            },
+            "view_contract": {
+                "baseline_count": len(baseline_views),
+                "candidate_count": len(candidate_views),
+                "names_equal": view_names_equal,
+                "contracts_equal": view_contracts_equal,
+                "changed_views": differing_view_contracts,
+            },
+            "preview_metadata_change_counts": change_counts,
+            "preview_metadata_changes": changes,
+            "findings": findings,
+            "report_json": str(report_json),
+            "report_markdown": str(report_markdown),
+        }
+        write_json(report_json, report)
+        _write_output_comparison_markdown(report_markdown, report)
+        return report
+    finally:
+        baseline.close()
+        candidate.close()
 
 
 class StateStore:
@@ -106,7 +416,9 @@ class Runner:
             "new_lor_version": state.get("new_lor_version"),
             "new_preview_folder": state.get("new_preview_folder"),
             "candidate_check": state.get("candidate_check"),
+            "baseline_parser_run": state.get("baseline_parser_run"),
             "candidate_parser_run": state.get("candidate_parser_run"),
+            "candidate_output_comparison": state.get("candidate_output_comparison"),
             "candidate_resolution": state.get("candidate_resolution"),
             "production_parser_run": state.get("production_parser_run"),
             "last_approval": state.get("last_approval"),
@@ -129,6 +441,7 @@ class Runner:
                 "new_preview_folder": str(folder),
                 "candidate_check": None,
                 "candidate_parser_run": None,
+                "candidate_output_comparison": None,
                 "candidate_resolution": None,
                 "candidate_selected_at": utc_now(),
                 "candidate_selected_by": actor,
@@ -176,6 +489,8 @@ class Runner:
             if current.get("new_lor_version") != version:
                 raise RuntimeError("Candidate changed while the compatibility check was running")
             current["candidate_check"] = record
+            current["candidate_parser_run"] = None
+            current["candidate_output_comparison"] = None
             current["candidate_resolution"] = None
 
         self.store.update(operation)
@@ -183,12 +498,29 @@ class Runner:
 
     def run_parser(self, target: str, actor: str) -> dict[str, Any]:
         state = self.store.read()
-        if target == "current":
+        if target in {"current", "baseline"}:
             version = state["current_lor_version"]
             folder = Path(state["current_preview_folder"])
-            db_file = self.production_db
-            run_mode = "PRODUCTION"
+            approved_manifest = json.loads(
+                Path(state["current_manifest_path"]).read_text(encoding="utf-8")
+            )
+            current_manifest = build_manifest(
+                folder,
+                version,
+                approved_manifest.get("deep_preview"),
+                deep_identity=approved_manifest.get("deep_preview_identity"),
+            )
+            if manifest_source_signature(current_manifest) != manifest_source_signature(approved_manifest):
+                raise ValueError(
+                    "The approved preview folder changed after approval; restore it or perform a new compatibility review"
+                )
             compatibility_manifest_sha256 = state["current_manifest_sha256"]
+            if target == "current":
+                db_file = self.production_db
+                run_mode = "PRODUCTION"
+            else:
+                db_file = self.reports_root / f"V{version}" / "parser" / "lor_output_v7_scene.db"
+                run_mode = "VERSION_CHECK"
         elif target == "candidate":
             version = state.get("new_lor_version")
             if not version:
@@ -204,9 +536,19 @@ class Runner:
             candidate_manifest = json.loads(
                 Path(check["candidate_manifest_path"]).read_text(encoding="utf-8")
             )
+            live_manifest = build_manifest(
+                folder,
+                version,
+                candidate_manifest.get("deep_preview"),
+                deep_identity=candidate_manifest.get("deep_preview_identity"),
+            )
+            if manifest_source_signature(live_manifest) != manifest_source_signature(candidate_manifest):
+                raise ValueError(
+                    "The candidate preview folder changed after its XML check; rerun XML compatibility"
+                )
             compatibility_manifest_sha256 = candidate_manifest["manifest_sha256"]
         else:
-            raise ValueError("Parser target must be current or candidate")
+            raise ValueError("Parser target must be current, baseline, or candidate")
         if not folder.is_dir():
             raise ValueError(f"Preview folder does not exist: {folder}")
 
@@ -235,13 +577,50 @@ class Runner:
         }
 
         def operation(current: dict[str, Any]) -> None:
-            expected = current["current_lor_version"] if target == "current" else current.get("new_lor_version")
+            expected = (
+                current["current_lor_version"]
+                if target in {"current", "baseline"}
+                else current.get("new_lor_version")
+            )
             if expected != version:
                 raise RuntimeError("LOR version changed while the parser was running; result was not recorded")
-            key = "production_parser_run" if target == "current" else "candidate_parser_run"
+            if target == "current":
+                key = "production_parser_run"
+            elif target == "baseline":
+                key = "baseline_parser_run"
+                current["candidate_output_comparison"] = None
+                current["candidate_resolution"] = None
+            else:
+                key = "candidate_parser_run"
+                current["candidate_output_comparison"] = None
+                current["candidate_resolution"] = None
             current[key] = record
 
         self.store.update(operation)
+        if target == "candidate":
+            refreshed = self.store.read()
+            baseline_run = refreshed.get("baseline_parser_run") or {}
+            if (
+                baseline_run.get("status") == "COMPLETE"
+                and baseline_run.get("validation_status") == "PASSED"
+                and baseline_run.get("source_lor_version") == refreshed["current_lor_version"]
+            ):
+                comparison_dir = self.reports_root / f"V{version}" / "comparison"
+                comparison = compare_parser_outputs(
+                    Path(baseline_run["sqlite_path"]),
+                    Path(record["sqlite_path"]),
+                    refreshed["current_lor_version"],
+                    version,
+                    comparison_dir / "parser-output-comparison.json",
+                    comparison_dir / "parser-output-comparison.md",
+                )
+
+                def save_comparison(current: dict[str, Any]) -> None:
+                    if current.get("new_lor_version") != version:
+                        raise RuntimeError("Candidate changed while parser outputs were compared")
+                    current["candidate_output_comparison"] = comparison
+
+                self.store.update(save_comparison)
         return record
 
     def resolve_candidate_findings(self, notes: str, actor: str) -> dict[str, Any]:
@@ -250,13 +629,19 @@ class Runner:
             raise ValueError("Engineering resolution notes are required")
         state = self.store.read()
         check = state.get("candidate_check") or {}
+        baseline_run = state.get("baseline_parser_run") or {}
         parser_run = state.get("candidate_parser_run") or {}
-        if check.get("status") == "PASSED":
-            raise ValueError("The compatibility check already passed; no resolution is required")
+        comparison = state.get("candidate_output_comparison") or {}
+        if check.get("status") == "PASSED" and comparison.get("status") == "PASSED":
+            raise ValueError("The compatibility and output checks passed; no resolution is required")
         if not check:
             raise ValueError("Run the compatibility check first")
+        if baseline_run.get("status") != "COMPLETE" or baseline_run.get("validation_status") != "PASSED":
+            raise ValueError("A validated approved-version baseline parser run is required")
         if parser_run.get("status") != "COMPLETE" or parser_run.get("validation_status") != "PASSED":
             raise ValueError("A validated candidate parser run is required before resolving findings")
+        if not comparison:
+            raise ValueError("Run the baseline/candidate SQLite output comparison first")
         resolution = {
             "status": "RESOLVED",
             "resolved_at": utc_now(),
@@ -264,6 +649,8 @@ class Runner:
             "parser_version": parser_run["parser_version"],
             "notes": notes,
             "parser_modifications_required": check.get("parser_modifications_required", []),
+            "xml_status": check.get("status"),
+            "output_comparison_status": comparison.get("status"),
         }
 
         def operation(current: dict[str, Any]) -> None:
@@ -279,13 +666,22 @@ class Runner:
         if version != state.get("new_lor_version"):
             raise ValueError("Approval confirmation does not match the selected new LOR version")
         check = state.get("candidate_check") or {}
+        baseline_run = state.get("baseline_parser_run") or {}
         parser_run = state.get("candidate_parser_run") or {}
+        comparison = state.get("candidate_output_comparison") or {}
         resolution = state.get("candidate_resolution") or {}
         check_accepted = check.get("status") == "PASSED" or resolution.get("status") == "RESOLVED"
+        comparison_accepted = (
+            comparison.get("status") == "PASSED" or resolution.get("status") == "RESOLVED"
+        )
         if not check_accepted:
             raise ValueError("Compatibility findings have not passed or been resolved")
+        if baseline_run.get("status") != "COMPLETE" or baseline_run.get("validation_status") != "PASSED":
+            raise ValueError("Approved-version comparison baseline has not passed")
         if parser_run.get("status") != "COMPLETE" or parser_run.get("validation_status") != "PASSED":
             raise ValueError("Candidate parser run has not passed")
+        if not comparison_accepted:
+            raise ValueError("Parser output differences have not passed or been resolved")
         candidate_manifest = Path(check["candidate_manifest_path"])
         manifest = json.loads(candidate_manifest.read_text(encoding="utf-8"))
         approved_manifest = self.store.path.with_name("current-lor-manifest.json")
@@ -302,7 +698,9 @@ class Runner:
                 "compatibility_report": check["report_json"],
                 "compatibility_manifest_sha256": manifest["manifest_sha256"],
                 "parser_version": parser_run["parser_version"],
+                "baseline_sqlite_sha256": baseline_run["sqlite_sha256"],
                 "candidate_sqlite_sha256": parser_run["sqlite_sha256"],
+                "output_comparison_report": comparison["report_json"],
                 "compatibility_resolution": resolution or None,
             }
             current["last_approval"] = approval
@@ -311,10 +709,14 @@ class Runner:
             current["current_preview_folder"] = current["new_preview_folder"]
             current["current_manifest_path"] = str(approved_manifest)
             current["current_manifest_sha256"] = manifest["manifest_sha256"]
+            current["deep_preview"] = manifest["deep_preview"]
+            current["deep_preview_identity"] = manifest["deep_preview_identity"]
             current["new_lor_version"] = None
             current["new_preview_folder"] = None
             current["candidate_check"] = None
+            current["baseline_parser_run"] = parser_run
             current["candidate_parser_run"] = None
+            current["candidate_output_comparison"] = None
             current["candidate_resolution"] = None
             current["production_parser_run"] = None
 
@@ -417,10 +819,13 @@ def initialize(arguments: argparse.Namespace) -> None:
         "current_manifest_path": str(manifest_path),
         "current_manifest_sha256": manifest["manifest_sha256"],
         "deep_preview": manifest["deep_preview"],
+        "deep_preview_identity": manifest["deep_preview_identity"],
         "new_lor_version": None,
         "new_preview_folder": None,
         "candidate_check": None,
+        "baseline_parser_run": None,
         "candidate_parser_run": None,
+        "candidate_output_comparison": None,
         "candidate_resolution": None,
         "production_parser_run": None,
         "last_approval": None,

--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/lor_version_checker.py
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/lor_version_checker.py
@@ -23,8 +23,8 @@ from pathlib import Path
 from typing import Any, Iterable
 
 
-CHECKER_VERSION = "V1.2.0"
-MANIFEST_VERSION = 3
+CHECKER_VERSION = "V1.3.0"
+MANIFEST_VERSION = 4
 CRITICAL_ELEMENTS = {"PreviewClass", "Scene", "PropClass"}
 UUID_RE = re.compile(
     r"^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
@@ -296,6 +296,23 @@ def preview_identity(contract: dict[str, Any]) -> str:
     return f"Filename:{contract['filename'].casefold()}"
 
 
+def manifest_source_signature(manifest: dict[str, Any]) -> str:
+    """Return a deterministic digest of the exact reviewed preview files."""
+    source_files = sorted(
+        (
+            {
+                "filename": item["filename"],
+                "identity": preview_identity(item),
+                "sha256": item["sha256"],
+            }
+            for item in manifest["files"]
+        ),
+        key=lambda item: (item["identity"], item["filename"].casefold()),
+    )
+    payload = json.dumps(source_files, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode()).hexdigest()
+
+
 def build_manifest(
     folder: Path,
     lor_version: str,
@@ -339,6 +356,7 @@ def build_manifest(
         "aggregate": merge_contracts(file_contracts),
         "deep_contract": deep,
     }
+    manifest["source_signature_sha256"] = manifest_source_signature(manifest)
     manifest_payload = json.dumps(manifest, sort_keys=True, separators=(",", ":"))
     manifest["manifest_sha256"] = hashlib.sha256(manifest_payload.encode()).hexdigest()
     return manifest

--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/test_lor_operator_runner.py
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/test_lor_operator_runner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import sqlite3
 import tempfile
 import unittest
 from pathlib import Path
@@ -71,8 +72,19 @@ class OperatorRunnerTests(unittest.TestCase):
             state["candidate_parser_run"] = {
                 "status": "COMPLETE",
                 "validation_status": "PASSED",
-                "parser_version": "V7.0.8",
+                "parser_version": "V7.0.10",
+                "source_lor_version": "6.6.10",
                 "sqlite_sha256": "a" * 64,
+            }
+            state["baseline_parser_run"] = {
+                "status": "COMPLETE",
+                "validation_status": "PASSED",
+                "source_lor_version": "6.6.4",
+                "sqlite_sha256": "b" * 64,
+            }
+            state["candidate_output_comparison"] = {
+                "status": "PASSED",
+                "report_json": str(self.root / "reports" / "output-comparison.json"),
             }
 
         self.store.update(prepare)
@@ -85,7 +97,127 @@ class OperatorRunnerTests(unittest.TestCase):
             candidate_manifest["manifest_sha256"],
         )
         self.assertEqual(len(state["approval_history"]), 1)
-        self.assertEqual(state["last_approval"]["parser_version"], "V7.0.8")
+        self.assertEqual(state["last_approval"]["parser_version"], "V7.0.10")
+        self.assertEqual(state["last_approval"]["baseline_sqlite_sha256"], "b" * 64)
+        self.assertEqual(state["baseline_parser_run"]["source_lor_version"], "6.6.10")
+
+    def test_approval_requires_output_comparison(self) -> None:
+        self.runner.select_candidate("6.6.10", "operator@example.com")
+
+        def prepare(state):
+            state["candidate_check"] = {"status": "PASSED"}
+            state["baseline_parser_run"] = {
+                "status": "COMPLETE",
+                "validation_status": "PASSED",
+            }
+            state["candidate_parser_run"] = {
+                "status": "COMPLETE",
+                "validation_status": "PASSED",
+            }
+
+        self.store.update(prepare)
+        with self.assertRaisesRegex(ValueError, "output differences"):
+            self.runner.approve_candidate("6.6.10", "operator@example.com")
+
+    def test_changed_candidate_folder_invalidates_checked_manifest(self) -> None:
+        self.runner.select_candidate("6.6.10", "operator@example.com")
+        manifest = build_manifest(self.candidate, "6.6.10", "test.lorprev")
+        manifest_path = self.root / "reports" / "candidate-manifest.json"
+        write_json(manifest_path, manifest)
+
+        def prepare(state):
+            state["candidate_check"] = {
+                "status": "PASSED",
+                "candidate_manifest_path": str(manifest_path),
+            }
+
+        self.store.update(prepare)
+        (self.candidate / "test.lorprev").write_text(
+            PREVIEW_XML.replace('Name="Stage 01"', 'Name="Stage 01 changed"'),
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(ValueError, "changed after its XML check"):
+            self.runner.run_parser("candidate", "operator@example.com")
+
+
+class ParserOutputComparisonTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        self.baseline = self.root / "baseline.db"
+        self.candidate = self.root / "candidate.db"
+        self._create_database(self.baseline, revision="1", name="Master 6.6.4", source="old.lorprev")
+        self._create_database(self.candidate, revision="2", name="Master 6.6.10", source="new.lorprev")
+
+    def _create_database(self, path: Path, revision: str, name: str, source: str) -> None:
+        with sqlite3.connect(path) as connection:
+            connection.execute(
+                "CREATE TABLE previews (IntPreviewID INTEGER PRIMARY KEY, id TEXT UNIQUE, "
+                "StageID TEXT, Name TEXT, Revision TEXT, Brightness REAL, "
+                "BackgroundFile TEXT, SourceFilename TEXT)"
+            )
+            connection.execute(
+                "INSERT INTO previews VALUES (1, 'preview-id', '01', ?, ?, 100.0, 'background.jpg', ?)",
+                (name, revision, source),
+            )
+            connection.execute(
+                "CREATE TABLE parser_run (ParserVersion TEXT, RunMode TEXT, ValidationStatus TEXT)"
+            )
+            connection.execute(
+                "INSERT INTO parser_run VALUES ('V7.0.10', 'VERSION_CHECK', 'PASSED')"
+            )
+            for table in runner_module.AUTHORITATIVE_OUTPUT_TABLES:
+                if table == "props":
+                    connection.execute(
+                        'CREATE TABLE props (IntPropID INTEGER PRIMARY KEY, '
+                        'Value TEXT, IndividualChannels TEXT)'
+                    )
+                    connection.execute('INSERT INTO props VALUES (1, "same", "True")')
+                else:
+                    connection.execute(
+                        f'CREATE TABLE "{table}" (IntRowID INTEGER PRIMARY KEY, Value TEXT)'
+                    )
+                    connection.execute(f'INSERT INTO "{table}" VALUES (1, "same")')
+            connection.execute("CREATE VIEW props_review_vw AS SELECT Value FROM props")
+
+    def compare(self) -> dict:
+        return runner_module.compare_parser_outputs(
+            self.baseline,
+            self.candidate,
+            "6.6.4",
+            "6.6.10",
+            self.root / "comparison.json",
+            self.root / "comparison.md",
+        )
+
+    def test_revision_is_informational_and_name_file_changes_require_review(self) -> None:
+        report = self.compare()
+        self.assertEqual(report["status"], "REVIEW_REQUIRED")
+        self.assertEqual(report["blocking_count"], 0)
+        self.assertEqual(report["review_count"], 2)
+        self.assertEqual(report["information_count"], 1)
+        self.assertEqual(report["preview_metadata_change_counts"]["Revision"], 1)
+        for table in runner_module.AUTHORITATIVE_OUTPUT_TABLES:
+            self.assertEqual(report["tables"][table]["baseline_only"], 0)
+            self.assertEqual(report["tables"][table]["candidate_only"], 0)
+
+    def test_authoritative_content_difference_is_blocking(self) -> None:
+        with sqlite3.connect(self.candidate) as connection:
+            connection.execute('UPDATE props SET Value = "changed"')
+        report = self.compare()
+        self.assertEqual(report["status"], "BLOCKED")
+        self.assertEqual(report["blocking_count"], 1)
+        self.assertEqual(report["tables"]["props"]["baseline_only"], 1)
+        self.assertEqual(report["tables"]["props"]["candidate_only"], 1)
+
+    def test_individual_channels_is_not_mistaken_for_surrogate_integer_key(self) -> None:
+        with sqlite3.connect(self.candidate) as connection:
+            connection.execute('UPDATE props SET IndividualChannels = "False"')
+        report = self.compare()
+        self.assertEqual(report["status"], "BLOCKED")
+        self.assertEqual(report["tables"]["props"]["baseline_only"], 1)
+        self.assertEqual(report["tables"]["props"]["candidate_only"], 1)
 
 
 if __name__ == "__main__":

--- a/LOR2DB/Application/README.md
+++ b/LOR2DB/Application/README.md
@@ -9,6 +9,7 @@
 
 | Date | Change |
 |---|---|
+| 2026-08-13 | Added the mandatory same-parser approved-version/candidate SQLite comparison. Approval now requires equal schemas and explained output differences; automatic LOR Revision increments are retained as informational evidence rather than treated as content changes. Candidate folders changed after XML review are rejected as stale. |
 | 2026-08-13 | Added the LOR version-of-record, complete XML compatibility gate, validated parser controls, and Windows/G-drive runner boundary. PostgreSQL ingest remains a separate manual approval step and requires the reviewed SQLite SHA-256. |
 | 2026-08-06 | Browser V0.4.3 opens the newly published run's immutable `report_url`, with the archive index only as a fallback. Backend V0.3.3 returns that URL after publication. Report framework V0.4.2 displays the authenticated Cloudflare email as the operator. Directus person resolution and role-based authorization remain a future enhancement. |
 | 2026-08-06 | Enforced permanent one-to-one snapshot ownership. The landing page now continues any unfinished run first and uses the existing `import_run_id` link instead of numeric run recency. Start is hidden and rejected when the snapshot already owns any reconciliation row; cancelled and failed runs also consume their snapshot. |
@@ -93,16 +94,22 @@ The workflow is intentionally gated:
 2. Run the parser-independent complete XML compatibility check.
 3. If the check fails, review the recorded parser modifications required and
    update the parser.
-4. Run the candidate parser into an isolated `VERSION_CHECK` SQLite file. A
-   check failure may proceed to this test only after the raw check has run.
-5. When structural findings were expected and the modified parser passes,
-   record the engineering resolution notes for every finding.
-6. Approve the version only after both gates pass or all findings are resolved.
-   The previous version folder
-   remains unchanged.
-7. Run the current parser in `PRODUCTION` mode. Inspect the resulting SQLite as
+4. Build the approved-version comparison baseline in isolated `VERSION_CHECK`
+   mode. The approved folder must still match its retained XML manifest.
+5. Run the candidate parser into a separate `VERSION_CHECK` SQLite file. The
+   runner verifies that the candidate folder still matches the just-reviewed
+   XML manifest, then compares both SQLite schemas and authoritative content.
+6. LOR-generated `Revision` changes are recorded as informational. Preview
+   identity metadata changes require review; authoritative prop, channel,
+   Scene, or membership differences block approval until explained.
+7. Record one engineering resolution that addresses every XML and SQLite
+   output finding.
+8. Approve the version only after the XML check, both parser runs, and output
+   comparison pass or all review findings are resolved. The previous version
+   folder remains unchanged.
+9. Run the current parser in `PRODUCTION` mode. Inspect the resulting SQLite as
    often as needed; no ingest is automatic.
-8. Supply its displayed SHA-256 to the separate manual PostgreSQL ingest.
+10. Supply its displayed SHA-256 to the separate manual PostgreSQL ingest.
 
 The raw SQLite `scenes` count is labeled **raw LOR Scene rows**. Operational
 true Scenes are classified by Folder Alignment naming rules and are not a

--- a/LOR2DB/Application/backend.py
+++ b/LOR2DB/Application/backend.py
@@ -500,8 +500,8 @@ def run_parser_compatibility_check() -> Response:
 def run_lor_parser() -> Response:
     operator = operator_email()
     target = str(json_body().get("target") or "").strip().lower()
-    if target not in {"current", "candidate"}:
-        raise ApiError("Parser target must be current or candidate")
+    if target not in {"current", "baseline", "candidate"}:
+        raise ApiError("Parser target must be current, baseline, or candidate")
     return jsonify(runner_request(
         "parser/run", {"target": target, "actor": operator}, timeout=920
     ))

--- a/LOR2DB/Application/landing/lor2db.js
+++ b/LOR2DB/Application/landing/lor2db.js
@@ -1,4 +1,4 @@
-/* MSB LOR landing page — 2026-08-13 V0.2.0 */
+/* MSB LOR landing page — 2026-08-13 V0.3.0 */
 (function () {
   "use strict";
 
@@ -73,16 +73,23 @@
       </section>`;
     }
     const check = runner.candidate_check;
+    const baselineRun = runner.baseline_parser_run;
     const candidateRun = runner.candidate_parser_run;
+    const comparison = runner.candidate_output_comparison;
     const resolution = runner.candidate_resolution;
     const productionRun = runner.production_parser_run;
     const candidate = runner.new_lor_version;
     const checkStatus = check?.status || "Not run";
+    const xmlFindings = check?.findings || [];
     const modifications = check?.parser_modifications_required || [];
     const findingsAccepted = checkStatus === "PASSED" || resolution?.status === "RESOLVED";
-    const mayResolve = candidate && check && checkStatus !== "PASSED" &&
-      candidateRun?.status === "COMPLETE" && candidateRun?.validation_status === "PASSED";
-    const mayApprove = candidate && findingsAccepted &&
+    const comparisonStatus = comparison?.status || "Not run";
+    const comparisonAccepted = comparisonStatus === "PASSED" || resolution?.status === "RESOLVED";
+    const baselinePassed = baselineRun?.status === "COMPLETE" && baselineRun?.validation_status === "PASSED";
+    const candidatePassed = candidateRun?.status === "COMPLETE" && candidateRun?.validation_status === "PASSED";
+    const mayResolve = candidate && check && comparison &&
+      (checkStatus !== "PASSED" || comparisonStatus !== "PASSED") && baselinePassed && candidatePassed;
+    const mayApprove = candidate && findingsAccepted && comparisonAccepted && baselinePassed &&
       candidateRun?.status === "COMPLETE" && candidateRun?.validation_status === "PASSED";
     return `<section class="card parser-card">
       <div class="card-title"><h2>LOR version and parser</h2><span class="pill">Runner ${esc(runner.runner_version)}</span></div>
@@ -90,16 +97,21 @@
         <div><dt>Current LOR version</dt><dd>${esc(runner.current_lor_version)}</dd></div>
         <div><dt>New LOR version</dt><dd>${esc(candidate || "Not selected")}</dd></div>
         <div><dt>Compatibility check</dt><dd>${esc(checkStatus)}</dd></div>
+        <div><dt>Approved-version baseline</dt><dd>${esc(baselineRun?.validation_status || "Not built")}</dd></div>
         <div><dt>Candidate parser</dt><dd>${esc(candidateRun?.validation_status || "Not run")}</dd></div>
+        <div><dt>SQLite output comparison</dt><dd>${esc(comparisonStatus)}</dd></div>
         <div><dt>Finding resolution</dt><dd>${esc(resolution?.status || "Not required/recorded")}</dd></div>
         <div><dt>Current parser</dt><dd>${esc(productionRun?.validation_status || "Not run")}</dd></div>
         <div><dt>Current SQLite SHA-256</dt><dd class="digest">${esc(productionRun?.sqlite_sha256 || "Not built in this runner state")}</dd></div>
       </dl>
+      ${xmlFindings.length ? `<div class="blocking"><strong>XML compatibility findings</strong><ul>${xmlFindings.map((item) => `<li><strong>${esc(item.severity)} — ${esc(item.area)}:</strong> ${esc(item.message)}</li>`).join("")}</ul></div>` : ""}
+      ${comparison?.findings?.length ? `<div class="blocking"><strong>SQLite output findings</strong><ul>${comparison.findings.map((item) => `<li><strong>${esc(item.severity)} — ${esc(item.area)}:</strong> ${esc(item.message)}</li>`).join("")}</ul></div>` : ""}
       ${modifications.length ? `<div class="blocking"><strong>Parser modifications required</strong><ul>${modifications.map((item) => `<li>${esc(item)}</li>`).join("")}</ul></div>` : ""}
       <div class="operator-actions">
         <button id="set-candidate" type="button">Set new LOR version</button>
         <button id="check-candidate" type="button" ${candidate ? "" : "disabled"}>Check XML compatibility</button>
-        <button id="run-candidate-parser" type="button" ${check ? "" : "disabled"}>Run candidate parser</button>
+        <button id="run-baseline-parser" type="button">Build approved-version baseline</button>
+        <button id="run-candidate-parser" type="button" ${check && baselinePassed ? "" : "disabled"}>Run and compare candidate parser</button>
         <button id="resolve-candidate" type="button" ${mayResolve ? "" : "disabled"}>Record findings resolved</button>
         <button id="approve-candidate" class="primary" type="button" ${mayApprove ? "" : "disabled"}>Approve new version</button>
         <button id="run-current-parser" class="primary" type="button">Run current parser</button>
@@ -155,10 +167,11 @@
       versionInput.focus();
     });
     document.querySelector("#check-candidate")?.addEventListener("click", (event) => runParserAction(event.currentTarget, "parser/check", {}));
+    document.querySelector("#run-baseline-parser")?.addEventListener("click", (event) => runParserAction(event.currentTarget, "parser/run", { target: "baseline" }));
     document.querySelector("#run-candidate-parser")?.addEventListener("click", (event) => runParserAction(event.currentTarget, "parser/run", { target: "candidate" }));
     document.querySelector("#run-current-parser")?.addEventListener("click", (event) => runParserAction(event.currentTarget, "parser/run", { target: "current" }));
     document.querySelector("#resolve-candidate")?.addEventListener("click", async (event) => {
-      const notes = window.prompt("Describe the parser modifications and validation that resolved every finding:");
+      const notes = window.prompt("Explain every XML and SQLite output finding, including intentional metadata changes and any parser modifications:");
       if (notes?.trim()) await runParserAction(event.currentTarget, "parser/resolve", { notes: notes.trim() });
     });
     document.querySelector("#approve-candidate")?.addEventListener("click", () => {

--- a/LOR2DB/Application/test_backend.py
+++ b/LOR2DB/Application/test_backend.py
@@ -198,6 +198,22 @@ class BackendSafetyTests(unittest.TestCase):
         )
         self.assertEqual(response.status_code, 400)
 
+    def test_parser_run_forwards_restricted_baseline_target(self) -> None:
+        with patch.object(backend, "runner_request", return_value={"ok": True}) as runner:
+            response = backend.app.test_client().post(
+                "/parser/run",
+                json={"target": "baseline"},
+                headers={
+                    "Cf-Access-Authenticated-User-Email": "greg@sheboyganlights.org"
+                },
+            )
+        self.assertEqual(response.status_code, 200)
+        runner.assert_called_once_with(
+            "parser/run",
+            {"target": "baseline", "actor": "greg@sheboyganlights.org"},
+            timeout=920,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What changed

- adds an isolated approved-version parser baseline to the LOR2DB workflow
- automatically compares baseline and candidate SQLite schemas, parser provenance, view contracts, preview metadata, and authoritative table content
- records LOR-generated `Revision` churn as informational instead of proof of content change
- requires review for preview metadata changes and blocks prop, subprop, DMX, Scene, or Scene-membership differences
- includes `IndividualChannels` and every other authoritative field while excluding only disposable integer primary keys
- rejects approved or candidate preview folders changed after their XML manifests were recorded
- displays XML and SQLite findings in the website and includes both SQLite hashes in approval history

## Why

The V6.6.4-to-V6.6.10 validation proved that XML shape checks and row counts are not enough. The required field-level SQLite comparison had to be run manually, and an initial ad-hoc exclusion rule could have skipped `IndividualChannels`. This makes the documented Phase 7 comparison a tested approval gate.

## Validation

- 18 parser/checker/runner tests passed
- 20 LOR2DB backend tests passed
- JavaScript syntax check passed
- Python compilation passed
- `git diff --check` passed