### PR TITLE
Close SQLite comparison test fixtures on Windows

### DIFF
--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/test_lor_operator_runner.py
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/test_lor_operator_runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+from contextlib import closing
 import json
 import os
 import sqlite3
@@ -151,7 +152,9 @@ class ParserOutputComparisonTests(unittest.TestCase):
         self._create_database(self.candidate, revision="2", name="Master 6.6.10", source="new.lorprev")
 
     def _create_database(self, path: Path, revision: str, name: str, source: str) -> None:
-        with sqlite3.connect(path) as connection:
+        # sqlite3.Connection.__exit__ commits/rolls back but does not close.
+        # Explicit closure is required before TemporaryDirectory cleanup on Windows.
+        with closing(sqlite3.connect(path)) as connection:
             connection.execute(
                 "CREATE TABLE previews (IntPreviewID INTEGER PRIMARY KEY, id TEXT UNIQUE, "
                 "StageID TEXT, Name TEXT, Revision TEXT, Brightness REAL, "
@@ -180,6 +183,7 @@ class ParserOutputComparisonTests(unittest.TestCase):
                     )
                     connection.execute(f'INSERT INTO "{table}" VALUES (1, "same")')
             connection.execute("CREATE VIEW props_review_vw AS SELECT Value FROM props")
+            connection.commit()
 
     def compare(self) -> dict:
         return runner_module.compare_parser_outputs(
@@ -203,8 +207,9 @@ class ParserOutputComparisonTests(unittest.TestCase):
             self.assertEqual(report["tables"][table]["candidate_only"], 0)
 
     def test_authoritative_content_difference_is_blocking(self) -> None:
-        with sqlite3.connect(self.candidate) as connection:
+        with closing(sqlite3.connect(self.candidate)) as connection:
             connection.execute('UPDATE props SET Value = "changed"')
+            connection.commit()
         report = self.compare()
         self.assertEqual(report["status"], "BLOCKED")
         self.assertEqual(report["blocking_count"], 1)
@@ -212,8 +217,9 @@ class ParserOutputComparisonTests(unittest.TestCase):
         self.assertEqual(report["tables"]["props"]["candidate_only"], 1)
 
     def test_individual_channels_is_not_mistaken_for_surrogate_integer_key(self) -> None:
-        with sqlite3.connect(self.candidate) as connection:
+        with closing(sqlite3.connect(self.candidate)) as connection:
             connection.execute('UPDATE props SET IndividualChannels = "False"')
+            connection.commit()
         report = self.compare()
         self.assertEqual(report["status"], "BLOCKED")
         self.assertEqual(report["tables"]["props"]["baseline_only"], 1)


### PR DESCRIPTION
## What changed

- explicitly closes every SQLite connection created by the parser-output comparison tests
- commits fixture creation and mutation before closing
- documents why SQLite's connection context manager alone is insufficient on Windows

## Why

Python 3.13 on Windows correctly refused to remove each temporary test database because the fixture used `with sqlite3.connect(...)`, which commits or rolls back but does not close the connection. The production comparator already closes its connections; this fixes the Windows-only test cleanup defect.

## Validation

- 18 parser/checker/runner tests passed
- Python compilation passed
- `git diff --check` passed
- Windows rerun remains the platform-specific acceptance check