### PR TITLE
Add safe stage decisions and terminal cancellation flow

### DIFF
--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/README.md
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/README.md
@@ -10,7 +10,7 @@ tools for operator convenience but does not own their XML interpretation.
 |---|---|
 | `parse_props_v7_scene_parser.py` | Canonical V7 parser; atomically publishes only a fully validated SQLite snapshot |
 | `lor_version_checker.py` | Parser-independent complete XML manifest and Current/New LOR compatibility comparison |
-| `lor_operator_runner.py` | Restricted Windows/G-drive API, stale-manifest guard, and same-parser SQLite output comparison used by the authenticated LOR2DB website |
+| `lor_operator_runner.py` | Restricted Windows/G-drive API, candidate stale-manifest guard, approved-version structural guard, and same-parser SQLite output comparison used by the authenticated LOR2DB website |
 | `test_lor_version_checker.py` | Regression tests for Scene count/structure, unused fields, ChannelGrid, and other delimiter-position changes |
 | `test_lor_operator_runner.py` | Regression tests for version-scoped paths, stale manifests, SQLite output comparison, Revision handling, and approval history |
 | `test_parse_props_console_encoding.py` | Regression test preventing Windows console/log encoding from aborting parser execution |
@@ -21,6 +21,12 @@ tools for operator convenience but does not own their XML interpretation.
 Use the LOR2DB website for normal version checks and parser runs. Direct command
 line execution remains supported for engineering and recovery. Parser execution
 never starts PostgreSQL ingest.
+
+An approved Current LOR folder may receive ordinary preview-authoring edits and
+be parsed repeatedly. Each run rebuilds the live manifest and rejects only a
+parser-breaking XML contract change relative to the approved LOR manifest. A
+New LOR candidate remains stricter: changing any reviewed candidate file after
+Version Check invalidates that check and requires it to be rerun.
 
 See:
 

--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/lor_operator_runner.py
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/lor_operator_runner.py
@@ -26,10 +26,10 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
-from lor_version_checker import build_manifest, manifest_source_signature, write_json
+from lor_version_checker import build_manifest, compare_manifests, manifest_source_signature, write_json
 
 
-RUNNER_VERSION = "V1.1.0"
+RUNNER_VERSION = "V1.2.0"
 
 AUTHORITATIVE_OUTPUT_TABLES = (
     "props",
@@ -510,9 +510,25 @@ class Runner:
                 approved_manifest.get("deep_preview"),
                 deep_identity=approved_manifest.get("deep_preview_identity"),
             )
-            if manifest_source_signature(current_manifest) != manifest_source_signature(approved_manifest):
+            # Approved LOR compatibility is a structural contract, not a ban on
+            # routine preview authoring.  Current-version production previews
+            # are expected to change between parser runs.  Rebuild their live
+            # manifest and block only a parser-breaking XML contract change.
+            # Candidate-version runs retain the exact-source guard below so a
+            # checked candidate cannot change between Check and Run Parser.
+            blocking = [
+                finding for finding in compare_manifests(
+                    approved_manifest, current_manifest
+                )
+                if finding.severity == "BLOCKING"
+            ]
+            if blocking:
+                detail = "; ".join(
+                    f"{finding.area}: {finding.message}" for finding in blocking
+                )
                 raise ValueError(
-                    "The approved preview folder changed after approval; restore it or perform a new compatibility review"
+                    "The current preview folder contains parser-breaking XML "
+                    f"changes relative to approved LOR {version}: {detail}"
                 )
             compatibility_manifest_sha256 = state["current_manifest_sha256"]
             if target == "current":

--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/test_lor_operator_runner.py
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/test_lor_operator_runner.py
@@ -140,6 +140,37 @@ class OperatorRunnerTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "changed after its XML check"):
             self.runner.run_parser("candidate", "operator@example.com")
 
+    @patch("lor_operator_runner.subprocess.run")
+    def test_current_parser_allows_compatible_preview_edits(self, run) -> None:
+        """Approved-version authoring changes must not make Run Parser stale."""
+        (self.current / "test.lorprev").write_text(
+            PREVIEW_XML.replace('Name="Stage 01"', 'Name="Stage 01 revised"'),
+            encoding="utf-8",
+        )
+
+        def complete(command, **_kwargs):
+            result_path = Path(command[command.index("--result-json") + 1])
+            result_path.parent.mkdir(parents=True, exist_ok=True)
+            result_path.write_text(json.dumps({
+                "status": "COMPLETE",
+                "validation_status": "PASSED",
+                "source_lor_version": "6.6.4",
+                "sqlite_sha256": "a" * 64,
+            }), encoding="utf-8")
+            return argparse.Namespace(returncode=0, stdout="", stderr="")
+
+        run.side_effect = complete
+        result = self.runner.run_parser("current", "operator@example.com")
+        self.assertEqual(result["status"], "COMPLETE")
+
+    def test_current_parser_blocks_new_xml_contract(self) -> None:
+        (self.current / "test.lorprev").write_text(
+            PREVIEW_XML.replace("</PreviewClass>", '<UnknownField value="1" /></PreviewClass>'),
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(ValueError, "parser-breaking XML changes"):
+            self.runner.run_parser("current", "operator@example.com")
+
 
 class ParserOutputComparisonTests(unittest.TestCase):
     def setUp(self) -> None:

--- a/LOR2DB/02_Reconciliation/00_LOR_Production_Import_and_Reconciliation_Procedure.md
+++ b/LOR2DB/02_Reconciliation/00_LOR_Production_Import_and_Reconciliation_Procedure.md
@@ -4,10 +4,10 @@
 |---|---|
 | Repository path | `LOR2DB/Reconciliation/00_LOR_Production_Import_and_Reconciliation_Procedure.md` |
 | Document type | Controlled production procedure |
-| Status | ACTIVE — reconciliation validated; parser runner pending deployment acceptance |
+| Status | ACTIVE — V0.5.0 combined stage/cancellation/parser-runner deployment pending acceptance |
 | Owner / author | GAL |
 | Initial release | 2026-07-31 |
-| Current revision | 2026-08-13 |
+| Current revision | 2026-08-14 |
 
 ## Purpose
 
@@ -30,6 +30,7 @@ The parser and snapshot ingest do **not** update production reference data by th
 
 | Date | Author | Revision |
 |---|---|---|
+| 2026-08-14 | GAL / OpenAI | Recorded the approved LOR 6.6.10 / parser V7.0.10 / digest-locked ingest 47 authority chain and cancelled reconciliation Run 6. Added evidence-gated existing/new stage approval paths, complete stage-group evidence, terminal cancellation confirmation/report/archive outcomes, and the combined Version Check / Run Parser deployment boundary. |
 | 2026-08-13 | GAL / OpenAI | Added the website-accessible V7 parser and complete XML version checker through a restricted Windows/G-drive runner. Added Current/New LOR version management, atomic SQLite publication, required finding resolution, and exact reviewed-SQLite SHA-256 ingest enforcement. Ingest remains separate and manual. |
 | 2026-08-06 | GAL / OpenAI | Recorded completed production reconciliation Run 4, the subsequent `0029` true-no-op correction, application grants V0.2.0, backend V0.3.0, and successful `/lor2db/` deployment validation. Parser and snapshot ingest remain manual until the controlled app-server runner is implemented. |
 | 2026-08-05 | GAL / OpenAI | Implemented the secured preflight backend, restricted operator authorization, persisted-decision endpoints, final-review concurrency check, Cancel, and retry-safe Finish/report publication. Deployment and Run 4 acceptance remain pending. |
@@ -133,23 +134,23 @@ The three documents describe one workflow at different levels and must not defin
 
 | Procedure component | Status |
 |---|---|
-| Master PC and preview-folder controls | Current/New LOR version state and versioned folder checks implemented; Windows runner deployment acceptance pending |
-| `Docs/01_LOR_System/02_Data_Extraction/Parser/parse_props_v7_scene_parser.py` | V7.0.8 implemented and validated against all 33 current 6.6.4 previews; production deployment pending |
-| `LOR2DB/01_Ingest/postgres_run_ingest_v7.ps1` | V0.4.0 implemented with required reviewed-SQLite SHA-256; migration/deployment pending |
+| Master PC and preview-folder controls | Current approved LOR state is 6.6.10; Current/New versioned-folder controls are implemented; Windows runner V1.2.0 deployment acceptance pending |
+| `Docs/01_LOR_System/02_Data_Extraction/Parser/parse_props_v7_scene_parser.py` | V7.0.10 production SQLite completed and validated against all 33 current 6.6.10 previews |
+| `LOR2DB/01_Ingest/postgres_run_ingest_v7.ps1` | V0.4.0 and migration `0031` production-applied; digest-locked ingest 47 completed successfully |
 | Latest-ingest capture and frozen preflight | Installed and production validated; manual operation documented in `02_LOR_Manual_Reconciliation_Runbook.md` |
 | Persistent reconciliation-run and display-candidate tables | Installed and live-validated from `reconciliation/0014_create_lor_reconciliation_decision_layer.sql` on 2026-08-02 |
 | Persistent stage candidate and binding tables | Installed from `0015` and rollback-validated by `11`; multi-preview metadata preservation installed from `0016` and rollback-validated by `12` |
 | Persistent scene and scene-membership candidate tables | Installed from `0018` and rollback-validated by `14` |
 | Operator decision database contract | Installed and live-validated for append-only group decisions, atomic reassociation assignments, `DEFER`, and review views; exercised by the application through Run 4 |
-| Operator decision application interface | Implemented, deployed, and production exercised through Run 4 |
-| Finish and cancel workflow actions | Installed from `0019`, rollback-validated by `15`, and Finish production-validated through Run 4; `0026`/`22` counter correction installed and passed |
-| P1 | Installed, rollback-validated, and executed only through controlled Finish |
+| Operator decision application interface | Existing interface deployed and production-exercised through Run 6; V0.5.0 complete stage evidence and safe stage decisions pending combined deployment acceptance |
+| Finish and cancel workflow actions | Installed from `0019`; Finish validated through Run 5 and Cancel production-validated by Run 6. V0.5.0 terminal cancellation confirmation/report/archive UX pending deployment acceptance |
+| P1 | Existing-stage P1 installed and controlled by Finish; migration `0032` evidence-gated stage change/new-stage extension pending installation and validation `27` |
 | P2 | Installed from `0017` and rollback-validated by `13`; legacy procedure remains prohibited |
 | P3/P4 | Installed from `0018` and rollback-validated by `14`; these remain internal engine phases |
 | Controlled manual workflow | Active and documented in `02_LOR_Manual_Reconciliation_Runbook.md` |
 | `/lor2db/` snapshot/reconciliation landing page | Deployed and production validated on 2026-08-06 against snapshot 45 and completed Run 4 |
-| Website parser invocation | Implemented through restricted Windows runner; deployment/acceptance pending. Ingest intentionally remains separate and manual. |
-| Timestamped HTML report publication | Installed and production validated; immutable publication, evaluation copies, and generated report index are implemented |
+| Website parser invocation | Implemented through restricted Windows runner V1.2.0; combined API/static/runner deployment acceptance pending. Ingest intentionally remains separate and manual. |
+| Timestamped HTML report publication | V0.4.2 installed and production validated; V0.5.0 cancelled outcome/banner/action corrections pending combined deployment acceptance |
 | True no-op protection | Migration `0029` V4 installed; validation `25` and the seven-part post-install definition/guard check passed on 2026-08-05 |
 
 ## Production Validation Record — Reconciliation Run 4
@@ -169,6 +170,24 @@ Run 4 is the first completed production exercise of the secured browser workflow
 
 The immutable Run 4 report was generated before migration `0029`. Its **Other Changes** table therefore includes provenance-only P1 stage bindings, P3 scenes, and P4 scene memberships that were evaluated but materially unchanged. Those rows are historical evidence of the defect and must not be interpreted as genuine changes. Migration `0029` V4 subsequently removed ingest IDs as change evidence, installed database no-op guards, passed validation `25`, and passed the post-install check for all four corrected procedures and three guards. The Run 4 report remains immutable; future reports use the corrected behavior.
 
+## Production Cancellation Record — Reconciliation Run 6
+
+Run 6 captured digest-locked ingest 47 from approved LOR 6.6.10 and parser
+V7.0.10. Preflight correctly identified two source display-name errors, one
+stage-key change, and one new stage, but the deployed interface had no safe
+approval paths for the stage items. The operator recorded source correction
+for the two display items and cancelled the run with a reason.
+
+The database cancellation completed: Run 6 is `CANCELLED`, no production
+promotion was committed, captured snapshot 47 was removed, and the current
+database snapshot returned to reconciled import 46 / Run 5. The immutable
+report is `lor-reconciliation-20260814-011807-run-6.html`.
+
+Run 6 exposed two application defects corrected by the V0.5.0 release: the
+browser reloaded the editable preflight instead of showing terminal proof, and
+the archive/report presentation did not clearly label cancellation. It also
+confirmed the need for evidence-gated stage decisions in migration `0032`.
+
 ## Production Application Deployment Record — 2026-08-06
 
 The production application deployment was validated in this order:
@@ -180,7 +199,7 @@ The production application deployment was validated in this order:
    `192.168.5.9:8784`.
 4. `GET /health` returned `{"status":"ok","version":"V0.3.0"}`.
 5. The landing-page files were deployed under `/mnt/msb-web/my/lor2db/`.
-6. `https://lortodb.sheboyganlights.org/lor2db/` displayed snapshot 45 and
+6. `https://my.sheboyganlights.org/lor2db/` displayed snapshot 45 and
    reconciliation Run 4 as reconciled, validation passed, all exception counts
    zero, the Run 4 report and archive links present, and no Start action for an
    already reconciled snapshot.

--- a/LOR2DB/02_Reconciliation/reconciliation/README.md
+++ b/LOR2DB/02_Reconciliation/reconciliation/README.md
@@ -10,9 +10,9 @@ change, or merely reports evidence.
 
 | Path | Contents | Execution rule |
 |---|---|---|
-| `current_procedures/` | Canonical standalone P1, P2, P3, and P4 definitions matching production after migration `0029 v4` | Inspection or explicitly authorized repair only; these files do not call promotion |
-| `migrations/` | Immutable installation history `0011` through `0029` | Run only the specifically authorized next migration; never rerun the folder as a batch |
-| `validation/` | Validation `10` through `25` | Follow each file's header; several are transaction-wrapped rollback tests |
+| `current_procedures/` | Canonical standalone P1, P2, P3, and P4 definitions matching the latest accepted migration chain | Inspection or explicitly authorized repair only; these files do not call promotion |
+| `migrations/` | Immutable installation history `0011` through `0032` | Run only the specifically authorized next migration; never rerun the folder as a batch |
+| `validation/` | Validation `10` through `27` | Follow each file's header; several are transaction-wrapped rollback tests |
 | `operator_queries/preflight/` | Read-only latest-ingest reports `01` through `09` | Run individually; no operator-supplied `import_run_id` |
 | `incidents/` | Production incident report and its incident-specific forensic SQL | Historical evidence; not part of routine reconciliation |
 
@@ -22,7 +22,7 @@ The root Markdown files are this index and the current design specification.
 
 | Phase | Database object | Canonical file | Definition lineage |
 |---|---|---|---|
-| P1 | `ref.p1_promote_stage_from_reconciliation(bigint)` | `current_procedures/P1_stage_promotion.sql` | Full definition from `0016`, then no-op correction from `0029 v4` |
+| P1 | `ref.p1_promote_stage_from_reconciliation(bigint)` | `current_procedures/P1_stage_promotion.sql` | Existing-stage definition from `0016`/`0029 v4`, wrapped by `0032` for evidence-gated new-stage creation |
 | P2 | `ref.p2_promote_display_from_reconciliation(bigint)` | `current_procedures/P2_display_promotion.sql` | Full definition from `0017`; unchanged by `0029` |
 | P3 | `ref.p3_promote_scene_from_reconciliation(bigint)` | `current_procedures/P3_scene_promotion.sql` | Full definition from `0018`, then no-op correction from `0029 v4` |
 | P4 | `ref.p4_promote_scene_display_from_reconciliation(bigint)` | `current_procedures/P4_scene_display_promotion.sql` | Full definition from `0018`, then no-op correction from `0029 v4` |
@@ -65,10 +65,14 @@ is retained only as incident evidence. It is not step 8A of the normal workflow.
 
 ## Migration and validation status
 
-The current feature-branch installation chain is `0011` through `0029`.
+The current feature-branch installation chain is `0011` through `0032`.
 Migration `0029` must be revision
 `2026-08-05-true-noop-reconciliation-writes-v4`; its corresponding validation
-is `validation/25_true_noop_reconciliation_write_validation.sql`.
+is `validation/25_true_noop_reconciliation_write_validation.sql`. Migration
+`0032` adds the safe stage-authority actions and is paired with
+`validation/27_safe_stage_authority_and_cancel_terminal_validation.sql`. It
+also guarantees that `CANCELLED` runs receive `completed_at` and backfills any
+older cancelled audit row where that terminal timestamp is missing.
 
 Do not infer that a numbered validation is harmless from its filename alone.
 Read its header. In particular,
@@ -81,6 +85,9 @@ not an installation script.
 - Preflight remains read-only.
 - Start captures the latest committed ingest internally and freezes evidence.
 - Operators and Directus users do not select `import_run_id`.
+- Contradictory stage evidence cannot expose an approval action.
+- A new permanent stage is inserted only by P1 after an explicit, evidence-
+  gated `ADD_NEW_STAGE` decision.
 - P1-P4 are internal and execute only through authorized Finish processing.
 - A new ingest ID alone is not a production-data change.
 - Numbered migrations are retained as audit history even when later migrations

--- a/LOR2DB/02_Reconciliation/reconciliation/current_procedures/P1_stage_promotion.sql
+++ b/LOR2DB/02_Reconciliation/reconciliation/current_procedures/P1_stage_promotion.sql
@@ -1,17 +1,16 @@
 /* ============================================================================
-Object group: Current installed reconciliation promotion procedures
-Repository:   LOR2DB/Reconciliation/reconciliation/current_procedures/
-Filename:     P1_stage_promotion.sql
-Revision:     2026-08-05-installed-after-0029-v4
+Object:       Current P1 stage promotion entry procedure
+Revision:     2026-08-14-after-0032
 
 Purpose:
-  Canonical standalone definition of the P1 procedure currently installed in
-  production after migrations 0016 and 0029 v4. This file is the inspection
-  and repair source for P1; numbered migrations remain installation history.
+  Canonical repair/inspection definition of the public P1 entry procedure
+  installed by migration 0032. The preserved existing-stage implementation
+  remains `ref.p1_promote_stage_from_reconciliation_before_0032(bigint)`.
 
 Safety:
-  Installing this file replaces the P1 procedure definition only. It does not
-  call P1, start or finish reconciliation, or modify production rows.
+  Installing this definition does not call P1 or modify production rows. New
+  stages are inserted only when Finish calls P1 for an explicitly approved,
+  unambiguous ADD_NEW_STAGE group.
 ============================================================================ */
 
 BEGIN;
@@ -25,198 +24,114 @@ SET search_path = pg_catalog, ops, lor_snap, ref
 AS $procedure$
 DECLARE
     v_import_run_id bigint;
-    v_status text;
-    v_unresolved integer;
-    v_bad_source integer;
-    v_stage record;
+    v_group record;
     v_binding record;
+    v_stage_id integer;
 BEGIN
-    SELECT r.import_run_id, r.status
-      INTO v_import_run_id, v_status
+    SELECT r.import_run_id INTO v_import_run_id
     FROM ops.lor_reconciliation_run AS r
     WHERE r.lor_reconciliation_run_id = p_lor_reconciliation_run_id
     FOR UPDATE;
-
-    IF v_import_run_id IS NULL THEN
+    IF NOT FOUND THEN
         RAISE EXCEPTION 'Reconciliation run % does not exist',
             p_lor_reconciliation_run_id;
     END IF;
 
-    IF v_status NOT IN ('READY_TO_FINISH', 'PROMOTING') THEN
-        RAISE EXCEPTION 'Reconciliation run % is %, not ready for P1',
-            p_lor_reconciliation_run_id, v_status;
-    END IF;
-
-    SELECT count(*) INTO v_unresolved
-    FROM ops.v_lor_reconciliation_group_review AS gr
-    WHERE gr.lor_reconciliation_run_id = p_lor_reconciliation_run_id
-      AND gr.entity_type = 'STAGE'
-      AND gr.effective_resolution_state = 'UNRESOLVED';
-
-    IF v_unresolved > 0 THEN
-        RAISE EXCEPTION 'Reconciliation run % has % unresolved stage groups',
-            p_lor_reconciliation_run_id, v_unresolved;
-    END IF;
-
-    SELECT count(*) INTO v_bad_source
-    FROM ops.lor_reconciliation_stage_candidate AS c
-    WHERE c.lor_reconciliation_run_id = p_lor_reconciliation_run_id
-      AND NOT (
-          (c.binding_type = 'PREVIEW' AND EXISTS (
-              SELECT 1 FROM lor_snap.previews AS p
-              WHERE p.import_run_id = v_import_run_id
-                AND p.id = c.preview_id
-                AND lower(btrim(p.stage_id)) = c.source_stage_key
-                AND btrim(p.name) IS NOT DISTINCT FROM c.source_name
-          ))
-          OR
-          (c.binding_type = 'SCENE' AND EXISTS (
-              SELECT 1
-              FROM lor_snap.scenes AS s
-              JOIN lor_snap.scene_lor_props AS slp
-                ON slp.import_run_id = s.import_run_id
-               AND slp.preview_id = s.preview_id
-               AND slp.scene_id = s.scene_id
-              WHERE s.import_run_id = v_import_run_id
-                AND s.preview_id = c.preview_id
-                AND s.scene_id = c.scene_id
-                AND lower(btrim(coalesce(slp.scene_stage_id, s.stage_id))) =
-                    c.source_stage_key
-                AND btrim(s.name) IS NOT DISTINCT FROM c.source_name
-          ))
-      );
-
-    IF v_bad_source > 0 THEN
-        RAISE EXCEPTION '% frozen stage candidates no longer match captured import_run_id %',
-            v_bad_source, v_import_run_id;
-    END IF;
-
-    FOR v_stage IN
+    FOR v_group IN
         SELECT
-            c.resolved_stage_id,
-            min(c.proposed_stage_key) AS proposed_stage_key,
-            min(c.proposed_stage_name) FILTER (WHERE c.metadata_authoritative)
-                AS proposed_stage_name,
-            min(c.proposed_folder_name) FILTER (WHERE c.metadata_authoritative)
-                AS proposed_folder_name,
-            min(c.proposed_park_order) AS proposed_park_order,
-            min(c.proposed_sub_order) AS proposed_sub_order
-        FROM ops.lor_reconciliation_stage_candidate AS c
-        JOIN ops.v_lor_reconciliation_group_review AS gr
-          ON gr.lor_reconciliation_group_id = c.lor_reconciliation_group_id
-        WHERE c.lor_reconciliation_run_id = p_lor_reconciliation_run_id
-          AND c.resolved_stage_id IS NOT NULL
-          AND gr.effective_resolution_state IN ('AUTO_APPROVED', 'APPROVED')
-          AND gr.effective_action_type IS DISTINCT FROM
-                'PRESERVE_EXISTING_STAGE_METADATA'
-        GROUP BY c.resolved_stage_id
-        HAVING count(DISTINCT c.proposed_stage_key) = 1
+            gr.lor_reconciliation_group_id,
+            min(c.proposed_stage_key) AS stage_key,
+            min(ops.f_normalize_lor_stage_name(
+                c.source_name, c.proposed_stage_key))
+                FILTER (WHERE c.metadata_authoritative)
+                AS stage_name,
+            min(c.proposed_stage_key || '-' ||
+                ops.f_normalize_lor_stage_name(
+                    c.source_name, c.proposed_stage_key))
+                FILTER (WHERE c.metadata_authoritative)
+                AS folder_name,
+            min(c.proposed_park_order) AS park_order,
+            min(c.proposed_sub_order) AS sub_order
+        FROM ops.v_lor_reconciliation_group_review AS gr
+        JOIN ops.lor_reconciliation_stage_candidate AS c
+          ON c.lor_reconciliation_group_id = gr.lor_reconciliation_group_id
+        WHERE gr.lor_reconciliation_run_id = p_lor_reconciliation_run_id
+          AND gr.effective_action_type = 'ADD_NEW_STAGE'
+          AND gr.effective_resolution_state = 'APPROVED'
+          AND ops.f_stage_group_can_add_new_stage(
+                gr.lor_reconciliation_group_id)
+        GROUP BY gr.lor_reconciliation_group_id
     LOOP
-        UPDATE ref.stage AS s
-           SET stage_key = v_stage.proposed_stage_key,
-               stage_name = coalesce(v_stage.proposed_stage_name, s.stage_name),
-               folder_name = coalesce(v_stage.proposed_folder_name, s.folder_name),
-               park_order = v_stage.proposed_park_order,
-               sub_order = v_stage.proposed_sub_order,
-               updated_at = now(),
-               updated_by = current_user
-         WHERE s.stage_id = v_stage.resolved_stage_id
-           AND (
-               s.stage_key IS DISTINCT FROM v_stage.proposed_stage_key
-               OR (v_stage.proposed_stage_name IS NOT NULL
-                   AND s.stage_name IS DISTINCT FROM v_stage.proposed_stage_name)
-               OR (v_stage.proposed_folder_name IS NOT NULL
-                   AND s.folder_name IS DISTINCT FROM v_stage.proposed_folder_name)
-               OR s.park_order IS DISTINCT FROM v_stage.proposed_park_order
-               OR s.sub_order IS DISTINCT FROM v_stage.proposed_sub_order
-           );
-
-        IF FOUND THEN
-            INSERT INTO ops.lor_reconciliation_result (
-                lor_reconciliation_run_id, import_run_id, entity_type,
-                entity_key, result_class, reason_code, operator_message, committed
-            ) VALUES (
-                p_lor_reconciliation_run_id, v_import_run_id, 'STAGE',
-                v_stage.resolved_stage_id::text, 'UPDATED',
-                'P1_STAGE_METADATA',
-                format('UPDATED: Stage %s metadata and preserved permanent stage_id %s.',
-                    v_stage.proposed_stage_key, v_stage.resolved_stage_id),
-                true
-            );
+        IF EXISTS (
+            SELECT 1 FROM ref.stage_lor_binding AS b
+            JOIN ops.lor_reconciliation_stage_candidate AS c
+              ON c.binding_type = b.binding_type
+             AND c.preview_id = b.preview_id
+             AND c.scene_id IS NOT DISTINCT FROM b.scene_id
+            WHERE c.lor_reconciliation_group_id =
+                v_group.lor_reconciliation_group_id
+        ) THEN
+            RAISE EXCEPTION 'A stable LOR binding for new stage group % was created after preflight',
+                v_group.lor_reconciliation_group_id;
         END IF;
-    END LOOP;
 
-    FOR v_binding IN
-        SELECT c.*
-        FROM ops.lor_reconciliation_stage_candidate AS c
-        JOIN ops.v_lor_reconciliation_group_review AS gr
-          ON gr.lor_reconciliation_group_id = c.lor_reconciliation_group_id
-        WHERE c.lor_reconciliation_run_id = p_lor_reconciliation_run_id
-          AND c.resolved_stage_id IS NOT NULL
-          AND gr.effective_resolution_state IN ('AUTO_APPROVED', 'APPROVED')
-    LOOP
-        INSERT INTO ref.stage_lor_binding (
-            stage_id, binding_type, preview_id, scene_id, source_name,
-            first_seen_import_run_id, last_seen_import_run_id
+        INSERT INTO ref.stage (
+            stage_key, stage_name, folder_name, park_order, sub_order
         ) VALUES (
-            v_binding.resolved_stage_id, v_binding.binding_type,
-            v_binding.preview_id, v_binding.scene_id, v_binding.source_name,
-            v_import_run_id, v_import_run_id
-        )
-        ON CONFLICT DO NOTHING;
+            v_group.stage_key, v_group.stage_name, v_group.folder_name,
+            v_group.park_order, v_group.sub_order
+        ) RETURNING stage_id INTO v_stage_id;
 
-        IF FOUND THEN
+        INSERT INTO ops.lor_reconciliation_result (
+            lor_reconciliation_run_id, import_run_id, entity_type,
+            entity_key, result_class, reason_code, operator_message, committed
+        ) VALUES (
+            p_lor_reconciliation_run_id, v_import_run_id, 'STAGE',
+            v_stage_id::text, 'ADDED', 'P1_ADD_NEW_STAGE',
+            format('ADDED: Stage %s as permanent stage_id %s.',
+                v_group.stage_key, v_stage_id), true
+        );
+
+        FOR v_binding IN
+            SELECT c.*
+            FROM ops.lor_reconciliation_stage_candidate AS c
+            WHERE c.lor_reconciliation_group_id =
+                v_group.lor_reconciliation_group_id
+            ORDER BY c.lor_reconciliation_stage_candidate_id
+        LOOP
+            INSERT INTO ref.stage_lor_binding (
+                stage_id, binding_type, preview_id, scene_id, source_name,
+                first_seen_import_run_id, last_seen_import_run_id
+            ) VALUES (
+                v_stage_id, v_binding.binding_type, v_binding.preview_id,
+                v_binding.scene_id, v_binding.source_name,
+                v_import_run_id, v_import_run_id
+            );
+
             INSERT INTO ops.lor_reconciliation_result (
                 lor_reconciliation_run_id, import_run_id, entity_type,
-                entity_key, result_class, reason_code, operator_message, committed
+                entity_key, result_class, reason_code,
+                operator_message, committed
             ) VALUES (
                 p_lor_reconciliation_run_id, v_import_run_id, 'STAGE',
                 v_binding.candidate_key, 'ADDED', 'P1_STAGE_LOR_BINDING',
-                format('ADDED: %s binding %s%s to permanent stage_id %s.',
-                    v_binding.binding_type,
-                    v_binding.preview_id,
+                format('ADDED: %s binding %s%s to new permanent stage_id %s.',
+                    v_binding.binding_type, v_binding.preview_id,
                     CASE WHEN v_binding.scene_id IS NULL THEN ''
                          ELSE '/' || v_binding.scene_id END,
-                    v_binding.resolved_stage_id),
-                true
+                    v_stage_id), true
             );
-        END IF;
-
-        UPDATE ref.stage_lor_binding AS b
-           SET source_name = v_binding.source_name,
-               last_seen_import_run_id = v_import_run_id,
-               updated_at = now(),
-               updated_by = current_user
-         WHERE b.binding_type = v_binding.binding_type
-           AND b.preview_id = v_binding.preview_id
-           AND b.scene_id IS NOT DISTINCT FROM v_binding.scene_id
-           AND b.stage_id = v_binding.resolved_stage_id
-           AND (
-               b.source_name IS DISTINCT FROM v_binding.source_name
-           );
-
-        IF FOUND THEN
-            INSERT INTO ops.lor_reconciliation_result (
-                lor_reconciliation_run_id, import_run_id, entity_type,
-                entity_key, result_class, reason_code, operator_message, committed
-            ) VALUES (
-                p_lor_reconciliation_run_id, v_import_run_id, 'STAGE',
-                v_binding.candidate_key, 'UPDATED', 'P1_STAGE_LOR_BINDING',
-                format('UPDATED: %s binding %s%s for permanent stage_id %s.',
-                    v_binding.binding_type,
-                    v_binding.preview_id,
-                    CASE WHEN v_binding.scene_id IS NULL THEN ''
-                         ELSE '/' || v_binding.scene_id END,
-                    v_binding.resolved_stage_id),
-                true
-            );
-        END IF;
+        END LOOP;
     END LOOP;
+
+    CALL ref.p1_promote_stage_from_reconciliation_before_0032(
+        p_lor_reconciliation_run_id
+    );
 END;
 $procedure$;
 
 COMMENT ON PROCEDURE ref.p1_promote_stage_from_reconciliation(bigint) IS
-'Internal reconciliation-gated P1. Promotes approved frozen stage metadata except where explicitly preserved, binds all approved LOR identities, never selects an ingest, and never deletes stages. Canonical revision 2026-08-05-installed-after-0029-v4.';
+'Reconciliation-gated P1. Adds explicitly approved unambiguous new stages, then delegates existing-stage metadata/binding promotion to the preserved implementation.';
 
 REVOKE EXECUTE ON PROCEDURE
     ref.p1_promote_stage_from_reconciliation(bigint) FROM PUBLIC;

--- a/LOR2DB/02_Reconciliation/reconciliation/migrations/0032_add_safe_stage_authority_and_terminal_cancel.sql
+++ b/LOR2DB/02_Reconciliation/reconciliation/migrations/0032_add_safe_stage_authority_and_terminal_cancel.sql
@@ -1,0 +1,520 @@
+/* ============================================================================
+Migration: 0032_add_safe_stage_authority_and_terminal_cancel.sql
+
+Purpose:
+  Expose explicit authority decisions for unambiguous stage changes and new
+  stages while keeping contradictory evidence non-approvable.  New stages are
+  created only inside the existing Finish transaction, receive a permanent
+  ref.stage.stage_id, and immediately receive their stable LOR bindings.
+
+Safety boundary:
+  - Installation records no decisions and changes no production stage rows.
+  - Existing frozen candidates remain immutable.
+  - Contradictory stage keys/names/folders/orders never receive an approval
+    action; only CORRECT_SOURCE_REQUIRED and DEFER remain available.
+  - All production writes still occur only through Finish/P1.
+  - CANCELLED is a terminal lifecycle state and always receives completed_at;
+    existing cancelled audit rows are repaired without changing production.
+============================================================================ */
+
+BEGIN;
+
+ALTER TABLE ops.lor_reconciliation_action
+    DROP CONSTRAINT ck_lor_reconciliation_action_type;
+
+ALTER TABLE ops.lor_reconciliation_action
+    ADD CONSTRAINT ck_lor_reconciliation_action_type CHECK (action_type IN (
+        'RENAME_DISPLAY', 'UPDATE_LOR_LINK', 'REASSOCIATE_DISPLAY',
+        'ADD_NEW_DISPLAY', 'SET_RETIRED', 'SET_RECYCLED',
+        'RESTORE_TO_LOR_REQUIRED', 'CORRECT_SOURCE_REQUIRED',
+        'EXCLUDE_NONPHYSICAL', 'DEFER', 'CANCEL_RECONCILIATION',
+        'PRESERVE_EXISTING_STAGE_METADATA',
+        'APPROVE_STAGE_CHANGE', 'ADD_NEW_STAGE'
+    ));
+
+CREATE OR REPLACE FUNCTION ops.f_normalize_lor_stage_name(
+    p_source_name text,
+    p_stage_key text
+)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $function$
+    SELECT coalesce(
+        nullif(btrim(regexp_replace(
+            regexp_replace(
+                coalesce(p_source_name, ''),
+                '(?i)^\s*(?:(?:show\s+(?:background\s+)?)?stage\s*)?0*'
+                    || p_stage_key || '\s*[- ]*\s*',
+                ''
+            ),
+            '\s+(with|w/)\s+.*$', '', 'i'
+        )), ''),
+        'Stage ' || p_stage_key
+    );
+$function$;
+
+CREATE OR REPLACE FUNCTION ops.f_stage_group_can_approve_change(
+    p_lor_reconciliation_group_id bigint
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, ops, ref
+AS $function$
+    SELECT
+        g.entity_type = 'STAGE'
+        AND g.decision_required
+        AND count(c.*) = g.member_count
+        AND count(c.*) > 0
+        AND count(DISTINCT c.resolved_stage_id) = 1
+        AND count(*) FILTER (WHERE c.resolved_stage_id IS NULL) = 0
+        AND count(DISTINCT c.proposed_stage_key) = 1
+        AND count(DISTINCT ops.f_normalize_lor_stage_name(
+            c.source_name, c.proposed_stage_key))
+            FILTER (WHERE c.metadata_authoritative) <= 1
+        AND count(DISTINCT (
+            c.proposed_stage_key || '-' || ops.f_normalize_lor_stage_name(
+                c.source_name, c.proposed_stage_key)))
+            FILTER (WHERE c.metadata_authoritative) <= 1
+        AND count(DISTINCT c.proposed_park_order) <= 1
+        AND count(DISTINCT c.proposed_sub_order) <= 1
+        AND count(*) FILTER (WHERE c.classification_code IN (
+            'SOURCE_FILENAME_MISSING',
+            'BINDING_STAGE_KEY_CONFLICT',
+            'NEW_STAGE_REQUIRES_AUTHORITATIVE_DECISION'
+        )) = 0
+        AND count(*) FILTER (
+            WHERE c.classification_code = 'BOUND_STAGE_KEY_CHANGED'
+        ) > 0
+    FROM ops.lor_reconciliation_group AS g
+    JOIN ops.lor_reconciliation_stage_candidate AS c
+      ON c.lor_reconciliation_group_id = g.lor_reconciliation_group_id
+    WHERE g.lor_reconciliation_group_id = p_lor_reconciliation_group_id
+    GROUP BY g.lor_reconciliation_group_id, g.entity_type,
+             g.decision_required, g.member_count;
+$function$;
+
+CREATE OR REPLACE FUNCTION ops.f_stage_group_can_add_new_stage(
+    p_lor_reconciliation_group_id bigint
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, ops, ref
+AS $function$
+    SELECT
+        g.entity_type = 'STAGE'
+        AND g.decision_required
+        AND count(c.*) = g.member_count
+        AND count(c.*) > 0
+        AND count(*) FILTER (WHERE c.resolved_stage_id IS NOT NULL) = 0
+        AND count(DISTINCT c.proposed_stage_key) = 1
+        AND count(*) FILTER (WHERE c.metadata_authoritative) > 0
+        AND count(DISTINCT ops.f_normalize_lor_stage_name(
+            c.source_name, c.proposed_stage_key))
+            FILTER (WHERE c.metadata_authoritative) = 1
+        AND count(DISTINCT (
+            c.proposed_stage_key || '-' || ops.f_normalize_lor_stage_name(
+                c.source_name, c.proposed_stage_key)))
+            FILTER (WHERE c.metadata_authoritative) = 1
+        AND count(DISTINCT c.proposed_park_order) = 1
+        AND count(DISTINCT c.proposed_sub_order) = 1
+        AND count(*) FILTER (WHERE c.classification_code <>
+            'NEW_STAGE_REQUIRES_AUTHORITATIVE_DECISION') = 0
+        AND min(c.proposed_stage_key) NOT IN (
+            SELECT s.stage_key FROM ref.stage AS s
+            WHERE s.stage_key IS NOT NULL
+        )
+    FROM ops.lor_reconciliation_group AS g
+    JOIN ops.lor_reconciliation_stage_candidate AS c
+      ON c.lor_reconciliation_group_id = g.lor_reconciliation_group_id
+    WHERE g.lor_reconciliation_group_id = p_lor_reconciliation_group_id
+    GROUP BY g.lor_reconciliation_group_id, g.entity_type,
+             g.decision_required, g.member_count;
+$function$;
+
+CREATE OR REPLACE VIEW ops.v_lor_reconciliation_group_review AS
+WITH latest_action AS (
+    SELECT DISTINCT ON (a.lor_reconciliation_group_id)
+        a.lor_reconciliation_group_id,
+        a.lor_reconciliation_action_id,
+        a.action_type,
+        a.reason,
+        a.acted_at,
+        a.acted_by,
+        a.acted_by_application
+    FROM ops.lor_reconciliation_action AS a
+    WHERE a.lor_reconciliation_group_id IS NOT NULL
+    ORDER BY a.lor_reconciliation_group_id, a.acted_at DESC,
+             a.lor_reconciliation_action_id DESC
+)
+SELECT
+    g.lor_reconciliation_group_id,
+    g.lor_reconciliation_run_id,
+    g.import_run_id,
+    g.entity_type,
+    g.logical_group_key,
+    g.group_kind,
+    g.member_count,
+    g.requires_atomic_decision,
+    g.decision_required,
+    g.allowed_action_types
+        || CASE WHEN ops.f_stage_group_can_preserve_existing_metadata(
+                g.lor_reconciliation_group_id)
+            THEN ARRAY['PRESERVE_EXISTING_STAGE_METADATA']::text[]
+            ELSE ARRAY[]::text[] END
+        || CASE WHEN ops.f_stage_group_can_approve_change(
+                g.lor_reconciliation_group_id)
+            THEN ARRAY['APPROVE_STAGE_CHANGE']::text[]
+            ELSE ARRAY[]::text[] END
+        || CASE WHEN ops.f_stage_group_can_add_new_stage(
+                g.lor_reconciliation_group_id)
+            THEN ARRAY['ADD_NEW_STAGE']::text[]
+            ELSE ARRAY[]::text[] END
+        AS allowed_action_types,
+    g.operator_message,
+    la.lor_reconciliation_action_id AS effective_action_id,
+    la.action_type AS effective_action_type,
+    la.reason AS effective_reason,
+    la.acted_at,
+    la.acted_by,
+    la.acted_by_application,
+    CASE
+        WHEN la.action_type = 'DEFER' THEN 'DEFERRED'
+        WHEN la.action_type = 'CORRECT_SOURCE_REQUIRED' THEN 'BLOCKED'
+        WHEN la.action_type IS NOT NULL THEN 'APPROVED'
+        WHEN g.decision_required THEN 'UNRESOLVED'
+        ELSE 'AUTO_APPROVED'
+    END AS effective_resolution_state
+FROM ops.lor_reconciliation_group AS g
+LEFT JOIN latest_action AS la
+  ON la.lor_reconciliation_group_id = g.lor_reconciliation_group_id;
+
+COMMENT ON VIEW ops.v_lor_reconciliation_group_review IS
+'One row per logical group. Safe stage approval actions are derived from complete frozen evidence; contradictory stage groups retain fallback actions only.';
+
+CREATE OR REPLACE VIEW ops.v_lor_reconciliation_operator_stage_review AS
+SELECT
+    gr.lor_reconciliation_run_id,
+    gr.import_run_id,
+    gr.lor_reconciliation_group_id,
+    gr.logical_group_key,
+    gr.member_count,
+    gr.effective_resolution_state,
+    gr.effective_action_type,
+    gr.effective_reason,
+    c.lor_reconciliation_stage_candidate_id,
+    c.binding_type,
+    c.preview_id,
+    c.scene_id,
+    c.source_name,
+    c.classification_code,
+    c.changed_fields,
+    c.resolved_stage_id,
+    c.current_stage_key,
+    c.proposed_stage_key,
+    c.current_stage_name,
+    CASE WHEN c.metadata_authoritative
+        THEN ops.f_normalize_lor_stage_name(
+            c.source_name, c.proposed_stage_key)
+        ELSE c.proposed_stage_name END AS proposed_stage_name,
+    c.current_folder_name,
+    CASE WHEN c.metadata_authoritative
+        THEN c.proposed_stage_key || '-' ||
+            ops.f_normalize_lor_stage_name(
+                c.source_name, c.proposed_stage_key)
+        ELSE c.proposed_folder_name END AS proposed_folder_name,
+    c.operator_message,
+    c.source_evidence,
+    c.source_stage_key,
+    c.metadata_authoritative
+FROM ops.v_lor_reconciliation_group_review AS gr
+JOIN ops.lor_reconciliation_stage_candidate AS c
+  ON c.lor_reconciliation_group_id = gr.lor_reconciliation_group_id
+WHERE cardinality(c.changed_fields) > 0
+   OR c.decision_required
+   OR gr.effective_action_type IS NOT NULL;
+
+CREATE OR REPLACE FUNCTION ops.f_record_lor_stage_authority_action(
+    p_lor_reconciliation_run_id bigint,
+    p_lor_reconciliation_group_id bigint,
+    p_action_type text,
+    p_reason text,
+    p_acted_by_application text DEFAULT NULL
+)
+RETURNS bigint
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, ops, ref
+AS $function$
+DECLARE
+    v_import_run_id bigint;
+    v_status text;
+    v_action_id bigint;
+    v_counts record;
+BEGIN
+    SELECT r.import_run_id, r.status
+      INTO v_import_run_id, v_status
+    FROM ops.lor_reconciliation_run AS r
+    WHERE r.lor_reconciliation_run_id = p_lor_reconciliation_run_id
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'Reconciliation run % does not exist',
+            p_lor_reconciliation_run_id;
+    END IF;
+    IF v_status NOT IN ('AWAITING_DECISIONS', 'READY_TO_FINISH') THEN
+        RAISE EXCEPTION 'Reconciliation run % does not accept decisions in status %',
+            p_lor_reconciliation_run_id, v_status;
+    END IF;
+    IF nullif(btrim(p_reason), '') IS NULL THEN
+        RAISE EXCEPTION 'A nonblank operator reason is required';
+    END IF;
+    IF p_action_type = 'APPROVE_STAGE_CHANGE' THEN
+        IF NOT coalesce(ops.f_stage_group_can_approve_change(
+            p_lor_reconciliation_group_id), false) THEN
+            RAISE EXCEPTION 'Stage group % does not contain one consistent existing-stage change',
+                p_lor_reconciliation_group_id;
+        END IF;
+    ELSIF p_action_type = 'ADD_NEW_STAGE' THEN
+        IF NOT coalesce(ops.f_stage_group_can_add_new_stage(
+            p_lor_reconciliation_group_id), false) THEN
+            RAISE EXCEPTION 'Stage group % does not contain one unambiguous new stage',
+                p_lor_reconciliation_group_id;
+        END IF;
+    ELSE
+        RAISE EXCEPTION 'Action % is not a stage authority action', p_action_type;
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM ops.lor_reconciliation_group AS g
+        WHERE g.lor_reconciliation_group_id = p_lor_reconciliation_group_id
+          AND g.lor_reconciliation_run_id = p_lor_reconciliation_run_id
+          AND g.entity_type = 'STAGE'
+    ) THEN
+        RAISE EXCEPTION 'Stage group % does not belong to reconciliation run %',
+            p_lor_reconciliation_group_id, p_lor_reconciliation_run_id;
+    END IF;
+
+    INSERT INTO ops.lor_reconciliation_action (
+        lor_reconciliation_run_id, lor_reconciliation_group_id,
+        import_run_id, action_type, reason, action_payload,
+        acted_by_application
+    ) VALUES (
+        p_lor_reconciliation_run_id, p_lor_reconciliation_group_id,
+        v_import_run_id, p_action_type, btrim(p_reason),
+        jsonb_build_object('stage_authority_decision', true),
+        nullif(btrim(p_acted_by_application), '')
+    ) RETURNING lor_reconciliation_action_id INTO v_action_id;
+
+    SELECT * INTO v_counts
+    FROM ops.f_sync_lor_reconciliation_effective_counters(
+        p_lor_reconciliation_run_id
+    );
+
+    UPDATE ops.lor_reconciliation_run AS r
+       SET status = CASE WHEN v_counts.unresolved_count = 0
+                         THEN 'READY_TO_FINISH'
+                         ELSE 'AWAITING_DECISIONS' END,
+           resumed_at = now(),
+           paused_at = CASE WHEN v_counts.unresolved_count > 0
+                            THEN coalesce(r.paused_at, now())
+                            ELSE r.paused_at END
+     WHERE r.lor_reconciliation_run_id = p_lor_reconciliation_run_id;
+
+    RETURN v_action_id;
+END;
+$function$;
+
+/* Preserve the proven existing-stage implementation and wrap it only for the
+   new-stage insertion that its frozen resolved_stage_id model cannot express. */
+ALTER PROCEDURE ref.p1_promote_stage_from_reconciliation(bigint)
+    RENAME TO p1_promote_stage_from_reconciliation_before_0032;
+
+CREATE OR REPLACE PROCEDURE ref.p1_promote_stage_from_reconciliation(
+    p_lor_reconciliation_run_id bigint
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, ops, lor_snap, ref
+AS $procedure$
+DECLARE
+    v_import_run_id bigint;
+    v_group record;
+    v_binding record;
+    v_stage_id integer;
+BEGIN
+    SELECT r.import_run_id INTO v_import_run_id
+    FROM ops.lor_reconciliation_run AS r
+    WHERE r.lor_reconciliation_run_id = p_lor_reconciliation_run_id
+    FOR UPDATE;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'Reconciliation run % does not exist',
+            p_lor_reconciliation_run_id;
+    END IF;
+
+    FOR v_group IN
+        SELECT
+            gr.lor_reconciliation_group_id,
+            min(c.proposed_stage_key) AS stage_key,
+            min(ops.f_normalize_lor_stage_name(
+                c.source_name, c.proposed_stage_key))
+                FILTER (WHERE c.metadata_authoritative)
+                AS stage_name,
+            min(c.proposed_stage_key || '-' ||
+                ops.f_normalize_lor_stage_name(
+                    c.source_name, c.proposed_stage_key))
+                FILTER (WHERE c.metadata_authoritative)
+                AS folder_name,
+            min(c.proposed_park_order) AS park_order,
+            min(c.proposed_sub_order) AS sub_order
+        FROM ops.v_lor_reconciliation_group_review AS gr
+        JOIN ops.lor_reconciliation_stage_candidate AS c
+          ON c.lor_reconciliation_group_id = gr.lor_reconciliation_group_id
+        WHERE gr.lor_reconciliation_run_id = p_lor_reconciliation_run_id
+          AND gr.effective_action_type = 'ADD_NEW_STAGE'
+          AND gr.effective_resolution_state = 'APPROVED'
+          AND ops.f_stage_group_can_add_new_stage(
+                gr.lor_reconciliation_group_id)
+        GROUP BY gr.lor_reconciliation_group_id
+    LOOP
+        IF EXISTS (
+            SELECT 1 FROM ref.stage_lor_binding AS b
+            JOIN ops.lor_reconciliation_stage_candidate AS c
+              ON c.binding_type = b.binding_type
+             AND c.preview_id = b.preview_id
+             AND c.scene_id IS NOT DISTINCT FROM b.scene_id
+            WHERE c.lor_reconciliation_group_id =
+                v_group.lor_reconciliation_group_id
+        ) THEN
+            RAISE EXCEPTION 'A stable LOR binding for new stage group % was created after preflight',
+                v_group.lor_reconciliation_group_id;
+        END IF;
+
+        INSERT INTO ref.stage (
+            stage_key, stage_name, folder_name, park_order, sub_order
+        ) VALUES (
+            v_group.stage_key, v_group.stage_name, v_group.folder_name,
+            v_group.park_order, v_group.sub_order
+        ) RETURNING stage_id INTO v_stage_id;
+
+        INSERT INTO ops.lor_reconciliation_result (
+            lor_reconciliation_run_id, import_run_id, entity_type,
+            entity_key, result_class, reason_code, operator_message, committed
+        ) VALUES (
+            p_lor_reconciliation_run_id, v_import_run_id, 'STAGE',
+            v_stage_id::text, 'ADDED', 'P1_ADD_NEW_STAGE',
+            format('ADDED: Stage %s as permanent stage_id %s.',
+                v_group.stage_key, v_stage_id), true
+        );
+
+        FOR v_binding IN
+            SELECT c.*
+            FROM ops.lor_reconciliation_stage_candidate AS c
+            WHERE c.lor_reconciliation_group_id =
+                v_group.lor_reconciliation_group_id
+            ORDER BY c.lor_reconciliation_stage_candidate_id
+        LOOP
+            INSERT INTO ref.stage_lor_binding (
+                stage_id, binding_type, preview_id, scene_id, source_name,
+                first_seen_import_run_id, last_seen_import_run_id
+            ) VALUES (
+                v_stage_id, v_binding.binding_type, v_binding.preview_id,
+                v_binding.scene_id, v_binding.source_name,
+                v_import_run_id, v_import_run_id
+            );
+
+            INSERT INTO ops.lor_reconciliation_result (
+                lor_reconciliation_run_id, import_run_id, entity_type,
+                entity_key, result_class, reason_code,
+                operator_message, committed
+            ) VALUES (
+                p_lor_reconciliation_run_id, v_import_run_id, 'STAGE',
+                v_binding.candidate_key, 'ADDED', 'P1_STAGE_LOR_BINDING',
+                format('ADDED: %s binding %s%s to new permanent stage_id %s.',
+                    v_binding.binding_type, v_binding.preview_id,
+                    CASE WHEN v_binding.scene_id IS NULL THEN ''
+                         ELSE '/' || v_binding.scene_id END,
+                    v_stage_id), true
+            );
+        END LOOP;
+    END LOOP;
+
+    CALL ref.p1_promote_stage_from_reconciliation_before_0032(
+        p_lor_reconciliation_run_id
+    );
+END;
+$procedure$;
+
+COMMENT ON PROCEDURE ref.p1_promote_stage_from_reconciliation(bigint) IS
+'Reconciliation-gated P1. Adds explicitly approved unambiguous new stages, then delegates existing-stage metadata/binding promotion to the preserved implementation.';
+
+/* Report publication historically assigned CANCELLED without completed_at.
+   Keep cancelled_at as the cancellation event time and completed_at as the
+   terminal lifecycle time.  The trigger also protects every future caller,
+   including report-publication retries. */
+CREATE OR REPLACE FUNCTION ops.f_set_cancelled_reconciliation_completed_at()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, ops
+AS $function$
+BEGIN
+    IF NEW.status = 'CANCELLED' AND NEW.completed_at IS NULL THEN
+        NEW.completed_at := coalesce(
+            NEW.report_published_at,
+            NEW.cancelled_at,
+            clock_timestamp()
+        );
+    END IF;
+    RETURN NEW;
+END;
+$function$;
+
+DROP TRIGGER IF EXISTS trg_set_cancelled_reconciliation_completed_at
+    ON ops.lor_reconciliation_run;
+
+CREATE TRIGGER trg_set_cancelled_reconciliation_completed_at
+BEFORE INSERT OR UPDATE OF status, completed_at, cancelled_at,
+    report_published_at
+ON ops.lor_reconciliation_run
+FOR EACH ROW
+EXECUTE FUNCTION ops.f_set_cancelled_reconciliation_completed_at();
+
+UPDATE ops.lor_reconciliation_run
+   SET completed_at = coalesce(report_published_at, cancelled_at)
+ WHERE status = 'CANCELLED'
+   AND completed_at IS NULL
+   AND cancelled_at IS NOT NULL;
+
+REVOKE EXECUTE ON FUNCTION ops.f_stage_group_can_approve_change(bigint)
+    FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION ops.f_normalize_lor_stage_name(text,text)
+    FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION ops.f_stage_group_can_add_new_stage(bigint)
+    FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION ops.f_record_lor_stage_authority_action(
+    bigint,bigint,text,text,text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION
+    ops.f_set_cancelled_reconciliation_completed_at() FROM PUBLIC;
+REVOKE EXECUTE ON PROCEDURE
+    ref.p1_promote_stage_from_reconciliation_before_0032(bigint) FROM PUBLIC;
+REVOKE EXECUTE ON PROCEDURE
+    ref.p1_promote_stage_from_reconciliation(bigint) FROM PUBLIC;
+
+COMMIT;
+
+SELECT
+    '2026-08-14-safe-stage-authority-terminal-cancel-v2'::text
+        AS installed_revision,
+    to_regprocedure(
+        'ops.f_record_lor_stage_authority_action(bigint,bigint,text,text,text)'
+    ) IS NOT NULL AS has_stage_authority_recorder,
+    to_regprocedure(
+        'ref.p1_promote_stage_from_reconciliation_before_0032(bigint)'
+    ) IS NOT NULL AS preserved_prior_p1;

--- a/LOR2DB/02_Reconciliation/reconciliation/validation/27_safe_stage_authority_and_cancel_terminal_validation.sql
+++ b/LOR2DB/02_Reconciliation/reconciliation/validation/27_safe_stage_authority_and_cancel_terminal_validation.sql
@@ -1,0 +1,119 @@
+/* Read-only acceptance checks for migration 0032. */
+
+DO $validation$
+DECLARE
+    v_constraint text;
+    v_cancel_trigger_present boolean;
+BEGIN
+    IF to_regprocedure(
+        'ops.f_normalize_lor_stage_name(text,text)'
+    ) IS NULL OR to_regprocedure(
+        'ops.f_stage_group_can_approve_change(bigint)'
+    ) IS NULL OR to_regprocedure(
+        'ops.f_stage_group_can_add_new_stage(bigint)'
+    ) IS NULL OR to_regprocedure(
+        'ops.f_record_lor_stage_authority_action(bigint,bigint,text,text,text)'
+    ) IS NULL THEN
+        RAISE EXCEPTION 'Migration 0032 stage authority functions are incomplete';
+    END IF;
+
+    IF ops.f_normalize_lor_stage_name(
+        'Show Stage 40-CommandCenter-CC', '40'
+    ) <> 'CommandCenter-CC' OR ops.f_normalize_lor_stage_name(
+        'Show Background Stage 05a Magic Star MS', '05a'
+    ) <> 'Magic Star MS' THEN
+        RAISE EXCEPTION 'Stage-name normalization does not match LOR naming forms';
+    END IF;
+
+    IF to_regprocedure(
+        'ref.p1_promote_stage_from_reconciliation_before_0032(bigint)'
+    ) IS NULL OR to_regprocedure(
+        'ref.p1_promote_stage_from_reconciliation(bigint)'
+    ) IS NULL THEN
+        RAISE EXCEPTION 'Migration 0032 P1 wrapper/preserved implementation is incomplete';
+    END IF;
+
+    SELECT EXISTS (
+        SELECT 1
+        FROM pg_trigger AS t
+        JOIN pg_class AS c ON c.oid = t.tgrelid
+        JOIN pg_namespace AS n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'ops'
+          AND c.relname = 'lor_reconciliation_run'
+          AND t.tgname = 'trg_set_cancelled_reconciliation_completed_at'
+          AND NOT t.tgisinternal
+    ) INTO v_cancel_trigger_present;
+
+    IF to_regprocedure(
+        'ops.f_set_cancelled_reconciliation_completed_at()'
+    ) IS NULL OR NOT v_cancel_trigger_present THEN
+        RAISE EXCEPTION 'Cancelled-run terminal timestamp guard is incomplete';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM ops.lor_reconciliation_run AS r
+        WHERE r.status = 'CANCELLED'
+          AND r.completed_at IS NULL
+    ) THEN
+        RAISE EXCEPTION 'A CANCELLED reconciliation is missing completed_at';
+    END IF;
+
+    SELECT pg_get_constraintdef(c.oid)
+      INTO v_constraint
+    FROM pg_constraint AS c
+    JOIN pg_class AS t ON t.oid = c.conrelid
+    JOIN pg_namespace AS n ON n.oid = t.relnamespace
+    WHERE n.nspname = 'ops'
+      AND t.relname = 'lor_reconciliation_action'
+      AND c.conname = 'ck_lor_reconciliation_action_type';
+
+    IF v_constraint NOT LIKE '%APPROVE_STAGE_CHANGE%'
+       OR v_constraint NOT LIKE '%ADD_NEW_STAGE%' THEN
+        RAISE EXCEPTION 'Stage authority action constraint is incomplete';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM ops.v_lor_reconciliation_group_review AS gr
+        WHERE gr.entity_type = 'STAGE'
+          AND (
+              'APPROVE_STAGE_CHANGE' = ANY(gr.allowed_action_types)
+              AND NOT ops.f_stage_group_can_approve_change(
+                  gr.lor_reconciliation_group_id)
+              OR
+              'ADD_NEW_STAGE' = ANY(gr.allowed_action_types)
+              AND NOT ops.f_stage_group_can_add_new_stage(
+                  gr.lor_reconciliation_group_id)
+          )
+    ) THEN
+        RAISE EXCEPTION 'A stage approval action escaped its evidence gate';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM ops.lor_reconciliation_group AS g
+        JOIN ops.lor_reconciliation_stage_candidate AS c
+          ON c.lor_reconciliation_group_id = g.lor_reconciliation_group_id
+        JOIN ops.v_lor_reconciliation_group_review AS gr
+          ON gr.lor_reconciliation_group_id = g.lor_reconciliation_group_id
+        WHERE g.entity_type = 'STAGE'
+        GROUP BY g.lor_reconciliation_group_id, gr.allowed_action_types
+        HAVING (
+            count(DISTINCT c.source_stage_key) > 1
+            OR count(DISTINCT c.proposed_stage_name)
+               FILTER (WHERE c.metadata_authoritative) > 1
+        ) AND (
+            'APPROVE_STAGE_CHANGE' = ANY(gr.allowed_action_types)
+            OR 'ADD_NEW_STAGE' = ANY(gr.allowed_action_types)
+        )
+    ) THEN
+        RAISE EXCEPTION 'Contradictory frozen stage evidence is approvable';
+    END IF;
+END;
+$validation$;
+
+SELECT
+    'PASS'::text AS validation_status,
+    'Safe stage authority is evidence-gated; CANCELLED runs are terminal.'::text
+        AS validation_detail;

--- a/LOR2DB/03_Reporting/publish_lor_reconciliation_report.py
+++ b/LOR2DB/03_Reporting/publish_lor_reconciliation_report.py
@@ -3,7 +3,7 @@ MSB Database - LOR Reconciliation Report Publisher
 publish_lor_reconciliation_report.py
 
 Initial Release : 2026-08-03  V0.1.0
-Current Version : 2026-08-04  V0.4.1
+Current Version : 2026-08-14  V0.5.0
 Author          : GAL / OpenAI
 
 Purpose:
@@ -21,6 +21,9 @@ Operation:
       revised without changing the production audit row.
 
 Revision History:
+    2026-08-14  GAL / OpenAI  V0.5.0
+        Made cancelled runs unmistakable, marked validation not applicable,
+        removed misleading follow-up actions, and added Outcome to the archive.
     2026-08-04  GAL / OpenAI  V0.4.1
         Changed the default NAS publication folder from lortodb to lor2db.
 
@@ -45,7 +48,7 @@ from pathlib import Path
 from typing import Any, Iterable, Sequence
 
 
-REPORT_VERSION = "V0.4.2"
+REPORT_VERSION = "V0.5.0"
 DEFAULT_OUTPUT_DIR = r"\\192.168.5.4\web\my\lor2db\reports"
 REPORT_FILENAME = re.compile(
     r"^lor-reconciliation-(?P<stamp>\d{8}-\d{6})-run-(?P<run>\d+)"
@@ -175,6 +178,14 @@ def report_index_entry(path: Path) -> dict[str, str] | None:
         r"\s+·\s+Captured ingest\s+([^<]+)",
         content,
     )
+    outcome_match = re.search(r'data-report-outcome="([A-Z_]+)"', content)
+    if outcome_match is None:
+        # Reports published before V0.5.0 already contain the durable final
+        # status in their ingest table. Recover it without rewriting the
+        # immutable report so the refreshed archive labels historical runs.
+        outcome_match = re.search(
+            r">(COMPLETED_WITH_EXCEPTIONS|CANCELLED|COMPLETED)<", content
+        )
     return {
         "filename": path.name,
         "run_id": match.group("run"),
@@ -182,6 +193,7 @@ def report_index_entry(path: Path) -> dict[str, str] | None:
         "generated": meta_match.group(1).strip() if meta_match else generated.strftime("%Y-%m-%d %H:%M:%S"),
         "framework": meta_match.group(2).strip() if meta_match else "—",
         "captured_ingest": meta_match.group(3).strip() if meta_match else "—",
+        "outcome": outcome_match.group(1).replace("_", " ") if outcome_match else "UNKNOWN",
         "sort_key": match.group("stamp"),
     }
 
@@ -200,6 +212,7 @@ def refresh_report_index(output_dir: str) -> Path:
         f'<td><a href="{html.escape(entry["filename"], quote=True)}">'
         f'{html.escape(entry["filename"])}</a></td>'
         f'<td>{html.escape(entry["report_type"])}</td>'
+        f'<td>{html.escape(entry["outcome"])}</td>'
         f'<td>{html.escape(entry["run_id"])}</td>'
         f'<td>{html.escape(entry["captured_ingest"])}</td>'
         f'<td>{html.escape(entry["generated"])}</td>'
@@ -208,13 +221,13 @@ def refresh_report_index(output_dir: str) -> Path:
         for entry in entries
     )
     if not rows_html:
-        rows_html = '<tr><td colspan="6" class="empty">No reconciliation reports are available.</td></tr>'
+        rows_html = '<tr><td colspan="7" class="empty">No reconciliation reports are available.</td></tr>'
     generated = datetime.now().astimezone()
     document = f"""<!doctype html><html lang="en"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1"><title>LOR Reconciliation Reports</title>
 <style>body{{font:14px/1.4 Arial,sans-serif;color:#1f2937;max-width:1400px;margin:24px auto;padding:0 18px}}h1{{margin-bottom:4px}}.meta{{color:#475569}}table{{width:100%;border-collapse:collapse;margin-top:18px}}th,td{{border:1px solid #cbd5e1;padding:8px;text-align:left;vertical-align:top}}th{{background:#e2e8f0}}tr:nth-child(even) td{{background:#f8fafc}}a{{color:#075985}}.empty{{font-style:italic;color:#475569}}</style></head><body>
 <h1>LOR Reconciliation Reports</h1><p class="meta">Index refreshed {html.escape(display(generated))} · {len(entries)} report(s)</p>
-<table><thead><tr><th>Report</th><th>Type</th><th>Reconciliation run</th><th>Captured ingest</th><th>Generated</th><th>Framework</th></tr></thead><tbody>{rows_html}</tbody></table>
+<table><thead><tr><th>Report</th><th>Type</th><th>Outcome</th><th>Reconciliation run</th><th>Captured ingest</th><th>Generated</th><th>Framework</th></tr></thead><tbody>{rows_html}</tbody></table>
 </body></html>"""
     destination = directory / "index.html"
     with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=directory, delete=False) as tmp:
@@ -338,7 +351,8 @@ def render_report(data: dict[str, Any], generated_at: datetime) -> str:
     for preview in previews:
         preview["preview_revision"] = integer_display(preview.get("preview_revision"))
         preview["brightness"] = integer_display(preview.get("brightness"))
-    if r.get("cancelled_at") is not None:
+    cancelled = r.get("cancelled_at") is not None
+    if cancelled:
         final_status = "CANCELLED"
     elif any(int(r.get(key) or 0) != 0 for key in (
         "blocked_count", "deferred_count", "unresolved_count"
@@ -401,13 +415,20 @@ def render_report(data: dict[str, Any], generated_at: datetime) -> str:
         ("reason", "Reason"), ("operator", "Operator"),
         ("acted_at", "Date/time"),
     ], decision_rows, "No operator decisions were required.")
-    validation = table([
-        ("validation_check", "Validation check"), ("result", "Result"),
-        ("detail", "Detail"), ("recorded_at", "Date/time"),
-    ], data["validations"], "No validation result was recorded.")
-    change_action = "Print replacement labels" if data["names"] else "NONE"
-    problem_action = "Review listed items" if data["problems"] else "NONE"
-    validation_action = "Investigate failed validation" if any(v["result"] != "PASS" for v in data["validations"]) else "NONE"
+    if cancelled:
+        validation = '<p class="not-applicable"><strong>Not applicable — reconciliation cancelled before production validation.</strong></p>'
+    else:
+        validation = table([
+            ("validation_check", "Validation check"), ("result", "Result"),
+            ("detail", "Detail"), ("recorded_at", "Date/time"),
+        ], data["validations"], "No validation result was recorded.")
+    change_action = "NONE" if cancelled else ("Print replacement labels" if data["names"] else "NONE")
+    problem_action = "NONE" if cancelled else ("Review listed items" if data["problems"] else "NONE")
+    validation_action = "NONE" if cancelled else (
+        "Investigate failed validation"
+        if any(v["result"] != "PASS" for v in data["validations"])
+        else "NONE"
+    )
     body = "".join([
         section(1, "Parser Run", parser, "NONE"),
         section(2, "PostgreSQL Ingest", ingest, "NONE"),
@@ -416,11 +437,22 @@ def render_report(data: dict[str, Any], generated_at: datetime) -> str:
         section(5, "Problems and Operator Decisions", '<h3>Problems</h3>' + issues + '<h3>Operator Decisions</h3>' + decisions, problem_action),
         section(6, "Final Validation", validation, validation_action),
     ])
-    title = f'LOR Production Reconciliation Report — Run {r["lor_reconciliation_run_id"]}'
+    title = (
+        f'LOR Reconciliation Cancellation Record — Run {r["lor_reconciliation_run_id"]}'
+        if cancelled else
+        f'LOR Production Reconciliation Report — Run {r["lor_reconciliation_run_id"]}'
+    )
+    banner = ""
+    if cancelled:
+        banner = (
+            '<div class="cancelled-banner"><strong>CANCELLED — NO PRODUCTION CHANGES COMMITTED</strong><br>'
+            'The captured ingest snapshot was removed and this run is closed. '
+            f'Cancellation reason: {html.escape(display(r.get("cancellation_reason")))}</div>'
+        )
     return f"""<!doctype html><html lang="en"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1"><title>{html.escape(title)}</title>
-<style>body{{font:14px/1.4 Arial,sans-serif;color:#1f2937;max-width:1400px;margin:24px auto;padding:0 18px}}h1{{margin-bottom:4px}}h2{{border-bottom:2px solid #334155;padding-bottom:5px;margin-top:30px}}h3{{margin-top:20px}}.meta{{color:#475569}}.action{{display:inline-block;padding:6px 10px;border-radius:4px}}.none{{background:#dcfce7}}.required{{background:#fef3c7}}table{{width:100%;border-collapse:collapse;margin:10px 0 18px}}th,td{{border:1px solid #cbd5e1;padding:6px 8px;text-align:left;vertical-align:top}}th{{background:#e2e8f0}}tr:nth-child(even) td{{background:#f8fafc}}.empty td{{font-style:italic;color:#475569}}@media print{{body{{margin:0;max-width:none}}section{{break-inside:avoid}}}}</style></head><body>
-<h1>{html.escape(title)}</h1><p class="meta">Generated {html.escape(display(generated_at))} · Report framework {REPORT_VERSION} · Captured ingest {r["import_run_id"]}</p>{body}</body></html>"""
+<style>body{{font:14px/1.4 Arial,sans-serif;color:#1f2937;max-width:1400px;margin:24px auto;padding:0 18px}}h1{{margin-bottom:4px}}h2{{border-bottom:2px solid #334155;padding-bottom:5px;margin-top:30px}}h3{{margin-top:20px}}.meta{{color:#475569}}.action{{display:inline-block;padding:6px 10px;border-radius:4px}}.none{{background:#dcfce7}}.required{{background:#fef3c7}}.cancelled-banner{{margin:18px 0;padding:14px;border:2px solid #991b1b;background:#fee2e2;color:#7f1d1d}}.not-applicable{{padding:10px;background:#e2e8f0}}table{{width:100%;border-collapse:collapse;margin:10px 0 18px}}th,td{{border:1px solid #cbd5e1;padding:6px 8px;text-align:left;vertical-align:top}}th{{background:#e2e8f0}}tr:nth-child(even) td{{background:#f8fafc}}.empty td{{font-style:italic;color:#475569}}@media print{{body{{margin:0;max-width:none}}section{{break-inside:avoid}}}}</style></head><body data-report-outcome="{html.escape(final_status, quote=True)}">
+<h1>{html.escape(title)}</h1><p class="meta">Generated {html.escape(display(generated_at))} · Report framework {REPORT_VERSION} · Captured ingest {r["import_run_id"]}</p>{banner}{body}</body></html>"""
 
 
 def publish(conn: Any, run_id: int, output_dir: str, base_url: str | None) -> Path:

--- a/LOR2DB/03_Reporting/test_publish_lor_reconciliation_report.py
+++ b/LOR2DB/03_Reporting/test_publish_lor_reconciliation_report.py
@@ -163,7 +163,28 @@ class ReportRenderingTests(unittest.TestCase):
                 REPORT.render_evaluation_copy(object(), 101, output_dir)
 
     def test_report_framework_version_identifies_evaluation_copy_release(self):
-        self.assertEqual(REPORT.REPORT_VERSION, "V0.4.2")
+        self.assertEqual(REPORT.REPORT_VERSION, "V0.5.0")
+
+    def test_cancelled_report_is_terminal_and_has_no_required_actions(self):
+        data = self.base_data()
+        data["run"].update({
+            "cancelled_at": datetime.now(timezone.utc),
+            "cancellation_reason": "Correct the LOR source and re-ingest.",
+            "validation_state": None,
+        })
+        data["problems"] = [{
+            "entity_type": "DISPLAY", "entity_key": "1",
+            "result_class": "BLOCKED", "reason_code": "CORRECT_SOURCE_REQUIRED",
+            "operator_message": "Fix source", "recorded_at": None,
+        }]
+
+        output = REPORT.render_report(data, datetime.now(timezone.utc))
+
+        self.assertIn('data-report-outcome="CANCELLED"', output)
+        self.assertIn("CANCELLED — NO PRODUCTION CHANGES COMMITTED", output)
+        self.assertIn("captured ingest snapshot was removed", output)
+        self.assertIn("Not applicable — reconciliation cancelled", output)
+        self.assertNotIn("Review listed items", output)
 
     def test_decision_operator_uses_authenticated_cloudflare_email(self):
         data = self.base_data()
@@ -185,11 +206,11 @@ class ReportRenderingTests(unittest.TestCase):
             published = directory / "lor-reconciliation-20260803-233221-run-3.html"
             evaluation = directory / "lor-reconciliation-20260804-170000-run-3-evaluation.html"
             published.write_text(
-                '<p class="meta">Generated 2026-08-03 23:32:21 CDT · '
+                '<body data-report-outcome="COMPLETED"><p class="meta">Generated 2026-08-03 23:32:21 CDT · '
                 'Report framework V0.1.0 · Captured ingest 44</p>', encoding="utf-8"
             )
             evaluation.write_text(
-                '<p class="meta">Generated 2026-08-04 17:00:00 CDT · '
+                '<body data-report-outcome="CANCELLED"><p class="meta">Generated 2026-08-04 17:00:00 CDT · '
                 'Report framework V0.3.0 · Captured ingest 44</p>', encoding="utf-8"
             )
 
@@ -200,6 +221,8 @@ class ReportRenderingTests(unittest.TestCase):
             self.assertIn("Published report", index)
             self.assertIn("Evaluation copy", index)
             self.assertIn("Captured ingest", index)
+            self.assertIn("Outcome", index)
+            self.assertIn("CANCELLED", index)
             self.assertLess(index.index(evaluation.name), index.index(published.name))
 
     def test_index_ignores_unrecognized_html_files(self):
@@ -211,6 +234,21 @@ class ReportRenderingTests(unittest.TestCase):
 
             self.assertNotIn("unrelated.html", index)
             self.assertIn("No reconciliation reports are available", index)
+
+    def test_index_recovers_cancelled_outcome_from_legacy_report(self):
+        with TemporaryDirectory() as output_dir:
+            path = Path(output_dir) / "lor-reconciliation-20260814-011807-run-6.html"
+            path.write_text(
+                '<p class="meta">Generated 2026-08-14 01:18:07 UTC · '
+                'Report framework V0.4.2 · Captured ingest 47</p>'
+                '<table><tr><td>6</td><td>CANCELLED</td></tr></table>',
+                encoding="utf-8",
+            )
+
+            index = REPORT.refresh_report_index(output_dir).read_text(encoding="utf-8")
+
+            self.assertIn("CANCELLED", index)
+            self.assertNotIn("UNKNOWN", index)
 
     def test_refresh_index_cli_needs_no_database_arguments(self):
         with TemporaryDirectory() as output_dir:

--- a/LOR2DB/Application/README.md
+++ b/LOR2DB/Application/README.md
@@ -2,13 +2,14 @@
 
 | Document control | Value |
 |---|---|
-| Status | CURRENT production reconciliation; parser runner pending deployment acceptance |
-| Initial release / current revision | 2026-08-04 / 2026-08-13 |
+| Status | CURRENT code; V0.5.0 combined reconciliation/parser-runner deployment pending acceptance |
+| Initial release / current revision | 2026-08-04 / 2026-08-14 |
 
 ## Revision history
 
 | Date | Change |
 |---|---|
+| 2026-08-14 | Added safe `APPROVE_STAGE_CHANGE` and `ADD_NEW_STAGE` paths gated by complete frozen evidence; contradictory stage groups remain non-approvable. The browser now shows every stage-group member. Cancellation now renders a terminal proof screen, cancelled reports have no misleading required actions, and the archive shows Outcome. Current-version parser runs permit structurally compatible authoring edits while candidate runs retain their exact checked-source guard. |
 | 2026-08-13 | Added the mandatory same-parser approved-version/candidate SQLite comparison. Approval now requires equal schemas and explained output differences; automatic LOR Revision increments are retained as informational evidence rather than treated as content changes. Candidate folders changed after XML review are rejected as stale. |
 | 2026-08-13 | Added the LOR version-of-record, complete XML compatibility gate, validated parser controls, and Windows/G-drive runner boundary. PostgreSQL ingest remains a separate manual approval step and requires the reviewed SQLite SHA-256. |
 | 2026-08-06 | Browser V0.4.3 opens the newly published run's immutable `report_url`, with the archive index only as a fallback. Backend V0.3.3 returns that URL after publication. Report framework V0.4.2 displays the authenticated Cloudflare email as the operator. Directus person resolution and role-based authorization remain a future enhancement. |
@@ -95,7 +96,9 @@ The workflow is intentionally gated:
 3. If the check fails, review the recorded parser modifications required and
    update the parser.
 4. Build the approved-version comparison baseline in isolated `VERSION_CHECK`
-   mode. The approved folder must still match its retained XML manifest.
+   mode. Routine authoring changes in the approved folder are allowed only
+   when the live XML remains structurally compatible with its retained
+   approved manifest; parser-breaking contract changes are rejected.
 5. Run the candidate parser into a separate `VERSION_CHECK` SQLite file. The
    runner verifies that the candidate folder still matches the just-reviewed
    XML manifest, then compares both SQLite schemas and authoritative content.
@@ -121,15 +124,16 @@ parser table-count interpretation.
 restricted Windows host/service account with the Shared Drive mounted as `G:`.
 It listens on the internal interface only and requires a bearer token shared
 with the Linux API. Configure its environment from
-`lor-operator-runner.env.example`, initialize the 6.6.4 approved state once,
-and then run its `serve` command.
+`lor-operator-runner.env.example`. Production already has an approved 6.6.10
+state and must retain it. Use `init` only on a new installation that has no
+state file; never initialize over approval history. Then run `serve`.
 
 ```powershell
 python lor_operator_runner.py init `
   --state-file "G:\Shared drives\MSB Database\LOR Version Reviews\runner-state.json" `
-  --current-lor-version 6.6.4 `
-  --current-preview-folder "G:\Shared drives\MSB Database\Database Previews V6.6.4" `
-  --deep-preview "2026 Master Musical Preview v6.6 2026-07-30.lorprev"
+  --current-lor-version 6.6.10 `
+  --current-preview-folder "G:\Shared drives\MSB Database\Database Previews V6.6.10" `
+  --deep-preview "2026 Master Musical Preview v6.6.10 2026-08-11.lorprev"
 
 python lor_operator_runner.py serve `
   --state-file "G:\Shared drives\MSB Database\LOR Version Reviews\runner-state.json" `
@@ -202,8 +206,17 @@ Body:
 
 The backend verifies the authenticated operator, run status, run/group
 relationship, allowed action, and optimistic `expected_action_id`; then calls
-`ops.f_record_lor_reconciliation_action`. It returns the complete refreshed run
-document as `{ "run": { ... } }`.
+the appropriate protected recorder. Display/scene decisions use
+`ops.f_record_lor_reconciliation_action`; evidence-gated stage decisions use
+`ops.f_record_lor_stage_authority_action`, and the existing multi-preview
+preservation choice uses its dedicated stage recorder. It returns the complete
+refreshed run document as `{ "run": { ... } }`.
+
+Stage candidates include the complete frozen `members` array and the browser
+renders every member. `APPROVE_STAGE_CHANGE` appears only when all members
+resolve to one permanent `stage_id` and agree on the proposed metadata.
+`ADD_NEW_STAGE` appears only when one authoritative source defines one new
+stage key/name/folder/order. Contradictory groups expose neither action.
 
 ### `POST api/runs/{run_id}/decisions/bulk`
 
@@ -215,7 +228,10 @@ allow the selected action. Reassociation cannot use this endpoint.
 
 Requires a nonblank reason and a second browser confirmation. The backend calls
 `ops.p_cancel_lor_reconciliation`, publishes the cancellation report, and never
-runs Finish.
+runs Finish. Its response includes the immutable cancellation `report_url`,
+snapshot-removal proof, and `production_changed: false`. The browser replaces
+the editable page with a terminal **Reconciliation cancelled** screen and an
+explicit **Safe to close browser: YES** result.
 
 ### `POST api/runs/{run_id}/finish`
 
@@ -228,6 +244,13 @@ If production promotion commits but report publication fails, the run remains
 `REPORTING`. The landing page must present **Continue previous reconciliation**;
 the run page presents **Retry report publication**. Repeating Finish does not
 repeat P1-P4; it retries only publication.
+
+### `POST api/runs/{run_id}/report`
+
+Retries report publication only for a run in `REPORTING`. This endpoint never
+repeats Cancel, Finish, or P1-P4 and returns the run's actual terminal status
+plus immutable `report_url`. It is used for both completed production updates
+and cancellations whose initial report publication failed.
 
 ## Deployment boundary
 
@@ -246,6 +269,36 @@ report publication function used by the existing publisher. It must not receive
 direct write privileges on `ref`, `lor_snap`, or the reconciliation tables.
 After creating the login separately with a secured password, apply
 `grant_lor_preflight_app.sql` to install this exact grant set.
+
+## V0.5.0 combined deployment order
+
+This release intentionally deploys the reconciliation corrections and the
+already-implemented Version Check / Run Parser controls as one acceptance
+unit. Do not deploy only the static page or only `backend.py`.
+
+1. Back up the current application files and record their hashes.
+2. Apply
+   `0032_add_safe_stage_authority_and_terminal_cancel.sql`, then run
+   `27_safe_stage_authority_and_cancel_terminal_validation.sql`.
+3. Reapply `grant_lor_preflight_app.sql` V0.3.0 so the restricted API role can
+   invoke only the two stage decision recorders in addition to its existing
+   entry points.
+4. On the approved Windows host, deploy the canonical parser directory,
+   including runner V1.2.0, version checker, parser V7.0.10, and tests. Retain
+   the existing `runner-state.json` whose current approved LOR is 6.6.10; do
+   not initialize over it. Configure and start the internal runner on port
+   8791, which must remain inaccessible from the public web.
+5. On `msb-prod-db`, deploy backend V0.5.0 and report publisher V0.5.0 together,
+   add `LOR_RUNNER_URL` and the matching `LOR_RUNNER_TOKEN` to the protected
+   environment file, and restart `lor-preflight-api.service`.
+6. Publish `landing/` plus the `preflight` HTML/CSS/JavaScript files to the NAS
+   web path.
+7. Verify the Linux `/health` response, Windows runner health, dashboard runner
+   status, cancellation terminal flow, archive Outcome column, and a no-write
+   stage decision review before production use.
+
+PostgreSQL ingest remains password-protected, digest-locked, and manual. This
+deployment does not add a browser ingest endpoint.
 
 ## Production deployment and acceptance record — 2026-08-05 through 2026-08-06
 
@@ -346,7 +399,7 @@ sudo -u lor-preflight test -r /opt/lor-preflight/publish_lor_reconciliation_repo
 curl -s http://192.168.5.9:8784/health
 ```
 
-The health response must report `V0.3.3`. Retrying Finish for a run already in
+The V0.5.0 health response must report `V0.5.0`. Retrying Finish for a run already in
 `REPORTING` does not execute P1-P4 again; it retries report publication only.
 
 The successful final mount showed the NAS `web` share at `/mnt/msb-web`,

--- a/LOR2DB/Application/backend.py
+++ b/LOR2DB/Application/backend.py
@@ -3,7 +3,7 @@ MSB Database - LOR reconciliation preflight API
 backend.py
 
 Initial Release : 2026-08-05  V0.1.0
-Current Version : 2026-08-13  V0.4.0
+Current Version : 2026-08-14  V0.5.0
 Author          : GAL / OpenAI
 
 Purpose:
@@ -12,6 +12,9 @@ Purpose:
     append-only decisions, Finish, Cancel, and report completion.
 
 Revision History:
+    2026-08-14  GAL / OpenAI  V0.5.0
+        Added explicit safe stage authority decisions, complete stage-group
+        evidence, and a terminal cancellation response with its report URL.
     2026-08-13  GAL / OpenAI  V0.4.0
         Added authenticated proxy endpoints for the Windows-side LOR version
         checker/parser runner. The Linux API never accepts filesystem or
@@ -66,8 +69,12 @@ from flask import Flask, Response, jsonify, request
 from psycopg2.extras import RealDictCursor
 
 
-APP_VERSION = "V0.4.0"
+APP_VERSION = "V0.5.0"
 FALLBACK_ACTIONS = {"DEFER", "CORRECT_SOURCE_REQUIRED", "RESTORE_TO_LOR_REQUIRED"}
+STAGE_AUTHORITY_ACTIONS = {
+    "APPROVE_STAGE_CHANGE", "ADD_NEW_STAGE",
+    "PRESERVE_EXISTING_STAGE_METADATA",
+}
 ACCEPTED_RUN_STATES = {"AWAITING_DECISIONS", "READY_TO_FINISH"}
 ENTITY_VIEWS = {
     "DISPLAY": "ops.v_lor_reconciliation_operator_display_review",
@@ -199,7 +206,8 @@ def load_run(conn: Any, run_id: int) -> dict[str, Any]:
         run = fetch_one(cur, """
             SELECT lor_reconciliation_run_id, import_run_id, status,
                    validation_state, unresolved_count, deferred_count,
-                   blocked_count
+                   blocked_count, completed_at, report_url, report_published_at,
+                   cancelled_at, cancellation_reason
             FROM ops.lor_reconciliation_run
             WHERE lor_reconciliation_run_id = %s
         """, (run_id,))
@@ -235,7 +243,11 @@ def load_run(conn: Any, run_id: int) -> dict[str, Any]:
             "entity_type": group["entity_type"],
             "entity_key": group["logical_group_key"],
             "classification_label": human_label(first.get("classification_code") or group.get("group_kind")),
-            "operator_message": first.get("operator_message") or group.get("operator_message") or "Operator decision required.",
+            "operator_message": (
+                group.get("operator_message")
+                if group["entity_type"] == "STAGE"
+                else first.get("operator_message")
+            ) or group.get("operator_message") or "Operator decision required.",
             "allowed_actions": actions,
             "proposed_action": proposed_action(actions),
             "effective_action_id": group.get("effective_action_id"),
@@ -256,9 +268,18 @@ def load_run(conn: Any, run_id: int) -> dict[str, Any]:
         "unresolved_count": run["unresolved_count"],
         "deferred_count": run["deferred_count"],
         "blocked_count": run["blocked_count"],
+        "completed_at": run.get("completed_at"),
+        "report_url": run.get("report_url"),
+        "report_published_at": run.get("report_published_at"),
+        "cancelled_at": run.get("cancelled_at"),
+        "cancellation_reason": run.get("cancellation_reason"),
         "candidates": candidates,
         "operator": operator_email(),
     }
+    if run["status"] == "CANCELLED":
+        document["snapshot_removed"] = True
+        document["production_changed"] = False
+        document["safe_to_close"] = True
     document["decision_version"] = decision_version(groups)
     return document
 
@@ -436,7 +457,7 @@ def publish_report(run_id: int) -> None:
     )
     if completed.returncode:
         detail = (completed.stderr or completed.stdout).strip()
-        raise ApiError(f"Production update committed, but report publication failed: {detail}", 500)
+        raise ApiError(f"Database lifecycle completed, but report publication failed: {detail}", 500)
 
 
 @app.errorhandler(ApiError)
@@ -573,15 +594,15 @@ def record_decision(run_id: int, group_id: int) -> Response:
     with database() as conn:
         with conn.cursor(cursor_factory=RealDictCursor) as cur:
             cur.execute("""
-                SELECT g.allowed_action_types,
+                SELECT gr.allowed_action_types, gr.entity_type,
                        (SELECT a.lor_reconciliation_action_id
                         FROM ops.lor_reconciliation_action AS a
-                        WHERE a.lor_reconciliation_group_id = g.lor_reconciliation_group_id
+                        WHERE a.lor_reconciliation_group_id = gr.lor_reconciliation_group_id
                         ORDER BY a.acted_at DESC, a.lor_reconciliation_action_id DESC
                         LIMIT 1) AS effective_action_id
-                FROM ops.lor_reconciliation_group AS g
-                WHERE g.lor_reconciliation_run_id = %s
-                  AND g.lor_reconciliation_group_id = %s
+                FROM ops.v_lor_reconciliation_group_review AS gr
+                WHERE gr.lor_reconciliation_run_id = %s
+                  AND gr.lor_reconciliation_group_id = %s
             """, (run_id, group_id))
             group = cur.fetchone()
             if group is None:
@@ -590,10 +611,21 @@ def record_decision(run_id: int, group_id: int) -> Response:
                 raise ApiError("This decision changed after the page loaded; the run has been refreshed", 409)
             if action not in group["allowed_action_types"]:
                 raise ApiError("The selected action is not allowed for this group")
-            cur.execute(
-                "SELECT ops.f_record_lor_reconciliation_action(%s,%s,%s,%s,NULL,%s)",
-                (run_id, group_id, action, reason, f"lor-preflight-api:{operator}"),
-            )
+            if action == "PRESERVE_EXISTING_STAGE_METADATA":
+                cur.execute(
+                    "SELECT ops.f_record_lor_stage_preserve_metadata_action(%s,%s,%s,%s)",
+                    (run_id, group_id, reason, f"lor-preflight-api:{operator}"),
+                )
+            elif group["entity_type"] == "STAGE" and action in STAGE_AUTHORITY_ACTIONS:
+                cur.execute(
+                    "SELECT ops.f_record_lor_stage_authority_action(%s,%s,%s,%s,%s)",
+                    (run_id, group_id, action, reason, f"lor-preflight-api:{operator}"),
+                )
+            else:
+                cur.execute(
+                    "SELECT ops.f_record_lor_reconciliation_action(%s,%s,%s,%s,NULL,%s)",
+                    (run_id, group_id, action, reason, f"lor-preflight-api:{operator}"),
+                )
         conn.commit()
         return jsonify(run=load_run(conn, run_id))
 
@@ -646,7 +678,19 @@ def cancel_run(run_id: int) -> Response:
                         (run_id, reason, f"lor-preflight-api:{operator}"))
         conn.commit()
     publish_report(run_id)
-    return jsonify(run_id=run_id, status="CANCELLED")
+    with database() as conn:
+        cancelled = load_run(conn, run_id)
+    return jsonify(
+        run_id=run_id,
+        status="CANCELLED",
+        report_url=cancelled["report_url"],
+        cancelled_at=cancelled["cancelled_at"],
+        completed_at=cancelled["completed_at"],
+        cancellation_reason=cancelled["cancellation_reason"],
+        snapshot_removed=True,
+        production_changed=False,
+        safe_to_close=True,
+    )
 
 
 @app.post("/runs/<int:run_id>/finish")
@@ -673,7 +717,25 @@ def finish_run(run_id: int) -> Response:
         completed = load_run(conn, run_id)
     return jsonify(
         run_id=run_id,
-        status="COMPLETED",
+        status=completed["status"],
+        report_url=completed["report_url"],
+    )
+
+
+@app.post("/runs/<int:run_id>/report")
+def retry_run_report(run_id: int) -> Response:
+    """Retry publication only; never rerun Cancel, Finish, or P1-P4."""
+    operator_email()
+    with database() as conn:
+        document = load_run(conn, run_id)
+    if document["status"] != "REPORTING":
+        raise ApiError("The run is not waiting for report publication", 409)
+    publish_report(run_id)
+    with database() as conn:
+        completed = load_run(conn, run_id)
+    return jsonify(
+        run_id=run_id,
+        status=completed["status"],
         report_url=completed["report_url"],
     )
 

--- a/LOR2DB/Application/grant_lor_preflight_app.sql
+++ b/LOR2DB/Application/grant_lor_preflight_app.sql
@@ -1,7 +1,7 @@
 /* ============================================================================
 Object:       LOR preflight application least-privilege grants
 Filename:     grant_lor_preflight_app.sql
-Revision:     2026-08-06 V0.2.0
+Revision:     2026-08-14 V0.3.0
 
 Purpose:
   Grant the existing login role lor_preflight_app only the reads and secured
@@ -9,6 +9,8 @@ Purpose:
   publisher. This script does not create the login or store its password.
 
 Revision history:
+  2026-08-14  GAL / OpenAI  Added the evidence-gated stage authority action
+                           recorder introduced by migration 0032.
   2026-08-06  GAL / OpenAI  Added current-snapshot read access and the unified
                            reconciliation Start function for the lor2db page.
   2026-08-05  GAL / OpenAI  Initial application-role grant set.
@@ -50,6 +52,8 @@ GRANT SELECT ON lor_snap.v_current_run TO lor_preflight_app;
 
 GRANT EXECUTE ON FUNCTION
     ops.f_record_lor_reconciliation_action(bigint,bigint,text,text,jsonb,text),
+    ops.f_record_lor_stage_authority_action(bigint,bigint,text,text,text),
+    ops.f_record_lor_stage_preserve_metadata_action(bigint,bigint,text,text),
     ops.f_record_lor_reconciliation_bulk_action(bigint,bigint[],text,text,text),
     ops.f_lor_reconciliation_display_name_changes_report(bigint),
     ops.f_start_lor_reconciliation(text)
@@ -64,5 +68,5 @@ TO lor_preflight_app;
 COMMIT;
 
 SELECT
-    '2026-08-06-lor-preflight-app-grants-v2' AS applied_revision,
+    '2026-08-14-lor-preflight-app-grants-v3' AS applied_revision,
     current_user AS applied_by;

--- a/LOR2DB/Application/index.html
+++ b/LOR2DB/Application/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>LOR reconciliation preflight</title>
-  <link rel="stylesheet" href="preflight.css">
+  <link rel="stylesheet" href="preflight.css?v=0.5.0">
 </head>
 <body>
   <main id="app" class="shell" aria-live="polite">
@@ -26,6 +26,6 @@
     </form>
   </dialog>
 
-  <script src="preflight.js" defer></script>
+  <script src="preflight.js?v=0.5.0" defer></script>
 </body>
 </html>

--- a/LOR2DB/Application/landing/index.html
+++ b/LOR2DB/Application/landing/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>LOR production database</title>
-  <link rel="stylesheet" href="lor2db.css">
+  <link rel="stylesheet" href="lor2db.css?v=0.4.0">
 </head>
 <body>
   <main class="shell">
@@ -60,6 +60,6 @@
       </div>
     </form>
   </dialog>
-  <script src="lor2db.js" defer></script>
+  <script src="lor2db.js?v=0.4.0" defer></script>
 </body>
 </html>

--- a/LOR2DB/Application/landing/lor2db.js
+++ b/LOR2DB/Application/landing/lor2db.js
@@ -1,4 +1,4 @@
-/* MSB LOR landing page — 2026-08-13 V0.3.0 */
+/* MSB LOR landing page — 2026-08-14 V0.4.0 */
 (function () {
   "use strict";
 

--- a/LOR2DB/Application/preflight.css
+++ b/LOR2DB/Application/preflight.css
@@ -38,6 +38,12 @@ select, textarea { border: 1px solid #aeb8c2; border-radius: 4px; background: #f
 .row-selector input { margin-top: 2px; }
 .title { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-bottom: 5px; }
 .facts { margin-top: 8px; font-size: 13px; }
+.member-evidence { margin-top: 12px; }
+.member-evidence summary { cursor: pointer; font-weight: 650; }
+.table-scroll { overflow-x: auto; margin-top: 8px; }
+.member-evidence table { width: 100%; min-width: 720px; border-collapse: collapse; font-size: 12px; }
+.member-evidence th, .member-evidence td { border: 1px solid var(--line); padding: 6px; text-align: left; vertical-align: top; }
+.member-evidence th { background: #edf2f7; }
 .decision-panel { display: grid; gap: 10px; }
 .decision { width: 100%; }
 .reason { width: 100%; }
@@ -45,6 +51,12 @@ select, textarea { border: 1px solid #aeb8c2; border-radius: 4px; background: #f
 .save-state.is-saved { color: var(--ok); font-weight: 650; }
 .save-state.is-unsaved { color: #9a5a00; font-weight: 650; }
 .error { color: var(--danger); font-weight: 650; }
+.eyebrow { color: var(--muted); font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
+.terminal.is-cancelled { border-top: 6px solid var(--danger); }
+.terminal-proof { display: flex; flex-wrap: wrap; gap: 12px; margin: 20px 0; }
+.terminal-proof span { min-width: 180px; border-radius: 5px; background: #edf2f7; padding: 10px; }
+.button-link { display: inline-block; border: 1px solid #aeb8c2; border-radius: 5px; color: var(--text); background: #fff; padding: .55rem .85rem; text-decoration: none; }
+.button-link.primary { color: #fff; border-color: var(--accent); background: var(--accent); }
 .footer { align-items: center; padding-top: 20px; border-top: 1px solid var(--line); }
 .final-list { margin: 18px 0; padding: 0; list-style: none; border-top: 1px solid var(--line); }
 .final-list li { padding: 14px 0; border-bottom: 1px solid var(--line); }

--- a/LOR2DB/Application/preflight.js
+++ b/LOR2DB/Application/preflight.js
@@ -1,7 +1,7 @@
 /*
  * MSB Database - reusable LOR reconciliation preflight interface
  * Initial release: 2026-08-04 V0.1.0
- * Current version: 2026-08-06 V0.4.3
+ * Current version: 2026-08-14 V0.5.0
  *
  * The browser never writes PostgreSQL directly. All durable decisions and
  * lifecycle changes go through the same-origin secured API described in
@@ -58,6 +58,9 @@
       SET_RETIRED: `Mark ${current} as RETIRED`,
       RESTORE_TO_LOR_REQUIRED: "LOR source needs correction — leave production unchanged",
       CORRECT_SOURCE_REQUIRED: "Source information is incorrect — leave production unchanged",
+      APPROVE_STAGE_CHANGE: "Approve this source StageID change and preserve its permanent Stage ID",
+      ADD_NEW_STAGE: "Add this source stage as a new permanent stage",
+      PRESERVE_EXISTING_STAGE_METADATA: "Approve all bindings and preserve the existing permanent stage metadata",
       DEFER: "Defer — leave production unchanged for this run"
     };
     if (labels[action]) return labels[action];
@@ -66,6 +69,22 @@
 
   function displayName(candidate) {
     return candidate.current_display_name || candidate.proposed_display_name || candidate.entity_key;
+  }
+
+  function stageMemberEvidence(candidate) {
+    if (candidate.entity_type !== "STAGE" || !candidate.members?.length) return "";
+    const rows = candidate.members.map((member) => `<tr>
+      <td>${esc(member.binding_type)}</td>
+      <td>${esc(member.source_name || "Unnamed")}</td>
+      <td>${esc(member.source_stage_key || "—")}</td>
+      <td>${esc(member.current_stage_key || "—")}</td>
+      <td>${esc(member.proposed_stage_name || "—")}</td>
+      <td>${esc(member.classification_code || "—")}</td>
+    </tr>`).join("");
+    return `<details class="member-evidence" open>
+      <summary>Complete stage evidence (${candidate.members.length} member${candidate.members.length === 1 ? "" : "s"})</summary>
+      <div class="table-scroll"><table><thead><tr><th>Binding</th><th>Source name</th><th>Source StageID</th><th>Current key</th><th>Proposed stage name</th><th>Finding</th></tr></thead><tbody>${rows}</tbody></table></div>
+    </details>`;
   }
 
   function openPublishedReport(result) {
@@ -90,6 +109,7 @@
           <div class="title"><h3>${esc(displayName(candidate))}</h3><span class="badge">${esc(candidate.classification_label)}</span></div>
           <div>${esc(candidate.operator_message)}</div>
           <div class="facts">${facts}</div>
+          ${stageMemberEvidence(candidate)}
         </div>
       </div>
       <div class="decision-panel">
@@ -109,7 +129,7 @@
     const complete = model.candidates.filter((candidate) => candidate.effective_action_type).length;
     const remaining = model.candidates.length - complete;
     const bulkActions = [...new Set(model.candidates.flatMap((candidate) => candidate.allowed_actions))]
-      .filter((action) => action !== "REASSOCIATE_DISPLAY");
+      .filter((action) => !["REASSOCIATE_DISPLAY", "APPROVE_STAGE_CHANGE", "ADD_NEW_STAGE", "PRESERVE_EXISTING_STAGE_METADATA"].includes(action));
     app.innerHTML = `<div class="card">
       <header class="header">
         <div><h1>Preflight review</h1><div class="meta"><span>Reconciliation run ${model.run_id}</span><span>Captured ingest ${model.import_run_id}</span><span class="badge">${model.candidates.length} decisions required</span></div></div>
@@ -193,8 +213,24 @@
     dialogConfirm.onclick = async (event) => {
       event.preventDefault();
       if (!dialogReason.value.trim()) return;
-      try { await request(`api/runs/${model.run_id}/cancel`, { method: "POST", body: JSON.stringify({ reason: dialogReason.value.trim() }) }); location.reload(); }
-      catch (failure) { dialogBody.textContent = failure.message; }
+      try {
+        const result = await request(`api/runs/${model.run_id}/cancel`, {
+          method: "POST", body: JSON.stringify({ reason: dialogReason.value.trim() })
+        });
+        dialog.close();
+        model = result;
+        renderTerminal();
+      }
+      catch (failure) {
+        if (failure.message.includes("report publication failed:")) {
+          model.status = "REPORTING";
+          model.cancellation_report_pending = true;
+          dialog.close();
+          renderReportingRetry(failure.message);
+          return;
+        }
+        dialogBody.textContent = failure.message;
+      }
     };
     dialog.showModal();
   }
@@ -221,7 +257,7 @@
         openPublishedReport(result);
       }
       catch (failure) {
-        if (failure.message.startsWith("Production update committed, but report publication failed:")) {
+        if (failure.message.includes("report publication failed:")) {
           model.status = "REPORTING";
           dialog.close();
           renderReportingRetry(failure.message);
@@ -233,14 +269,16 @@
     dialog.showModal();
   }
 
-  function renderReportingRetry(detail = "Production changes are committed, but the report has not been published.") {
-    app.innerHTML = `<div class="card"><h1>Report publication required</h1><p>Reconciliation run ${model.run_id} is in <strong>REPORTING</strong>. Production changes are already committed. P1–P4 will not run again.</p><p class="error">${esc(detail)}</p><div class="footer-actions"><button id="retry-report" class="primary">Retry report publication</button></div></div>`;
+  function renderReportingRetry(detail = "The database lifecycle completed, but the report has not been published.") {
+    const lifecycle = model.cancellation_report_pending || model.cancelled_at
+      ? "Cancellation is committed: the captured snapshot was removed and production was unchanged."
+      : "Production changes are already committed.";
+    app.innerHTML = `<div class="card"><h1>Report publication required</h1><p>Reconciliation run ${model.run_id} is in <strong>REPORTING</strong>. ${esc(lifecycle)} Cancel, Finish, and P1–P4 will not run again.</p><p class="error">${esc(detail)}</p><div class="footer-actions"><button id="retry-report" class="primary">Retry report publication</button></div></div>`;
     document.querySelector("#retry-report").addEventListener("click", async (event) => {
       event.currentTarget.disabled = true;
       try {
-        const result = await request(`api/runs/${model.run_id}/finish`, {
-          method: "POST",
-          body: JSON.stringify({ expected_decision_version: model.decision_version })
+        const result = await request(`api/runs/${model.run_id}/report`, {
+          method: "POST", body: "{}"
         });
         openPublishedReport(result);
       } catch (failure) {
@@ -249,10 +287,33 @@
     });
   }
 
+  function renderTerminal() {
+    const cancelled = model.status === "CANCELLED";
+    const report = model.report_url
+      ? `<a class="primary button-link" href="${esc(model.report_url)}">Open ${cancelled ? "cancellation" : "completed run"} report</a>`
+      : `<a class="button-link" href="../reports/">Open report archive</a>`;
+    app.innerHTML = `<div class="card terminal ${cancelled ? "is-cancelled" : ""}">
+      <p class="eyebrow">Reconciliation run ${esc(model.run_id)}</p>
+      <h1>${cancelled ? "Reconciliation cancelled" : "Reconciliation complete"}</h1>
+      <p>${cancelled
+        ? "The captured ingest snapshot was removed. No production reconciliation changes were committed."
+        : "The reconciliation is closed and its immutable report is available."}</p>
+      ${cancelled && model.cancellation_reason ? `<p><strong>Cancellation reason:</strong> ${esc(model.cancellation_reason)}</p>` : ""}
+      <div class="terminal-proof">
+        <span><strong>Status</strong><br>${esc(model.status)}</span>
+        <span><strong>Closed</strong><br>${esc(model.completed_at || model.cancelled_at || "Recorded")}</span>
+        <span><strong>Production changed</strong><br>${model.production_changed === false ? "NO" : "See report"}</span>
+        <span><strong>Safe to close browser</strong><br>YES</span>
+      </div>
+      <div class="footer-actions">${report}<a class="button-link" href="../">Return to LOR2DB</a></div>
+    </div>`;
+  }
+
   async function load() {
     if (!runId || !/^\d+$/.test(runId)) throw new Error("Open the page with a numeric reconciliation run, for example ?run=4.");
     model = await request(`api/runs/${runId}`);
     if (model.status === "REPORTING") renderReportingRetry();
+    else if (["CANCELLED", "COMPLETED", "COMPLETED_WITH_EXCEPTIONS"].includes(model.status)) renderTerminal();
     else renderReview();
   }
 

--- a/LOR2DB/Application/test_backend.py
+++ b/LOR2DB/Application/test_backend.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import tempfile
 import unittest
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch
 
@@ -29,6 +30,69 @@ class BackendSafetyTests(unittest.TestCase):
         source = Path(__file__).with_name("preflight.js").read_text(encoding="utf-8")
         self.assertIn('result.report_url || "../reports/"', source)
         self.assertEqual(source.count("openPublishedReport(result);"), 2)
+
+    def test_browser_renders_terminal_cancellation_proof(self) -> None:
+        source = Path(__file__).with_name("preflight.js").read_text(encoding="utf-8")
+        self.assertIn("Reconciliation cancelled", source)
+        self.assertIn("captured ingest snapshot was removed", source)
+        self.assertIn("Safe to close browser", source)
+        self.assertNotIn("location.reload();", source)
+
+    def test_browser_exposes_safe_stage_authority_labels_and_full_evidence(self) -> None:
+        source = Path(__file__).with_name("preflight.js").read_text(encoding="utf-8")
+        self.assertIn("APPROVE_STAGE_CHANGE", source)
+        self.assertIn("ADD_NEW_STAGE", source)
+        self.assertIn("Complete stage evidence", source)
+        self.assertIn("candidate.members.map", source)
+
+    def test_cancel_endpoint_returns_terminal_proof_and_report_url(self) -> None:
+        class Cursor:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def execute(self, *_args):
+                return None
+
+        class Connection:
+            def cursor(self, **_kwargs):
+                return Cursor()
+
+            def commit(self):
+                return None
+
+        @contextmanager
+        def fake_database():
+            yield Connection()
+
+        cancelled = {
+            "report_url": "https://example.test/reports/run-6.html",
+            "cancelled_at": "2026-08-14T01:18:07Z",
+            "completed_at": "2026-08-14T01:18:08Z",
+            "cancellation_reason": "Correct LOR source",
+        }
+        with patch.object(backend, "database", fake_database), \
+             patch.object(backend, "publish_report") as publish, \
+             patch.object(backend, "load_run", return_value=cancelled):
+            response = backend.app.test_client().post(
+                "/runs/6/cancel",
+                json={"reason": "Correct LOR source"},
+                headers={
+                    "Cf-Access-Authenticated-User-Email":
+                        "greg@sheboyganlights.org"
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json["status"], "CANCELLED")
+        self.assertTrue(response.json["snapshot_removed"])
+        self.assertFalse(response.json["production_changed"])
+        self.assertTrue(response.json["safe_to_close"])
+        self.assertEqual(response.json["report_url"], cancelled["report_url"])
+        self.assertEqual(response.json["completed_at"], cancelled["completed_at"])
+        publish.assert_called_once_with(6)
 
     def test_dashboard_marks_completed_snapshot_consumed(self) -> None:
         state = backend.dashboard_state(

--- a/LOR2DB/Application/test_stage_authority_migration.py
+++ b/LOR2DB/Application/test_stage_authority_migration.py
@@ -1,0 +1,56 @@
+"""Static safety contracts for reconciliation migration 0032.
+
+The transactional PostgreSQL validation script exercises the installed
+objects.  These fast repository tests prevent accidental removal of the
+evidence gates, permanent-ID preservation, or least-privilege grant.
+"""
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).parents[1]
+MIGRATION = ROOT / "02_Reconciliation" / "reconciliation" / "migrations" / (
+    "0032_add_safe_stage_authority_and_terminal_cancel.sql"
+)
+GRANTS = ROOT / "Application" / "grant_lor_preflight_app.sql"
+
+
+class StageAuthorityMigrationTests(unittest.TestCase):
+    def test_contradictory_evidence_is_not_approvable(self) -> None:
+        source = MIGRATION.read_text(encoding="utf-8")
+        self.assertIn("count(DISTINCT c.proposed_stage_key) = 1", source)
+        self.assertIn("count(DISTINCT ops.f_normalize_lor_stage_name", source)
+        self.assertIn("BINDING_STAGE_KEY_CONFLICT", source)
+        self.assertIn("SOURCE_FILENAME_MISSING", source)
+
+    def test_existing_stage_change_preserves_stage_id(self) -> None:
+        source = MIGRATION.read_text(encoding="utf-8")
+        self.assertIn("APPROVE_STAGE_CHANGE", source)
+        self.assertIn("p1_promote_stage_from_reconciliation_before_0032", source)
+
+    def test_new_stage_gets_permanent_row_and_stable_bindings(self) -> None:
+        source = MIGRATION.read_text(encoding="utf-8")
+        self.assertIn("f_normalize_lor_stage_name", source)
+        self.assertIn("source_stage_key", source)
+        self.assertIn("INSERT INTO ref.stage (", source)
+        self.assertIn("RETURNING stage_id INTO v_stage_id", source)
+        self.assertIn("INSERT INTO ref.stage_lor_binding", source)
+
+    def test_application_role_can_call_only_the_authority_recorder(self) -> None:
+        source = GRANTS.read_text(encoding="utf-8")
+        self.assertIn(
+            "ops.f_record_lor_stage_authority_action(bigint,bigint,text,text,text)",
+            source,
+        )
+
+    def test_cancelled_runs_receive_a_terminal_completion_timestamp(self) -> None:
+        source = MIGRATION.read_text(encoding="utf-8")
+        self.assertIn("f_set_cancelled_reconciliation_completed_at", source)
+        self.assertIn("NEW.status = 'CANCELLED'", source)
+        self.assertIn("WHERE status = 'CANCELLED'", source)
+        self.assertIn("AND completed_at IS NULL", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This combines the reconciliation defects found in cancelled Run 6 with the pending LOR Version Check / Run Parser deployment.

- adds migration `0032` with evidence-gated stage decisions:
  - an existing source StageID change may be approved only when the complete frozen group resolves consistently to one permanent stage; its permanent `stage_id` is preserved
  - one unambiguous authoritative new stage may be added and receives a permanent `stage_id` plus stable LOR bindings
  - contradictory or incomplete stage evidence never exposes either approval action
  - the browser renders every stage-group member before a decision
- makes cancellation visibly and durably terminal:
  - replaces the editable page with cancellation proof, snapshot-removal proof, production-changed `NO`, report link, and safe-to-close `YES`
  - adds a report-only retry path that never repeats Cancel, Finish, or P1-P4
  - labels cancelled reports and archive rows as `CANCELLED` and removes misleading required actions
  - guarantees `completed_at` for future cancelled runs and backfills older cancelled rows such as Run 6
- deploys the already-merged Version Check / Run Parser controls as part of the same acceptance unit
- allows repeated parser runs after structurally compatible edits in the approved Current LOR folder, while preserving the exact-source stale guard for a checked New LOR candidate
- records the approved LOR 6.6.10 / parser V7.0.10 / ingest 47 / cancelled Run 6 authority chain and the controlled deployment order

## Safety boundaries

- No production deployment or PostgreSQL migration was performed by this PR.
- PostgreSQL ingest remains separate, digest-locked, password-protected, and manual.
- Stage approval actions are computed from complete frozen evidence and revalidated inside a protected database function.
- P1 writes occur only inside the existing Finish transaction.
- Routine Current-version preview changes still fail closed on parser-breaking XML contract changes.
- Candidate preview changes still invalidate the completed Version Check.

## Verification

- 20 parser/runner tests passed.
- 28 application and migration-contract tests passed.
- 15 reporting tests passed.
- 63 tests passed in total.
- Both browser JavaScript files passed `node --check`.
- Python sources passed `compileall`.
- Migration 0032, canonical P1, validation 27, and application grants all parsed successfully as PostgreSQL SQL.
- `git diff --check` passed.
- The immutable uploaded Run 6 report is recovered by the new archive index as outcome `CANCELLED` without rewriting the report.

## Deployment

The required order is documented in `LOR2DB/Application/README.md`: backup and hashes; migration 0032; validation 27; least-privilege grants; Windows runner/parser deployment while retaining the existing 6.6.10 state; Linux API/report publisher deployment; static assets; acceptance checks.
