### PR TITLE
Make LOR runner deployment reliable

### DIFF
--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/README.md
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/README.md
@@ -16,6 +16,11 @@ tools for operator convenience but does not own their XML interpretation.
 | `test_parse_props_console_encoding.py` | Regression test preventing Windows console/log encoding from aborting parser execution |
 | `test_parse_props_atomic_publish.py` | Regression tests for transient Windows file-lock retry and fail-closed atomic publication |
 
+The repository-root `run_lor_runner.ps1` is the canonical deployment and
+runtime launcher. It owns DPAPI secret storage, the logged-in-user Scheduled
+Task, authenticated status checks, and SSH pairing to the Linux API. Do not
+assemble runner environment variables or tokens manually.
+
 ## Operating Boundary
 
 Use the LOR2DB website for normal version checks and parser runs. Direct command
@@ -27,6 +32,12 @@ be parsed repeatedly. Each run rebuilds the live manifest and rejects only a
 parser-breaking XML contract change relative to the approved LOR manifest. A
 New LOR candidate remains stricter: changing any reviewed candidate file after
 Version Check invalidates that check and requires it to be rerun.
+
+The production runner task uses the logged-in Greg account because that Windows
+session owns the mapped `G:` drive. Screen locking does not stop the task. After
+a reboot, the runner remains unavailable until Greg signs in and Google Drive
+restores `G:`; the website reports the runner as unavailable without affecting
+command-line parser use or PostgreSQL.
 
 See:
 

--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/lor_operator_runner.py
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/lor_operator_runner.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 from collections import Counter
+import hashlib
 import hmac
 import json
 import os
@@ -29,7 +30,7 @@ from urllib.parse import urlparse
 from lor_version_checker import build_manifest, compare_manifests, manifest_source_signature, write_json
 
 
-RUNNER_VERSION = "V1.2.0"
+RUNNER_VERSION = "V1.3.0"
 
 AUTHORITATIVE_OUTPUT_TABLES = (
     "props",
@@ -53,6 +54,13 @@ def required_environment(name: str) -> str:
     if not value:
         raise RuntimeError(f"Required setting {name} is missing")
     return value
+
+
+def credential_fingerprint(value: str) -> str:
+    """Return a non-secret diagnostic identifier for a credential value."""
+    if not value:
+        return "missing"
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()[:16]
 
 
 def utc_now() -> str:
@@ -752,7 +760,16 @@ class RequestHandler(BaseHTTPRequestHandler):
     def authorized(self) -> bool:
         expected = f"Bearer {required_environment('LOR_RUNNER_TOKEN')}"
         provided = self.headers.get("Authorization", "")
-        return hmac.compare_digest(provided, expected)
+        authorized = hmac.compare_digest(provided, expected)
+        if not authorized:
+            self.log_error(
+                "Runner authentication rejected; expected fingerprint=%s; "
+                "provided fingerprint=%s; provided length=%d",
+                credential_fingerprint(expected),
+                credential_fingerprint(provided),
+                len(provided),
+            )
+        return authorized
 
     def body(self) -> dict[str, Any]:
         length = int(self.headers.get("Content-Length", "0"))
@@ -873,7 +890,15 @@ def main(argv: list[str] | None = None) -> int:
     runner = Runner(StateStore(arguments.state_file.resolve()))
     server = ThreadingHTTPServer((arguments.host, arguments.port), RequestHandler)
     server.runner = runner  # type: ignore[attr-defined]
-    print(f"[INFO] LOR runner {RUNNER_VERSION} listening on {arguments.host}:{arguments.port}")
+    token = required_environment("LOR_RUNNER_TOKEN")
+    print(
+        f"[INFO] LOR runner {RUNNER_VERSION} listening on "
+        f"{arguments.host}:{arguments.port}"
+    )
+    print(
+        "[INFO] Runner credential fingerprint: "
+        f"{credential_fingerprint(f'Bearer {token}')}"
+    )
     server.serve_forever()
     return 0
 

--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/test_lor_operator_runner.py
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/test_lor_operator_runner.py
@@ -51,6 +51,15 @@ class OperatorRunnerTests(unittest.TestCase):
         self.store = runner_module.StateStore(self.state_file)
         self.runner = runner_module.Runner(self.store)
 
+    def test_credential_fingerprint_is_stable_and_does_not_reveal_token(self) -> None:
+        token = "a" * 64
+        first = runner_module.credential_fingerprint(f"Bearer {token}")
+        second = runner_module.credential_fingerprint(f"Bearer {token}")
+        self.assertEqual(first, second)
+        self.assertEqual(len(first), 16)
+        self.assertNotIn(token, first)
+        self.assertEqual(runner_module.credential_fingerprint(""), "missing")
+
     def test_candidate_is_resolved_only_from_versioned_preview_root(self) -> None:
         state = self.runner.select_candidate("6.6.10", "operator@example.com")
         self.assertEqual(state["new_lor_version"], "6.6.10")

--- a/LOR2DB/Application/README.md
+++ b/LOR2DB/Application/README.md
@@ -2,13 +2,14 @@
 
 | Document control | Value |
 |---|---|
-| Status | CURRENT code; V0.5.0 combined reconciliation/parser-runner deployment pending acceptance |
+| Status | CURRENT code; V0.5.1 reliable runner deployment pending acceptance |
 | Initial release / current revision | 2026-08-04 / 2026-08-14 |
 
 ## Revision history
 
 | Date | Change |
 |---|---|
+| 2026-08-14 | Replaced manual runner-token commands with the root `run_lor_runner.ps1` installer. The token is generated once, protected with Windows DPAPI, paired to Linux through SSH, and verified by a non-secret fingerprint. Runner V1.3.0 logs rejected-header fingerprints; backend V0.5.1 bypasses HTTP proxies for the fixed private runner connection. |
 | 2026-08-14 | Added safe `APPROVE_STAGE_CHANGE` and `ADD_NEW_STAGE` paths gated by complete frozen evidence; contradictory stage groups remain non-approvable. The browser now shows every stage-group member. Cancellation now renders a terminal proof screen, cancelled reports have no misleading required actions, and the archive shows Outcome. Current-version parser runs permit structurally compatible authoring edits while candidate runs retain their exact checked-source guard. |
 | 2026-08-13 | Added the mandatory same-parser approved-version/candidate SQLite comparison. Approval now requires equal schemas and explained output differences; automatic LOR Revision increments are retained as informational evidence rather than treated as content changes. Candidate folders changed after XML review are rejected as stale. |
 | 2026-08-13 | Added the LOR version-of-record, complete XML compatibility gate, validated parser controls, and Windows/G-drive runner boundary. PostgreSQL ingest remains a separate manual approval step and requires the reviewed SQLite SHA-256. |
@@ -120,31 +121,41 @@ parser table-count interpretation.
 
 ### Windows runner deployment boundary
 
-`Docs/01_LOR_System/02_Data_Extraction/Parser/lor_operator_runner.py` runs on a
-restricted Windows host/service account with the Shared Drive mounted as `G:`.
-It listens on the internal interface only and requires a bearer token shared
-with the Linux API. Configure its environment from
-`lor-operator-runner.env.example`. Production already has an approved 6.6.10
-state and must retain it. Use `init` only on a new installation that has no
-state file; never initialize over approval history. Then run `serve`.
+`Docs/01_LOR_System/02_Data_Extraction/Parser/lor_operator_runner.py` runs on the
+restricted Office PC under the logged-in Greg account because that session owns
+the Shared Drive mounted as `G:`. It listens on the internal interface only and
+requires a bearer token shared with the Linux API. Production already has an
+approved 6.6.10 state and must retain it. Never run `init` over that state.
+
+Use only the repository-root launcher. `Install` generates one random token,
+protects it with Windows DPAPI, and registers the **MSB LOR Operator Runner**
+task at Greg's logon. It never starts the parser. `PairServer` transfers the
+same token over SSH to a mode-0600 pending file without displaying or placing
+the secret in command history.
 
 ```powershell
-python lor_operator_runner.py init `
-  --state-file "G:\Shared drives\MSB Database\LOR Version Reviews\runner-state.json" `
-  --current-lor-version 6.6.10 `
-  --current-preview-folder "G:\Shared drives\MSB Database\Database Previews V6.6.10" `
-  --deep-preview "2026 Master Musical Preview v6.6.10 2026-08-11.lorprev"
-
-python lor_operator_runner.py serve `
-  --state-file "G:\Shared drives\MSB Database\LOR Version Reviews\runner-state.json" `
-  --host REPLACE_INTERNAL_WINDOWS_IP `
-  --port 8791
+.\run_lor_runner.ps1 -Action Install
+.\run_lor_runner.ps1 -Action PairServer
+.\run_lor_runner.ps1 -Action Status
 ```
 
-The Linux API uses `LOR_RUNNER_URL` and `LOR_RUNNER_TOKEN`. The reverse proxy
-continues to expose only the Linux LOR2DB API; do not publish port 8791 to the
-Internet. Deploy migration `0031_preserve_lor_sqlite_authority_chain.sql`
-before deploying ingest V0.4.0 or the expanded dashboard query.
+From the repository root on `msb-prod-db`, consume the pending token with:
+
+```bash
+sudo python3 LOR2DB/Application/install_lor_runner_pairing.py
+```
+
+The installer backs up `/etc/msb/lor-preflight-api.env`, atomically installs
+`LOR_RUNNER_URL` and `LOR_RUNNER_TOKEN`, preserves its ownership/mode, reports
+the same non-secret fingerprint as Windows, and deletes the pending plaintext
+file. The reverse proxy continues to expose only the Linux LOR2DB API; do not
+publish port 8791 to the Internet.
+
+The task runs while Greg remains logged in, including while the screen is
+locked. After a Windows update or reboot, the runner remains unavailable until
+Greg signs in and `G:` is restored. This is an explicit availability boundary:
+the website reports the runner offline, while command-line parser operation,
+the existing SQLite snapshot, PostgreSQL, and reconciliation remain unaffected.
 
 ## Required API
 
@@ -270,7 +281,7 @@ direct write privileges on `ref`, `lor_snap`, or the reconciliation tables.
 After creating the login separately with a secured password, apply
 `grant_lor_preflight_app.sql` to install this exact grant set.
 
-## V0.5.0 combined deployment order
+## V0.5.1 combined deployment order
 
 This release intentionally deploys the reconciliation corrections and the
 already-implemented Version Check / Run Parser controls as one acceptance
@@ -284,13 +295,13 @@ unit. Do not deploy only the static page or only `backend.py`.
    invoke only the two stage decision recorders in addition to its existing
    entry points.
 4. On the approved Windows host, deploy the canonical parser directory,
-   including runner V1.2.0, version checker, parser V7.0.10, and tests. Retain
-   the existing `runner-state.json` whose current approved LOR is 6.6.10; do
-   not initialize over it. Configure and start the internal runner on port
-   8791, which must remain inaccessible from the public web.
-5. On `msb-prod-db`, deploy backend V0.5.0 and report publisher V0.5.0 together,
-   add `LOR_RUNNER_URL` and the matching `LOR_RUNNER_TOKEN` to the protected
-   environment file, and restart `lor-preflight-api.service`.
+   including runner V1.3.0, version checker, parser V7.0.10, tests, and the root
+   runner launcher. Retain the existing `runner-state.json` whose current
+   approved LOR is 6.6.10; do not initialize over it. Run launcher `Install`
+   and `PairServer`; do not manually create or paste a token.
+5. On `msb-prod-db`, run `install_lor_runner_pairing.py`, confirm its fingerprint
+   matches Windows, deploy backend V0.5.1 and report publisher V0.5.0 together,
+   and restart `lor-preflight-api.service`.
 6. Publish `landing/` plus the `preflight` HTML/CSS/JavaScript files to the NAS
    web path.
 7. Verify the Linux `/health` response, Windows runner health, dashboard runner
@@ -399,7 +410,7 @@ sudo -u lor-preflight test -r /opt/lor-preflight/publish_lor_reconciliation_repo
 curl -s http://192.168.5.9:8784/health
 ```
 
-The V0.5.0 health response must report `V0.5.0`. Retrying Finish for a run already in
+The V0.5.1 health response must report `V0.5.1`. Retrying Finish for a run already in
 `REPORTING` does not execute P1-P4 again; it retries report publication only.
 
 The successful final mount showed the NAS `web` share at `/mnt/msb-web`,

--- a/LOR2DB/Application/backend.py
+++ b/LOR2DB/Application/backend.py
@@ -3,7 +3,7 @@ MSB Database - LOR reconciliation preflight API
 backend.py
 
 Initial Release : 2026-08-05  V0.1.0
-Current Version : 2026-08-14  V0.5.0
+Current Version : 2026-08-14  V0.5.1
 Author          : GAL / OpenAI
 
 Purpose:
@@ -12,6 +12,9 @@ Purpose:
     append-only decisions, Finish, Cancel, and report completion.
 
 Revision History:
+    2026-08-14  GAL / OpenAI  V0.5.1
+        Forced internal Windows-runner requests to bypass process and system
+        HTTP proxies so the bearer credential cannot be stripped in transit.
     2026-08-14  GAL / OpenAI  V0.5.0
         Added explicit safe stage authority decisions, complete stage-group
         evidence, and a terminal cancellation response with its report URL.
@@ -62,14 +65,14 @@ from pathlib import Path
 from typing import Any, Iterator
 from urllib.parse import unquote, urlparse
 from urllib.error import HTTPError, URLError
-from urllib.request import Request, urlopen
+from urllib.request import ProxyHandler, Request, build_opener
 
 import psycopg2
 from flask import Flask, Response, jsonify, request
 from psycopg2.extras import RealDictCursor
 
 
-APP_VERSION = "V0.5.0"
+APP_VERSION = "V0.5.1"
 FALLBACK_ACTIONS = {"DEFER", "CORRECT_SOURCE_REQUIRED", "RESTORE_TO_LOR_REQUIRED"}
 STAGE_AUTHORITY_ACTIONS = {
     "APPROVE_STAGE_CHANGE", "ADD_NEW_STAGE",
@@ -84,6 +87,7 @@ ENTITY_VIEWS = {
 }
 
 app = Flask(__name__)
+DIRECT_RUNNER_OPENER = build_opener(ProxyHandler({}))
 
 OPEN_RUN_STATES = {
     "STARTING", "PREFLIGHT", "AWAITING_DECISIONS", "READY_TO_FINISH",
@@ -120,7 +124,9 @@ def runner_request(path: str, payload: dict[str, Any] | None = None,
         },
     )
     try:
-        with urlopen(request_object, timeout=timeout) as response:
+        # The runner is a fixed private-LAN dependency.  Never allow ambient
+        # HTTP_PROXY/HTTPS_PROXY settings to relay or rewrite its bearer header.
+        with DIRECT_RUNNER_OPENER.open(request_object, timeout=timeout) as response:
             result = json.loads(response.read().decode("utf-8"))
     except HTTPError as error:
         try:

--- a/LOR2DB/Application/install_lor_runner_pairing.py
+++ b/LOR2DB/Application/install_lor_runner_pairing.py
@@ -1,0 +1,190 @@
+"""Install a one-time Windows runner pairing secret into the Linux API env.
+
+The Windows launcher transfers the generated secret to a mode-0600 pending
+file through SSH.  This root-only installer atomically updates the protected
+API environment, removes the pending file, and reports only a SHA-256
+fingerprint.  It never prints or accepts the secret as a command-line value.
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import hashlib
+import ipaddress
+import os
+from pathlib import Path
+import re
+import shutil
+import stat
+import tempfile
+from urllib.parse import urlparse
+
+
+INSTALLER_VERSION = "V1.0.0"
+TOKEN_PATTERN = re.compile(r"[0-9a-fA-F]{64}")
+
+
+def credential_fingerprint(token: str) -> str:
+    """Match the safe fingerprint printed by the Windows runner."""
+    return hashlib.sha256(f"Bearer {token}".encode("utf-8")).hexdigest()[:16]
+
+
+def validate_runner_url(value: str) -> str:
+    """Allow only an uncredentialed HTTP URL to a private IP and fixed port."""
+    parsed = urlparse(value)
+    if (
+        parsed.scheme != "http"
+        or not parsed.hostname
+        or parsed.username
+        or parsed.password
+        or parsed.path not in ("", "/")
+        or parsed.query
+        or parsed.fragment
+        or parsed.port != 8791
+    ):
+        raise ValueError("Runner URL must be http://<private-ip>:8791")
+    try:
+        address = ipaddress.ip_address(parsed.hostname)
+    except ValueError as error:
+        raise ValueError("Runner URL must use a private IP address") from error
+    if not address.is_private:
+        raise ValueError("Runner URL must use a private IP address")
+    return value.rstrip("/")
+
+
+def upsert_environment(source: str, replacements: dict[str, str]) -> str:
+    """Replace named dotenv assignments once while preserving unrelated text."""
+    emitted: set[str] = set()
+    output: list[str] = []
+    for line in source.splitlines():
+        match = re.match(r"^([A-Za-z_][A-Za-z0-9_]*)=", line)
+        key = match.group(1) if match else None
+        if key in replacements:
+            if key not in emitted:
+                output.append(f"{key}={replacements[key]}")
+                emitted.add(key)
+        else:
+            output.append(line)
+    missing = [key for key in replacements if key not in emitted]
+    if missing:
+        if output and output[-1]:
+            output.append("")
+        output.extend(f"{key}={replacements[key]}" for key in missing)
+    return "\n".join(output) + "\n"
+
+
+def install_pairing(
+    pending_file: Path,
+    environment_file: Path,
+    runner_url: str,
+    *,
+    expected_pending_uid: int | None = None,
+) -> tuple[Path, str]:
+    """Consume a protected pending token and atomically update the API env."""
+    runner_url = validate_runner_url(runner_url)
+    for path, label in (
+        (pending_file, "Pending token file"),
+        (environment_file, "API environment file"),
+    ):
+        if path.is_symlink():
+            raise RuntimeError(f"{label} must not be a symbolic link: {path}")
+        if not path.is_file():
+            raise RuntimeError(f"{label} was not found: {path}")
+
+    pending_stat = pending_file.stat()
+    pending_mode = stat.S_IMODE(pending_stat.st_mode)
+    if pending_mode & 0o077:
+        raise RuntimeError("Pending token file must not be accessible by group or others")
+    if expected_pending_uid is not None and pending_stat.st_uid != expected_pending_uid:
+        raise RuntimeError("Pending token file is not owned by the invoking operator")
+
+    token = pending_file.read_text(encoding="utf-8").strip()
+    if not TOKEN_PATTERN.fullmatch(token):
+        raise RuntimeError("Pending token must contain exactly 64 hexadecimal characters")
+
+    environment_stat = environment_file.stat()
+    current = environment_file.read_text(encoding="utf-8")
+    updated = upsert_environment(current, {
+        "LOR_RUNNER_URL": runner_url,
+        "LOR_RUNNER_TOKEN": token,
+    })
+
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S-%fZ")
+    backup = environment_file.with_name(
+        f"{environment_file.name}.pre-runner-pairing-{stamp}.bak"
+    )
+    shutil.copy2(environment_file, backup)
+
+    temporary_name: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=environment_file.parent,
+            prefix=f".{environment_file.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temporary:
+            temporary.write(updated)
+            temporary.flush()
+            os.fsync(temporary.fileno())
+            temporary_name = temporary.name
+        os.chmod(temporary_name, stat.S_IMODE(environment_stat.st_mode))
+        os.chown(temporary_name, environment_stat.st_uid, environment_stat.st_gid)
+        os.replace(temporary_name, environment_file)
+        temporary_name = None
+    finally:
+        if temporary_name:
+            Path(temporary_name).unlink(missing_ok=True)
+
+    pending_file.unlink()
+    return backup, credential_fingerprint(token)
+
+
+def default_pending_file() -> Path:
+    operator = os.environ.get("SUDO_USER") or os.environ.get("USER") or "msbadmin"
+    return Path("/home") / operator / ".msb-lor-runner-token.pending"
+
+
+def command_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Install the protected LOR Windows-runner pairing secret"
+    )
+    parser.add_argument("--pending-file", type=Path)
+    parser.add_argument(
+        "--environment-file",
+        type=Path,
+        default=Path("/etc/msb/lor-preflight-api.env"),
+    )
+    parser.add_argument(
+        "--runner-url",
+        default="http://192.168.5.55:8791",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    arguments = command_parser().parse_args(argv)
+    if os.name != "nt" and os.geteuid() != 0:
+        raise SystemExit("Run this installer with sudo; no changes were made")
+    pending_file = arguments.pending_file or default_pending_file()
+    expected_uid = None
+    if os.environ.get("SUDO_UID"):
+        expected_uid = int(os.environ["SUDO_UID"])
+    backup, fingerprint = install_pairing(
+        pending_file.absolute(),
+        arguments.environment_file.absolute(),
+        arguments.runner_url,
+        expected_pending_uid=expected_uid,
+    )
+    print(f"[OK] LOR runner pairing installer {INSTALLER_VERSION} completed")
+    print(f"[OK] Credential fingerprint: {fingerprint}")
+    print(f"[OK] Previous environment backup: {backup}")
+    print("[INFO] Pending plaintext token file removed")
+    print("[INFO] Restart the API only after backend V0.5.1 is deployed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/LOR2DB/Application/lor-operator-runner.env.example
+++ b/LOR2DB/Application/lor-operator-runner.env.example
@@ -1,6 +1,7 @@
-# Windows service-account environment for lor_operator_runner.py.
-# Do not commit the real token or credentials.
-LOR_RUNNER_TOKEN=REPLACE_WITH_SAME_LONG_RANDOM_TOKEN
+# Reference values loaded by run_lor_runner.ps1. Do not copy this file into a
+# user profile or paste a token into it. The launcher stores the real token with
+# Windows DPAPI and injects it only into the runner process.
+LOR_RUNNER_TOKEN=MANAGED_BY_RUN_LOR_RUNNER_PS1
 LOR_PREVIEW_PARENT=G:\Shared drives\MSB Database
 LOR_SQLITE_OUTPUT=G:\Shared drives\MSB Database\database\lor_output_v7_scene.db
 LOR_RUNNER_REPORTS_ROOT=G:\Shared drives\MSB Database\LOR Version Reviews

--- a/LOR2DB/Application/test_backend.py
+++ b/LOR2DB/Application/test_backend.py
@@ -7,7 +7,7 @@ import tempfile
 import unittest
 from contextlib import contextmanager
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 os.environ.setdefault("LOR_PREFLIGHT_OPERATORS", "greg@sheboyganlights.org")
 
@@ -15,6 +15,29 @@ import backend  # noqa: E402  (environment must exist before app import)
 
 
 class BackendSafetyTests(unittest.TestCase):
+    def test_runner_request_uses_direct_opener_and_bearer_header(self) -> None:
+        response = MagicMock()
+        response.__enter__.return_value = response
+        response.read.return_value = b'{"status":"ok","version":"V1.3.0"}'
+        settings = {
+            "LOR_RUNNER_URL": "http://192.168.5.55:8791",
+            "LOR_RUNNER_TOKEN": "a" * 64,
+        }
+        with patch.dict(os.environ, settings), patch.object(
+            backend.DIRECT_RUNNER_OPENER,
+            "open",
+            return_value=response,
+        ) as direct_open:
+            result = backend.runner_request("health")
+
+        self.assertEqual(result["status"], "ok")
+        request_object = direct_open.call_args.args[0]
+        self.assertEqual(
+            request_object.get_header("Authorization"),
+            f"Bearer {settings['LOR_RUNNER_TOKEN']}",
+        )
+        self.assertEqual(direct_open.call_args.kwargs["timeout"], 30)
+
     def test_publish_report_requires_an_absolute_publisher_path(self) -> None:
         with patch.dict(os.environ, {"LOR_REPORT_PUBLISHER_PATH": "publisher.py"}):
             with self.assertRaisesRegex(RuntimeError, "must be an absolute path"):

--- a/LOR2DB/Application/test_install_lor_runner_pairing.py
+++ b/LOR2DB/Application/test_install_lor_runner_pairing.py
@@ -1,0 +1,91 @@
+"""Safety tests for the Linux-side runner pairing installer."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import stat
+import tempfile
+import unittest
+
+from install_lor_runner_pairing import (
+    credential_fingerprint,
+    install_pairing,
+    upsert_environment,
+    validate_runner_url,
+)
+
+
+class RunnerPairingInstallerTests(unittest.TestCase):
+    def test_environment_upsert_replaces_without_duplicates(self) -> None:
+        result = upsert_environment(
+            "KEEP=value\nLOR_RUNNER_TOKEN=old\nLOR_RUNNER_TOKEN=duplicate\n",
+            {
+                "LOR_RUNNER_URL": "http://192.168.5.55:8791",
+                "LOR_RUNNER_TOKEN": "a" * 64,
+            },
+        )
+        self.assertEqual(result.count("LOR_RUNNER_TOKEN="), 1)
+        self.assertEqual(result.count("LOR_RUNNER_URL="), 1)
+        self.assertIn("KEEP=value", result)
+
+    def test_installer_is_atomic_preserves_mode_and_consumes_pending(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            pending = root / "pending"
+            environment = root / "api.env"
+            token = "b" * 64
+            pending.write_text(token + "\n", encoding="utf-8")
+            environment.write_text("KEEP=value\n", encoding="utf-8")
+            pending.chmod(0o600)
+            environment.chmod(0o640)
+
+            backup, fingerprint = install_pairing(
+                pending,
+                environment,
+                "http://192.168.5.55:8791",
+                expected_pending_uid=os.getuid(),
+            )
+
+            self.assertFalse(pending.exists())
+            self.assertTrue(backup.is_file())
+            self.assertEqual(stat.S_IMODE(environment.stat().st_mode), 0o640)
+            installed = environment.read_text(encoding="utf-8")
+            self.assertIn("LOR_RUNNER_URL=http://192.168.5.55:8791", installed)
+            self.assertIn(f"LOR_RUNNER_TOKEN={token}", installed)
+            self.assertEqual(fingerprint, credential_fingerprint(token))
+            self.assertNotIn(token, str(backup))
+
+    def test_installer_rejects_exposed_pending_secret(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            pending = root / "pending"
+            environment = root / "api.env"
+            pending.write_text("c" * 64, encoding="utf-8")
+            environment.write_text("KEEP=value\n", encoding="utf-8")
+            pending.chmod(0o644)
+            with self.assertRaisesRegex(RuntimeError, "group or others"):
+                install_pairing(
+                    pending,
+                    environment,
+                    "http://192.168.5.55:8791",
+                )
+
+    def test_runner_url_must_be_private_fixed_port(self) -> None:
+        self.assertEqual(
+            validate_runner_url("http://192.168.5.55:8791"),
+            "http://192.168.5.55:8791",
+        )
+        for invalid in (
+            "https://192.168.5.55:8791",
+            "http://example.com:8791",
+            "http://8.8.8.8:8791",
+            "http://192.168.5.55:80",
+            "http://user:pass@192.168.5.55:8791",
+        ):
+            with self.subTest(invalid=invalid), self.assertRaises(ValueError):
+                validate_runner_url(invalid)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,8 @@ V7 is the current supported breakpoint. Superseded V6, spreadsheet, Excel-report
 
 ## Production LOR-to-database flow
 
-The repository root provides two operator launchers for the two separate manual steps:
+The repository root provides two operator launchers for the two separate manual
+data steps:
 
 ```powershell
 .\run_parse_props.ps1
@@ -26,6 +27,17 @@ The repository root provides two operator launchers for the two separate manual 
 ```
 
 They are intentionally separate. Running the parser does **not** automatically ingest anything into PostgreSQL.
+
+The restricted website runner has its own root management launcher:
+
+```powershell
+.\run_lor_runner.ps1 -Action Status
+```
+
+`run_lor_runner.ps1` installs and starts the internal Windows service boundary;
+it does not run the parser merely because the runner starts. Its protected
+token is generated once, stored with Windows DPAPI, and paired to the Linux API
+through SSH without copying the secret through operator commands.
 
 ```text
 Authoritative LOR previews

--- a/run_lor_runner.ps1
+++ b/run_lor_runner.ps1
@@ -1,0 +1,339 @@
+# MSB LOR operator-runner launcher
+#
+# Purpose:
+#   Install, pair, start, and inspect the restricted Windows/G-drive runner
+#   used by the authenticated LOR2DB website.
+#
+# Security:
+#   The shared bearer token is generated once and stored with Windows DPAPI.
+#   It is never printed or accepted as a command-line argument. PairServer
+#   transfers it through SSH to a mode-0600 pending file for root installation.
+
+[CmdletBinding()]
+param(
+    [ValidateSet('Install', 'PairServer', 'Start', 'Status')]
+    [string]$Action = 'Status',
+
+    [string]$RunnerHost = '192.168.5.55',
+    [ValidateRange(1, 65535)]
+    [int]$Port = 8791,
+
+    [string]$Server = 'msbadmin@192.168.5.9',
+
+    [string]$StateFile = 'G:\Shared drives\MSB Database\LOR Version Reviews\runner-state.json',
+
+    [switch]$RotateToken
+)
+
+$ErrorActionPreference = 'Stop'
+$TaskName = 'MSB LOR Operator Runner'
+$RepoRoot = $PSScriptRoot
+$RunnerPath = Join-Path $RepoRoot `
+    'Docs\01_LOR_System\02_Data_Extraction\Parser\lor_operator_runner.py'
+$ParserPath = Join-Path $RepoRoot `
+    'Docs\01_LOR_System\02_Data_Extraction\Parser\parse_props_v7_scene_parser.py'
+$CheckerPath = Join-Path $RepoRoot `
+    'Docs\01_LOR_System\02_Data_Extraction\Parser\lor_version_checker.py'
+$PythonPath = Join-Path $RepoRoot '.venv\Scripts\python.exe'
+$SecretRoot = Join-Path $env:LOCALAPPDATA 'MSB\LORRunner'
+$SecretPath = Join-Path $SecretRoot 'runner-token.dpapi'
+$ServiceLogPath = Join-Path $SecretRoot 'runner-service.log'
+$PendingRemotePath = '~/.msb-lor-runner-token.pending'
+
+function Get-TokenFingerprint {
+    param([Parameter(Mandatory = $true)][string]$Token)
+
+    $sha = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        $bytes = [System.Text.Encoding]::UTF8.GetBytes("Bearer $Token")
+        $digest = $sha.ComputeHash($bytes)
+        return (-join ($digest | ForEach-Object { $_.ToString('x2') })).Substring(0, 16)
+    }
+    finally {
+        $sha.Dispose()
+    }
+}
+
+function New-RunnerToken {
+    $bytes = New-Object byte[] 32
+    $generator = [System.Security.Cryptography.RandomNumberGenerator]::Create()
+    try {
+        $generator.GetBytes($bytes)
+        return -join ($bytes | ForEach-Object { $_.ToString('x2') })
+    }
+    finally {
+        $generator.Dispose()
+    }
+}
+
+function Set-SecretAcl {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    $identity = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+    $acl = New-Object System.Security.AccessControl.FileSecurity
+    $acl.SetAccessRuleProtection($true, $false)
+    $acl.AddAccessRule(([System.Security.AccessControl.FileSystemAccessRule]::new(
+        $identity,
+        [System.Security.AccessControl.FileSystemRights]::FullControl,
+        [System.Security.AccessControl.AccessControlType]::Allow
+    )))
+    $acl.AddAccessRule(([System.Security.AccessControl.FileSystemAccessRule]::new(
+        'NT AUTHORITY\SYSTEM',
+        [System.Security.AccessControl.FileSystemRights]::FullControl,
+        [System.Security.AccessControl.AccessControlType]::Allow
+    )))
+    Set-Acl -LiteralPath $Path -AclObject $acl
+}
+
+function Save-ProtectedToken {
+    param([Parameter(Mandatory = $true)][string]$Token)
+
+    if ($Token -notmatch '^[0-9a-fA-F]{64}$') {
+        throw 'Runner token must contain exactly 64 hexadecimal characters.'
+    }
+    New-Item -ItemType Directory -Force -Path $SecretRoot | Out-Null
+    $secureToken = ConvertTo-SecureString -String $Token -AsPlainText -Force
+    $encrypted = ConvertFrom-SecureString -SecureString $secureToken
+    Set-Content -LiteralPath $SecretPath -Value $encrypted -Encoding ASCII -NoNewline
+    Set-SecretAcl -Path $SecretPath
+}
+
+function Read-ProtectedToken {
+    if (-not (Test-Path -LiteralPath $SecretPath -PathType Leaf)) {
+        throw "Runner is not installed. Protected token was not found: $SecretPath"
+    }
+    $encrypted = (Get-Content -LiteralPath $SecretPath -Raw).Trim()
+    $secureToken = ConvertTo-SecureString -String $encrypted
+    $pointer = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secureToken)
+    try {
+        $token = [Runtime.InteropServices.Marshal]::PtrToStringBSTR($pointer)
+    }
+    finally {
+        [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($pointer)
+    }
+    if ($token -notmatch '^[0-9a-fA-F]{64}$') {
+        throw 'Protected runner token is invalid or belongs to another Windows account.'
+    }
+    return $token
+}
+
+function Assert-RunnerPrerequisites {
+    foreach ($requiredPath in @(
+        $StateFile,
+        $RunnerPath,
+        $ParserPath,
+        $CheckerPath,
+        $PythonPath
+    )) {
+        if (-not (Test-Path -LiteralPath $requiredPath -PathType Leaf)) {
+            throw "Required runner file was not found: $requiredPath"
+        }
+    }
+    $state = Get-Content -LiteralPath $StateFile -Raw | ConvertFrom-Json
+    if (-not $state.current_lor_version -or -not $state.current_preview_folder) {
+        throw 'Existing runner state does not identify the approved Current LOR source.'
+    }
+    if (-not (Test-Path -LiteralPath $state.current_preview_folder -PathType Container)) {
+        throw "Approved Current LOR folder is unavailable: $($state.current_preview_folder)"
+    }
+    if (-not (Test-Path -LiteralPath $state.current_manifest_path -PathType Leaf)) {
+        throw "Approved Current LOR manifest is unavailable: $($state.current_manifest_path)"
+    }
+    return $state
+}
+
+function Test-AuthenticatedHealth {
+    param([Parameter(Mandatory = $true)][string]$Token)
+
+    $request = [System.Net.HttpWebRequest]::Create(
+        "http://${RunnerHost}:$Port/health"
+    )
+    $request.Method = 'GET'
+    $request.Proxy = $null
+    $request.Timeout = 5000
+    $request.Headers.Add('Authorization', "Bearer $Token")
+    $response = $null
+    try {
+        $response = $request.GetResponse()
+        $reader = New-Object System.IO.StreamReader($response.GetResponseStream())
+        try {
+            return ($reader.ReadToEnd() | ConvertFrom-Json)
+        }
+        finally {
+            $reader.Dispose()
+        }
+    }
+    finally {
+        if ($response) {
+            $response.Dispose()
+        }
+    }
+}
+
+function Install-ScheduledRunner {
+    $account = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+    $arguments = "-NoProfile -ExecutionPolicy Bypass -File `"$PSCommandPath`" " +
+        "-Action Start -RunnerHost $RunnerHost -Port $Port " +
+        "-StateFile `"$StateFile`""
+    $taskAction = New-ScheduledTaskAction `
+        -Execute 'powershell.exe' `
+        -Argument $arguments `
+        -WorkingDirectory $RepoRoot
+    $trigger = New-ScheduledTaskTrigger -AtLogOn -User $account
+    $principal = New-ScheduledTaskPrincipal `
+        -UserId $account `
+        -LogonType Interactive `
+        -RunLevel Limited
+    $settings = New-ScheduledTaskSettingsSet `
+        -StartWhenAvailable `
+        -RestartCount 3 `
+        -RestartInterval (New-TimeSpan -Minutes 1) `
+        -ExecutionTimeLimit ([TimeSpan]::Zero) `
+        -MultipleInstances IgnoreNew
+    Register-ScheduledTask `
+        -TaskName $TaskName `
+        -Action $taskAction `
+        -Trigger $trigger `
+        -Principal $principal `
+        -Settings $settings `
+        -Description 'Restricted LOR2DB parser/version-check runner; requires Greg logon and G: drive.' `
+        -Force | Out-Null
+}
+
+function Start-InstalledRunner {
+    param([Parameter(Mandatory = $true)][string]$Token)
+
+    $existingTask = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+    if (-not $existingTask) {
+        throw "Scheduled Task is not installed: $TaskName"
+    }
+    Start-ScheduledTask -TaskName $TaskName
+    $lastError = $null
+    foreach ($attempt in 1..10) {
+        Start-Sleep -Seconds 1
+        try {
+            $health = Test-AuthenticatedHealth -Token $Token
+            Write-Host "[OK] Local authenticated health: $($health.status) $($health.version)"
+            return
+        }
+        catch {
+            $lastError = $_.Exception.Message
+        }
+    }
+    throw "Runner task did not pass local health within 10 seconds: $lastError"
+}
+
+switch ($Action) {
+    'Install' {
+        Assert-RunnerPrerequisites | Out-Null
+        $existingTask = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+        if ($existingTask -and $existingTask.State -eq 'Running') {
+            Stop-ScheduledTask -TaskName $TaskName
+            Start-Sleep -Seconds 1
+        }
+        $listener = Get-NetTCPConnection `
+            -LocalPort $Port `
+            -State Listen `
+            -ErrorAction SilentlyContinue
+        if ($listener) {
+            throw "Port $Port is already in use. Stop the manually started runner first."
+        }
+        if ((Test-Path -LiteralPath $SecretPath) -and -not $RotateToken) {
+            $token = Read-ProtectedToken
+            Write-Host '[INFO] Existing protected runner token retained.'
+        }
+        else {
+            $token = New-RunnerToken
+            Save-ProtectedToken -Token $token
+            Write-Host '[OK] New runner token generated and protected with Windows DPAPI.'
+        }
+        Install-ScheduledRunner
+        Write-Host "[OK] Scheduled Task installed for logged-in account: $TaskName"
+        Write-Host "[OK] Credential fingerprint: $(Get-TokenFingerprint -Token $token)"
+        Start-InstalledRunner -Token $token
+        Write-Host '[NEXT] Run: .\run_lor_runner.ps1 -Action PairServer'
+        Remove-Variable token -ErrorAction SilentlyContinue
+    }
+
+    'PairServer' {
+        $token = Read-ProtectedToken
+        $ssh = Get-Command ssh -ErrorAction SilentlyContinue
+        if (-not $ssh) {
+            throw 'Windows OpenSSH client was not found.'
+        }
+        Write-Host "[INFO] Transferring protected pairing material to $Server through SSH."
+        $token | & $ssh.Source $Server `
+            "umask 077; cat > $PendingRemotePath"
+        if ($LASTEXITCODE -ne 0) {
+            throw 'SSH pairing transfer failed; the Linux API environment was not changed.'
+        }
+        Write-Host '[OK] Pairing token transferred to a mode-0600 pending file.'
+        Write-Host "[OK] Credential fingerprint: $(Get-TokenFingerprint -Token $token)"
+        Write-Host '[NEXT] From the repository root on msb-prod-db, run:'
+        Write-Host 'sudo python3 LOR2DB/Application/install_lor_runner_pairing.py'
+        Remove-Variable token -ErrorAction SilentlyContinue
+    }
+
+    'Start' {
+        $state = Assert-RunnerPrerequisites
+        $listener = Get-NetTCPConnection `
+            -LocalPort $Port `
+            -State Listen `
+            -ErrorAction SilentlyContinue
+        if ($listener) {
+            throw "Port $Port already has a listener; a second runner was not started."
+        }
+        $token = Read-ProtectedToken
+        $env:LOR_RUNNER_TOKEN = $token
+        $env:LOR_PREVIEW_PARENT = 'G:\Shared drives\MSB Database'
+        $env:LOR_SQLITE_OUTPUT =
+            'G:\Shared drives\MSB Database\database\lor_output_v7_scene.db'
+        $env:LOR_RUNNER_REPORTS_ROOT =
+            'G:\Shared drives\MSB Database\LOR Version Reviews'
+        $env:LOR_PARSER_PATH = $ParserPath
+        $env:LOR_CHECKER_PATH = $CheckerPath
+        Write-Host "[INFO] Approved Current LOR: $($state.current_lor_version)"
+        Write-Host "[INFO] Credential fingerprint: $(Get-TokenFingerprint -Token $token)"
+        Write-Host '[INFO] Starting restricted runner. Parser and ingest remain idle.'
+        New-Item -ItemType Directory -Force -Path $SecretRoot | Out-Null
+        & $PythonPath $RunnerPath serve `
+            --state-file $StateFile `
+            --host $RunnerHost `
+            --port $Port 2>&1 | Tee-Object -FilePath $ServiceLogPath -Append
+        exit $LASTEXITCODE
+    }
+
+    'Status' {
+        Write-Host "Task: $TaskName"
+        $task = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+        if ($task) {
+            Write-Host "Scheduled Task state: $($task.State)"
+        }
+        else {
+            Write-Host 'Scheduled Task state: NOT INSTALLED'
+        }
+        if (-not (Test-Path -LiteralPath $SecretPath -PathType Leaf)) {
+            Write-Host 'Protected token: NOT INSTALLED'
+            exit 3
+        }
+        $token = Read-ProtectedToken
+        Write-Host 'Protected token: AVAILABLE'
+        Write-Host "Credential fingerprint: $(Get-TokenFingerprint -Token $token)"
+        try {
+            $health = Test-AuthenticatedHealth -Token $token
+            Write-Host "Runner health: $($health.status)"
+            Write-Host "Runner version: $($health.version)"
+        }
+        catch {
+            Write-Host "Runner health: OFFLINE OR REJECTED — $($_.Exception.Message)"
+            if (Test-Path -LiteralPath $ServiceLogPath -PathType Leaf) {
+                Write-Host "Recent runner log: $ServiceLogPath"
+                Get-Content -LiteralPath $ServiceLogPath -Tail 10
+            }
+            exit 4
+        }
+        finally {
+            Remove-Variable token -ErrorAction SilentlyContinue
+        }
+    }
+}


### PR DESCRIPTION
## What changed

- adds a repository-root Windows runner manager with Install, PairServer, Start, and Status actions
- generates one runner credential, protects it with Windows DPAPI, and transfers it to the server through SSH without manual token copying
- installs a logged-in-user Scheduled Task so screen lock does not stop the runner
- adds a root-only Linux pairing installer that atomically updates the protected API environment and removes the pending plaintext token
- makes the Linux backend bypass ambient HTTP proxies for the fixed private runner connection
- adds non-secret credential fingerprints to both sides for reliable authentication diagnosis
- documents the explicit reboot boundary: Greg must sign in and restore the mapped G: drive

## Why

Manual token entry repeatedly produced unexplained 401 responses and was too error-prone for production operation. The website runner also needs a defined startup and recovery method that preserves the parser’s ownership under the LOR data-extraction subsystem.

## Safety and operator impact

Starting the runner does not run the parser, ingest PostgreSQL, or start reconciliation. Existing SQLite and PostgreSQL data remain unchanged. After a Windows reboot, the website reports the runner offline until Greg signs in and G: is available.

## Validation

- Parser: 21 tests passed
- LOR2DB Application: 33 tests passed
- Reporting: 15 tests passed
- Total: 69 tests passed
- Python compilation passed
- `git diff --check` passed

Windows PowerShell 5.1 Scheduled Task installation and the Linux pairing/restart sequence still require acceptance testing after merge.