### PR TITLE
Fix Windows PowerShell runner encoding

### DIFF
--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/test_lor_operator_runner.py
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/test_lor_operator_runner.py
@@ -60,6 +60,11 @@ class OperatorRunnerTests(unittest.TestCase):
         self.assertNotIn(token, first)
         self.assertEqual(runner_module.credential_fingerprint(""), "missing")
 
+    def test_windows_launcher_is_ascii_for_powershell_51(self) -> None:
+        """Windows PowerShell 5.1 misreads BOM-less UTF-8 punctuation."""
+        launcher = Path(__file__).resolve().parents[4] / "run_lor_runner.ps1"
+        launcher.read_bytes().decode("ascii")
+
     def test_candidate_is_resolved_only_from_versioned_preview_root(self) -> None:
         state = self.runner.select_candidate("6.6.10", "operator@example.com")
         self.assertEqual(state["new_lor_version"], "6.6.10")

--- a/run_lor_runner.ps1
+++ b/run_lor_runner.ps1
@@ -325,7 +325,7 @@ switch ($Action) {
             Write-Host "Runner version: $($health.version)"
         }
         catch {
-            Write-Host "Runner health: OFFLINE OR REJECTED — $($_.Exception.Message)"
+            Write-Host "Runner health: OFFLINE OR REJECTED - $($_.Exception.Message)"
             if (Test-Path -LiteralPath $ServiceLogPath -PathType Leaf) {
                 Write-Host "Recent runner log: $ServiceLogPath"
                 Get-Content -LiteralPath $ServiceLogPath -Tail 10


### PR DESCRIPTION
## Fix

Windows PowerShell 5.1 interpreted one BOM-less UTF-8 em dash in `run_lor_runner.ps1` incorrectly and reported a false unterminated string near the Status output.

This hotfix:

- replaces that character with an ASCII hyphen
- adds a regression test requiring the entire Windows launcher to decode as ASCII

## Impact

The previous launcher never executed on the Office PC because parsing failed first. No token, Scheduled Task, parser run, ingest, database write, or reconciliation was created.

## Validation

- launcher contains no non-ASCII bytes
- 22 parser/runner tests passed
- `git diff --check` passed