### PR TITLE
Harden LOR runner task lifecycle

### DIFF
--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/test_lor_operator_runner.py
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/test_lor_operator_runner.py
@@ -63,7 +63,11 @@ class OperatorRunnerTests(unittest.TestCase):
     def test_windows_launcher_is_ascii_for_powershell_51(self) -> None:
         """Windows PowerShell 5.1 misreads BOM-less UTF-8 punctuation."""
         launcher = Path(__file__).resolve().parents[4] / "run_lor_runner.ps1"
-        launcher.read_bytes().decode("ascii")
+        source = launcher.read_bytes().decode("ascii")
+        self.assertIn("PYTHONUNBUFFERED", source)
+        self.assertIn("START FAILED", source)
+        self.assertIn("AllowStartIfOnBatteries", source)
+        self.assertIn("DontStopIfGoingOnBatteries", source)
 
     def test_candidate_is_resolved_only_from_versioned_preview_root(self) -> None:
         state = self.runner.select_candidate("6.6.10", "operator@example.com")

--- a/run_lor_runner.ps1
+++ b/run_lor_runner.ps1
@@ -40,6 +40,17 @@ $SecretPath = Join-Path $SecretRoot 'runner-token.dpapi'
 $ServiceLogPath = Join-Path $SecretRoot 'runner-service.log'
 $PendingRemotePath = '~/.msb-lor-runner-token.pending'
 
+function Write-ServiceLog {
+    param([Parameter(Mandatory = $true)][string]$Message)
+
+    New-Item -ItemType Directory -Force -Path $SecretRoot | Out-Null
+    $timestamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+    Add-Content `
+        -LiteralPath $ServiceLogPath `
+        -Value "[$timestamp] $Message" `
+        -Encoding UTF8
+}
+
 function Get-TokenFingerprint {
     param([Parameter(Mandatory = $true)][string]$Token)
 
@@ -186,6 +197,8 @@ function Install-ScheduledRunner {
         -RunLevel Limited
     $settings = New-ScheduledTaskSettingsSet `
         -StartWhenAvailable `
+        -AllowStartIfOnBatteries `
+        -DontStopIfGoingOnBatteries `
         -RestartCount 3 `
         -RestartInterval (New-TimeSpan -Minutes 1) `
         -ExecutionTimeLimit ([TimeSpan]::Zero) `
@@ -275,32 +288,52 @@ switch ($Action) {
     }
 
     'Start' {
-        $state = Assert-RunnerPrerequisites
-        $listener = Get-NetTCPConnection `
-            -LocalPort $Port `
-            -State Listen `
-            -ErrorAction SilentlyContinue
-        if ($listener) {
-            throw "Port $Port already has a listener; a second runner was not started."
+        Write-ServiceLog "Start requested for ${RunnerHost}:$Port."
+        try {
+            $state = Assert-RunnerPrerequisites
+            Write-ServiceLog (
+                "Prerequisites passed for approved LOR " +
+                "$($state.current_lor_version)."
+            )
+            $listener = Get-NetTCPConnection `
+                -LocalPort $Port `
+                -State Listen `
+                -ErrorAction SilentlyContinue
+            if ($listener) {
+                throw "Port $Port already has a listener; a second runner was not started."
+            }
+            $token = Read-ProtectedToken
+            $env:LOR_RUNNER_TOKEN = $token
+            $env:LOR_PREVIEW_PARENT = 'G:\Shared drives\MSB Database'
+            $env:LOR_SQLITE_OUTPUT =
+                'G:\Shared drives\MSB Database\database\lor_output_v7_scene.db'
+            $env:LOR_RUNNER_REPORTS_ROOT =
+                'G:\Shared drives\MSB Database\LOR Version Reviews'
+            $env:LOR_PARSER_PATH = $ParserPath
+            $env:LOR_CHECKER_PATH = $CheckerPath
+            $env:PYTHONUNBUFFERED = '1'
+            Write-ServiceLog (
+                "Starting runner V1.3.0; credential fingerprint=" +
+                "$(Get-TokenFingerprint -Token $token)."
+            )
+            & $PythonPath -u $RunnerPath serve `
+                --state-file $StateFile `
+                --host $RunnerHost `
+                --port $Port 2>&1 | Tee-Object -FilePath $ServiceLogPath -Append
+            $runnerExitCode = $LASTEXITCODE
+            Write-ServiceLog "Runner process exited with code $runnerExitCode."
+            exit $runnerExitCode
         }
-        $token = Read-ProtectedToken
-        $env:LOR_RUNNER_TOKEN = $token
-        $env:LOR_PREVIEW_PARENT = 'G:\Shared drives\MSB Database'
-        $env:LOR_SQLITE_OUTPUT =
-            'G:\Shared drives\MSB Database\database\lor_output_v7_scene.db'
-        $env:LOR_RUNNER_REPORTS_ROOT =
-            'G:\Shared drives\MSB Database\LOR Version Reviews'
-        $env:LOR_PARSER_PATH = $ParserPath
-        $env:LOR_CHECKER_PATH = $CheckerPath
-        Write-Host "[INFO] Approved Current LOR: $($state.current_lor_version)"
-        Write-Host "[INFO] Credential fingerprint: $(Get-TokenFingerprint -Token $token)"
-        Write-Host '[INFO] Starting restricted runner. Parser and ingest remain idle.'
-        New-Item -ItemType Directory -Force -Path $SecretRoot | Out-Null
-        & $PythonPath $RunnerPath serve `
-            --state-file $StateFile `
-            --host $RunnerHost `
-            --port $Port 2>&1 | Tee-Object -FilePath $ServiceLogPath -Append
-        exit $LASTEXITCODE
+        catch {
+            $failure = $_.Exception.Message
+            Write-ServiceLog "START FAILED: $failure"
+            Write-Error $failure
+            exit 1
+        }
+        finally {
+            Remove-Item Env:\LOR_RUNNER_TOKEN -ErrorAction SilentlyContinue
+            Remove-Variable token -ErrorAction SilentlyContinue
+        }
     }
 
     'Status' {


### PR DESCRIPTION
## Fix

The managed runner passed its initial local health check but the Scheduled Task later exited with result 1. Startup failures occurred before the existing Python-output log was created, leaving no diagnostic evidence.

This change:

- writes startup milestones before prerequisite checks and Python launch
- records the exact failure when startup aborts
- forces unbuffered Python output so runner diagnostics reach disk immediately
- records the runner process exit code
- prevents Windows' default battery transition rules from stopping this service task
- clears the token from the process environment during shutdown
- extends the Windows launcher regression test

## Impact

The currently installed task is offline. The Linux API and published V0.5.1 website remain healthy; parser, ingest, SQLite, PostgreSQL, and reconciliation were not run.

## Validation

- 22 parser/runner tests passed
- launcher is ASCII-only for Windows PowerShell 5.1
- `git diff --check` passed