### PR TITLE
Handle runner access logs without exit

### DIFF
--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/test_lor_operator_runner.py
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/test_lor_operator_runner.py
@@ -68,6 +68,8 @@ class OperatorRunnerTests(unittest.TestCase):
         self.assertIn("START FAILED", source)
         self.assertIn("AllowStartIfOnBatteries", source)
         self.assertIn("DontStopIfGoingOnBatteries", source)
+        self.assertIn("savedErrorActionPreference", source)
+        self.assertIn("native process exit code remains authoritative", source)
 
     def test_candidate_is_resolved_only_from_versioned_preview_root(self) -> None:
         state = self.runner.select_candidate("6.6.10", "operator@example.com")

--- a/run_lor_runner.ps1
+++ b/run_lor_runner.ps1
@@ -316,11 +316,23 @@ switch ($Action) {
                 "Starting runner V1.3.0; credential fingerprint=" +
                 "$(Get-TokenFingerprint -Token $token)."
             )
-            & $PythonPath -u $RunnerPath serve `
-                --state-file $StateFile `
-                --host $RunnerHost `
-                --port $Port 2>&1 | Tee-Object -FilePath $ServiceLogPath -Append
-            $runnerExitCode = $LASTEXITCODE
+            # BaseHTTPRequestHandler writes normal HTTP access records to
+            # stderr. Windows PowerShell converts redirected native stderr to
+            # ErrorRecord objects; the global Stop preference would otherwise
+            # terminate this healthy long-running process after its first
+            # request. The native process exit code remains authoritative.
+            $savedErrorActionPreference = $ErrorActionPreference
+            try {
+                $ErrorActionPreference = 'Continue'
+                & $PythonPath -u $RunnerPath serve `
+                    --state-file $StateFile `
+                    --host $RunnerHost `
+                    --port $Port 2>&1 | Tee-Object -FilePath $ServiceLogPath -Append
+                $runnerExitCode = $LASTEXITCODE
+            }
+            finally {
+                $ErrorActionPreference = $savedErrorActionPreference
+            }
             Write-ServiceLog "Runner process exited with code $runnerExitCode."
             exit $runnerExitCode
         }


### PR DESCRIPTION
## Fix

The scheduled runner was healthy and returned HTTP 200, but Python's normal `BaseHTTPRequestHandler` access record is written to native `stderr`. Windows PowerShell 5.1 converted that redirected record into a PowerShell error, and the launcher's global `ErrorActionPreference = Stop` terminated the long-running process.

This change:

- temporarily uses `Continue` only while the native Python server is running
- continues writing both stdout and stderr to the service log
- restores the launcher's strict error preference afterward
- keeps the Python process exit code as the authoritative success/failure result
- extends the PowerShell launcher regression contract

## Evidence

The recorded failure itself was a successful request:

`GET /health HTTP/1.1 200`

## Impact

No token rotation, server pairing, API deployment, parser run, ingest, SQLite change, PostgreSQL write, or reconciliation is required.

## Validation

- 22 parser/runner tests passed
- launcher remains ASCII-only for Windows PowerShell 5.1
- `git diff --check` passed