### PR TITLE
Hide LOR runner console and normalize access logs

### DIFF
--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/lor_operator_runner.py
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/lor_operator_runner.py
@@ -755,7 +755,12 @@ class RequestHandler(BaseHTTPRequestHandler):
         return self.server.runner  # type: ignore[attr-defined]
 
     def log_message(self, format_string: str, *args: Any) -> None:
-        sys.stderr.write(f"[{self.log_date_time_string()}] {format_string % args}\n")
+        """Write normal HTTP access records to the managed stdout log."""
+        print(
+            f"{self.address_string()} - - [{self.log_date_time_string()}] "
+            f"{format_string % args}",
+            flush=True,
+        )
 
     def authorized(self) -> bool:
         expected = f"Bearer {required_environment('LOR_RUNNER_TOKEN')}"

--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/test_lor_operator_runner.py
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/test_lor_operator_runner.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import argparse
-from contextlib import closing
+from contextlib import closing, redirect_stderr, redirect_stdout
+import io
 import json
 import os
 import sqlite3
@@ -70,6 +71,21 @@ class OperatorRunnerTests(unittest.TestCase):
         self.assertIn("DontStopIfGoingOnBatteries", source)
         self.assertIn("savedErrorActionPreference", source)
         self.assertIn("native process exit code remains authoritative", source)
+        self.assertIn("WindowStyle Hidden", source)
+
+    def test_http_access_log_uses_stdout_not_stderr(self) -> None:
+        """A successful request must not become a PowerShell native error."""
+        handler = object.__new__(runner_module.RequestHandler)
+        handler.address_string = lambda: "192.168.5.9"
+        handler.log_date_time_string = lambda: "15/Aug/2026 09:08:51"
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            handler.log_message('"GET /health HTTP/1.1" %d -', 200)
+
+        self.assertIn('"GET /health HTTP/1.1" 200 -', stdout.getvalue())
+        self.assertEqual(stderr.getvalue(), "")
 
     def test_candidate_is_resolved_only_from_versioned_preview_root(self) -> None:
         state = self.runner.select_candidate("6.6.10", "operator@example.com")

--- a/run_lor_runner.ps1
+++ b/run_lor_runner.ps1
@@ -183,7 +183,8 @@ function Test-AuthenticatedHealth {
 
 function Install-ScheduledRunner {
     $account = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
-    $arguments = "-NoProfile -ExecutionPolicy Bypass -File `"$PSCommandPath`" " +
+    $arguments = "-NoProfile -WindowStyle Hidden " +
+        "-ExecutionPolicy Bypass -File `"$PSCommandPath`" " +
         "-Action Start -RunnerHost $RunnerHost -Port $Port " +
         "-StateFile `"$StateFile`""
     $taskAction = New-ScheduledTaskAction `


### PR DESCRIPTION
## Summary

The scheduled runner now survives repeated health checks, but its PowerShell host remains visible and successful HTTP access records are rendered as PowerShell native errors.

This change:

- launches the scheduled task with `-WindowStyle Hidden`
- sends normal HTTP access records to stdout instead of stderr
- preserves stderr for actual runner errors
- adds regression coverage for the hidden task argument and stdout-only access logging

## Verification

- 23 parser/runner tests passed
- Windows launcher remains ASCII-only for Windows PowerShell 5.1
- `git diff --check` passed

## Scope

No token rotation or re-pairing. No API, database, parser output, ingest, or reconciliation changes. Reinstalling the existing runner task retains the protected DPAPI token.