### PR TITLE
Separate parser and LOR version workflows

### DIFF
--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/README.md
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/README.md
@@ -10,7 +10,7 @@ tools for operator convenience but does not own their XML interpretation.
 |---|---|
 | `parse_props_v7_scene_parser.py` | Canonical V7 parser; atomically publishes only a fully validated SQLite snapshot |
 | `lor_version_checker.py` | Parser-independent complete XML manifest and Current/New LOR compatibility comparison |
-| `lor_operator_runner.py` | Restricted Windows/G-drive API, candidate stale-manifest guard, approved-version structural guard, and same-parser SQLite output comparison used by the authenticated LOR2DB website |
+| `lor_operator_runner.py` | Restricted Windows/G-drive API, single-operation lock, durable read-only parser console record, candidate stale-manifest guard, approved-version structural guard, and same-parser SQLite output comparison used by the authenticated LOR2DB website |
 | `test_lor_version_checker.py` | Regression tests for Scene count/structure, unused fields, ChannelGrid, and other delimiter-position changes |
 | `test_lor_operator_runner.py` | Regression tests for version-scoped paths, stale manifests, SQLite output comparison, Revision handling, and approval history |
 | `test_parse_props_console_encoding.py` | Regression test preventing Windows console/log encoding from aborting parser execution |
@@ -23,9 +23,17 @@ assemble runner environment variables or tokens manually.
 
 ## Operating Boundary
 
-Use the LOR2DB website for normal version checks and parser runs. Direct command
-line execution remains supported for engineering and recovery. Parser execution
-never starts PostgreSQL ingest.
+Use the main LOR2DB parser page for normal repeatable production SQLite builds.
+Use the separate guided version-check page only when evaluating a different LOR
+software version. Direct command-line execution remains supported for
+engineering and recovery. Parser execution never starts PostgreSQL ingest.
+
+The runner accepts only one state-changing or parser request at a time. A
+second request is rejected instead of queued. Each browser parser attempt
+records its terminal status and complete console output in the version review
+tree; the API returns a bounded read-only copy for diagnosis. Restarting the
+runner changes any stale `RUNNING` marker to `INTERRUPTED` rather than leaving
+the website in a false running state.
 
 An approved Current LOR folder may receive ordinary preview-authoring edits and
 be parsed repeatedly. Each run rebuilds the live manifest and rejects only a

--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/lor_operator_runner.py
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/lor_operator_runner.py
@@ -30,7 +30,8 @@ from urllib.parse import urlparse
 from lor_version_checker import build_manifest, compare_manifests, manifest_source_signature, write_json
 
 
-RUNNER_VERSION = "V1.3.0"
+RUNNER_VERSION = "V1.4.0"
+MAX_BROWSER_CONSOLE_CHARACTERS = 500_000
 
 AUTHORITATIVE_OUTPUT_TABLES = (
     "props",
@@ -413,9 +414,107 @@ class Runner:
         for script in (self.parser_path, self.checker_path):
             if not script.is_file():
                 raise RuntimeError(f"Runner executable is missing: {script}")
+        self._mark_interrupted_parser_activity()
+
+    def _mark_interrupted_parser_activity(self) -> None:
+        """Make a stale RUNNING marker truthful after a runner restart."""
+        state = self.store.read()
+        activity = state.get("parser_activity") or {}
+        if activity.get("status") != "RUNNING":
+            return
+
+        def operation(current: dict[str, Any]) -> None:
+            stale = current.get("parser_activity") or {}
+            if stale.get("status") == "RUNNING":
+                stale.update({
+                    "status": "INTERRUPTED",
+                    "completed_at": utc_now(),
+                    "error": "The runner restarted before this parser operation completed.",
+                })
+                current["parser_activity"] = stale
+
+        self.store.update(operation)
+
+    def _start_parser_activity(
+        self, target: str, version: str, folder: Path, actor: str
+    ) -> tuple[dict[str, Any], Path]:
+        """Record one recoverable browser-visible parser attempt."""
+        stamp = datetime.now().strftime("%Y%m%d-%H%M%S-%f")
+        log_path = (
+            self.reports_root / f"V{version}" / "browser-parser-runs" /
+            f"{target}-{stamp}.log"
+        )
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        activity = {
+            "activity_id": f"{target}-{stamp}",
+            "target": target,
+            "status": "RUNNING",
+            "source_lor_version": version,
+            "source_preview_folder": str(folder),
+            "started_at": utc_now(),
+            "completed_at": None,
+            "run_by": actor,
+            "console_log_path": str(log_path),
+            "error": None,
+            "result": None,
+        }
+
+        def operation(current: dict[str, Any]) -> None:
+            current["parser_activity"] = activity
+
+        self.store.update(operation)
+        return activity, log_path
+
+    def _finish_parser_activity(
+        self,
+        activity: dict[str, Any],
+        status: str,
+        log_path: Path,
+        console_output: str,
+        *,
+        result: dict[str, Any] | None = None,
+        error: str | None = None,
+    ) -> None:
+        """Persist the terminal parser result and its complete console log."""
+        log_path.write_text(console_output, encoding="utf-8")
+
+        def operation(current: dict[str, Any]) -> None:
+            latest = current.get("parser_activity") or {}
+            if latest.get("activity_id") != activity["activity_id"]:
+                raise RuntimeError("A newer parser activity replaced this run")
+            latest.update({
+                "status": status,
+                "completed_at": utc_now(),
+                "error": error,
+                "result": result,
+            })
+            current["parser_activity"] = latest
+
+        self.store.update(operation)
+
+    def public_parser_activity(self) -> dict[str, Any] | None:
+        """Return the latest parser attempt with bounded read-only output."""
+        activity = (self.store.read().get("parser_activity") or None)
+        if not activity:
+            return None
+        public = dict(activity)
+        log_path = Path(str(public.pop("console_log_path", "")))
+        console_output = ""
+        truncated = False
+        if log_path.is_file():
+            console_output = log_path.read_text(encoding="utf-8", errors="replace")
+            if len(console_output) > MAX_BROWSER_CONSOLE_CHARACTERS:
+                console_output = console_output[-MAX_BROWSER_CONSOLE_CHARACTERS:]
+                truncated = True
+        public["console_output"] = console_output
+        public["console_truncated"] = truncated
+        return public
 
     def public_state(self) -> dict[str, Any]:
         state = self.store.read()
+        parser_activity = dict(state.get("parser_activity") or {}) or None
+        if parser_activity:
+            parser_activity.pop("console_log_path", None)
         return {
             "runner_version": RUNNER_VERSION,
             "current_lor_version": state["current_lor_version"],
@@ -429,6 +528,7 @@ class Runner:
             "candidate_output_comparison": state.get("candidate_output_comparison"),
             "candidate_resolution": state.get("candidate_resolution"),
             "production_parser_run": state.get("production_parser_run"),
+            "parser_activity": parser_activity,
             "last_approval": state.get("last_approval"),
             "approval_history": state.get("approval_history", []),
         }
@@ -589,10 +689,37 @@ class Runner:
             "--result-json", str(result_json),
             "--non-interactive",
         ]
-        completed = subprocess.run(command, capture_output=True, text=True, timeout=900, check=False)
+        activity, console_log = self._start_parser_activity(target, version, folder, actor)
+        try:
+            completed = subprocess.run(
+                command, capture_output=True, text=True, timeout=900,
+                check=False,
+            )
+        except Exception as error:
+            detail = f"[FATAL] Parser process could not complete: {error}"
+            self._finish_parser_activity(
+                activity, "FAILED", console_log, detail, error=str(error)
+            )
+            raise RuntimeError(detail) from error
+        console_output = "\n".join(
+            part.strip() for part in (completed.stdout, completed.stderr)
+            if part and part.strip()
+        )
         if completed.returncode or not result_json.is_file():
-            raise RuntimeError((completed.stderr or completed.stdout).strip() or "Parser run failed")
-        result = json.loads(result_json.read_text(encoding="utf-8"))
+            detail = console_output or "Parser run failed"
+            self._finish_parser_activity(
+                activity, "FAILED", console_log, detail, error=detail
+            )
+            raise RuntimeError(detail)
+        try:
+            result = json.loads(result_json.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as error:
+            detail = f"[FATAL] Parser result file is invalid: {error}"
+            diagnostic = "\n".join(part for part in (console_output, detail) if part)
+            self._finish_parser_activity(
+                activity, "FAILED", console_log, diagnostic, error=detail
+            )
+            raise RuntimeError(detail) from error
         record = {
             **result,
             "run_by": actor,
@@ -645,6 +772,9 @@ class Runner:
                     current["candidate_output_comparison"] = comparison
 
                 self.store.update(save_comparison)
+        self._finish_parser_activity(
+            activity, "PASSED", console_log, console_output, result=record
+        )
         return record
 
     def resolve_candidate_findings(self, notes: str, actor: str) -> dict[str, Any]:
@@ -743,6 +873,7 @@ class Runner:
             current["candidate_output_comparison"] = None
             current["candidate_resolution"] = None
             current["production_parser_run"] = None
+            current["parser_activity"] = None
 
         return self.store.update(operation)
 
@@ -801,13 +932,20 @@ class RequestHandler(BaseHTTPRequestHandler):
             return HTTPStatus.OK, {"status": "ok", "version": RUNNER_VERSION}
         if self.command == "GET" and path == "/state":
             return HTTPStatus.OK, self.runner.public_state()
+        if self.command == "GET" and path == "/parser/activity":
+            return HTTPStatus.OK, {"activity": self.runner.public_parser_activity()}
         payload = self.body()
         actor = str(payload.get("actor") or "unknown-operator")
         if self.command == "POST":
             # Only one state-changing/check/parser operation may run at a time.
             # This prevents concurrent website clicks from targeting the same
-            # candidate database or changing the version record mid-run.
-            with self.runner.operation_lock:
+            # candidate database or changing the version record mid-run. A
+            # second request is rejected rather than queued to run later.
+            if not self.runner.operation_lock.acquire(blocking=False):
+                return HTTPStatus.CONFLICT, {
+                    "error": "Another parser or version-check operation is already running"
+                }
+            try:
                 if path == "/candidate":
                     self.runner.select_candidate(
                         str(payload.get("new_lor_version") or ""), actor
@@ -828,6 +966,8 @@ class RequestHandler(BaseHTTPRequestHandler):
                         str(payload.get("confirm_lor_version") or ""), actor
                     )
                     return HTTPStatus.OK, self.runner.public_state()
+            finally:
+                self.runner.operation_lock.release()
         return HTTPStatus.NOT_FOUND, {"error": "Runner endpoint was not found"}
 
     def handle_request(self) -> None:
@@ -866,6 +1006,7 @@ def initialize(arguments: argparse.Namespace) -> None:
         "candidate_output_comparison": None,
         "candidate_resolution": None,
         "production_parser_run": None,
+        "parser_activity": None,
         "last_approval": None,
         "approval_history": [],
     })

--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/test_lor_operator_runner.py
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/test_lor_operator_runner.py
@@ -10,6 +10,7 @@ import os
 import sqlite3
 import tempfile
 import unittest
+from http import HTTPStatus
 from pathlib import Path
 from unittest.mock import patch
 
@@ -86,6 +87,28 @@ class OperatorRunnerTests(unittest.TestCase):
 
         self.assertIn('"GET /health HTTP/1.1" 200 -', stdout.getvalue())
         self.assertEqual(stderr.getvalue(), "")
+
+    def test_second_runner_operation_is_rejected_instead_of_queued(self) -> None:
+        """Two browser tabs cannot schedule sequential parser executions."""
+        handler = object.__new__(runner_module.RequestHandler)
+        handler.command = "POST"
+        handler.path = "/parser/run"
+        handler.headers = {
+            "Authorization": "Bearer " + ("a" * 64),
+            "Content-Length": "0",
+        }
+        handler.rfile = io.BytesIO()
+        handler.server = argparse.Namespace(runner=self.runner)
+
+        with patch.dict(os.environ, {"LOR_RUNNER_TOKEN": "a" * 64}):
+            self.runner.operation_lock.acquire()
+            try:
+                status, payload = handler.dispatch()
+            finally:
+                self.runner.operation_lock.release()
+
+        self.assertEqual(status, HTTPStatus.CONFLICT)
+        self.assertIn("already running", payload["error"])
 
     def test_candidate_is_resolved_only_from_versioned_preview_root(self) -> None:
         state = self.runner.select_candidate("6.6.10", "operator@example.com")
@@ -193,11 +216,53 @@ class OperatorRunnerTests(unittest.TestCase):
                 "source_lor_version": "6.6.4",
                 "sqlite_sha256": "a" * 64,
             }), encoding="utf-8")
-            return argparse.Namespace(returncode=0, stdout="", stderr="")
+            return argparse.Namespace(
+                returncode=0,
+                stdout="[OK] parser complete\n",
+                stderr="",
+            )
 
         run.side_effect = complete
         result = self.runner.run_parser("current", "operator@example.com")
         self.assertEqual(result["status"], "COMPLETE")
+        activity = self.runner.public_parser_activity()
+        self.assertEqual(activity["status"], "PASSED")
+        self.assertEqual(activity["target"], "current")
+        self.assertIn("[OK] parser complete", activity["console_output"])
+        self.assertNotIn("console_log_path", self.runner.public_state()["parser_activity"])
+
+    @patch("lor_operator_runner.subprocess.run")
+    def test_failed_parser_records_console_and_preserves_terminal_status(self, run) -> None:
+        """Browser diagnostics must survive a failed parser request."""
+        run.return_value = argparse.Namespace(
+            returncode=2,
+            stdout="[INFO] parser started\n",
+            stderr="[FATAL] invalid preview\n",
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "invalid preview"):
+            self.runner.run_parser("current", "operator@example.com")
+
+        activity = self.runner.public_parser_activity()
+        self.assertEqual(activity["status"], "FAILED")
+        self.assertIn("[INFO] parser started", activity["console_output"])
+        self.assertIn("[FATAL] invalid preview", activity["console_output"])
+        self.assertIn("invalid preview", activity["error"])
+
+    def test_runner_restart_marks_incomplete_parser_activity_interrupted(self) -> None:
+        """A process restart cannot leave the browser claiming RUNNING forever."""
+        def prepare(state):
+            state["parser_activity"] = {
+                "activity_id": "current-stale",
+                "status": "RUNNING",
+                "console_log_path": str(self.root / "missing.log"),
+            }
+
+        self.store.update(prepare)
+        runner_module.Runner(self.store)
+        activity = self.runner.public_parser_activity()
+        self.assertEqual(activity["status"], "INTERRUPTED")
+        self.assertIn("restarted", activity["error"])
 
     def test_current_parser_blocks_new_xml_contract(self) -> None:
         (self.current / "test.lorprev").write_text(

--- a/LOR2DB/Application/README.md
+++ b/LOR2DB/Application/README.md
@@ -2,13 +2,14 @@
 
 | Document control | Value |
 |---|---|
-| Status | CURRENT code; V0.5.1 reliable runner deployment pending acceptance |
-| Initial release / current revision | 2026-08-04 / 2026-08-14 |
+| Status | CURRENT code; V0.6.0 workflow separation pending review/deployment |
+| Initial release / current revision | 2026-08-04 / 2026-08-15 |
 
 ## Revision history
 
 | Date | Change |
 |---|---|
+| 2026-08-15 | Separated routine parser execution from infrequent LOR-version approval. The landing page now has distinct parser, version, and reconciliation boxes; dedicated parser and version-check pages own their respective workflows. Runner V1.4.0 preserves bounded read-only console output, records failures, rejects concurrent operations, and marks interrupted work truthfully after restart. |
 | 2026-08-14 | Replaced manual runner-token commands with the root `run_lor_runner.ps1` installer. The token is generated once, protected with Windows DPAPI, paired to Linux through SSH, and verified by a non-secret fingerprint. Runner V1.3.0 logs rejected-header fingerprints; backend V0.5.1 bypasses HTTP proxies for the fixed private runner connection. |
 | 2026-08-14 | Added safe `APPROVE_STAGE_CHANGE` and `ADD_NEW_STAGE` paths gated by complete frozen evidence; contradictory stage groups remain non-approvable. The browser now shows every stage-group member. Cancellation now renders a terminal proof screen, cancelled reports have no misleading required actions, and the archive shows Outcome. Current-version parser runs permit structurally compatible authoring edits while candidate runs retain their exact checked-source guard. |
 | 2026-08-13 | Added the mandatory same-parser approved-version/candidate SQLite comparison. Approval now requires equal schemas and explained output differences; automatic LOR Revision increments are retained as informational evidence rather than treated as content changes. Candidate folders changed after XML review are rejected as stale. |
@@ -46,9 +47,15 @@ Publish the files in `landing/` at:
 `https://my.sheboyganlights.org/lor2db/`
 
 The page calls the existing authenticated backend through
-`/lor2db/preflight/api/`. It shows:
+`/lor2db/preflight/api/`. Its separate function boxes show:
 
-- the current committed snapshot, parser/ingest provenance, and row counts;
+- the normal repeatable **Run LOR parser** workflow;
+- the current approved LOR version and a link to the separate infrequent
+  **Check new version** workflow;
+- PostgreSQL reconciliation status, with no action button when no action is
+  valid;
+- the current reconciled PostgreSQL snapshot, parser/ingest provenance, and
+  row counts;
 - the persistent reconciliation run that owns or blocks the current snapshot;
 - the immutable report for a published run;
 - **Continue previous reconciliation** whenever any run is unfinished;
@@ -77,30 +84,36 @@ function, repeats eligibility inside that transaction, and captures the
 current snapshot through `ops.f_start_lor_reconciliation(text)`. No request
 parameter accepts an ingest number.
 
-The parser is now available from this landing page through the separately
-deployed Windows/G-drive runner. PostgreSQL ingest remains separate and manual.
-The page never starts ingest and the Linux API never executes a user-supplied
-path or command.
+The parser page is published at `/lor2db/parser/`. It permits repeated
+production SQLite builds, shows the last result, and displays the runner's
+bounded read-only console record. A parser failure retains the last valid
+SQLite database. Only one runner operation is accepted at a time; a second
+request is rejected rather than queued.
 
-## LOR version and parser workspace
+The version-check page is published at `/lor2db/version-check/`. It shows the
+current approved LOR version and exact preview-folder path, resolves a candidate
+only beneath the configured versioned preview root, and runs the XML check,
+approved-version baseline, candidate parser, and SQLite comparison in order.
+Approval returns to the landing page with the new approved version and folder
+and marks the production parser as requiring a deliberate rebuild.
 
-The landing page exposes two operator-controlled version fields:
+PostgreSQL ingest remains separate and manual. No browser page starts ingest,
+and the Linux API never executes a user-supplied path or command.
 
-- **Current LOR version** — the approved version of record;
-- **New LOR version** — the candidate version folder under review.
+## LOR version-check workspace
 
-The workflow is intentionally gated:
+The infrequent version workflow is intentionally gated:
 
 1. Select the new LOR version. The runner resolves only `Database Previews
    V<version>` beneath its configured preview root.
 2. Run the parser-independent complete XML compatibility check.
 3. If the check fails, review the recorded parser modifications required and
    update the parser.
-4. Build the approved-version comparison baseline in isolated `VERSION_CHECK`
-   mode. Routine authoring changes in the approved folder are allowed only
-   when the live XML remains structurally compatible with its retained
-   approved manifest; parser-breaking contract changes are rejected.
-5. Run the candidate parser into a separate `VERSION_CHECK` SQLite file. The
+4. The guided page builds the approved-version comparison baseline in isolated
+   `VERSION_CHECK` mode. Routine authoring changes in the approved folder are
+   allowed only when the live XML remains structurally compatible with its
+   retained approved manifest; parser-breaking contract changes are rejected.
+5. The guided page runs the candidate parser into a separate `VERSION_CHECK` SQLite file. The
    runner verifies that the candidate folder still matches the just-reviewed
    XML manifest, then compares both SQLite schemas and authoritative content.
 6. LOR-generated `Revision` changes are recorded as informational. Preview
@@ -111,9 +124,12 @@ The workflow is intentionally gated:
 8. Approve the version only after the XML check, both parser runs, and output
    comparison pass or all review findings are resolved. The previous version
    folder remains unchanged.
-9. Run the current parser in `PRODUCTION` mode. Inspect the resulting SQLite as
-   often as needed; no ingest is automatic.
-10. Supply its displayed SHA-256 to the separate manual PostgreSQL ingest.
+9. Return to the landing page. The approved version and preview-folder path now
+   identify the new source, while production SQLite is explicitly marked for
+   rebuild.
+10. Use the normal parser page to run the current parser in `PRODUCTION` mode.
+   Inspect the resulting SQLite as often as needed; no ingest is automatic.
+11. Supply its displayed SHA-256 to the separate manual PostgreSQL ingest.
 
 The raw SQLite `scenes` count is labeled **raw LOR Scene rows**. Operational
 true Scenes are classified by Folder Alignment naming rules and are not a
@@ -281,7 +297,31 @@ direct write privileges on `ref`, `lor_snap`, or the reconciliation tables.
 After creating the login separately with a secured password, apply
 `grant_lor_preflight_app.sql` to install this exact grant set.
 
-## V0.5.1 combined deployment order
+## V0.6.0 incremental deployment order
+
+This release changes the Windows runner, Linux API, and NAS browser files as
+one interface contract. It requires no PostgreSQL migration, grant change,
+token rotation, or runner re-pairing.
+
+1. Back up `/opt/lor-preflight/backend.py` and the published
+   `/mnt/msb-web/my/lor2db` landing-page files; record their hashes.
+2. On the approved Windows host, pull the reviewed commit and run the complete
+   parser/runner tests. Retain the existing DPAPI token and `runner-state.json`.
+3. Reinstall the logged-in-user runner task with `run_lor_runner.ps1 -Action
+   Install`. Confirm hidden runner V1.4.0 health. Do not run `PairServer`.
+4. Deploy backend V0.6.0 to `/opt/lor-preflight/backend.py`, restart
+   `lor-preflight-api.service`, and verify `/health` reports V0.6.0.
+5. Publish the complete `landing/` tree, including `parser/` and
+   `version-check/`, to `/mnt/msb-web/my/lor2db/`. Preserve the existing
+   `preflight/` and `reports/` trees.
+6. Verify the three distinct landing-page boxes, open both dedicated workflow
+   pages, and confirm the parser console endpoint can read the last activity.
+   Do not run the parser or select a candidate during deployment acceptance.
+
+PostgreSQL ingest remains password-protected, digest-locked, and manual. This
+deployment adds no browser ingest endpoint.
+
+## Historical V0.5.1 combined deployment order
 
 This release intentionally deploys the reconciliation corrections and the
 already-implemented Version Check / Run Parser controls as one acceptance

--- a/LOR2DB/Application/backend.py
+++ b/LOR2DB/Application/backend.py
@@ -3,7 +3,7 @@ MSB Database - LOR reconciliation preflight API
 backend.py
 
 Initial Release : 2026-08-05  V0.1.0
-Current Version : 2026-08-14  V0.5.1
+Current Version : 2026-08-15  V0.6.0
 Author          : GAL / OpenAI
 
 Purpose:
@@ -12,6 +12,10 @@ Purpose:
     append-only decisions, Finish, Cancel, and report completion.
 
 Revision History:
+    2026-08-15  GAL / OpenAI  V0.6.0
+        Separated routine parser execution from the infrequent LOR version
+        approval workflow and exposed the runner's latest read-only console
+        record through an authenticated fixed endpoint.
     2026-08-14  GAL / OpenAI  V0.5.1
         Forced internal Windows-runner requests to bypass process and system
         HTTP proxies so the bearer credential cannot be stripped in transit.
@@ -72,7 +76,7 @@ from flask import Flask, Response, jsonify, request
 from psycopg2.extras import RealDictCursor
 
 
-APP_VERSION = "V0.5.1"
+APP_VERSION = "V0.6.0"
 FALLBACK_ACTIONS = {"DEFER", "CORRECT_SOURCE_REQUIRED", "RESTORE_TO_LOR_REQUIRED"}
 STAGE_AUTHORITY_ACTIONS = {
     "APPROVE_STAGE_CHANGE", "ADD_NEW_STAGE",
@@ -513,6 +517,13 @@ def select_parser_candidate() -> Response:
     return jsonify(runner_request(
         "candidate", {"new_lor_version": version, "actor": operator}
     ))
+
+
+@app.get("/parser/activity")
+def get_parser_activity() -> Response:
+    """Return only the runner's bounded, read-only parser console record."""
+    operator_email()
+    return jsonify(runner_request("parser/activity"))
 
 
 @app.post("/parser/check")

--- a/LOR2DB/Application/landing/index.html
+++ b/LOR2DB/Application/landing/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>LOR production database</title>
-  <link rel="stylesheet" href="lor2db.css?v=0.4.0">
+  <link rel="stylesheet" href="lor2db.css?v=0.5.0">
 </head>
 <body>
   <main class="shell">
@@ -33,33 +33,6 @@
     </form>
   </dialog>
 
-  <dialog id="version-dialog">
-    <form method="dialog">
-      <h2>Select new LOR version</h2>
-      <p>The runner will use the versioned folder <code>Database Previews V&lt;version&gt;</code>.</p>
-      <label for="new-lor-version">New LOR version</label>
-      <input id="new-lor-version" name="new_lor_version" placeholder="6.6.10" autocomplete="off" required>
-      <p id="version-error" class="error" role="alert"></p>
-      <div class="dialog-actions">
-        <button value="cancel">Back</button>
-        <button id="confirm-version" class="primary" value="confirm">Set candidate</button>
-      </div>
-    </form>
-  </dialog>
-
-  <dialog id="approve-dialog">
-    <form method="dialog">
-      <h2>Approve new LOR version?</h2>
-      <p>This changes the approved version of record. The previous versioned preview folder is preserved.</p>
-      <label for="approve-lor-version">Type the exact new LOR version</label>
-      <input id="approve-lor-version" name="confirm_lor_version" autocomplete="off" required>
-      <p id="approve-error" class="error" role="alert"></p>
-      <div class="dialog-actions">
-        <button value="cancel">Back</button>
-        <button id="confirm-approval" class="primary danger-button" value="confirm">Approve version</button>
-      </div>
-    </form>
-  </dialog>
-  <script src="lor2db.js?v=0.4.0" defer></script>
+  <script src="lor2db.js?v=0.5.0" defer></script>
 </body>
 </html>

--- a/LOR2DB/Application/landing/lor2db.css
+++ b/LOR2DB/Application/landing/lor2db.css
@@ -21,8 +21,11 @@ h1 { margin-bottom: 0; font-size: clamp(1.8rem, 4vw, 2.5rem); }
 h2 { margin-bottom: 10px; }
 .eyebrow { margin-bottom: 4px; color: var(--accent); font-size: .78rem; font-weight: 750; letter-spacing: .08em; text-transform: uppercase; }
 .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; margin-top: 18px; }
+.task-grid { display: grid; grid-template-columns: 1.15fr .85fr; gap: 18px; margin-bottom: 18px; }
 .card { background: var(--card); border: 1px solid var(--line); border-radius: 9px; padding: 22px; box-shadow: 0 2px 9px #0000000a; }
-.parser-card { margin-bottom: 18px; }
+.task-card { display: flex; flex-direction: column; align-items: flex-start; }
+.task-card .card-title { align-self: stretch; }
+.task-card > .primary, .task-card > .secondary { margin-top: auto; }
 .workflow { align-items: flex-start; flex-wrap: wrap; }
 .workflow > div:first-child { flex: 1 1 500px; }
 .workflow-action { flex: 0 0 auto; }
@@ -37,22 +40,35 @@ button:disabled { cursor: wait; opacity: .55; }
 .blocking ul { margin-bottom: 0; }
 .digest { font-family: ui-monospace, SFMono-Regular, Consolas, monospace; font-size: .78rem; overflow-wrap: anywhere; }
 label { display: block; margin: 12px 0 5px; font-weight: 700; }
-input { width: 100%; border: 1px solid #aeb8c2; border-radius: 5px; padding: .65rem .75rem; font: inherit; }
+input, textarea { width: 100%; border: 1px solid #aeb8c2; border-radius: 5px; padding: .65rem .75rem; font: inherit; }
+textarea { resize: vertical; }
 .danger-button { background: var(--danger); border-color: var(--danger); }
 .pill { display: inline-block; border-radius: 999px; background: #e8eef4; padding: 3px 10px; font-size: 12px; font-weight: 700; }
 .state-completed, .state-completed_with_exceptions { color: #fff; background: var(--ok); }
 .facts { display: grid; grid-template-columns: 1fr 1fr; gap: 12px 18px; margin: 18px 0; }
+.stacked-facts { display: grid; gap: 11px; width: 100%; margin: 16px 0 20px; }
 .facts div { min-width: 0; }
+.stacked-facts div { min-width: 0; }
 dt { color: var(--muted); font-size: .8rem; }
 dd { margin: 2px 0 0; overflow-wrap: anywhere; font-weight: 650; }
 .counts { display: flex; flex-wrap: wrap; gap: 8px; }
 .counts span { border-radius: 5px; background: #f0f3f6; padding: 7px 9px; }
 .error { color: var(--danger); font-weight: 650; }
+.state-error, .state-failed, .state-interrupted { color: #fff; background: var(--danger); }
+.state-running { color: #17212b; background: #f4cf63; }
+.path-value { font-family: ui-monospace, SFMono-Regular, Consolas, monospace; font-size: .82rem; font-weight: 550; overflow-wrap: anywhere; }
+.notice { border-left: 4px solid var(--accent); background: #eef7fd; padding: 12px 14px; }
+.warning { border-left: 4px solid #9a6a00; background: #fff8df; padding: 12px 14px; }
+.console { min-height: 320px; max-height: 62vh; overflow: auto; margin: 14px 0 0; border-radius: 6px; background: #111820; color: #e9f1f7; padding: 16px; white-space: pre-wrap; overflow-wrap: anywhere; font: 13px/1.45 ui-monospace, SFMono-Regular, Consolas, monospace; }
+.step-list { padding-left: 1.4rem; }
+.step-list li { margin-bottom: 10px; }
+.page-actions { display: flex; flex-wrap: wrap; gap: 9px; margin: 18px 0; }
+.status-line { display: flex; flex-wrap: wrap; align-items: center; gap: 10px; }
 dialog { width: min(560px, calc(100% - 32px)); border: 1px solid var(--line); border-radius: 9px; padding: 22px; }
 dialog::backdrop { background: #0008; }
 .dialog-actions { display: flex; justify-content: flex-end; gap: 9px; margin-top: 18px; }
 @media (max-width: 760px) {
-  .grid { grid-template-columns: 1fr; }
+  .grid, .task-grid { grid-template-columns: 1fr; }
   .page-header, .card-title { align-items: flex-start; }
   .facts { grid-template-columns: 1fr; }
 }

--- a/LOR2DB/Application/landing/lor2db.js
+++ b/LOR2DB/Application/landing/lor2db.js
@@ -1,4 +1,4 @@
-/* MSB LOR landing page — 2026-08-14 V0.4.0 */
+/* MSB LOR landing page - 2026-08-15 V0.5.0 */
 (function () {
   "use strict";
 
@@ -7,14 +7,6 @@
   const startMessage = document.querySelector("#start-message");
   const dialogError = document.querySelector("#dialog-error");
   const confirmStart = document.querySelector("#confirm-start");
-  const versionDialog = document.querySelector("#version-dialog");
-  const versionInput = document.querySelector("#new-lor-version");
-  const versionError = document.querySelector("#version-error");
-  const confirmVersion = document.querySelector("#confirm-version");
-  const approveDialog = document.querySelector("#approve-dialog");
-  const approveInput = document.querySelector("#approve-lor-version");
-  const approveError = document.querySelector("#approve-error");
-  const confirmApproval = document.querySelector("#confirm-approval");
   let model;
 
   const esc = (value) => String(value ?? "").replace(/[&<>"']/g, (char) => ({
@@ -39,84 +31,73 @@
     return payload;
   }
 
-  function snapshotCard(snapshot) {
-    if (!snapshot) return `<section class="card"><h2>Current LOR snapshot</h2><p>No committed snapshot is available.</p></section>`;
-    return `<section class="card">
-      <div class="card-title"><h2>Current LOR snapshot</h2><span class="pill">Ingest ${esc(snapshot.import_run_id)}</span></div>
-      <dl class="facts">
-        <div><dt>Parsed</dt><dd>${esc(displayDate(snapshot.parser_completed_at))}</dd></div>
-        <div><dt>Parser</dt><dd>${esc(snapshot.parser_version || "Not recorded")}</dd></div>
-        <div><dt>LOR version</dt><dd>${esc(snapshot.source_lor_version || "Legacy snapshot — not recorded")}</dd></div>
-        <div><dt>Parser validation</dt><dd>${esc(snapshot.parser_validation_status || "Legacy snapshot — not recorded")}</dd></div>
-        <div><dt>Ingested</dt><dd>${esc(displayDate(snapshot.ingest_completed_at || snapshot.run_ts))}</dd></div>
-        <div><dt>Ingest script</dt><dd>${esc(snapshot.ingest_script_version || "Not recorded")}</dd></div>
-        <div><dt>Reviewed SQLite SHA-256</dt><dd class="digest">${esc(snapshot.source_sqlite_sha256 || "Legacy snapshot — not recorded")}</dd></div>
-        <div><dt>XML compatibility manifest</dt><dd class="digest">${esc(snapshot.compatibility_manifest_sha256 || "Legacy snapshot — not recorded")}</dd></div>
-      </dl>
-      <div class="counts">
-        <span><strong>${esc(snapshot.preview_count ?? "—")}</strong> previews</span>
-        <span><strong>${esc(snapshot.scene_count ?? "—")}</strong> raw LOR Scene rows</span>
-        <span><strong>${esc(snapshot.prop_count ?? "—")}</strong> props</span>
-        <span><strong>${esc(snapshot.sub_prop_count ?? "—")}</strong> subprops</span>
-        <span><strong>${esc(snapshot.dmx_channel_count ?? "—")}</strong> DMX</span>
-        <span><strong>${esc(snapshot.scene_lor_prop_count ?? "—")}</strong> scene/prop</span>
-      </div>
-    </section>`;
-  }
-
-  function parserCard(runner, runnerError) {
+  function parserWorkflowCard(runner, runnerError) {
     if (!runner) {
-      return `<section class="card parser-card">
-        <div class="card-title"><h2>LOR version and parser</h2><span class="pill">Runner offline</span></div>
-        <p>The Windows/G-drive runner is not available. Parser and version approval controls are disabled.</p>
+      return `<section class="card task-card">
+        <div class="card-title"><h2>Run LOR parser</h2><span class="pill state-error">Runner offline</span></div>
+        <p>The Windows/G-drive runner is unavailable. No parser can be started from this page.</p>
         ${runnerError ? `<p class="error">${esc(runnerError)}</p>` : ""}
       </section>`;
     }
-    const check = runner.candidate_check;
-    const baselineRun = runner.baseline_parser_run;
-    const candidateRun = runner.candidate_parser_run;
-    const comparison = runner.candidate_output_comparison;
-    const resolution = runner.candidate_resolution;
-    const productionRun = runner.production_parser_run;
-    const candidate = runner.new_lor_version;
-    const checkStatus = check?.status || "Not run";
-    const xmlFindings = check?.findings || [];
-    const modifications = check?.parser_modifications_required || [];
-    const findingsAccepted = checkStatus === "PASSED" || resolution?.status === "RESOLVED";
-    const comparisonStatus = comparison?.status || "Not run";
-    const comparisonAccepted = comparisonStatus === "PASSED" || resolution?.status === "RESOLVED";
-    const baselinePassed = baselineRun?.status === "COMPLETE" && baselineRun?.validation_status === "PASSED";
-    const candidatePassed = candidateRun?.status === "COMPLETE" && candidateRun?.validation_status === "PASSED";
-    const mayResolve = candidate && check && comparison &&
-      (checkStatus !== "PASSED" || comparisonStatus !== "PASSED") && baselinePassed && candidatePassed;
-    const mayApprove = candidate && findingsAccepted && comparisonAccepted && baselinePassed &&
-      candidateRun?.status === "COMPLETE" && candidateRun?.validation_status === "PASSED";
-    return `<section class="card parser-card">
-      <div class="card-title"><h2>LOR version and parser</h2><span class="pill">Runner ${esc(runner.runner_version)}</span></div>
-      <dl class="facts">
-        <div><dt>Current LOR version</dt><dd>${esc(runner.current_lor_version)}</dd></div>
-        <div><dt>New LOR version</dt><dd>${esc(candidate || "Not selected")}</dd></div>
-        <div><dt>Compatibility check</dt><dd>${esc(checkStatus)}</dd></div>
-        <div><dt>Approved-version baseline</dt><dd>${esc(baselineRun?.validation_status || "Not built")}</dd></div>
-        <div><dt>Candidate parser</dt><dd>${esc(candidateRun?.validation_status || "Not run")}</dd></div>
-        <div><dt>SQLite output comparison</dt><dd>${esc(comparisonStatus)}</dd></div>
-        <div><dt>Finding resolution</dt><dd>${esc(resolution?.status || "Not required/recorded")}</dd></div>
-        <div><dt>Current parser</dt><dd>${esc(productionRun?.validation_status || "Not run")}</dd></div>
-        <div><dt>Current SQLite SHA-256</dt><dd class="digest">${esc(productionRun?.sqlite_sha256 || "Not built in this runner state")}</dd></div>
+    const run = runner.production_parser_run;
+    const parserStatus = run?.validation_status || "Rebuild required";
+    return `<section class="card task-card">
+      <div class="card-title"><h2>Run LOR parser</h2><span class="pill">Runner ${esc(runner.runner_version)}</span></div>
+      <p>Build the production SQLite database from the currently approved preview folder. You may run this repeatedly before the separate PostgreSQL ingest.</p>
+      <dl class="stacked-facts">
+        <div><dt>Approved LOR version</dt><dd>${esc(runner.current_lor_version)}</dd></div>
+        <div><dt>Preview source folder</dt><dd class="path-value">${esc(runner.current_preview_folder)}</dd></div>
+        <div><dt>Last production parser result</dt><dd>${esc(parserStatus)}</dd></div>
+        <div><dt>Last completed</dt><dd>${esc(displayDate(run?.completed_at))}</dd></div>
+        <div><dt>Production SQLite</dt><dd class="path-value">${esc(run?.sqlite_path || "Not built in the current approved-version state")}</dd></div>
+        <div><dt>SQLite SHA-256</dt><dd class="digest">${esc(run?.sqlite_sha256 || "Not available until a validated parser run completes")}</dd></div>
       </dl>
-      ${xmlFindings.length ? `<div class="blocking"><strong>XML compatibility findings</strong><ul>${xmlFindings.map((item) => `<li><strong>${esc(item.severity)} — ${esc(item.area)}:</strong> ${esc(item.message)}</li>`).join("")}</ul></div>` : ""}
-      ${comparison?.findings?.length ? `<div class="blocking"><strong>SQLite output findings</strong><ul>${comparison.findings.map((item) => `<li><strong>${esc(item.severity)} — ${esc(item.area)}:</strong> ${esc(item.message)}</li>`).join("")}</ul></div>` : ""}
-      ${modifications.length ? `<div class="blocking"><strong>Parser modifications required</strong><ul>${modifications.map((item) => `<li>${esc(item)}</li>`).join("")}</ul></div>` : ""}
-      <div class="operator-actions">
-        <button id="set-candidate" type="button">Set new LOR version</button>
-        <button id="check-candidate" type="button" ${candidate ? "" : "disabled"}>Check XML compatibility</button>
-        <button id="run-baseline-parser" type="button">Build approved-version baseline</button>
-        <button id="run-candidate-parser" type="button" ${check && baselinePassed ? "" : "disabled"}>Run and compare candidate parser</button>
-        <button id="resolve-candidate" type="button" ${mayResolve ? "" : "disabled"}>Record findings resolved</button>
-        <button id="approve-candidate" class="primary" type="button" ${mayApprove ? "" : "disabled"}>Approve new version</button>
-        <button id="run-current-parser" class="primary" type="button">Run current parser</button>
+      <a class="primary" href="parser/">Run parser or view output</a>
+    </section>`;
+  }
+
+  function versionWorkflowCard(runner, runnerError) {
+    if (!runner) {
+      return `<section class="card task-card">
+        <div class="card-title"><h2>LOR version approval</h2><span class="pill state-error">Unavailable</span></div>
+        <p>The version checker is unavailable until the Windows runner reconnects.</p>
+        ${runnerError ? `<p class="error">${esc(runnerError)}</p>` : ""}
+      </section>`;
+    }
+    return `<section class="card task-card">
+      <div class="card-title"><h2>LOR version approval</h2><span class="pill">Infrequent workflow</span></div>
+      <p>Use this only when evaluating a different LOR software version. Routine preview edits use the parser workflow.</p>
+      <dl class="stacked-facts">
+        <div><dt>Current approved LOR version</dt><dd>${esc(runner.current_lor_version)}</dd></div>
+        <div><dt>Approved preview folder</dt><dd class="path-value">${esc(runner.current_preview_folder)}</dd></div>
+        <div><dt>Last approval</dt><dd>${esc(displayDate(runner.last_approval?.approved_at))}</dd></div>
+      </dl>
+      <a class="secondary" href="version-check/">Check new version</a>
+    </section>`;
+  }
+
+  function snapshotCard(snapshot) {
+    if (!snapshot) return `<section class="card"><h2>Current reconciled PostgreSQL snapshot</h2><p>No production snapshot is available.</p></section>`;
+    return `<section class="card">
+      <div class="card-title"><h2>Current reconciled PostgreSQL snapshot</h2><span class="pill">Ingest ${esc(snapshot.import_run_id)}</span></div>
+      <dl class="facts">
+        <div><dt>Parsed</dt><dd>${esc(displayDate(snapshot.parser_completed_at))}</dd></div>
+        <div><dt>Parser</dt><dd>${esc(snapshot.parser_version || "Not recorded")}</dd></div>
+        <div><dt>LOR version</dt><dd>${esc(snapshot.source_lor_version || "Legacy snapshot - not recorded")}</dd></div>
+        <div><dt>Parser validation</dt><dd>${esc(snapshot.parser_validation_status || "Legacy snapshot - not recorded")}</dd></div>
+        <div><dt>Ingested</dt><dd>${esc(displayDate(snapshot.ingest_completed_at || snapshot.run_ts))}</dd></div>
+        <div><dt>Ingest script</dt><dd>${esc(snapshot.ingest_script_version || "Not recorded")}</dd></div>
+        <div><dt>Reviewed SQLite SHA-256</dt><dd class="digest">${esc(snapshot.source_sqlite_sha256 || "Legacy snapshot - not recorded")}</dd></div>
+        <div><dt>XML compatibility manifest</dt><dd class="digest">${esc(snapshot.compatibility_manifest_sha256 || "Legacy snapshot - not recorded")}</dd></div>
+      </dl>
+      <div class="counts">
+        <span><strong>${esc(snapshot.preview_count ?? "-")}</strong> previews</span>
+        <span><strong>${esc(snapshot.scene_count ?? "-")}</strong> raw LOR Scene rows</span>
+        <span><strong>${esc(snapshot.prop_count ?? "-")}</strong> props</span>
+        <span><strong>${esc(snapshot.sub_prop_count ?? "-")}</strong> subprops</span>
+        <span><strong>${esc(snapshot.dmx_channel_count ?? "-")}</strong> DMX</span>
+        <span><strong>${esc(snapshot.scene_lor_prop_count ?? "-")}</strong> scene/prop</span>
       </div>
-      <p class="manual-note"><strong>Ingest remains separate.</strong> Review the generated SQLite and record its SHA-256 before running the manual PostgreSQL ingest.</p>
     </section>`;
   }
 
@@ -133,13 +114,19 @@
         <div><dt>Started</dt><dd>${esc(displayDate(run.started_at))}</dd></div>
         <div><dt>Completed</dt><dd>${esc(displayDate(run.completed_at))}</dd></div>
         <div><dt>Validation</dt><dd>${esc(run.validation_state)}</dd></div>
-        <div><dt>Exceptions</dt><dd>${esc(run.blocked_count)} blocked · ${esc(run.deferred_count)} deferred · ${esc(run.unresolved_count)} unresolved</dd></div>
+        <div><dt>Exceptions</dt><dd>${esc(run.blocked_count)} blocked / ${esc(run.deferred_count)} deferred / ${esc(run.unresolved_count)} unresolved</dd></div>
       </dl>
       ${report}
     </section>`;
   }
 
-  function workflowCard(workflow, snapshot) {
+  function workflowCard(workflow) {
+    const headings = {
+      SNAPSHOT_CONSUMED: "NO NEW SNAPSHOT TO RECONCILE",
+      READY_TO_START: "NEW SNAPSHOT READY FOR REVIEW",
+      IN_PROGRESS: "RECONCILIATION IN PROGRESS",
+      NO_SNAPSHOT: "NO PRODUCTION SNAPSHOT"
+    };
     let action = "";
     if (workflow.action?.kind === "review") {
       action = `<a class="primary" href="${esc(workflow.action.url)}">${esc(workflow.action.label)}</a>`;
@@ -147,58 +134,24 @@
       action = `<button id="start-run" class="primary" type="button">Start reconciliation</button>`;
     }
     return `<section class="card workflow">
-      <div><p class="eyebrow">Current state</p><h2>${esc(workflow.state.replaceAll("_", " "))}</h2><p>${esc(workflow.message)}</p></div>
+      <div><p class="eyebrow">PostgreSQL reconciliation status</p><h2>${esc(headings[workflow.state] || workflow.state.replaceAll("_", " "))}</h2><p>${esc(workflow.message)}</p></div>
       <div class="workflow-action">${action}</div>
-      <div class="manual-note"><strong>PostgreSQL ingest remains separate.</strong> Run and inspect the approved V7 parser output first, then perform the digest-locked ingest. This page detects the newly committed snapshot; no ingest number is entered here.</div>
+      <div class="manual-note"><strong>PostgreSQL ingest remains separate.</strong> Run and inspect the approved parser output first, then perform the digest-locked ingest. This page never starts an ingest.</div>
     </section>`;
   }
 
   function render() {
-    app.innerHTML = `${parserCard(model.parser_runner, model.parser_runner_error)}${workflowCard(model.workflow, model.snapshot)}<div class="grid">${snapshotCard(model.snapshot)}${runCard(model.latest_run)}</div>`;
+    app.innerHTML = `<div class="task-grid">${parserWorkflowCard(model.parser_runner, model.parser_runner_error)}${versionWorkflowCard(model.parser_runner, model.parser_runner_error)}</div>${workflowCard(model.workflow)}<div class="grid">${snapshotCard(model.snapshot)}${runCard(model.latest_run)}</div>`;
     document.querySelector("#start-run")?.addEventListener("click", () => {
       dialogError.textContent = "";
       startMessage.textContent = `Snapshot ${model.snapshot.import_run_id} will be captured for a new reconciliation run.`;
       dialog.showModal();
-    });
-    document.querySelector("#set-candidate")?.addEventListener("click", () => {
-      versionError.textContent = "";
-      versionInput.value = model.parser_runner?.new_lor_version || "";
-      versionDialog.showModal();
-      versionInput.focus();
-    });
-    document.querySelector("#check-candidate")?.addEventListener("click", (event) => runParserAction(event.currentTarget, "parser/check", {}));
-    document.querySelector("#run-baseline-parser")?.addEventListener("click", (event) => runParserAction(event.currentTarget, "parser/run", { target: "baseline" }));
-    document.querySelector("#run-candidate-parser")?.addEventListener("click", (event) => runParserAction(event.currentTarget, "parser/run", { target: "candidate" }));
-    document.querySelector("#run-current-parser")?.addEventListener("click", (event) => runParserAction(event.currentTarget, "parser/run", { target: "current" }));
-    document.querySelector("#resolve-candidate")?.addEventListener("click", async (event) => {
-      const notes = window.prompt("Explain every XML and SQLite output finding, including intentional metadata changes and any parser modifications:");
-      if (notes?.trim()) await runParserAction(event.currentTarget, "parser/resolve", { notes: notes.trim() });
-    });
-    document.querySelector("#approve-candidate")?.addEventListener("click", () => {
-      approveError.textContent = "";
-      approveInput.value = "";
-      approveDialog.showModal();
-      approveInput.focus();
     });
   }
 
   async function refresh() {
     model = await request("dashboard");
     render();
-  }
-
-  async function runParserAction(button, path, payload) {
-    const original = button.textContent;
-    button.disabled = true;
-    button.textContent = "Working…";
-    try {
-      await request(path, { method: "POST", body: JSON.stringify(payload) });
-      await refresh();
-    } catch (error) {
-      button.disabled = false;
-      button.textContent = original;
-      window.alert(error.message);
-    }
   }
 
   confirmStart.addEventListener("click", async (event) => {
@@ -211,40 +164,6 @@
     } catch (error) {
       dialogError.textContent = error.message;
       confirmStart.disabled = false;
-    }
-  });
-
-  confirmVersion.addEventListener("click", async (event) => {
-    event.preventDefault();
-    confirmVersion.disabled = true;
-    versionError.textContent = "";
-    try {
-      await request("parser/candidate", {
-        method: "POST", body: JSON.stringify({ new_lor_version: versionInput.value.trim() })
-      });
-      versionDialog.close();
-      await refresh();
-    } catch (error) {
-      versionError.textContent = error.message;
-    } finally {
-      confirmVersion.disabled = false;
-    }
-  });
-
-  confirmApproval.addEventListener("click", async (event) => {
-    event.preventDefault();
-    confirmApproval.disabled = true;
-    approveError.textContent = "";
-    try {
-      await request("parser/approve", {
-        method: "POST", body: JSON.stringify({ confirm_lor_version: approveInput.value.trim() })
-      });
-      approveDialog.close();
-      await refresh();
-    } catch (error) {
-      approveError.textContent = error.message;
-    } finally {
-      confirmApproval.disabled = false;
     }
   });
 

--- a/LOR2DB/Application/landing/parser/index.html
+++ b/LOR2DB/Application/landing/parser/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Run LOR parser</title>
+  <link rel="stylesheet" href="../lor2db.css?v=0.5.0">
+</head>
+<body>
+  <main class="shell">
+    <header class="page-header">
+      <div>
+        <p class="eyebrow">MSB production database</p>
+        <h1>Run LOR parser</h1>
+      </div>
+      <a class="secondary" href="../">Return to dashboard</a>
+    </header>
+    <div id="app" aria-live="polite">
+      <section class="card"><p>Loading parser status...</p></section>
+    </div>
+  </main>
+  <script src="parser.js?v=0.5.0" defer></script>
+</body>
+</html>

--- a/LOR2DB/Application/landing/parser/parser.js
+++ b/LOR2DB/Application/landing/parser/parser.js
@@ -1,0 +1,136 @@
+/* MSB read-only parser console - 2026-08-15 V0.5.0 */
+(function () {
+  "use strict";
+
+  const app = document.querySelector("#app");
+  let model;
+  let activity;
+  let pollTimer;
+
+  const esc = (value) => String(value ?? "").replace(/[&<>"']/g, (char) => ({
+    "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;"
+  })[char]);
+
+  function displayDate(value) {
+    if (!value) return "Not recorded";
+    return new Intl.DateTimeFormat(undefined, {
+      dateStyle: "medium", timeStyle: "medium"
+    }).format(new Date(value));
+  }
+
+  async function request(path, options) {
+    const response = await fetch(`../preflight/api/${path}`, {
+      credentials: "same-origin",
+      headers: { "Content-Type": "application/json" },
+      ...options
+    });
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok) throw new Error(payload.error || `Request failed (${response.status})`);
+    return payload;
+  }
+
+  function counts(result) {
+    const values = result?.counts;
+    if (!values) return "";
+    return `<div class="counts">
+      <span><strong>${esc(values.previews ?? "-")}</strong> previews</span>
+      <span><strong>${esc(values.scenes ?? "-")}</strong> raw LOR Scene rows</span>
+      <span><strong>${esc(values.props ?? "-")}</strong> props</span>
+      <span><strong>${esc(values.subProps ?? "-")}</strong> subprops</span>
+      <span><strong>${esc(values.dmxChannels ?? "-")}</strong> DMX</span>
+      <span><strong>${esc(values.scene_lor_props ?? "-")}</strong> scene/prop</span>
+    </div>`;
+  }
+
+  function render() {
+    const runner = model?.parser_runner;
+    if (!runner) {
+      app.innerHTML = `<section class="card"><h2>Runner unavailable</h2><p class="error">${esc(model?.parser_runner_error || "The Windows/G-drive runner is offline.")}</p></section>`;
+      return;
+    }
+    const latest = activity?.activity;
+    const running = latest?.status === "RUNNING";
+    const run = latest?.result || runner.production_parser_run;
+    const status = latest?.status || "NOT RUN FROM THIS PAGE";
+    const consoleText = latest?.console_output || (running
+      ? "Parser process is running. Complete console output will appear when the process finishes."
+      : "No parser console output has been recorded yet.");
+    const error = latest?.error ? `<p class="error">${esc(latest.error)}</p>` : "";
+    const targetNote = latest && latest.target !== "current"
+      ? `<p class="warning">The latest recorded parser activity belongs to the ${esc(latest.target)} version-check workflow, not a production parser run.</p>`
+      : "";
+    app.innerHTML = `<section class="card">
+      <div class="card-title"><h2>Production SQLite parser</h2><span class="pill">Runner ${esc(runner.runner_version)}</span></div>
+      <p>This reads the approved preview folder and atomically rebuilds the production SQLite file. It does not ingest PostgreSQL or start reconciliation.</p>
+      <dl class="facts">
+        <div><dt>Approved LOR version</dt><dd>${esc(runner.current_lor_version)}</dd></div>
+        <div><dt>Parser status</dt><dd>${esc(status)}</dd></div>
+        <div><dt>Preview source folder</dt><dd class="path-value">${esc(runner.current_preview_folder)}</dd></div>
+        <div><dt>Started</dt><dd>${esc(displayDate(latest?.started_at))}</dd></div>
+        <div><dt>Production SQLite</dt><dd class="path-value">${esc(run?.sqlite_path || "Not recorded")}</dd></div>
+        <div><dt>Completed</dt><dd>${esc(displayDate(latest?.completed_at || run?.completed_at))}</dd></div>
+        <div><dt>SQLite SHA-256</dt><dd class="digest">${esc(run?.sqlite_sha256 || "Not recorded")}</dd></div>
+        <div><dt>Validation</dt><dd>${esc(run?.validation_status || "Not recorded")}</dd></div>
+      </dl>
+      ${targetNote}${error}${counts(run)}
+      <div class="page-actions">
+        <button id="run-parser" class="primary" type="button" ${running ? "disabled" : ""}>${running ? "Parser is running..." : "Run parser"}</button>
+        <button id="refresh-output" type="button">Refresh output</button>
+        <a class="secondary" href="../">Return to dashboard</a>
+      </div>
+    </section>
+    <section class="card">
+      <div class="card-title"><h2>Read-only console output</h2><span class="pill state-${esc(status.toLowerCase())}">${esc(status)}</span></div>
+      ${latest?.console_truncated ? '<p class="warning">The display is limited to the most recent 500,000 characters. The complete log remains on the runner host.</p>' : ""}
+      <pre id="console-output" class="console">${esc(consoleText)}</pre>
+    </section>`;
+
+    document.querySelector("#refresh-output")?.addEventListener("click", refresh);
+    document.querySelector("#run-parser")?.addEventListener("click", runParser);
+    const consoleElement = document.querySelector("#console-output");
+    if (consoleElement) consoleElement.scrollTop = consoleElement.scrollHeight;
+    if (running && !pollTimer) pollTimer = window.setInterval(refreshActivity, 2000);
+    if (!running && pollTimer) {
+      window.clearInterval(pollTimer);
+      pollTimer = undefined;
+    }
+  }
+
+  async function refreshActivity() {
+    try {
+      activity = await request("parser/activity");
+      render();
+    } catch (error) {
+      window.clearInterval(pollTimer);
+      pollTimer = undefined;
+      app.insertAdjacentHTML("afterbegin", `<p class="error">${esc(error.message)}</p>`);
+    }
+  }
+
+  async function refresh() {
+    [model, activity] = await Promise.all([
+      request("dashboard"), request("parser/activity")
+    ]);
+    render();
+  }
+
+  async function runParser(event) {
+    if (!window.confirm("Run the parser for the approved LOR version now? This rebuilds SQLite only; PostgreSQL remains unchanged.")) return;
+    event.currentTarget.disabled = true;
+    event.currentTarget.textContent = "Starting parser...";
+    pollTimer = window.setInterval(refreshActivity, 2000);
+    try {
+      await request("parser/run", {
+        method: "POST", body: JSON.stringify({ target: "current" })
+      });
+    } catch (error) {
+      window.alert(error.message);
+    } finally {
+      await refresh();
+    }
+  }
+
+  refresh().catch((error) => {
+    app.innerHTML = `<section class="card"><h2>Parser status unavailable</h2><p class="error">${esc(error.message)}</p></section>`;
+  });
+}());

--- a/LOR2DB/Application/landing/version-check/index.html
+++ b/LOR2DB/Application/landing/version-check/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Check a new LOR version</title>
+  <link rel="stylesheet" href="../lor2db.css?v=0.5.0">
+</head>
+<body>
+  <main class="shell">
+    <header class="page-header">
+      <div>
+        <p class="eyebrow">MSB production database</p>
+        <h1>Check a new LOR version</h1>
+      </div>
+      <a class="secondary" href="../">Return without approval</a>
+    </header>
+    <div id="app" aria-live="polite">
+      <section class="card"><p>Loading version-check status...</p></section>
+    </div>
+  </main>
+  <script src="version-check.js?v=0.5.0" defer></script>
+</body>
+</html>

--- a/LOR2DB/Application/landing/version-check/version-check.js
+++ b/LOR2DB/Application/landing/version-check/version-check.js
@@ -1,0 +1,209 @@
+/* MSB guided LOR version check - 2026-08-15 V0.5.0 */
+(function () {
+  "use strict";
+
+  const app = document.querySelector("#app");
+  let model;
+  let working = false;
+
+  const esc = (value) => String(value ?? "").replace(/[&<>"']/g, (char) => ({
+    "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;"
+  })[char]);
+
+  async function request(path, options) {
+    const response = await fetch(`../preflight/api/${path}`, {
+      credentials: "same-origin",
+      headers: { "Content-Type": "application/json" },
+      ...options
+    });
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok) throw new Error(payload.error || `Request failed (${response.status})`);
+    return payload;
+  }
+
+  function status(value, fallback) {
+    return esc(value || fallback);
+  }
+
+  function findings(title, items) {
+    if (!items?.length) return "";
+    return `<div class="blocking"><strong>${esc(title)}</strong><ul>${items.map((item) => `<li><strong>${esc(item.severity)} - ${esc(item.area)}:</strong> ${esc(item.message)}</li>`).join("")}</ul></div>`;
+  }
+
+  function render() {
+    const runner = model?.parser_runner;
+    if (!runner) {
+      app.innerHTML = `<section class="card"><h2>Version checker unavailable</h2><p class="error">${esc(model?.parser_runner_error || "The Windows/G-drive runner is offline.")}</p><a class="secondary" href="../">Return to dashboard</a></section>`;
+      return;
+    }
+    const candidate = runner.new_lor_version;
+    const check = runner.candidate_check;
+    const baseline = runner.baseline_parser_run;
+    const candidateRun = runner.candidate_parser_run;
+    const comparison = runner.candidate_output_comparison;
+    const resolution = runner.candidate_resolution;
+    const baselinePassed = baseline?.status === "COMPLETE" && baseline?.validation_status === "PASSED";
+    const candidatePassed = candidateRun?.status === "COMPLETE" && candidateRun?.validation_status === "PASSED";
+    const checkAccepted = check?.status === "PASSED" || resolution?.status === "RESOLVED";
+    const comparisonAccepted = comparison?.status === "PASSED" || resolution?.status === "RESOLVED";
+    const mayResolve = candidate && check && comparison && baselinePassed && candidatePassed &&
+      (check.status !== "PASSED" || comparison.status !== "PASSED");
+    const mayApprove = candidate && checkAccepted && comparisonAccepted && baselinePassed && candidatePassed;
+    const blockingCheck = (check?.blocking_count || 0) > 0;
+
+    app.innerHTML = `<section class="card">
+      <div class="card-title"><h2>Before you begin</h2><span class="pill">Runner ${esc(runner.runner_version)}</span></div>
+      <p>Use this workflow only after installing a different LOR software version and exporting its complete preview set. Routine preview edits under LOR ${esc(runner.current_lor_version)} use the normal parser page.</p>
+      <div class="notice"><strong>This workflow is isolated.</strong> It does not replace production SQLite, ingest PostgreSQL, or start reconciliation.</div>
+      <dl class="facts">
+        <div><dt>Current approved LOR version</dt><dd>${esc(runner.current_lor_version)}</dd></div>
+        <div><dt>Current approved preview folder</dt><dd class="path-value">${esc(runner.current_preview_folder)}</dd></div>
+      </dl>
+      <ol class="step-list">
+        <li>Enter the new LOR version. The runner resolves only <code>Database Previews V&lt;version&gt;</code>.</li>
+        <li>Confirm the detected candidate folder.</li>
+        <li>Run the complete XML, baseline, candidate-parser, and SQLite-output checks.</li>
+        <li>Review and resolve any findings.</li>
+        <li>Approve the new version explicitly. Approval returns to the dashboard and marks production SQLite for rebuild.</li>
+      </ol>
+    </section>
+
+    <section class="card">
+      <h2>1. Select candidate version</h2>
+      <label for="candidate-version">New LOR version</label>
+      <input id="candidate-version" value="${esc(candidate || "")}" placeholder="6.6.11" autocomplete="off" ${working ? "disabled" : ""}>
+      <div class="page-actions">
+        <button id="set-candidate" type="button" ${working ? "disabled" : ""}>Detect candidate folder</button>
+      </div>
+      <dl class="stacked-facts">
+        <div><dt>Selected candidate version</dt><dd>${esc(candidate || "Not selected")}</dd></div>
+        <div><dt>Detected candidate preview folder</dt><dd class="path-value">${esc(runner.new_preview_folder || "Not detected")}</dd></div>
+      </dl>
+    </section>
+
+    <section class="card">
+      <h2>2. Run version check</h2>
+      <p>One button runs the required checks in order. The approved baseline and candidate databases remain isolated under the LOR Version Reviews folder.</p>
+      <div class="page-actions">
+        <button id="run-version-check" class="primary" type="button" ${!candidate || working ? "disabled" : ""}>${working ? "Version check is running..." : "Run version check"}</button>
+      </div>
+      ${blockingCheck ? '<p class="error">Blocking XML changes were found. Parser comparison was not run.</p>' : ""}
+      <dl class="facts">
+        <div><dt>XML compatibility</dt><dd>${status(check?.status, "Not run")}</dd></div>
+        <div><dt>Approved-version baseline</dt><dd>${status(baseline?.validation_status, "Not built")}</dd></div>
+        <div><dt>Candidate parser</dt><dd>${status(candidateRun?.validation_status, "Not run")}</dd></div>
+        <div><dt>SQLite output comparison</dt><dd>${status(comparison?.status, "Not run")}</dd></div>
+      </dl>
+      ${findings("XML compatibility findings", check?.findings)}
+      ${findings("SQLite output findings", comparison?.findings)}
+      ${check?.parser_modifications_required?.length ? `<div class="blocking"><strong>Parser modifications required</strong><ul>${check.parser_modifications_required.map((item) => `<li>${esc(item)}</li>`).join("")}</ul></div>` : ""}
+      <details>
+        <summary>Show technical details</summary>
+        <dl class="stacked-facts">
+          <div><dt>Baseline SQLite SHA-256</dt><dd class="digest">${esc(baseline?.sqlite_sha256 || "Not available")}</dd></div>
+          <div><dt>Candidate SQLite SHA-256</dt><dd class="digest">${esc(candidateRun?.sqlite_sha256 || "Not available")}</dd></div>
+          <div><dt>Compatibility report</dt><dd class="path-value">${esc(check?.report_markdown || "Not available")}</dd></div>
+          <div><dt>Output comparison report</dt><dd class="path-value">${esc(comparison?.report_markdown || "Not available")}</dd></div>
+        </dl>
+      </details>
+    </section>
+
+    <section class="card">
+      <h2>3. Resolve and approve</h2>
+      <p>Approval changes only the approved LOR version, preview path, and compatibility authority. It does not run the production parser.</p>
+      ${mayResolve ? `<label for="resolution-notes">Engineering resolution for every finding</label><textarea id="resolution-notes" rows="5" placeholder="Explain intentional changes, parser modifications, and why the candidate is acceptable."></textarea><div class="page-actions"><button id="resolve-findings" type="button">Record findings resolved</button></div>` : ""}
+      <dl class="stacked-facts">
+        <div><dt>Finding resolution</dt><dd>${status(resolution?.status, check && comparison && check.status === "PASSED" && comparison.status === "PASSED" ? "Not required" : "Not recorded")}</dd></div>
+        <div><dt>Approval readiness</dt><dd>${mayApprove ? "Ready for explicit approval" : "Required checks or resolutions are incomplete"}</dd></div>
+      </dl>
+      <div class="page-actions">
+        <button id="approve-version" class="primary" type="button" ${!mayApprove || working ? "disabled" : ""}>Approve new version</button>
+        <a class="secondary" href="../">Return without approval</a>
+      </div>
+    </section>`;
+
+    document.querySelector("#set-candidate")?.addEventListener("click", selectCandidate);
+    document.querySelector("#run-version-check")?.addEventListener("click", runVersionCheck);
+    document.querySelector("#resolve-findings")?.addEventListener("click", resolveFindings);
+    document.querySelector("#approve-version")?.addEventListener("click", approveVersion);
+  }
+
+  async function refresh() {
+    model = await request("dashboard");
+    render();
+  }
+
+  async function withWorking(action) {
+    working = true;
+    render();
+    try {
+      await action();
+    } catch (error) {
+      window.alert(error.message);
+    } finally {
+      working = false;
+      await refresh();
+    }
+  }
+
+  function selectCandidate() {
+    const input = document.querySelector("#candidate-version");
+    const version = input?.value.trim();
+    if (!version) {
+      window.alert("Enter the new LOR version first.");
+      return;
+    }
+    withWorking(() => request("parser/candidate", {
+      method: "POST", body: JSON.stringify({ new_lor_version: version })
+    }));
+  }
+
+  function runVersionCheck() {
+    withWorking(async () => {
+      const check = await request("parser/check", { method: "POST", body: "{}" });
+      if (check.status === "BLOCKED" || (check.blocking_count || 0) > 0) return;
+      await request("parser/run", {
+        method: "POST", body: JSON.stringify({ target: "baseline" })
+      });
+      await request("parser/run", {
+        method: "POST", body: JSON.stringify({ target: "candidate" })
+      });
+    });
+  }
+
+  function resolveFindings() {
+    const notes = document.querySelector("#resolution-notes")?.value.trim();
+    if (!notes) {
+      window.alert("Enter an engineering resolution for every finding.");
+      return;
+    }
+    withWorking(() => request("parser/resolve", {
+      method: "POST", body: JSON.stringify({ notes })
+    }));
+  }
+
+  async function approveVersion() {
+    const version = model.parser_runner?.new_lor_version;
+    const confirmation = window.prompt(`Type ${version} to approve this LOR version:`);
+    if (confirmation !== version) {
+      if (confirmation !== null) window.alert("The entered version did not match. Nothing was approved.");
+      return;
+    }
+    working = true;
+    render();
+    try {
+      await request("parser/approve", {
+        method: "POST", body: JSON.stringify({ confirm_lor_version: confirmation })
+      });
+      location.href = "../";
+    } catch (error) {
+      working = false;
+      window.alert(error.message);
+      await refresh();
+    }
+  }
+
+  refresh().catch((error) => {
+    app.innerHTML = `<section class="card"><h2>Version-check status unavailable</h2><p class="error">${esc(error.message)}</p></section>`;
+  });
+}());

--- a/LOR2DB/Application/test_backend.py
+++ b/LOR2DB/Application/test_backend.py
@@ -301,6 +301,47 @@ class BackendSafetyTests(unittest.TestCase):
             timeout=920,
         )
 
+    def test_parser_activity_is_authenticated_and_read_only(self) -> None:
+        expected = {
+            "activity": {
+                "status": "PASSED",
+                "console_output": "[OK] complete",
+            }
+        }
+        with patch.object(backend, "runner_request", return_value=expected) as runner:
+            response = backend.app.test_client().get(
+                "/parser/activity",
+                headers={
+                    "Cf-Access-Authenticated-User-Email":
+                        "greg@sheboyganlights.org"
+                },
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json, expected)
+        runner.assert_called_once_with("parser/activity")
+
+    def test_landing_page_separates_parser_and_version_workflows(self) -> None:
+        landing = Path(__file__).with_name("landing")
+        source = (landing / "lor2db.js").read_text(encoding="utf-8")
+        version_source = (
+            landing / "version-check" / "version-check.js"
+        ).read_text(encoding="utf-8")
+        parser_source = (
+            landing / "parser" / "parser.js"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn('href="parser/"', source)
+        self.assertIn('href="version-check/"', source)
+        self.assertNotIn("run-baseline-parser", source)
+        self.assertNotIn("approve-candidate", source)
+        self.assertIn("Current approved preview folder", version_source)
+        self.assertIn("Run version check", version_source)
+        self.assertIn('target: "baseline"', version_source)
+        self.assertIn('target: "candidate"', version_source)
+        self.assertIn("Read-only console output", parser_source)
+        self.assertIn('target: "current"', parser_source)
+        self.assertIn("only; PostgreSQL remains unchanged", parser_source)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/run_lor_runner.ps1
+++ b/run_lor_runner.ps1
@@ -314,7 +314,7 @@ switch ($Action) {
             $env:LOR_CHECKER_PATH = $CheckerPath
             $env:PYTHONUNBUFFERED = '1'
             Write-ServiceLog (
-                "Starting runner V1.3.0; credential fingerprint=" +
+                "Starting runner V1.4.0; credential fingerprint=" +
                 "$(Get-TokenFingerprint -Token $token)."
             )
             # BaseHTTPRequestHandler writes normal HTTP access records to


### PR DESCRIPTION
## Outcome

The landing page now presents three separate operator functions instead of one combined parser/version box:

1. **Run LOR parser** — the normal repeatable production SQLite workflow.
2. **LOR version approval** — an infrequent entry point to a separate guided page.
3. **PostgreSQL reconciliation status** — status-only when no valid action exists.

## Parser workflow

- Dedicated `/lor2db/parser/` page.
- Production parser may be run repeatedly before manual ingest.
- Only one runner operation is accepted at a time; a second request is rejected rather than queued.
- Full console output is saved after completion and exposed as a bounded read-only diagnostic.
- Passed, failed, and interrupted attempts remain visible.
- Failed parser publication retains the previous valid SQLite snapshot.
- PostgreSQL ingest and reconciliation remain separate.

## Version-check workflow

- Dedicated `/lor2db/version-check/` page.
- Shows the approved LOR version and exact current preview-folder path.
- Guides the operator through candidate selection, XML comparison, isolated approved baseline, candidate parser, SQLite comparison, findings resolution, and explicit approval.
- Baseline mechanics are performed behind one **Run version check** action.
- Approval updates the version-of-record and preview path, returns to the dashboard, and marks production SQLite for a deliberate rebuild.
- Version checking never replaces production SQLite, ingests PostgreSQL, or starts reconciliation.

## Versions

- Windows runner: V1.4.0
- Linux API: V0.6.0
- Landing/browser workflow: V0.5.0

No database migration, grant change, token rotation, or runner re-pairing is required.

## Verification

- 26 parser/runner tests passed
- 35 application tests passed
- 15 reporting tests passed
- Python compilation passed
- All three JavaScript files passed `node --check`
- Windows PowerShell launcher remains ASCII-only
- `git diff --check` passed

## Deployment boundary

This PR changes repository code only. Nothing was deployed, and no parser, ingest, database, or reconciliation operation was run.