### PR TITLE
Skip Linux ownership test on Windows

### DIFF
--- a/LOR2DB/Application/test_install_lor_runner_pairing.py
+++ b/LOR2DB/Application/test_install_lor_runner_pairing.py
@@ -29,6 +29,10 @@ class RunnerPairingInstallerTests(unittest.TestCase):
         self.assertEqual(result.count("LOR_RUNNER_URL="), 1)
         self.assertIn("KEEP=value", result)
 
+    @unittest.skipUnless(
+        hasattr(os, "getuid") and hasattr(os, "chown"),
+        "requires POSIX ownership semantics",
+    )
     def test_installer_is_atomic_preserves_mode_and_consumes_pending(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)


### PR DESCRIPTION
## Fix

The Linux runner-pairing installer test used `os.getuid()`, which is unavailable on Windows. Mark the ownership/permission integration test as POSIX-only.

The remaining pairing validation tests continue to run on Windows. Production code is unchanged.

## Verification

- Pairing installer tests pass on Linux.
- The POSIX ownership test is skipped explicitly on Windows.
- `git diff --check` passes.