### PR TITLE
Recover safely from orphaned LOR runner

### DIFF
--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/test_lor_operator_runner.py
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/test_lor_operator_runner.py
@@ -73,6 +73,9 @@ class OperatorRunnerTests(unittest.TestCase):
         self.assertIn("savedErrorActionPreference", source)
         self.assertIn("native process exit code remains authoritative", source)
         self.assertIn("WindowStyle Hidden", source)
+        self.assertIn("function Stop-InstalledRunner", source)
+        self.assertIn("not the managed LOR runner", source)
+        self.assertIn("parser_activity.status -eq 'RUNNING'", source)
 
     def test_http_access_log_uses_stdout_not_stderr(self) -> None:
         """A successful request must not become a PowerShell native error."""

--- a/LOR2DB/Application/README.md
+++ b/LOR2DB/Application/README.md
@@ -152,8 +152,16 @@ the secret in command history.
 ```powershell
 .\run_lor_runner.ps1 -Action Install
 .\run_lor_runner.ps1 -Action PairServer
+.\run_lor_runner.ps1 -Action Stop
 .\run_lor_runner.ps1 -Action Status
 ```
+
+`Install` safely replaces an existing managed runner, including an orphaned
+runner process left listening after its Scheduled Task has exited. It will stop
+only a Python listener whose command line matches this repository's runner,
+host, and port. It refuses to interrupt a parser recorded as `RUNNING` and
+refuses to terminate an unrelated process using port 8791. `Stop` applies the
+same checks without reinstalling the task.
 
 From the repository root on `msb-prod-db`, consume the pending token with:
 

--- a/run_lor_runner.ps1
+++ b/run_lor_runner.ps1
@@ -11,7 +11,7 @@
 
 [CmdletBinding()]
 param(
-    [ValidateSet('Install', 'PairServer', 'Start', 'Status')]
+    [ValidateSet('Install', 'PairServer', 'Start', 'Stop', 'Status')]
     [string]$Action = 'Status',
 
     [string]$RunnerHost = '192.168.5.55',
@@ -214,6 +214,67 @@ function Install-ScheduledRunner {
         -Force | Out-Null
 }
 
+function Stop-InstalledRunner {
+    $state = Get-Content -LiteralPath $StateFile -Raw | ConvertFrom-Json
+    if ($state.parser_activity -and $state.parser_activity.status -eq 'RUNNING') {
+        throw 'The LOR parser is running. Wait for it to finish before reinstalling the runner.'
+    }
+
+    $existingTask = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+    if ($existingTask -and $existingTask.State -eq 'Running') {
+        Stop-ScheduledTask -TaskName $TaskName
+        Start-Sleep -Seconds 2
+    }
+
+    $listeners = @(
+        Get-NetTCPConnection `
+            -LocalPort $Port `
+            -State Listen `
+            -ErrorAction SilentlyContinue
+    )
+    $listenerProcessIds = @(
+        $listeners | Select-Object -ExpandProperty OwningProcess -Unique
+    )
+    foreach ($listenerProcessId in $listenerProcessIds) {
+        $process = Get-CimInstance Win32_Process `
+            -Filter "ProcessId = $listenerProcessId" `
+            -ErrorAction SilentlyContinue
+        $commandLine = [string]$process.CommandLine
+        $isManagedRunner = $process -and `
+            ($process.Name -ieq 'python.exe') -and `
+            ($commandLine.IndexOf(
+                $RunnerPath,
+                [System.StringComparison]::OrdinalIgnoreCase
+            ) -ge 0) -and `
+            ($commandLine -match '(?i)(?:^|\s)serve(?:\s|$)') -and `
+            ($commandLine -match "(?i)--host\s+$([regex]::Escape($RunnerHost))(?:\s|$)") -and `
+            ($commandLine -match "(?i)--port\s+$Port(?:\s|$)")
+        if (-not $isManagedRunner) {
+            throw (
+                "Port $Port is held by PID $listenerProcessId, " +
+                'which is not the managed LOR runner. No process was stopped.'
+            )
+        }
+        Stop-Process -Id $listenerProcessId -Force
+        Write-Host (
+            '[INFO] Stopped existing managed runner process ' +
+            "(PID $listenerProcessId)."
+        )
+    }
+
+    foreach ($attempt in 1..10) {
+        $remaining = Get-NetTCPConnection `
+            -LocalPort $Port `
+            -State Listen `
+            -ErrorAction SilentlyContinue
+        if (-not $remaining) {
+            return
+        }
+        Start-Sleep -Milliseconds 500
+    }
+    throw "Port $Port did not become available after stopping the managed runner."
+}
+
 function Start-InstalledRunner {
     param([Parameter(Mandatory = $true)][string]$Token)
 
@@ -240,18 +301,7 @@ function Start-InstalledRunner {
 switch ($Action) {
     'Install' {
         Assert-RunnerPrerequisites | Out-Null
-        $existingTask = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
-        if ($existingTask -and $existingTask.State -eq 'Running') {
-            Stop-ScheduledTask -TaskName $TaskName
-            Start-Sleep -Seconds 1
-        }
-        $listener = Get-NetTCPConnection `
-            -LocalPort $Port `
-            -State Listen `
-            -ErrorAction SilentlyContinue
-        if ($listener) {
-            throw "Port $Port is already in use. Stop the manually started runner first."
-        }
+        Stop-InstalledRunner
         if ((Test-Path -LiteralPath $SecretPath) -and -not $RotateToken) {
             $token = Read-ProtectedToken
             Write-Host '[INFO] Existing protected runner token retained.'
@@ -347,6 +397,12 @@ switch ($Action) {
             Remove-Item Env:\LOR_RUNNER_TOKEN -ErrorAction SilentlyContinue
             Remove-Variable token -ErrorAction SilentlyContinue
         }
+    }
+
+    'Stop' {
+        Assert-RunnerPrerequisites | Out-Null
+        Stop-InstalledRunner
+        Write-Host '[OK] Managed LOR runner is stopped and its port is free.'
     }
 
     'Status' {


### PR DESCRIPTION
## Problem

The runner could remain bound to port 8791 after its Scheduled Task reported `Ready`. `Install` then refused to proceed and required manual PID cleanup.

## Fix

- Add a checked `Stop` launcher action.
- Make `Install` stop the existing Scheduled Task and recover an orphaned managed runner.
- Kill a listener only when its process is `python.exe` and its command line matches this repository's runner path, `serve` command, configured host, and port.
- Refuse to kill an unrelated process using port 8791.
- Refuse to interrupt a parser activity recorded as `RUNNING`.
- Verify port 8791 is free before reinstalling.

## Verification

- 26 parser/runner tests pass on Linux.
- Pairing installer tests pass on Linux.
- Launcher remains ASCII-only for Windows PowerShell 5.1.
- `git diff --check` passes.

Production parser, SQLite, PostgreSQL ingest, and reconciliation were not run.