### PR TITLE
Add reviewed web parser ingest workflow

### DIFF
--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/lor_operator_runner.py
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/lor_operator_runner.py
@@ -1,6 +1,12 @@
-"""Authenticated Windows-side runner for LOR2DB parser operations.
+"""Authenticated Windows-side runner for LOR2DB parser and ingest operations.
 
 Initial release: 2026-08-13 V1.0.0
+
+Current version: 2026-08-15 V1.5.0
+
+V1.5.0 adds the fixed, digest-locked PostgreSQL ingest operation and bounded
+read-only ingest console. Parser execution remains repeatable and never starts
+ingest automatically.
 
 The production LOR2DB API runs on Linux. This small internal service owns the
 Windows/G-drive execution boundary and exposes only version-scoped operations;
@@ -30,7 +36,7 @@ from urllib.parse import urlparse
 from lor_version_checker import build_manifest, compare_manifests, manifest_source_signature, write_json
 
 
-RUNNER_VERSION = "V1.4.0"
+RUNNER_VERSION = "V1.5.0"
 MAX_BROWSER_CONSOLE_CHARACTERS = 500_000
 
 AUTHORITATIVE_OUTPUT_TABLES = (
@@ -408,13 +414,20 @@ class Runner:
             os.environ.get("LOR_CHECKER_PATH")
             or Path(__file__).with_name("lor_version_checker.py")
         ).resolve()
+        self.ingest_path = Path(
+            os.environ.get("LOR_INGEST_PATH")
+            or Path(__file__).resolve().parents[4]
+            / "LOR2DB" / "01_Ingest"
+            / "postgres_ingest_from_lor_sqlite_v7.py"
+        ).resolve()
         self.preview_parent = Path(required_environment("LOR_PREVIEW_PARENT")).resolve()
         self.production_db = Path(required_environment("LOR_SQLITE_OUTPUT")).resolve()
         self.reports_root = Path(required_environment("LOR_RUNNER_REPORTS_ROOT")).resolve()
-        for script in (self.parser_path, self.checker_path):
+        for script in (self.parser_path, self.checker_path, self.ingest_path):
             if not script.is_file():
                 raise RuntimeError(f"Runner executable is missing: {script}")
         self._mark_interrupted_parser_activity()
+        self._mark_interrupted_ingest_activity()
 
     def _mark_interrupted_parser_activity(self) -> None:
         """Make a stale RUNNING marker truthful after a runner restart."""
@@ -432,6 +445,25 @@ class Runner:
                     "error": "The runner restarted before this parser operation completed.",
                 })
                 current["parser_activity"] = stale
+
+        self.store.update(operation)
+
+    def _mark_interrupted_ingest_activity(self) -> None:
+        """Make a stale RUNNING ingest marker truthful after a restart."""
+        state = self.store.read()
+        activity = state.get("ingest_activity") or {}
+        if activity.get("status") != "RUNNING":
+            return
+
+        def operation(current: dict[str, Any]) -> None:
+            stale = current.get("ingest_activity") or {}
+            if stale.get("status") == "RUNNING":
+                stale.update({
+                    "status": "INTERRUPTED",
+                    "completed_at": utc_now(),
+                    "error": "The runner restarted before this ingest completed.",
+                })
+                current["ingest_activity"] = stale
 
         self.store.update(operation)
 
@@ -510,11 +542,191 @@ class Runner:
         public["console_truncated"] = truncated
         return public
 
+    def _start_ingest_activity(
+        self, digest: str, actor: str
+    ) -> tuple[dict[str, Any], Path]:
+        """Record one recoverable browser-visible PostgreSQL ingest attempt."""
+        state = self.store.read()
+        version = state["current_lor_version"]
+        stamp = datetime.now().strftime("%Y%m%d-%H%M%S-%f")
+        log_path = (
+            self.reports_root / f"V{version}" / "browser-ingest-runs" /
+            f"ingest-{stamp}.log"
+        )
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        activity = {
+            "activity_id": f"ingest-{stamp}",
+            "status": "RUNNING",
+            "source_lor_version": version,
+            "sqlite_sha256": digest,
+            "started_at": utc_now(),
+            "completed_at": None,
+            "run_by": actor,
+            "console_log_path": str(log_path),
+            "error": None,
+            "result": None,
+        }
+
+        def operation(current: dict[str, Any]) -> None:
+            current["ingest_activity"] = activity
+
+        self.store.update(operation)
+        return activity, log_path
+
+    def _finish_ingest_activity(
+        self,
+        activity: dict[str, Any],
+        status: str,
+        log_path: Path,
+        console_output: str,
+        *,
+        result: dict[str, Any] | None = None,
+        error: str | None = None,
+    ) -> None:
+        """Persist the terminal ingest result and its complete console log."""
+        log_path.write_text(console_output, encoding="utf-8")
+
+        def operation(current: dict[str, Any]) -> None:
+            latest = current.get("ingest_activity") or {}
+            if latest.get("activity_id") != activity["activity_id"]:
+                raise RuntimeError("A newer ingest activity replaced this run")
+            latest.update({
+                "status": status,
+                "completed_at": utc_now(),
+                "error": error,
+                "result": result,
+            })
+            current["ingest_activity"] = latest
+            if result:
+                current["production_ingest_run"] = result
+
+        self.store.update(operation)
+
+    def public_ingest_activity(self) -> dict[str, Any] | None:
+        """Return the latest ingest attempt with bounded read-only output."""
+        activity = self.store.read().get("ingest_activity") or None
+        if not activity:
+            return None
+        public = dict(activity)
+        log_path = Path(str(public.pop("console_log_path", "")))
+        console_output = ""
+        truncated = False
+        if log_path.is_file():
+            console_output = log_path.read_text(
+                encoding="utf-8", errors="replace"
+            )
+            if len(console_output) > MAX_BROWSER_CONSOLE_CHARACTERS:
+                console_output = console_output[-MAX_BROWSER_CONSOLE_CHARACTERS:]
+                truncated = True
+        public["console_output"] = console_output
+        public["console_truncated"] = truncated
+        return public
+
+    def run_ingest(self, expected_digest: str, actor: str) -> dict[str, Any]:
+        """Run the one fixed, parser-authorized SQLite-to-PostgreSQL ingest."""
+        digest = expected_digest.strip().lower()
+        if not re.fullmatch(r"[0-9a-f]{64}", digest):
+            raise ValueError("Expected SQLite SHA-256 must contain 64 hexadecimal characters")
+        state = self.store.read()
+        parser_run = state.get("production_parser_run") or {}
+        if (
+            parser_run.get("status") != "COMPLETE"
+            or parser_run.get("validation_status") != "PASSED"
+        ):
+            raise ValueError("Run and validate the production parser before ingest")
+        if str(parser_run.get("sqlite_sha256") or "").lower() != digest:
+            raise ValueError("The requested SQLite digest is not the latest validated parser output")
+        if Path(str(parser_run.get("sqlite_path") or "")).resolve() != self.production_db:
+            raise ValueError("The validated parser output is not the production SQLite file")
+        if parser_run.get("source_lor_version") != state["current_lor_version"]:
+            raise ValueError("The validated parser output does not use the approved LOR version")
+        if not self.production_db.is_file():
+            raise ValueError(f"Production SQLite file does not exist: {self.production_db}")
+        with self.production_db.open("rb") as source:
+            actual_digest = hashlib.file_digest(source, "sha256").hexdigest()
+        if actual_digest != digest:
+            raise ValueError("Production SQLite changed after the validated parser run")
+        previous = state.get("production_ingest_run") or {}
+        if (
+            previous.get("status") == "COMPLETE"
+            and previous.get("sqlite_sha256") == digest
+        ):
+            raise ValueError("This exact SQLite digest was already ingested")
+
+        password = required_environment("LOR_INGEST_PG_PASSWORD")
+        version = state["current_lor_version"]
+        activity, console_log = self._start_ingest_activity(digest, actor)
+        command = [
+            sys.executable,
+            str(self.ingest_path),
+            "--sqlite", str(self.production_db),
+            "--expected-sqlite-sha256", digest,
+            "--pg-host", "192.168.5.9",
+            "--pg-db", "msb",
+            "--pg-user", "msbadmin",
+            "--notes", (
+                f"LOR2DB web ingest for approved LOR {version}; "
+                f"requested by {actor}"
+            ),
+        ]
+        child_environment = os.environ.copy()
+        child_environment["PGPASSWORD"] = password
+        try:
+            completed = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=900,
+                check=False,
+                env=child_environment,
+            )
+        except Exception as error:
+            detail = f"[FATAL] PostgreSQL ingest could not complete: {error}"
+            self._finish_ingest_activity(
+                activity, "FAILED", console_log, detail, error=str(error)
+            )
+            raise RuntimeError(detail) from error
+        console_output = "\n".join(
+            part.strip() for part in (completed.stdout, completed.stderr)
+            if part and part.strip()
+        )
+        if completed.returncode:
+            detail = console_output or "PostgreSQL ingest failed"
+            self._finish_ingest_activity(
+                activity, "FAILED", console_log, detail, error=detail
+            )
+            raise RuntimeError(detail)
+        match = re.search(r"import_run_id=(\d+)", console_output)
+        if not match:
+            detail = "Ingest completed without reporting its import_run_id"
+            diagnostic = "\n".join(
+                part for part in (console_output, f"[FATAL] {detail}") if part
+            )
+            self._finish_ingest_activity(
+                activity, "FAILED", console_log, diagnostic, error=detail
+            )
+            raise RuntimeError(detail)
+        result = {
+            "status": "COMPLETE",
+            "sqlite_sha256": digest,
+            "source_lor_version": version,
+            "import_run_id": int(match.group(1)),
+            "completed_at": utc_now(),
+            "run_by": actor,
+        }
+        self._finish_ingest_activity(
+            activity, "PASSED", console_log, console_output, result=result
+        )
+        return result
+
     def public_state(self) -> dict[str, Any]:
         state = self.store.read()
         parser_activity = dict(state.get("parser_activity") or {}) or None
         if parser_activity:
             parser_activity.pop("console_log_path", None)
+        ingest_activity = dict(state.get("ingest_activity") or {}) or None
+        if ingest_activity:
+            ingest_activity.pop("console_log_path", None)
         return {
             "runner_version": RUNNER_VERSION,
             "current_lor_version": state["current_lor_version"],
@@ -529,6 +741,11 @@ class Runner:
             "candidate_resolution": state.get("candidate_resolution"),
             "production_parser_run": state.get("production_parser_run"),
             "parser_activity": parser_activity,
+            "production_ingest_run": state.get("production_ingest_run"),
+            "ingest_activity": ingest_activity,
+            "ingest_configured": bool(
+                os.environ.get("LOR_INGEST_PG_PASSWORD", "").strip()
+            ),
             "last_approval": state.get("last_approval"),
             "approval_history": state.get("approval_history", []),
         }
@@ -737,6 +954,10 @@ class Runner:
                 raise RuntimeError("LOR version changed while the parser was running; result was not recorded")
             if target == "current":
                 key = "production_parser_run"
+                previous_ingest = current.get("production_ingest_run") or {}
+                if previous_ingest.get("sqlite_sha256") != record.get("sqlite_sha256"):
+                    current["production_ingest_run"] = None
+                    current["ingest_activity"] = None
             elif target == "baseline":
                 key = "baseline_parser_run"
                 current["candidate_output_comparison"] = None
@@ -874,6 +1095,8 @@ class Runner:
             current["candidate_resolution"] = None
             current["production_parser_run"] = None
             current["parser_activity"] = None
+            current["production_ingest_run"] = None
+            current["ingest_activity"] = None
 
         return self.store.update(operation)
 
@@ -934,16 +1157,18 @@ class RequestHandler(BaseHTTPRequestHandler):
             return HTTPStatus.OK, self.runner.public_state()
         if self.command == "GET" and path == "/parser/activity":
             return HTTPStatus.OK, {"activity": self.runner.public_parser_activity()}
+        if self.command == "GET" and path == "/ingest/activity":
+            return HTTPStatus.OK, {"activity": self.runner.public_ingest_activity()}
         payload = self.body()
         actor = str(payload.get("actor") or "unknown-operator")
         if self.command == "POST":
-            # Only one state-changing/check/parser operation may run at a time.
+            # Only one state-changing/check/parser/ingest operation may run at a time.
             # This prevents concurrent website clicks from targeting the same
             # candidate database or changing the version record mid-run. A
             # second request is rejected rather than queued to run later.
             if not self.runner.operation_lock.acquire(blocking=False):
                 return HTTPStatus.CONFLICT, {
-                    "error": "Another parser or version-check operation is already running"
+                    "error": "Another parser, ingest, or version-check operation is already running"
                 }
             try:
                 if path == "/candidate":
@@ -956,6 +1181,10 @@ class RequestHandler(BaseHTTPRequestHandler):
                 if path == "/parser/run":
                     return HTTPStatus.OK, self.runner.run_parser(
                         str(payload.get("target") or ""), actor
+                    )
+                if path == "/ingest/run":
+                    return HTTPStatus.OK, self.runner.run_ingest(
+                        str(payload.get("expected_sqlite_sha256") or ""), actor
                     )
                 if path == "/candidate/resolve":
                     return HTTPStatus.OK, self.runner.resolve_candidate_findings(
@@ -1007,6 +1236,8 @@ def initialize(arguments: argparse.Namespace) -> None:
         "candidate_resolution": None,
         "production_parser_run": None,
         "parser_activity": None,
+        "production_ingest_run": None,
+        "ingest_activity": None,
         "last_approval": None,
         "approval_history": [],
     })

--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/test_lor_operator_runner.py
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/test_lor_operator_runner.py
@@ -76,6 +76,9 @@ class OperatorRunnerTests(unittest.TestCase):
         self.assertIn("function Stop-InstalledRunner", source)
         self.assertIn("not the managed LOR runner", source)
         self.assertIn("parser_activity.status -eq 'RUNNING'", source)
+        self.assertIn("ConfigureIngest", source)
+        self.assertIn("postgres-ingest-password.dpapi", source)
+        self.assertIn("LOR_INGEST_PG_PASSWORD", source)
 
     def test_http_access_log_uses_stdout_not_stderr(self) -> None:
         """A successful request must not become a PowerShell native error."""
@@ -264,6 +267,77 @@ class OperatorRunnerTests(unittest.TestCase):
         self.store.update(prepare)
         runner_module.Runner(self.store)
         activity = self.runner.public_parser_activity()
+        self.assertEqual(activity["status"], "INTERRUPTED")
+        self.assertIn("restarted", activity["error"])
+
+    @patch("lor_operator_runner.subprocess.run")
+    def test_web_ingest_is_locked_to_latest_validated_sqlite_digest(self, run) -> None:
+        database = self.root / "lor_output_v7_scene.db"
+        database.write_bytes(b"reviewed sqlite")
+        digest = runner_module.hashlib.sha256(database.read_bytes()).hexdigest()
+
+        def prepare(state):
+            state["production_parser_run"] = {
+                "status": "COMPLETE",
+                "validation_status": "PASSED",
+                "source_lor_version": "6.6.4",
+                "sqlite_path": str(database),
+                "sqlite_sha256": digest,
+            }
+
+        self.store.update(prepare)
+        run.return_value = argparse.Namespace(
+            returncode=0,
+            stdout="[DONE] Snapshot ingest complete. import_run_id=47\n",
+            stderr="",
+        )
+        with patch.dict(os.environ, {"LOR_INGEST_PG_PASSWORD": "secret"}):
+            result = self.runner.run_ingest(digest, "operator@example.com")
+
+        self.assertEqual(result["status"], "COMPLETE")
+        self.assertEqual(result["import_run_id"], 47)
+        command = run.call_args.args[0]
+        self.assertIn("--expected-sqlite-sha256", command)
+        self.assertIn(digest, command)
+        self.assertNotIn("secret", command)
+        self.assertEqual(run.call_args.kwargs["env"]["PGPASSWORD"], "secret")
+        activity = self.runner.public_ingest_activity()
+        self.assertEqual(activity["status"], "PASSED")
+        self.assertIn("import_run_id=47", activity["console_output"])
+        with patch.dict(os.environ, {"LOR_INGEST_PG_PASSWORD": "secret"}):
+            with self.assertRaisesRegex(ValueError, "already ingested"):
+                self.runner.run_ingest(digest, "operator@example.com")
+        self.assertEqual(run.call_count, 1)
+
+    def test_web_ingest_rejects_digest_not_approved_by_parser(self) -> None:
+        database = self.root / "lor_output_v7_scene.db"
+        database.write_bytes(b"reviewed sqlite")
+        digest = runner_module.hashlib.sha256(database.read_bytes()).hexdigest()
+
+        def prepare(state):
+            state["production_parser_run"] = {
+                "status": "COMPLETE",
+                "validation_status": "PASSED",
+                "source_lor_version": "6.6.4",
+                "sqlite_path": str(database),
+                "sqlite_sha256": digest,
+            }
+
+        self.store.update(prepare)
+        with self.assertRaisesRegex(ValueError, "not the latest validated"):
+            self.runner.run_ingest("0" * 64, "operator@example.com")
+
+    def test_runner_restart_marks_incomplete_ingest_activity_interrupted(self) -> None:
+        def prepare(state):
+            state["ingest_activity"] = {
+                "activity_id": "ingest-stale",
+                "status": "RUNNING",
+                "console_log_path": str(self.root / "missing-ingest.log"),
+            }
+
+        self.store.update(prepare)
+        restarted = runner_module.Runner(self.store)
+        activity = restarted.public_ingest_activity()
         self.assertEqual(activity["status"], "INTERRUPTED")
         self.assertIn("restarted", activity["error"])
 

--- a/LOR2DB/Application/README.md
+++ b/LOR2DB/Application/README.md
@@ -2,13 +2,14 @@
 
 | Document control | Value |
 |---|---|
-| Status | CURRENT code; V0.6.0 workflow separation pending review/deployment |
+| Status | CURRENT code; web ingest workflow pending review/deployment |
 | Initial release / current revision | 2026-08-04 / 2026-08-15 |
 
 ## Revision history
 
 | Date | Change |
 |---|---|
+| 2026-08-15 | Added the complete browser-operated parser-to-ingest workflow. The idempotent parser remains repeatable until the operator approves the exact displayed SQLite digest. The Windows runner then performs the fixed digest-locked PostgreSQL ingest and exposes read-only console output on the same page. Ingest never starts reconciliation automatically. |
 | 2026-08-15 | Separated routine parser execution from infrequent LOR-version approval. The landing page now has distinct parser, version, and reconciliation boxes; dedicated parser and version-check pages own their respective workflows. Runner V1.4.0 preserves bounded read-only console output, records failures, rejects concurrent operations, and marks interrupted work truthfully after restart. |
 | 2026-08-14 | Replaced manual runner-token commands with the root `run_lor_runner.ps1` installer. The token is generated once, protected with Windows DPAPI, paired to Linux through SSH, and verified by a non-secret fingerprint. Runner V1.3.0 logs rejected-header fingerprints; backend V0.5.1 bypasses HTTP proxies for the fixed private runner connection. |
 | 2026-08-14 | Added safe `APPROVE_STAGE_CHANGE` and `ADD_NEW_STAGE` paths gated by complete frozen evidence; contradictory stage groups remain non-approvable. The browser now shows every stage-group member. Cancellation now renders a terminal proof screen, cancelled reports have no misleading required actions, and the archive shows Outcome. Current-version parser runs permit structurally compatible authoring edits while candidate runs retain their exact checked-source guard. |
@@ -50,6 +51,8 @@ The page calls the existing authenticated backend through
 `/lor2db/preflight/api/`. Its separate function boxes show:
 
 - the normal repeatable **Run LOR parser** workflow;
+- the explicit parser review and **Ingest to PostgreSQL** step whenever a
+  successful parser output has not yet been ingested;
 - the current approved LOR version and a link to the separate infrequent
   **Check new version** workflow;
 - PostgreSQL reconciliation status, with no action button when no action is
@@ -305,29 +308,34 @@ direct write privileges on `ref`, `lor_snap`, or the reconciliation tables.
 After creating the login separately with a secured password, apply
 `grant_lor_preflight_app.sql` to install this exact grant set.
 
-## V0.6.0 incremental deployment order
+## Web ingest incremental deployment order
 
-This release changes the Windows runner, Linux API, and NAS browser files as
-one interface contract. It requires no PostgreSQL migration, grant change,
-token rotation, or runner re-pairing.
+This release changes the Windows runner, Linux API, and NAS browser files. It
+requires no PostgreSQL migration, grant change, runner-token rotation, or
+runner re-pairing. The Office PC records the existing PostgreSQL ingest
+password once in a Windows DPAPI-protected file; the password is never sent to
+the browser or Linux API.
 
-1. Back up `/opt/lor-preflight/backend.py` and the published
-   `/mnt/msb-web/my/lor2db` landing-page files; record their hashes.
-2. On the approved Windows host, pull the reviewed commit and run the complete
-   parser/runner tests. Retain the existing DPAPI token and `runner-state.json`.
-3. Reinstall the logged-in-user runner task with `run_lor_runner.ps1 -Action
-   Install`. Confirm hidden runner V1.4.0 health. Do not run `PairServer`.
-4. Deploy backend V0.6.0 to `/opt/lor-preflight/backend.py`, restart
-   `lor-preflight-api.service`, and verify `/health` reports V0.6.0.
+1. Back up the runner launcher/state and the deployed Linux/static application
+   files; record their hashes.
+2. Pull the reviewed commit on the Office PC and run the parser/runner and
+   application tests plus PowerShell and JavaScript syntax checks.
+3. Run `run_lor_runner.ps1 -Action Install`. Retain the existing runner token,
+   enter the PostgreSQL `msbadmin` password once at the secure prompt, and
+   verify runner V1.5.0. Do not run `PairServer`.
+4. Deploy backend V0.6.1, restart `lor-preflight-api.service`, and verify its
+   health response plus the existing backend-to-runner connection.
 5. Publish the complete `landing/` tree, including `parser/` and
    `version-check/`, to `/mnt/msb-web/my/lor2db/`. Preserve the existing
    `preflight/` and `reports/` trees.
-6. Verify the three distinct landing-page boxes, open both dedicated workflow
-   pages, and confirm the parser console endpoint can read the last activity.
-   Do not run the parser or select a candidate during deployment acceptance.
+6. Verify that parser review approval is tied to the displayed digest, the
+   ingest button is disabled until that approval is checked, and both parser
+   and ingest consoles load. Do not run a production ingest during deployment
+   acceptance.
 
-PostgreSQL ingest remains password-protected, digest-locked, and manual. This
-deployment adds no browser ingest endpoint.
+PostgreSQL ingest remains password-protected, digest-locked, and explicitly
+operator-approved. The browser starts only the fixed ingest operation and
+cannot provide a path, command, database account, or executable.
 
 ## Historical V0.5.1 combined deployment order
 

--- a/LOR2DB/Application/backend.py
+++ b/LOR2DB/Application/backend.py
@@ -3,7 +3,7 @@ MSB Database - LOR reconciliation preflight API
 backend.py
 
 Initial Release : 2026-08-05  V0.1.0
-Current Version : 2026-08-15  V0.6.0
+Current Version : 2026-08-15  V0.6.1
 Author          : GAL / OpenAI
 
 Purpose:
@@ -12,6 +12,9 @@ Purpose:
     append-only decisions, Finish, Cancel, and report completion.
 
 Revision History:
+    2026-08-15  GAL / OpenAI  V0.6.1
+        Added authenticated fixed endpoints for the Windows runner's
+        digest-locked PostgreSQL ingest and its read-only console output.
     2026-08-15  GAL / OpenAI  V0.6.0
         Separated routine parser execution from the infrequent LOR version
         approval workflow and exposed the runner's latest read-only console
@@ -61,6 +64,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import subprocess
 import sys
 from collections import defaultdict
@@ -76,7 +80,7 @@ from flask import Flask, Response, jsonify, request
 from psycopg2.extras import RealDictCursor
 
 
-APP_VERSION = "V0.6.0"
+APP_VERSION = "V0.6.1"
 FALLBACK_ACTIONS = {"DEFER", "CORRECT_SOURCE_REQUIRED", "RESTORE_TO_LOR_REQUIRED"}
 STAGE_AUTHORITY_ACTIONS = {
     "APPROVE_STAGE_CHANGE", "ADD_NEW_STAGE",
@@ -526,6 +530,13 @@ def get_parser_activity() -> Response:
     return jsonify(runner_request("parser/activity"))
 
 
+@app.get("/ingest/activity")
+def get_ingest_activity() -> Response:
+    """Return only the runner's bounded, read-only ingest console record."""
+    operator_email()
+    return jsonify(runner_request("ingest/activity"))
+
+
 @app.post("/parser/check")
 def run_parser_compatibility_check() -> Response:
     operator = operator_email()
@@ -542,6 +553,22 @@ def run_lor_parser() -> Response:
         raise ApiError("Parser target must be current, baseline, or candidate")
     return jsonify(runner_request(
         "parser/run", {"target": target, "actor": operator}, timeout=920
+    ))
+
+
+@app.post("/ingest/run")
+def run_postgresql_ingest() -> Response:
+    """Run only the latest validated SQLite digest through the fixed runner."""
+    operator = operator_email()
+    digest = str(
+        json_body().get("expected_sqlite_sha256") or ""
+    ).strip().lower()
+    if not re.fullmatch(r"[0-9a-f]{64}", digest):
+        raise ApiError("Expected SQLite SHA-256 must contain 64 hexadecimal characters")
+    return jsonify(runner_request(
+        "ingest/run",
+        {"expected_sqlite_sha256": digest, "actor": operator},
+        timeout=920,
     ))
 
 

--- a/LOR2DB/Application/landing/index.html
+++ b/LOR2DB/Application/landing/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>LOR production database</title>
-  <link rel="stylesheet" href="lor2db.css?v=0.5.0">
+  <link rel="stylesheet" href="lor2db.css?v=0.6.0">
 </head>
 <body>
   <main class="shell">
@@ -33,6 +33,6 @@
     </form>
   </dialog>
 
-  <script src="lor2db.js?v=0.5.0" defer></script>
+  <script src="lor2db.js?v=0.6.0" defer></script>
 </body>
 </html>

--- a/LOR2DB/Application/landing/lor2db.css
+++ b/LOR2DB/Application/landing/lor2db.css
@@ -23,6 +23,7 @@ h2 { margin-bottom: 10px; }
 .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; margin-top: 18px; }
 .task-grid { display: grid; grid-template-columns: 1.15fr .85fr; gap: 18px; margin-bottom: 18px; }
 .card { background: var(--card); border: 1px solid var(--line); border-radius: 9px; padding: 22px; box-shadow: 0 2px 9px #0000000a; }
+#app > .card + .card { margin-top: 18px; }
 .task-card { display: flex; flex-direction: column; align-items: flex-start; }
 .task-card .card-title { align-self: stretch; }
 .task-card > .primary, .task-card > .secondary { margin-top: auto; }
@@ -30,6 +31,11 @@ h2 { margin-bottom: 10px; }
 .workflow > div:first-child { flex: 1 1 500px; }
 .workflow-action { flex: 0 0 auto; }
 .manual-note { flex: 1 0 100%; border-top: 1px solid var(--line); padding-top: 15px; color: var(--muted); }
+.next-step-card { border-color: #7aa9c9; box-shadow: 0 3px 12px #145a8d18; }
+.next-step-card.workflow > div:first-child { flex-basis: 100%; }
+.compact-steps { margin-bottom: 14px; }
+.review-confirmation { display: flex; align-items: flex-start; gap: 9px; border: 1px solid var(--line); border-radius: 6px; background: #f6f9fb; padding: 12px 14px; }
+.review-confirmation input { width: auto; margin: 4px 0 0; }
 .primary, .secondary, button { display: inline-block; border: 1px solid #aeb8c2; border-radius: 5px; padding: .62rem .9rem; cursor: pointer; }
 .primary { color: #fff; border-color: var(--accent); background: var(--accent); }
 .secondary { color: var(--accent); background: #fff; }

--- a/LOR2DB/Application/landing/lor2db.js
+++ b/LOR2DB/Application/landing/lor2db.js
@@ -1,4 +1,4 @@
-/* MSB LOR landing page - 2026-08-15 V0.5.0 */
+/* MSB LOR landing page - 2026-08-15 V0.6.0 */
 (function () {
   "use strict";
 
@@ -31,6 +31,21 @@
     return payload;
   }
 
+  function parserHandoff(document) {
+    const run = document?.parser_runner?.production_parser_run;
+    const activity = document?.parser_runner?.parser_activity;
+    const digest = String(run?.sqlite_sha256 || "").toLowerCase();
+    if (run?.validation_status !== "PASSED" || !/^[0-9a-f]{64}$/.test(digest)) return null;
+    if (
+      activity?.target !== "current"
+      || activity?.status !== "PASSED"
+      || String(activity?.result?.sqlite_sha256 || "").toLowerCase() !== digest
+    ) return null;
+    const ingested = document?.parser_runner?.production_ingest_run;
+    if (ingested?.status === "COMPLETE" && ingested.sqlite_sha256 === digest) return null;
+    return { sqlite_sha256: digest };
+  }
+
   function parserWorkflowCard(runner, runnerError) {
     if (!runner) {
       return `<section class="card task-card">
@@ -43,7 +58,7 @@
     const parserStatus = run?.validation_status || "Rebuild required";
     return `<section class="card task-card">
       <div class="card-title"><h2>Run LOR parser</h2><span class="pill">Runner ${esc(runner.runner_version)}</span></div>
-      <p>Build the production SQLite database from the currently approved preview folder. You may run this repeatedly before the separate PostgreSQL ingest.</p>
+      <p>Build and inspect production SQLite from the approved preview folder. Repeat the parser until the results look correct, then approve the web-based PostgreSQL ingest.</p>
       <dl class="stacked-facts">
         <div><dt>Approved LOR version</dt><dd>${esc(runner.current_lor_version)}</dd></div>
         <div><dt>Preview source folder</dt><dd class="path-value">${esc(runner.current_preview_folder)}</dd></div>
@@ -52,7 +67,7 @@
         <div><dt>Production SQLite</dt><dd class="path-value">${esc(run?.sqlite_path || "Not built in the current approved-version state")}</dd></div>
         <div><dt>SQLite SHA-256</dt><dd class="digest">${esc(run?.sqlite_sha256 || "Not available until a validated parser run completes")}</dd></div>
       </dl>
-      <a class="primary" href="parser/">Run parser or view output</a>
+      <a class="primary" href="parser/">${runner.parser_activity?.target === "current" && runner.parser_activity?.status === "PASSED" ? "Review parser output" : "Run parser"}</a>
     </section>`;
   }
 
@@ -120,7 +135,18 @@
     </section>`;
   }
 
-  function workflowCard(workflow) {
+  function workflowCard(workflow, handoff) {
+    if (handoff) {
+      return `<section class="card workflow next-step-card">
+        <div>
+          <p class="eyebrow">Next step</p>
+          <h2>REVIEW PARSER OUTPUT</h2>
+          <p>The parser passed, but nothing has been ingested. Review the parser console, reports, counts, and SQLite results. Make corrections and rerun the parser as many times as needed.</p>
+        </div>
+        <div class="workflow-action"><a class="primary" href="parser/#parser-console">Review parser output</a></div>
+        <div class="manual-note"><strong>PostgreSQL remains unchanged.</strong> Ingest becomes available on the parser page only after you confirm that the displayed output looks correct.</div>
+      </section>`;
+    }
     const headings = {
       SNAPSHOT_CONSUMED: "NO NEW SNAPSHOT TO RECONCILE",
       READY_TO_START: "NEW SNAPSHOT READY FOR REVIEW",
@@ -136,12 +162,13 @@
     return `<section class="card workflow">
       <div><p class="eyebrow">PostgreSQL reconciliation status</p><h2>${esc(headings[workflow.state] || workflow.state.replaceAll("_", " "))}</h2><p>${esc(workflow.message)}</p></div>
       <div class="workflow-action">${action}</div>
-      <div class="manual-note"><strong>PostgreSQL ingest remains separate.</strong> Run and inspect the approved parser output first, then perform the digest-locked ingest. This page never starts an ingest.</div>
+      <div class="manual-note"><strong>Parser, ingest, and reconciliation are separate approvals.</strong> Each action appears only when its prior step is complete.</div>
     </section>`;
   }
 
   function render() {
-    app.innerHTML = `<div class="task-grid">${parserWorkflowCard(model.parser_runner, model.parser_runner_error)}${versionWorkflowCard(model.parser_runner, model.parser_runner_error)}</div>${workflowCard(model.workflow)}<div class="grid">${snapshotCard(model.snapshot)}${runCard(model.latest_run)}</div>`;
+    const handoff = parserHandoff(model);
+    app.innerHTML = `<div class="task-grid">${parserWorkflowCard(model.parser_runner, model.parser_runner_error)}${versionWorkflowCard(model.parser_runner, model.parser_runner_error)}</div>${workflowCard(model.workflow, handoff)}<div class="grid">${snapshotCard(model.snapshot)}${runCard(model.latest_run)}</div>`;
     document.querySelector("#start-run")?.addEventListener("click", () => {
       dialogError.textContent = "";
       startMessage.textContent = `Snapshot ${model.snapshot.import_run_id} will be captured for a new reconciliation run.`;

--- a/LOR2DB/Application/landing/parser/index.html
+++ b/LOR2DB/Application/landing/parser/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Run LOR parser</title>
-  <link rel="stylesheet" href="../lor2db.css?v=0.5.0">
+  <link rel="stylesheet" href="../lor2db.css?v=0.6.0">
 </head>
 <body>
   <main class="shell">
@@ -19,6 +19,6 @@
       <section class="card"><p>Loading parser status...</p></section>
     </div>
   </main>
-  <script src="parser.js?v=0.5.0" defer></script>
+  <script src="parser.js?v=0.6.0" defer></script>
 </body>
 </html>

--- a/LOR2DB/Application/landing/parser/parser.js
+++ b/LOR2DB/Application/landing/parser/parser.js
@@ -1,11 +1,13 @@
-/* MSB read-only parser console - 2026-08-15 V0.5.0 */
+/* MSB parser and ingest workflow - 2026-08-15 V0.6.0 */
 (function () {
   "use strict";
 
   const app = document.querySelector("#app");
   let model;
-  let activity;
+  let parserActivity;
+  let ingestActivity;
   let pollTimer;
+  let reviewedDigest;
 
   const esc = (value) => String(value ?? "").replace(/[&<>"']/g, (char) => ({
     "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;"
@@ -42,26 +44,120 @@
     </div>`;
   }
 
+  function validatedDigest(runner) {
+    const run = runner?.production_parser_run;
+    const activity = runner?.parser_activity;
+    const digest = String(run?.sqlite_sha256 || "").toLowerCase();
+    if (run?.validation_status !== "PASSED" || !/^[0-9a-f]{64}$/.test(digest)) return null;
+    if (
+      activity?.target !== "current"
+      || activity?.status !== "PASSED"
+      || String(activity?.result?.sqlite_sha256 || "").toLowerCase() !== digest
+    ) return null;
+    return digest;
+  }
+
+  function ingestWorkflow(runner, digest, workflow) {
+    if (!digest) return "";
+    const ingest = ingestActivity?.activity;
+    const ingested = runner.production_ingest_run;
+    const sameDigestComplete = ingested?.status === "COMPLETE" && ingested.sqlite_sha256 === digest;
+    const running = ingest?.status === "RUNNING";
+    const failed = ingest?.status === "FAILED" || ingest?.status === "INTERRUPTED";
+    const reviewed = reviewedDigest === digest;
+    let status = reviewed ? "READY FOR INGEST" : "REVIEW REQUIRED";
+    let detail = reviewed
+      ? "You marked this exact parser output as correct. Ingest is now available for this SQLite SHA-256 only."
+      : "Review the parser console, counts, reports, and SQLite output above. If anything is wrong, make corrections and run the parser again. Continue only when this exact output looks correct.";
+    let controls = reviewed
+      ? `<div class="page-actions">
+          <button id="run-ingest" class="primary" type="button">Ingest to PostgreSQL</button>
+          <button id="rerun-parser" type="button">Make corrections and run parser again</button>
+        </div>`
+      : `<div class="page-actions">
+          <button id="mark-ready-ingest" class="primary" type="button">Parser output looks correct — ready for ingest</button>
+          <button id="rerun-parser" type="button">Make corrections and run parser again</button>
+        </div>`;
+
+    if (!runner.ingest_configured) {
+      status = "SETUP REQUIRED";
+      detail = "The Office PC does not yet have its protected PostgreSQL ingest credential. Configure it once before using web ingest.";
+      controls = '<p class="error">Web ingest is unavailable until the protected credential is configured.</p>';
+    } else if (running) {
+      status = "INGEST RUNNING";
+      detail = "PostgreSQL ingest is running. Its read-only console output updates below.";
+      controls = '<div class="page-actions"><button class="primary" type="button" disabled>Ingest is running...</button></div>';
+    } else if (sameDigestComplete) {
+      status = "INGEST COMPLETE";
+      detail = `PostgreSQL snapshot ${esc(ingested.import_run_id)} was created successfully. Review the ingest console below before starting reconciliation.`;
+      controls = "";
+    } else if (failed) {
+      status = "INGEST FAILED";
+      detail = "Review the ingest console error below. Reconciliation has not started. Correct the problem and retry this same validated snapshot.";
+      controls = reviewed
+        ? '<div class="page-actions"><button id="run-ingest" class="primary" type="button">Retry PostgreSQL ingest</button><button id="rerun-parser" type="button">Make corrections and run parser again</button></div>'
+        : '<div class="page-actions"><button id="mark-ready-ingest" class="primary" type="button">Parser output still looks correct — retry ingest</button><button id="rerun-parser" type="button">Make corrections and run parser again</button></div>';
+    }
+
+    return `<section id="ingest-step" class="card next-step-card">
+      <div class="card-title"><div><p class="eyebrow">2. Operator approval and ingest</p><h2>PostgreSQL snapshot ingest</h2></div><span class="pill">${esc(status)}</span></div>
+      <p>${detail}</p>
+      <dl class="facts">
+        <div><dt>Validated SQLite SHA-256</dt><dd class="digest">${esc(digest)}</dd></div>
+        <div><dt>PostgreSQL import run</dt><dd>${esc(ingested?.import_run_id || "Not yet created")}</dd></div>
+      </dl>
+      ${controls}
+    </section>`;
+  }
+
+  function reconciliationWorkflow(runner, digest, workflow) {
+    const ingested = runner?.production_ingest_run;
+    const sameDigestComplete = digest
+      && ingested?.status === "COMPLETE"
+      && ingested.sqlite_sha256 === digest;
+    if (!sameDigestComplete) return "";
+    const controls = workflow?.can_start
+      ? '<button id="start-reconciliation" class="primary" type="button">Start reconciliation</button>'
+      : '<button id="refresh-reconciliation" type="button">Refresh reconciliation status</button>';
+    return `<section class="card next-step-card">
+      <div class="card-title"><div><p class="eyebrow">3. Reconcile the new snapshot</p><h2>Start reconciliation</h2></div><span class="pill">INGEST ${esc(ingested.import_run_id)} READY</span></div>
+      <p>The PostgreSQL ingest completed. After reviewing its console output, start reconciliation for this newly committed snapshot.</p>
+      <div class="page-actions">${controls}<a class="secondary" href="../">Return to dashboard</a></div>
+    </section>`;
+  }
+
+  function consoleCard(id, title, activity, emptyMessage) {
+    const record = activity?.activity;
+    const status = record?.status || "NOT RUN";
+    const output = record?.console_output || (status === "RUNNING" ? "Operation is running..." : emptyMessage);
+    return `<section id="${esc(id)}" class="card">
+      <div class="card-title"><h2>${esc(title)}</h2><span class="pill state-${esc(status.toLowerCase())}">${esc(status)}</span></div>
+      ${record?.console_truncated ? '<p class="warning">Only the most recent 500,000 characters are displayed. The complete log remains on the Office PC.</p>' : ""}
+      ${record?.error ? `<p class="error">${esc(record.error)}</p>` : ""}
+      <pre class="console">${esc(output)}</pre>
+    </section>`;
+  }
+
   function render() {
     const runner = model?.parser_runner;
     if (!runner) {
       app.innerHTML = `<section class="card"><h2>Runner unavailable</h2><p class="error">${esc(model?.parser_runner_error || "The Windows/G-drive runner is offline.")}</p></section>`;
       return;
     }
-    const latest = activity?.activity;
-    const running = latest?.status === "RUNNING";
+    const latest = parserActivity?.activity;
+    const parserRunning = latest?.status === "RUNNING";
+    const ingestRunning = ingestActivity?.activity?.status === "RUNNING";
     const run = latest?.result || runner.production_parser_run;
     const status = latest?.status || "NOT RUN FROM THIS PAGE";
-    const consoleText = latest?.console_output || (running
-      ? "Parser process is running. Complete console output will appear when the process finishes."
-      : "No parser console output has been recorded yet.");
-    const error = latest?.error ? `<p class="error">${esc(latest.error)}</p>` : "";
+    const digest = validatedDigest(runner);
+    if (reviewedDigest && reviewedDigest !== digest) reviewedDigest = undefined;
     const targetNote = latest && latest.target !== "current"
-      ? `<p class="warning">The latest recorded parser activity belongs to the ${esc(latest.target)} version-check workflow, not a production parser run.</p>`
+      ? `<p class="warning">The latest parser activity belongs to the ${esc(latest.target)} version-check workflow, not the production parser.</p>`
       : "";
+
     app.innerHTML = `<section class="card">
-      <div class="card-title"><h2>Production SQLite parser</h2><span class="pill">Runner ${esc(runner.runner_version)}</span></div>
-      <p>This reads the approved preview folder and atomically rebuilds the production SQLite file. It does not ingest PostgreSQL or start reconciliation.</p>
+      <div class="card-title"><h2>1. Build and review production SQLite</h2><span class="pill">Runner ${esc(runner.runner_version)}</span></div>
+      <p>Run the parser, inspect its output, and make any needed corrections. You may run this step again as many times as necessary. Each run rebuilds and replaces the SQLite output; PostgreSQL remains unchanged until you explicitly approve ingest.</p>
       <dl class="facts">
         <div><dt>Approved LOR version</dt><dd>${esc(runner.current_lor_version)}</dd></div>
         <div><dt>Parser status</dt><dd>${esc(status)}</dd></div>
@@ -72,56 +168,78 @@
         <div><dt>SQLite SHA-256</dt><dd class="digest">${esc(run?.sqlite_sha256 || "Not recorded")}</dd></div>
         <div><dt>Validation</dt><dd>${esc(run?.validation_status || "Not recorded")}</dd></div>
       </dl>
-      ${targetNote}${error}${counts(run)}
+      ${targetNote}${counts(run)}
       <div class="page-actions">
-        <button id="run-parser" class="primary" type="button" ${running ? "disabled" : ""}>${running ? "Parser is running..." : "Run parser"}</button>
+        ${digest && !parserRunning && !ingestRunning
+          ? '<a class="primary" href="#parser-console">Review parser output</a>'
+          : `<button id="run-parser" class="primary" type="button" ${parserRunning || ingestRunning ? "disabled" : ""}>${parserRunning ? "Parser is running..." : "Run parser"}</button>`}
         <button id="refresh-output" type="button">Refresh output</button>
         <a class="secondary" href="../">Return to dashboard</a>
       </div>
     </section>
-    <section class="card">
-      <div class="card-title"><h2>Read-only console output</h2><span class="pill state-${esc(status.toLowerCase())}">${esc(status)}</span></div>
-      ${latest?.console_truncated ? '<p class="warning">The display is limited to the most recent 500,000 characters. The complete log remains on the runner host.</p>' : ""}
-      <pre id="console-output" class="console">${esc(consoleText)}</pre>
-    </section>`;
+    ${consoleCard("parser-console", "Parser console output", parserActivity, "No parser console output has been recorded yet.")}
+    ${ingestWorkflow(runner, digest, model.workflow)}
+    ${consoleCard("ingest-console", "PostgreSQL ingest console output", ingestActivity, "No PostgreSQL ingest has been run for this parser output.")}
+    ${reconciliationWorkflow(runner, digest, model.workflow)}`;
 
-    document.querySelector("#refresh-output")?.addEventListener("click", refresh);
     document.querySelector("#run-parser")?.addEventListener("click", runParser);
-    const consoleElement = document.querySelector("#console-output");
-    if (consoleElement) consoleElement.scrollTop = consoleElement.scrollHeight;
-    if (running && !pollTimer) pollTimer = window.setInterval(refreshActivity, 2000);
+    document.querySelector("#rerun-parser")?.addEventListener("click", runParser);
+    document.querySelector("#mark-ready-ingest")?.addEventListener("click", () => {
+      reviewedDigest = digest;
+      render();
+      document.querySelector("#ingest-step")?.scrollIntoView({ behavior: "smooth", block: "start" });
+    });
+    document.querySelector("#run-ingest")?.addEventListener("click", runIngest);
+    document.querySelector("#start-reconciliation")?.addEventListener("click", startReconciliation);
+    document.querySelector("#refresh-output")?.addEventListener("click", refresh);
+    document.querySelector("#refresh-reconciliation")?.addEventListener("click", refresh);
+    document.querySelectorAll(".console").forEach((element) => {
+      element.scrollTop = element.scrollHeight;
+    });
+    const running = parserRunning || ingestRunning;
+    if (running && !pollTimer) pollTimer = window.setInterval(refresh, 2000);
     if (!running && pollTimer) {
       window.clearInterval(pollTimer);
       pollTimer = undefined;
     }
   }
 
-  async function refreshActivity() {
-    try {
-      activity = await request("parser/activity");
-      render();
-    } catch (error) {
-      window.clearInterval(pollTimer);
-      pollTimer = undefined;
-      app.insertAdjacentHTML("afterbegin", `<p class="error">${esc(error.message)}</p>`);
-    }
-  }
-
   async function refresh() {
-    [model, activity] = await Promise.all([
-      request("dashboard"), request("parser/activity")
+    [model, parserActivity, ingestActivity] = await Promise.all([
+      request("dashboard"), request("parser/activity"), request("ingest/activity")
     ]);
     render();
   }
 
   async function runParser(event) {
-    if (!window.confirm("Run the parser for the approved LOR version now? This rebuilds SQLite only; PostgreSQL remains unchanged.")) return;
+    if (!window.confirm("Run the parser now? You can inspect the output and run it again before ingest.")) return;
+    reviewedDigest = undefined;
     event.currentTarget.disabled = true;
     event.currentTarget.textContent = "Starting parser...";
-    pollTimer = window.setInterval(refreshActivity, 2000);
+    if (!pollTimer) pollTimer = window.setInterval(refresh, 2000);
     try {
-      await request("parser/run", {
-        method: "POST", body: JSON.stringify({ target: "current" })
+      await request("parser/run", { method: "POST", body: JSON.stringify({ target: "current" }) });
+    } catch (error) {
+      window.alert(error.message);
+    } finally {
+      await refresh();
+    }
+  }
+
+  async function runIngest(event) {
+    const digest = validatedDigest(model?.parser_runner);
+    if (!digest || reviewedDigest !== digest) {
+      window.alert("Review and approve this exact parser output before ingest.");
+      return;
+    }
+    if (!window.confirm("Ingest this reviewed SQLite snapshot into PostgreSQL now? Reconciliation will not start automatically.")) return;
+    event.currentTarget.disabled = true;
+    event.currentTarget.textContent = "Starting ingest...";
+    if (!pollTimer) pollTimer = window.setInterval(refresh, 2000);
+    try {
+      await request("ingest/run", {
+        method: "POST",
+        body: JSON.stringify({ expected_sqlite_sha256: digest })
       });
     } catch (error) {
       window.alert(error.message);
@@ -130,7 +248,21 @@
     }
   }
 
+  async function startReconciliation(event) {
+    if (!window.confirm("Start reconciliation for the newly ingested PostgreSQL snapshot?")) return;
+    event.currentTarget.disabled = true;
+    event.currentTarget.textContent = "Starting reconciliation...";
+    try {
+      const result = await request("runs/start", { method: "POST", body: "{}" });
+      location.href = `../${result.review_url}`;
+    } catch (error) {
+      window.alert(error.message);
+      event.currentTarget.disabled = false;
+      event.currentTarget.textContent = "Start reconciliation";
+    }
+  }
+
   refresh().catch((error) => {
-    app.innerHTML = `<section class="card"><h2>Parser status unavailable</h2><p class="error">${esc(error.message)}</p></section>`;
+    app.innerHTML = `<section class="card"><h2>Parser workflow unavailable</h2><p class="error">${esc(error.message)}</p></section>`;
   });
 }());

--- a/LOR2DB/Application/landing/version-check/index.html
+++ b/LOR2DB/Application/landing/version-check/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Check a new LOR version</title>
-  <link rel="stylesheet" href="../lor2db.css?v=0.5.0">
+  <link rel="stylesheet" href="../lor2db.css?v=0.6.0">
 </head>
 <body>
   <main class="shell">

--- a/LOR2DB/Application/test_backend.py
+++ b/LOR2DB/Application/test_backend.py
@@ -320,6 +320,44 @@ class BackendSafetyTests(unittest.TestCase):
         self.assertEqual(response.json, expected)
         runner.assert_called_once_with("parser/activity")
 
+    def test_ingest_forwards_only_validated_digest_and_authenticated_actor(self) -> None:
+        digest = "a" * 64
+        with patch.object(backend, "runner_request", return_value={"status": "COMPLETE"}) as runner:
+            response = backend.app.test_client().post(
+                "/ingest/run",
+                json={
+                    "expected_sqlite_sha256": digest,
+                    "sqlite_path": "C:\\unsafe.db",
+                    "command": "arbitrary",
+                },
+                headers={
+                    "Cf-Access-Authenticated-User-Email":
+                        "greg@sheboyganlights.org"
+                },
+            )
+        self.assertEqual(response.status_code, 200)
+        runner.assert_called_once_with(
+            "ingest/run",
+            {
+                "expected_sqlite_sha256": digest,
+                "actor": "greg@sheboyganlights.org",
+            },
+            timeout=920,
+        )
+
+    def test_ingest_rejects_invalid_digest_before_runner_use(self) -> None:
+        with patch.object(backend, "runner_request") as runner:
+            response = backend.app.test_client().post(
+                "/ingest/run",
+                json={"expected_sqlite_sha256": "not-a-digest"},
+                headers={
+                    "Cf-Access-Authenticated-User-Email":
+                        "greg@sheboyganlights.org"
+                },
+            )
+        self.assertEqual(response.status_code, 400)
+        runner.assert_not_called()
+
     def test_landing_page_separates_parser_and_version_workflows(self) -> None:
         landing = Path(__file__).with_name("landing")
         source = (landing / "lor2db.js").read_text(encoding="utf-8")
@@ -338,9 +376,16 @@ class BackendSafetyTests(unittest.TestCase):
         self.assertIn("Run version check", version_source)
         self.assertIn('target: "baseline"', version_source)
         self.assertIn('target: "candidate"', version_source)
-        self.assertIn("Read-only console output", parser_source)
+        self.assertIn("Parser console output", parser_source)
+        self.assertIn("PostgreSQL ingest console output", parser_source)
         self.assertIn('target: "current"', parser_source)
-        self.assertIn("only; PostgreSQL remains unchanged", parser_source)
+        self.assertIn("Each run rebuilds and replaces the SQLite output", parser_source)
+        self.assertIn("Parser output looks correct — ready for ingest", parser_source)
+        self.assertIn("Ingest to PostgreSQL", parser_source)
+        self.assertIn('request("ingest/run"', parser_source)
+        self.assertIn("Start reconciliation", parser_source)
+        self.assertIn('request("runs/start"', parser_source)
+        self.assertIn("Review parser output", source)
 
 
 if __name__ == "__main__":

--- a/run_lor_runner.ps1
+++ b/run_lor_runner.ps1
@@ -8,10 +8,14 @@
 #   The shared bearer token is generated once and stored with Windows DPAPI.
 #   It is never printed or accepted as a command-line argument. PairServer
 #   transfers it through SSH to a mode-0600 pending file for root installation.
+#   The PostgreSQL ingest password is also stored with account-bound DPAPI and
+#   is available only to the managed runner and fixed ingest child process. It
+#   is never returned to the browser, Linux API, runner state, console output,
+#   or command line.
 
 [CmdletBinding()]
 param(
-    [ValidateSet('Install', 'PairServer', 'Start', 'Stop', 'Status')]
+    [ValidateSet('Install', 'ConfigureIngest', 'PairServer', 'Start', 'Stop', 'Status')]
     [string]$Action = 'Status',
 
     [string]$RunnerHost = '192.168.5.55',
@@ -34,9 +38,12 @@ $ParserPath = Join-Path $RepoRoot `
     'Docs\01_LOR_System\02_Data_Extraction\Parser\parse_props_v7_scene_parser.py'
 $CheckerPath = Join-Path $RepoRoot `
     'Docs\01_LOR_System\02_Data_Extraction\Parser\lor_version_checker.py'
+$IngestPath = Join-Path $RepoRoot `
+    'LOR2DB\01_Ingest\postgres_ingest_from_lor_sqlite_v7.py'
 $PythonPath = Join-Path $RepoRoot '.venv\Scripts\python.exe'
 $SecretRoot = Join-Path $env:LOCALAPPDATA 'MSB\LORRunner'
 $SecretPath = Join-Path $SecretRoot 'runner-token.dpapi'
+$IngestSecretPath = Join-Path $SecretRoot 'postgres-ingest-password.dpapi'
 $ServiceLogPath = Join-Path $SecretRoot 'runner-service.log'
 $PendingRemotePath = '~/.msb-lor-runner-token.pending'
 
@@ -128,12 +135,55 @@ function Read-ProtectedToken {
     return $token
 }
 
+function Save-ProtectedIngestCredential {
+    param(
+        [Parameter(Mandatory = $true)]
+        [Security.SecureString]$Credential
+    )
+
+    if ($Credential.Length -eq 0) {
+        throw 'PostgreSQL ingest password cannot be blank.'
+    }
+    New-Item -ItemType Directory -Force -Path $SecretRoot | Out-Null
+    $encrypted = ConvertFrom-SecureString -SecureString $Credential
+    Set-Content `
+        -LiteralPath $IngestSecretPath `
+        -Value $encrypted `
+        -Encoding ASCII `
+        -NoNewline
+    Set-SecretAcl -Path $IngestSecretPath
+}
+
+function Read-ProtectedIngestCredential {
+    if (-not (Test-Path -LiteralPath $IngestSecretPath -PathType Leaf)) {
+        throw 'PostgreSQL ingest credential is not configured.'
+    }
+    $encrypted = (Get-Content -LiteralPath $IngestSecretPath -Raw).Trim()
+    $secureCredential = ConvertTo-SecureString -String $encrypted
+    $pointer = [Runtime.InteropServices.Marshal]::SecureStringToBSTR(
+        $secureCredential
+    )
+    try {
+        $credential = [Runtime.InteropServices.Marshal]::PtrToStringBSTR(
+            $pointer
+        )
+    }
+    finally {
+        [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($pointer)
+    }
+    if (-not $credential) {
+        throw 'Protected PostgreSQL ingest credential is invalid.'
+    }
+    return $credential
+}
+
 function Assert-RunnerPrerequisites {
     foreach ($requiredPath in @(
         $StateFile,
         $RunnerPath,
         $ParserPath,
         $CheckerPath,
+        $IngestPath,
         $PythonPath
     )) {
         if (-not (Test-Path -LiteralPath $requiredPath -PathType Leaf)) {
@@ -210,7 +260,7 @@ function Install-ScheduledRunner {
         -Trigger $trigger `
         -Principal $principal `
         -Settings $settings `
-        -Description 'Restricted LOR2DB parser/version-check runner; requires Greg logon and G: drive.' `
+        -Description 'Restricted LOR2DB parser/ingest/version-check runner; requires Greg logon and G: drive.' `
         -Force | Out-Null
 }
 
@@ -218,6 +268,9 @@ function Stop-InstalledRunner {
     $state = Get-Content -LiteralPath $StateFile -Raw | ConvertFrom-Json
     if ($state.parser_activity -and $state.parser_activity.status -eq 'RUNNING') {
         throw 'The LOR parser is running. Wait for it to finish before reinstalling the runner.'
+    }
+    if ($state.ingest_activity -and $state.ingest_activity.status -eq 'RUNNING') {
+        throw 'The PostgreSQL ingest is running. Wait for it to finish before reinstalling the runner.'
     }
 
     $existingTask = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
@@ -311,11 +364,38 @@ switch ($Action) {
             Save-ProtectedToken -Token $token
             Write-Host '[OK] New runner token generated and protected with Windows DPAPI.'
         }
+        if (Test-Path -LiteralPath $IngestSecretPath -PathType Leaf) {
+            Write-Host '[INFO] Existing protected PostgreSQL ingest credential retained.'
+        }
+        else {
+            Write-Host '[SETUP] Enter the PostgreSQL msbadmin password once for web ingest.'
+            $secureIngestCredential = Read-Host `
+                'PostgreSQL ingest password' `
+                -AsSecureString
+            Save-ProtectedIngestCredential `
+                -Credential $secureIngestCredential
+            Write-Host '[OK] PostgreSQL ingest credential protected with Windows DPAPI.'
+            Remove-Variable secureIngestCredential -ErrorAction SilentlyContinue
+        }
         Install-ScheduledRunner
         Write-Host "[OK] Scheduled Task installed for logged-in account: $TaskName"
         Write-Host "[OK] Credential fingerprint: $(Get-TokenFingerprint -Token $token)"
         Start-InstalledRunner -Token $token
         Write-Host '[NEXT] Run: .\run_lor_runner.ps1 -Action PairServer'
+        Remove-Variable token -ErrorAction SilentlyContinue
+    }
+
+    'ConfigureIngest' {
+        Assert-RunnerPrerequisites | Out-Null
+        $secureIngestCredential = Read-Host `
+            'Enter the PostgreSQL msbadmin password for web ingest' `
+            -AsSecureString
+        Save-ProtectedIngestCredential -Credential $secureIngestCredential
+        Remove-Variable secureIngestCredential -ErrorAction SilentlyContinue
+        Stop-InstalledRunner
+        $token = Read-ProtectedToken
+        Start-InstalledRunner -Token $token
+        Write-Host '[OK] PostgreSQL ingest credential updated and runner restarted.'
         Remove-Variable token -ErrorAction SilentlyContinue
     }
 
@@ -354,7 +434,9 @@ switch ($Action) {
                 throw "Port $Port already has a listener; a second runner was not started."
             }
             $token = Read-ProtectedToken
+            $ingestCredential = Read-ProtectedIngestCredential
             $env:LOR_RUNNER_TOKEN = $token
+            $env:LOR_INGEST_PG_PASSWORD = $ingestCredential
             $env:LOR_PREVIEW_PARENT = 'G:\Shared drives\MSB Database'
             $env:LOR_SQLITE_OUTPUT =
                 'G:\Shared drives\MSB Database\database\lor_output_v7_scene.db'
@@ -362,9 +444,10 @@ switch ($Action) {
                 'G:\Shared drives\MSB Database\LOR Version Reviews'
             $env:LOR_PARSER_PATH = $ParserPath
             $env:LOR_CHECKER_PATH = $CheckerPath
+            $env:LOR_INGEST_PATH = $IngestPath
             $env:PYTHONUNBUFFERED = '1'
             Write-ServiceLog (
-                "Starting runner V1.4.0; credential fingerprint=" +
+                "Starting runner V1.5.0; credential fingerprint=" +
                 "$(Get-TokenFingerprint -Token $token)."
             )
             # BaseHTTPRequestHandler writes normal HTTP access records to
@@ -395,7 +478,9 @@ switch ($Action) {
         }
         finally {
             Remove-Item Env:\LOR_RUNNER_TOKEN -ErrorAction SilentlyContinue
+            Remove-Item Env:\LOR_INGEST_PG_PASSWORD -ErrorAction SilentlyContinue
             Remove-Variable token -ErrorAction SilentlyContinue
+            Remove-Variable ingestCredential -ErrorAction SilentlyContinue
         }
     }
 
@@ -420,6 +505,12 @@ switch ($Action) {
         }
         $token = Read-ProtectedToken
         Write-Host 'Protected token: AVAILABLE'
+        if (Test-Path -LiteralPath $IngestSecretPath -PathType Leaf) {
+            Write-Host 'Protected PostgreSQL ingest credential: AVAILABLE'
+        }
+        else {
+            Write-Host 'Protected PostgreSQL ingest credential: NOT CONFIGURED'
+        }
         Write-Host "Credential fingerprint: $(Get-TokenFingerprint -Token $token)"
         try {
             $health = Test-AuthenticatedHealth -Token $token


### PR DESCRIPTION
## What changed

- Adds the complete browser-operated workflow:
  1. Run the production parser.
  2. Review parser output.
  3. Make corrections and rerun as many times as needed.
  4. Mark the exact validated SQLite output ready for ingest.
  5. Ingest to PostgreSQL and review its console.
  6. Start reconciliation.
- Keeps parser runs repeatable and atomic; parser execution never starts ingest.
- Adds a digest-locked PostgreSQL ingest operation to the restricted Windows runner.
- Adds browser-readable parser and ingest activity records and console output.
- Adds an explicit review gate bound to the latest validated SQLite SHA-256. Any parser rerun clears the browser approval.
- Blocks concurrent parser, ingest, and version-check operations.
- Prevents a second ingest of the same SQLite digest.
- Adds a one-time DPAPI-protected PostgreSQL credential for the fixed ingest child process.
- Corrects dashboard and parser-page wording so each page presents the actual next step.
- Exposes Start reconciliation only after the reviewed snapshot has been ingested successfully.

## Why

The deployed UI stopped after building SQLite and still directed the operator toward a separate manual ingest. It also displayed misleading reconciliation wording while a newly parsed SQLite artifact was waiting for review. That broke the intended parser-review-correction loop and forced the operator back to PowerShell.

This change keeps the entire normal workflow in LOR2DB while preserving the parser as a standalone, repeatable step.

## Safety boundaries

- The browser supplies only the displayed 64-character SQLite SHA-256.
- The runner accepts no executable, SQLite path, database target, or database credential from the browser.
- The runner verifies the exact latest production parser result, approved LOR version, fixed production SQLite path, validation status, and current on-disk digest before ingest.
- PostgreSQL ingest remains transactional.
- Ingest never starts reconciliation automatically.
- The protected PostgreSQL password is not returned through the API, state, logs, browser, or command line.

## Versions

- Windows runner: V1.5.0
- API backend: V0.6.1
- Browser workflow: V0.6.0

## Validation

- 29 parser/runner tests passed.
- Python compilation checks passed.
- JavaScript syntax checks passed.
- `git diff --check` passed.
- The complete Flask backend suite could not run in the Work Mode container because `psycopg2` is unavailable.
- Windows PowerShell syntax and the full Application suite must be rerun on the Windows checkout before deployment.

## Deployment impact

- Reinstall the Office PC runner after merge. Install retains the existing runner token and prompts once for the PostgreSQL `msbadmin` password if the DPAPI ingest credential is not configured.
- Deploy backend V0.6.1 and the V0.6.0 landing/parser assets.
- No PostgreSQL migration, grant change, runner token rotation, or server re-pairing is required.
