### PR TITLE
Restore permanent Run parser action

### DIFF
--- a/LOR2DB/Application/README.md
+++ b/LOR2DB/Application/README.md
@@ -2,13 +2,14 @@
 
 | Document control | Value |
 |---|---|
-| Status | CURRENT code; web ingest workflow pending review/deployment |
-| Initial release / current revision | 2026-08-04 / 2026-08-15 |
+| Status | CURRENT code; web ingest workflow deployed; V0.6.1 action-clarity hotfix pending deployment |
+| Initial release / current revision | 2026-08-04 / 2026-08-16 |
 
 ## Revision history
 
 | Date | Change |
 |---|---|
+| 2026-08-16 | Kept `Run parser` permanently available after successful runs and made `Review parser output` an additional action instead of a replacement. Corrected the Windows installer message so an unchanged protected token does not instruct the operator to pair the server again. |
 | 2026-08-15 | Added the complete browser-operated parser-to-ingest workflow. The idempotent parser remains repeatable until the operator approves the exact displayed SQLite digest. The Windows runner then performs the fixed digest-locked PostgreSQL ingest and exposes read-only console output on the same page. Ingest never starts reconciliation automatically. |
 | 2026-08-15 | Separated routine parser execution from infrequent LOR-version approval. The landing page now has distinct parser, version, and reconciliation boxes; dedicated parser and version-check pages own their respective workflows. Runner V1.4.0 preserves bounded read-only console output, records failures, rejects concurrent operations, and marks interrupted work truthfully after restart. |
 | 2026-08-14 | Replaced manual runner-token commands with the root `run_lor_runner.ps1` installer. The token is generated once, protected with Windows DPAPI, paired to Linux through SSH, and verified by a non-secret fingerprint. Runner V1.3.0 logs rejected-header fingerprints; backend V0.5.1 bypasses HTTP proxies for the fixed private runner connection. |

--- a/LOR2DB/Application/landing/index.html
+++ b/LOR2DB/Application/landing/index.html
@@ -33,6 +33,6 @@
     </form>
   </dialog>
 
-  <script src="lor2db.js?v=0.6.0" defer></script>
+  <script src="lor2db.js?v=0.6.1" defer></script>
 </body>
 </html>

--- a/LOR2DB/Application/landing/lor2db.js
+++ b/LOR2DB/Application/landing/lor2db.js
@@ -1,4 +1,4 @@
-/* MSB LOR landing page - 2026-08-15 V0.6.0 */
+/* MSB LOR landing page - 2026-08-16 V0.6.1 */
 (function () {
   "use strict";
 
@@ -67,7 +67,7 @@
         <div><dt>Production SQLite</dt><dd class="path-value">${esc(run?.sqlite_path || "Not built in the current approved-version state")}</dd></div>
         <div><dt>SQLite SHA-256</dt><dd class="digest">${esc(run?.sqlite_sha256 || "Not available until a validated parser run completes")}</dd></div>
       </dl>
-      <a class="primary" href="parser/">${runner.parser_activity?.target === "current" && runner.parser_activity?.status === "PASSED" ? "Review parser output" : "Run parser"}</a>
+      <a class="primary" href="parser/">Run parser</a>
     </section>`;
   }
 

--- a/LOR2DB/Application/landing/parser/index.html
+++ b/LOR2DB/Application/landing/parser/index.html
@@ -19,6 +19,6 @@
       <section class="card"><p>Loading parser status...</p></section>
     </div>
   </main>
-  <script src="parser.js?v=0.6.0" defer></script>
+  <script src="parser.js?v=0.6.1" defer></script>
 </body>
 </html>

--- a/LOR2DB/Application/landing/parser/parser.js
+++ b/LOR2DB/Application/landing/parser/parser.js
@@ -1,4 +1,4 @@
-/* MSB parser and ingest workflow - 2026-08-15 V0.6.0 */
+/* MSB parser and ingest workflow - 2026-08-16 V0.6.1 */
 (function () {
   "use strict";
 
@@ -170,9 +170,10 @@
       </dl>
       ${targetNote}${counts(run)}
       <div class="page-actions">
+        <button id="run-parser" class="primary" type="button" ${parserRunning || ingestRunning ? "disabled" : ""}>${parserRunning ? "Parser is running..." : "Run parser"}</button>
         ${digest && !parserRunning && !ingestRunning
-          ? '<a class="primary" href="#parser-console">Review parser output</a>'
-          : `<button id="run-parser" class="primary" type="button" ${parserRunning || ingestRunning ? "disabled" : ""}>${parserRunning ? "Parser is running..." : "Run parser"}</button>`}
+          ? '<a class="secondary" href="#parser-console">Review parser output</a>'
+          : ""}
         <button id="refresh-output" type="button">Refresh output</button>
         <a class="secondary" href="../">Return to dashboard</a>
       </div>

--- a/LOR2DB/Application/test_backend.py
+++ b/LOR2DB/Application/test_backend.py
@@ -386,6 +386,9 @@ class BackendSafetyTests(unittest.TestCase):
         self.assertIn("Start reconciliation", parser_source)
         self.assertIn('request("runs/start"', parser_source)
         self.assertIn("Review parser output", source)
+        self.assertIn('<a class="primary" href="parser/">Run parser</a>', source)
+        self.assertIn('id="run-parser"', parser_source)
+        self.assertIn('href="#parser-console">Review parser output</a>', parser_source)
 
 
 if __name__ == "__main__":

--- a/run_lor_runner.ps1
+++ b/run_lor_runner.ps1
@@ -355,6 +355,7 @@ switch ($Action) {
     'Install' {
         Assert-RunnerPrerequisites | Out-Null
         Stop-InstalledRunner
+        $pairingRequired = $false
         if ((Test-Path -LiteralPath $SecretPath) -and -not $RotateToken) {
             $token = Read-ProtectedToken
             Write-Host '[INFO] Existing protected runner token retained.'
@@ -362,6 +363,7 @@ switch ($Action) {
         else {
             $token = New-RunnerToken
             Save-ProtectedToken -Token $token
+            $pairingRequired = $true
             Write-Host '[OK] New runner token generated and protected with Windows DPAPI.'
         }
         if (Test-Path -LiteralPath $IngestSecretPath -PathType Leaf) {
@@ -381,7 +383,12 @@ switch ($Action) {
         Write-Host "[OK] Scheduled Task installed for logged-in account: $TaskName"
         Write-Host "[OK] Credential fingerprint: $(Get-TokenFingerprint -Token $token)"
         Start-InstalledRunner -Token $token
-        Write-Host '[NEXT] Run: .\run_lor_runner.ps1 -Action PairServer'
+        if ($pairingRequired) {
+            Write-Host '[NEXT] Run: .\run_lor_runner.ps1 -Action PairServer'
+        }
+        else {
+            Write-Host '[OK] Existing server pairing remains valid; PairServer is not required.'
+        }
         Remove-Variable token -ErrorAction SilentlyContinue
     }
 


### PR DESCRIPTION
## What changed

- Keeps **Run parser** visible on the dashboard and parser page after every successful run.
- Shows **Review parser output** as a separate secondary action instead of replacing the run action.
- Preserves unlimited sequential parser reruns; existing single-operation locking still blocks only concurrent work.
- Corrects the Windows installer wording so retained credentials no longer instruct the operator to pair the server again.
- Adds focused regression assertions for the permanent run action.

## Root cause

The browser replaced the run control with a review link whenever a validated parser digest existed. That made a repeatable operation appear unavailable even though the runner still supported it.

## Validation

- JavaScript syntax checks passed for both modified scripts.
- Focused UI regression checks passed.
- Python test source compiles.
- `git diff --check` passed.
- Full application import tests could not run in this container because Flask and psycopg2 are absent; the full suite passed in the production Windows environment immediately before this narrow UI hotfix.
- PowerShell syntax must be rerun on Windows because PowerShell is not installed in this container.

This PR is intentionally left as a draft and must not be merged without Greg's explicit approval.