### PR TITLE
Recover committed ingest after console failure

### DIFF
--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/README.md
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/README.md
@@ -10,7 +10,7 @@ tools for operator convenience but does not own their XML interpretation.
 |---|---|
 | `parse_props_v7_scene_parser.py` | Canonical V7 parser; atomically publishes only a fully validated SQLite snapshot |
 | `lor_version_checker.py` | Parser-independent complete XML manifest and Current/New LOR compatibility comparison |
-| `lor_operator_runner.py` | Restricted Windows/G-drive API, single-operation lock, durable read-only parser console record, candidate stale-manifest guard, approved-version structural guard, and same-parser SQLite output comparison used by the authenticated LOR2DB website |
+| `lor_operator_runner.py` | Restricted Windows/G-drive API, single-operation lock, durable read-only parser and ingest console records, digest-locked PostgreSQL ingest, candidate stale-manifest guard, approved-version structural guard, and same-parser SQLite output comparison used by the authenticated LOR2DB website |
 | `test_lor_version_checker.py` | Regression tests for Scene count/structure, unused fields, ChannelGrid, and other delimiter-position changes |
 | `test_lor_operator_runner.py` | Regression tests for version-scoped paths, stale manifests, SQLite output comparison, Revision handling, and approval history |
 | `test_parse_props_console_encoding.py` | Regression test preventing Windows console/log encoding from aborting parser execution |

--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/lor_operator_runner.py
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/lor_operator_runner.py
@@ -2,11 +2,14 @@
 
 Initial release: 2026-08-13 V1.0.0
 
-Current version: 2026-08-15 V1.5.0
+Current version: 2026-08-16 V1.5.1
 
 V1.5.0 adds the fixed, digest-locked PostgreSQL ingest operation and bounded
 read-only ingest console. Parser execution remains repeatable and never starts
 ingest automatically.
+
+V1.5.1 pairs that operation with ingest V0.4.1, whose digest-idempotent recovery
+recognizes an already-committed snapshot after a console/reporting failure.
 
 The production LOR2DB API runs on Linux. This small internal service owns the
 Windows/G-drive execution boundary and exposes only version-scoped operations;
@@ -36,7 +39,7 @@ from urllib.parse import urlparse
 from lor_version_checker import build_manifest, compare_manifests, manifest_source_signature, write_json
 
 
-RUNNER_VERSION = "V1.5.0"
+RUNNER_VERSION = "V1.5.1"
 MAX_BROWSER_CONSOLE_CHARACTERS = 500_000
 
 AUTHORITATIVE_OUTPUT_TABLES = (

--- a/LOR2DB/01_Ingest/README.md
+++ b/LOR2DB/01_Ingest/README.md
@@ -11,17 +11,20 @@ In this documentation, **ingest** refers to the parser and import programs that 
 
 The normal sequence is:
 
-1. In LOR2DB, confirm **Current LOR version** and use **Run current parser**.
+1. In LOR2DB, confirm **Current LOR version** and use **Run parser**.
 2. Inspect the generated SQLite repeatedly as needed; parser runs never ingest.
-3. Record the displayed SHA-256 for the exact approved SQLite file.
+3. Mark the exact displayed SQLite SHA-256 as ready for ingest only after its
+   console, counts, reports, and data look correct.
 4. Apply migration `0031_preserve_lor_sqlite_authority_chain.sql` before the
    first V0.4.0 ingest.
-5. Run `postgres_run_ingest_v7.ps1`, supplying that exact digest to the V0.4.0
-   ingest command.
+5. Use **Ingest to PostgreSQL** on the same page and review its console output.
 6. Continue to [LOR2DB Reconciliation](../02_Reconciliation/README.md).
 
 The ingest rejects a modified/replaced SQLite file and rejects any snapshot
 that was not produced in `PRODUCTION` mode with `ValidationStatus=PASSED`.
+V0.4.1 also makes retry recovery digest-idempotent: if the exact SQLite digest
+was already committed, the existing completed `import_run_id` is returned and
+no duplicate snapshot is created.
 
 The exact engineering rules behind the parser are documented under [LOR Data Extraction](../../Docs/01_LOR_System/02_Data_Extraction/README.md). This README does not duplicate those rules.
 

--- a/LOR2DB/01_Ingest/postgres_ingest_from_lor_sqlite_v7.py
+++ b/LOR2DB/01_Ingest/postgres_ingest_from_lor_sqlite_v7.py
@@ -2,7 +2,7 @@
 # postgres_ingest_from_lor_sqlite_v7.py
 # Initial Release : 2026-02-21  V0.1.0
 # Version         : 2026-02-21  V0.1.0
-# Current Version : 2026-08-13  V0.4.0
+# Current Version : 2026-08-16  V0.4.1
 #
 # Changes:
 # - Initial append-only ingestion layer (SQLite → Postgres)
@@ -22,6 +22,9 @@
 # - V0.3.2 refuses to ingest unless parser_run.Status is COMPLETE.
 # - V0.4.0 requires the exact operator-reviewed SQLite SHA-256 and a current V7
 #   production/validation provenance before any PostgreSQL write.
+# - V0.4.1 makes console diagnostics safe on legacy Windows code pages, reports
+#   post-commit failures truthfully, and treats an already-completed matching
+#   SQLite digest as a successful idempotent recovery instead of duplicating it.
 # (GAL)
 #
 # Author          : Greg Liebig, Engineering Innovations, LLC.
@@ -104,6 +107,11 @@
 #
 # -----------------------------------------------------------------------------
 # Change Log
+# 2026-08-16  GAL / OpenAI  V0.4.1
+#   - Prevented Unicode diagnostics from aborting a committed Windows ingest.
+#   - Detects an already-completed exact SQLite digest and returns its existing
+#     import_run_id without creating a duplicate snapshot.
+#   - Never claims that a committed transaction was rolled back.
 # 2026-08-13  GAL / OpenAI  V0.4.0
 #   - Requires --expected-sqlite-sha256 and rejects any byte-level change.
 #   - Requires parser_run RunMode=PRODUCTION, ValidationStatus=PASSED,
@@ -173,12 +181,26 @@ import psycopg2
 import psycopg2.extras
 
 
-INGEST_SCRIPT_VERSION = "V0.4.0"
+INGEST_SCRIPT_VERSION = "V0.4.1"
 
 
 # ---------------------------
 # Helpers
 # ---------------------------
+
+def configure_console_output() -> None:
+    """Make diagnostics non-fatal on legacy Windows console code pages."""
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if callable(reconfigure):
+            try:
+                reconfigure(errors="backslashreplace")
+            except (AttributeError, OSError, ValueError):
+                # Embedded and test streams may not support reconfiguration.
+                pass
+
+
+configure_console_output()
 
 def norm_name(s: str) -> str:
     """Normalize a column name for matching: lowercase and remove underscores/spaces."""
@@ -572,6 +594,24 @@ def complete_import_run(pg_conn, import_run_id: int, completed_at: datetime) -> 
         )
 
 
+def find_completed_import_run(pg_conn, sqlite_sha256: str) -> int | None:
+    """Return the completed run for an exact SQLite digest, if it exists."""
+    with pg_conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT import_run_id
+            FROM lor_snap.import_run
+            WHERE lower(source_sqlite_sha256) = %s
+              AND ingest_completed_at IS NOT NULL
+            ORDER BY import_run_id DESC
+            LIMIT 1
+            """,
+            (sqlite_sha256.lower(),),
+        )
+        row = cur.fetchone()
+    return int(row[0]) if row else None
+
+
 def bulk_insert(
     pg_conn,
     target_schema: str,
@@ -687,6 +727,7 @@ def main() -> int:
         print(f"[FATAL] SQLite file not found: {sqlite_path}", file=sys.stderr)
         return 2
 
+    committed = False
     try:
         reviewed_sqlite_sha256 = verify_reviewed_sqlite(
             sqlite_path, args.expected_sqlite_sha256
@@ -725,6 +766,17 @@ def main() -> int:
         source_counts = get_sqlite_snapshot_counts(sqlite_conn)
         ingest_actor, ingest_host = get_actor_host()
         ingest_started_at = datetime.now().astimezone()
+
+        existing_import_run_id = find_completed_import_run(
+            pg_conn, reviewed_sqlite_sha256
+        )
+        if existing_import_run_id is not None:
+            pg_conn.rollback()
+            print(
+                "[DONE] Snapshot already ingested; using existing "
+                f"import_run_id={existing_import_run_id}"
+            )
+            return 0
 
         import_run_id = insert_import_run(
             pg_conn,
@@ -820,6 +872,7 @@ def main() -> int:
 
         # One commit at the end = atomic run
         pg_conn.commit()
+        committed = True
         print(f"[DONE] Snapshot ingest complete. import_run_id={import_run_id}")
 
         # -----------------------------------------------------------------
@@ -840,7 +893,7 @@ def main() -> int:
             row = cur.fetchone()
 
             print(
-                "[INFO] Run summary → "
+                "[INFO] Run summary -> "
                 f"run={row[0]} | "
                 f"previews={row[1]} | "
                 f"scenes={row[2]} | "
@@ -851,14 +904,21 @@ def main() -> int:
                 f"field_wiring={row[7]}"
             )
         if row[7] == 0:
-            print("[WARN] wiring_field_rows is 0 — views likely failed or current_run is empty.", file=sys.stderr)
+            print("[WARN] wiring_field_rows is 0; views likely failed or current_run is empty.", file=sys.stderr)
 
         return 0
     
 
     except Exception as e:
-        pg_conn.rollback()
-        print("[FATAL] Ingest failed; transaction rolled back.", file=sys.stderr)
+        if committed:
+            print(
+                "[FATAL] Ingest committed, but post-commit reporting failed; "
+                "do not retry without checking PostgreSQL.",
+                file=sys.stderr,
+            )
+        else:
+            pg_conn.rollback()
+            print("[FATAL] Ingest failed; transaction rolled back.", file=sys.stderr)
         print(f"        {type(e).__name__}: {e}", file=sys.stderr)
         return 1
 

--- a/LOR2DB/01_Ingest/test_postgres_ingest_from_lor_sqlite_v7.py
+++ b/LOR2DB/01_Ingest/test_postgres_ingest_from_lor_sqlite_v7.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import hashlib
 import importlib.util
+import os
 import sqlite3
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -21,6 +23,32 @@ SPEC.loader.exec_module(ingest)
 
 
 class IngestAuthorityTests(unittest.TestCase):
+    def test_ascii_redirect_cannot_abort_unicode_diagnostic(self) -> None:
+        script = (
+            "import runpy, sys, types; "
+            "pg=types.ModuleType('psycopg2'); "
+            "extras=types.ModuleType('psycopg2.extras'); "
+            "pg.extras=extras; "
+            "sys.modules['psycopg2']=pg; "
+            "sys.modules['psycopg2.extras']=extras; "
+            f"runpy.run_path({str(MODULE_PATH)!r}, run_name='ingest_encoding_test'); "
+            "print('ingest output \\u2192 browser log')"
+        )
+        environment = os.environ.copy()
+        environment["PYTHONIOENCODING"] = "ascii:strict"
+        completed = subprocess.run(
+            [sys.executable, "-c", script],
+            env=environment,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(
+            completed.returncode,
+            0,
+            completed.stderr.decode(errors="replace"),
+        )
+        self.assertIn(b"ingest output \\u2192 browser log", completed.stdout)
+
     def test_reviewed_sqlite_hash_accepts_exact_bytes(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             path = Path(temporary) / "lor_output_v7_scene.db"
@@ -124,6 +152,31 @@ class IngestAuthorityTests(unittest.TestCase):
             "d" * 64,
         )
         self.assertEqual(import_run_id, 41)
+
+    def test_completed_exact_digest_is_reused(self) -> None:
+        class Cursor:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def execute(self, statement, parameters):
+                self.statement = statement
+                self.parameters = parameters
+
+            def fetchone(self):
+                return (48,)
+
+        class Connection:
+            def cursor(self):
+                return Cursor()
+
+        digest = "d" * 64
+        self.assertEqual(
+            ingest.find_completed_import_run(Connection(), digest),
+            48,
+        )
 
 
 if __name__ == "__main__":

--- a/LOR2DB/Application/README.md
+++ b/LOR2DB/Application/README.md
@@ -9,6 +9,7 @@
 
 | Date | Change |
 |---|---|
+| 2026-08-16 | Added ingest V0.4.1 / runner V1.5.1 recovery for a Windows console encoding failure after PostgreSQL commit. The exact completed SQLite digest is reused without creating a duplicate import run, and post-commit failures can no longer claim rollback. |
 | 2026-08-16 | Kept `Run parser` permanently available after successful runs and made `Review parser output` an additional action instead of a replacement. Corrected the Windows installer message so an unchanged protected token does not instruct the operator to pair the server again. |
 | 2026-08-15 | Added the complete browser-operated parser-to-ingest workflow. The idempotent parser remains repeatable until the operator approves the exact displayed SQLite digest. The Windows runner then performs the fixed digest-locked PostgreSQL ingest and exposes read-only console output on the same page. Ingest never starts reconciliation automatically. |
 | 2026-08-15 | Separated routine parser execution from infrequent LOR-version approval. The landing page now has distinct parser, version, and reconciliation boxes; dedicated parser and version-check pages own their respective workflows. Runner V1.4.0 preserves bounded read-only console output, records failures, rejects concurrent operations, and marks interrupted work truthfully after restart. |

--- a/run_lor_runner.ps1
+++ b/run_lor_runner.ps1
@@ -454,7 +454,7 @@ switch ($Action) {
             $env:LOR_INGEST_PATH = $IngestPath
             $env:PYTHONUNBUFFERED = '1'
             Write-ServiceLog (
-                "Starting runner V1.5.0; credential fingerprint=" +
+                "Starting runner V1.5.1; credential fingerprint=" +
                 "$(Get-TokenFingerprint -Token $token)."
             )
             # BaseHTTPRequestHandler writes normal HTTP access records to


### PR DESCRIPTION
## What changed

- Makes ingest V0.4.1 console output safe on legacy Windows code pages.
- Replaces Unicode status punctuation in ingest output with ASCII.
- Tracks whether PostgreSQL has committed so a later reporting error can never claim rollback.
- Detects an already-completed exact SQLite SHA-256 and returns its existing `import_run_id` without creating a duplicate snapshot.
- Updates runner health to V1.5.1 and documents the recovery behavior.

## Production incident

The web ingest created and committed `import_run_id=48`, then a Windows `charmap` encoding error occurred while printing the Unicode arrow in the post-commit run summary. The script returned failure and incorrectly printed that the transaction had rolled back. Retrying the old code could create a duplicate import run.

With this patch, retrying the same reviewed digest safely recognizes run 48 and records it as the successful browser ingest without inserting run 49.

## Validation

- 7 ingest authority/encoding/idempotency tests passed.
- 29 parser/runner tests passed.
- Python compilation passed.
- `git diff --check` passed.

Do not retry production ingest until this patch is merged, pulled, and runner V1.5.1 is installed.