### PR TITLE
Allow approved substage key changes

### DIFF
--- a/LOR2DB/02_Reconciliation/reconciliation/README.md
+++ b/LOR2DB/02_Reconciliation/reconciliation/README.md
@@ -11,8 +11,8 @@ change, or merely reports evidence.
 | Path | Contents | Execution rule |
 |---|---|---|
 | `current_procedures/` | Canonical standalone P1, P2, P3, and P4 definitions matching the latest accepted migration chain | Inspection or explicitly authorized repair only; these files do not call promotion |
-| `migrations/` | Immutable installation history `0011` through `0032` | Run only the specifically authorized next migration; never rerun the folder as a batch |
-| `validation/` | Validation `10` through `27` | Follow each file's header; several are transaction-wrapped rollback tests |
+| `migrations/` | Immutable installation history `0011` through `0033` | Run only the specifically authorized next migration; never rerun the folder as a batch |
+| `validation/` | Validation `10` through `28` | Follow each file's header; several are transaction-wrapped rollback tests |
 | `operator_queries/preflight/` | Read-only latest-ingest reports `01` through `09` | Run individually; no operator-supplied `import_run_id` |
 | `incidents/` | Production incident report and its incident-specific forensic SQL | Historical evidence; not part of routine reconciliation |
 
@@ -22,7 +22,7 @@ The root Markdown files are this index and the current design specification.
 
 | Phase | Database object | Canonical file | Definition lineage |
 |---|---|---|---|
-| P1 | `ref.p1_promote_stage_from_reconciliation(bigint)` | `current_procedures/P1_stage_promotion.sql` | Existing-stage definition from `0016`/`0029 v4`, wrapped by `0032` for evidence-gated new-stage creation |
+| P1 | `ref.p1_promote_stage_from_reconciliation(bigint)` | `current_procedures/P1_stage_promotion.sql` | Existing-stage definition from `0016`/`0029 v4`, wrapped by `0032` for new-stage creation and by `0033` for approved canonical StageID/substage changes and accepted binding aliases |
 | P2 | `ref.p2_promote_display_from_reconciliation(bigint)` | `current_procedures/P2_display_promotion.sql` | Full definition from `0017`; unchanged by `0029` |
 | P3 | `ref.p3_promote_scene_from_reconciliation(bigint)` | `current_procedures/P3_scene_promotion.sql` | Full definition from `0018`, then no-op correction from `0029 v4` |
 | P4 | `ref.p4_promote_scene_display_from_reconciliation(bigint)` | `current_procedures/P4_scene_display_promotion.sql` | Full definition from `0018`, then no-op correction from `0029 v4` |
@@ -65,7 +65,7 @@ is retained only as incident evidence. It is not step 8A of the normal workflow.
 
 ## Migration and validation status
 
-The current feature-branch installation chain is `0011` through `0032`.
+The current installation chain is `0011` through `0033`.
 Migration `0029` must be revision
 `2026-08-05-true-noop-reconciliation-writes-v4`; its corresponding validation
 is `validation/25_true_noop_reconciliation_write_validation.sql`. Migration
@@ -73,6 +73,10 @@ is `validation/25_true_noop_reconciliation_write_validation.sql`. Migration
 `validation/27_safe_stage_authority_and_cancel_terminal_validation.sql`. It
 also guarantees that `CANCELLED` runs receive `completed_at` and backfills any
 older cancelled audit row where that terminal timestamp is missing.
+Migration `0033` applies operator-approved canonical StageID/substage changes
+without replacing permanent stage identity, records accepted StageID aliases
+for stable bindings, exposes every frozen decision-group member, and is paired
+with `validation/28_complete_stage_decision_evidence_validation.sql`.
 
 Do not infer that a numbered validation is harmless from its filename alone.
 Read its header. In particular,

--- a/LOR2DB/02_Reconciliation/reconciliation/current_procedures/P1_stage_promotion.sql
+++ b/LOR2DB/02_Reconciliation/reconciliation/current_procedures/P1_stage_promotion.sql
@@ -1,16 +1,17 @@
 /* ============================================================================
 Object:       Current P1 stage promotion entry procedure
-Revision:     2026-08-14-after-0032
+Revision:     2026-08-16-after-0033
 
 Purpose:
   Canonical repair/inspection definition of the public P1 entry procedure
-  installed by migration 0032. The preserved existing-stage implementation
-  remains `ref.p1_promote_stage_from_reconciliation_before_0032(bigint)`.
+  installed by migration 0033. The migration 0032 implementation remains
+  `ref.p1_promote_stage_from_reconciliation_before_0033(bigint)`.
 
 Safety:
-  Installing this definition does not call P1 or modify production rows. New
-  stages are inserted only when Finish calls P1 for an explicitly approved,
-  unambiguous ADD_NEW_STAGE group.
+  Installing this definition does not call P1 or modify production rows. Finish
+  calls P1 only after all operator decisions have been recorded. Explicitly
+  approved canonical StageID changes preserve permanent stage_id, and accepted
+  per-binding source StageIDs prevent the same alias from reopening later.
 ============================================================================ */
 
 BEGIN;
@@ -24,9 +25,8 @@ SET search_path = pg_catalog, ops, lor_snap, ref
 AS $procedure$
 DECLARE
     v_import_run_id bigint;
-    v_group record;
-    v_binding record;
-    v_stage_id integer;
+    v_change record;
+    v_old_stage_key text;
 BEGIN
     SELECT r.import_run_id INTO v_import_run_id
     FROM ops.lor_reconciliation_run AS r
@@ -37,101 +37,108 @@ BEGIN
             p_lor_reconciliation_run_id;
     END IF;
 
-    FOR v_group IN
+    CALL ref.p1_promote_stage_from_reconciliation_before_0033(
+        p_lor_reconciliation_run_id
+    );
+
+    FOR v_change IN
         SELECT
             gr.lor_reconciliation_group_id,
-            min(c.proposed_stage_key) AS stage_key,
-            min(ops.f_normalize_lor_stage_name(
-                c.source_name, c.proposed_stage_key))
-                FILTER (WHERE c.metadata_authoritative)
-                AS stage_name,
-            min(c.proposed_stage_key || '-' ||
-                ops.f_normalize_lor_stage_name(
-                    c.source_name, c.proposed_stage_key))
-                FILTER (WHERE c.metadata_authoritative)
-                AS folder_name,
-            min(c.proposed_park_order) AS park_order,
-            min(c.proposed_sub_order) AS sub_order
+            min(c.resolved_stage_id) AS stage_id,
+            a.action_payload ->> 'target_stage_key' AS target_stage_key,
+            min(c.proposed_park_order) FILTER (
+                WHERE c.proposed_stage_key =
+                    a.action_payload ->> 'target_stage_key'
+            ) AS park_order,
+            min(c.proposed_sub_order) FILTER (
+                WHERE c.proposed_stage_key =
+                    a.action_payload ->> 'target_stage_key'
+            ) AS sub_order
         FROM ops.v_lor_reconciliation_group_review AS gr
+        JOIN ops.lor_reconciliation_action AS a
+          ON a.lor_reconciliation_action_id = gr.effective_action_id
         JOIN ops.lor_reconciliation_stage_candidate AS c
           ON c.lor_reconciliation_group_id = gr.lor_reconciliation_group_id
         WHERE gr.lor_reconciliation_run_id = p_lor_reconciliation_run_id
-          AND gr.effective_action_type = 'ADD_NEW_STAGE'
+          AND gr.effective_action_type = 'APPROVE_STAGE_CHANGE'
           AND gr.effective_resolution_state = 'APPROVED'
-          AND ops.f_stage_group_can_add_new_stage(
-                gr.lor_reconciliation_group_id)
-        GROUP BY gr.lor_reconciliation_group_id
+        GROUP BY gr.lor_reconciliation_group_id, a.action_payload
     LOOP
-        IF EXISTS (
-            SELECT 1 FROM ref.stage_lor_binding AS b
-            JOIN ops.lor_reconciliation_stage_candidate AS c
-              ON c.binding_type = b.binding_type
-             AND c.preview_id = b.preview_id
-             AND c.scene_id IS NOT DISTINCT FROM b.scene_id
-            WHERE c.lor_reconciliation_group_id =
-                v_group.lor_reconciliation_group_id
-        ) THEN
-            RAISE EXCEPTION 'A stable LOR binding for new stage group % was created after preflight',
-                v_group.lor_reconciliation_group_id;
+        IF nullif(btrim(v_change.target_stage_key), '') IS NULL THEN
+            RAISE EXCEPTION 'Approved stage group % has no target StageID',
+                v_change.lor_reconciliation_group_id;
         END IF;
 
-        INSERT INTO ref.stage (
-            stage_key, stage_name, folder_name, park_order, sub_order
-        ) VALUES (
-            v_group.stage_key, v_group.stage_name, v_group.folder_name,
-            v_group.park_order, v_group.sub_order
-        ) RETURNING stage_id INTO v_stage_id;
+        SELECT s.stage_key INTO v_old_stage_key
+        FROM ref.stage AS s
+        WHERE s.stage_id = v_change.stage_id
+        FOR UPDATE;
 
-        INSERT INTO ops.lor_reconciliation_result (
-            lor_reconciliation_run_id, import_run_id, entity_type,
-            entity_key, result_class, reason_code, operator_message, committed
-        ) VALUES (
-            p_lor_reconciliation_run_id, v_import_run_id, 'STAGE',
-            v_stage_id::text, 'ADDED', 'P1_ADD_NEW_STAGE',
-            format('ADDED: Stage %s as permanent stage_id %s.',
-                v_group.stage_key, v_stage_id), true
-        );
+        IF EXISTS (
+            SELECT 1 FROM ref.stage AS s
+            WHERE s.stage_key = v_change.target_stage_key
+              AND s.stage_id <> v_change.stage_id
+        ) THEN
+            RAISE EXCEPTION 'Approved StageID % already belongs to another permanent stage',
+                v_change.target_stage_key;
+        END IF;
 
-        FOR v_binding IN
-            SELECT c.*
-            FROM ops.lor_reconciliation_stage_candidate AS c
-            WHERE c.lor_reconciliation_group_id =
-                v_group.lor_reconciliation_group_id
-            ORDER BY c.lor_reconciliation_stage_candidate_id
-        LOOP
-            INSERT INTO ref.stage_lor_binding (
-                stage_id, binding_type, preview_id, scene_id, source_name,
-                first_seen_import_run_id, last_seen_import_run_id
-            ) VALUES (
-                v_stage_id, v_binding.binding_type, v_binding.preview_id,
-                v_binding.scene_id, v_binding.source_name,
-                v_import_run_id, v_import_run_id
-            );
+        UPDATE ref.stage AS s
+           SET stage_key = v_change.target_stage_key,
+               folder_name = CASE
+                   WHEN s.folder_name LIKE v_old_stage_key || '-%'
+                   THEN v_change.target_stage_key ||
+                        substr(s.folder_name, length(v_old_stage_key) + 1)
+                   ELSE s.folder_name
+               END,
+               park_order = v_change.park_order,
+               sub_order = v_change.sub_order,
+               updated_at = now(),
+               updated_by = current_user
+         WHERE s.stage_id = v_change.stage_id
+           AND (
+               s.stage_key IS DISTINCT FROM v_change.target_stage_key
+               OR s.park_order IS DISTINCT FROM v_change.park_order
+               OR s.sub_order IS DISTINCT FROM v_change.sub_order
+           );
 
+        IF FOUND THEN
             INSERT INTO ops.lor_reconciliation_result (
                 lor_reconciliation_run_id, import_run_id, entity_type,
                 entity_key, result_class, reason_code,
                 operator_message, committed
             ) VALUES (
                 p_lor_reconciliation_run_id, v_import_run_id, 'STAGE',
-                v_binding.candidate_key, 'ADDED', 'P1_STAGE_LOR_BINDING',
-                format('ADDED: %s binding %s%s to new permanent stage_id %s.',
-                    v_binding.binding_type, v_binding.preview_id,
-                    CASE WHEN v_binding.scene_id IS NULL THEN ''
-                         ELSE '/' || v_binding.scene_id END,
-                    v_stage_id), true
+                v_change.stage_id::text, 'UPDATED',
+                'P1_APPROVED_STAGE_KEY_CHANGE',
+                format(
+                    'UPDATED: Stage %s to canonical StageID %s and preserved permanent stage_id %s.',
+                    v_old_stage_key, v_change.target_stage_key,
+                    v_change.stage_id
+                ),
+                true
             );
-        END LOOP;
+        END IF;
     END LOOP;
 
-    CALL ref.p1_promote_stage_from_reconciliation_before_0032(
-        p_lor_reconciliation_run_id
-    );
+    UPDATE ref.stage_lor_binding AS b
+       SET accepted_source_stage_key = c.source_stage_key,
+           updated_at = now(),
+           updated_by = current_user
+    FROM ops.lor_reconciliation_stage_candidate AS c
+    JOIN ops.v_lor_reconciliation_group_review AS gr
+      ON gr.lor_reconciliation_group_id = c.lor_reconciliation_group_id
+    WHERE gr.lor_reconciliation_run_id = p_lor_reconciliation_run_id
+      AND gr.effective_resolution_state IN ('AUTO_APPROVED', 'APPROVED')
+      AND b.binding_type = c.binding_type
+      AND b.preview_id = c.preview_id
+      AND b.scene_id IS NOT DISTINCT FROM c.scene_id
+      AND b.accepted_source_stage_key IS DISTINCT FROM c.source_stage_key;
 END;
 $procedure$;
 
 COMMENT ON PROCEDURE ref.p1_promote_stage_from_reconciliation(bigint) IS
-'Reconciliation-gated P1. Adds explicitly approved unambiguous new stages, then delegates existing-stage metadata/binding promotion to the preserved implementation.';
+'Reconciliation-gated P1. Preserves permanent stage identity, applies explicitly approved canonical StageID/substage changes, remembers accepted per-binding source StageIDs, and delegates established/new-stage promotion to the preserved implementation.';
 
 REVOKE EXECUTE ON PROCEDURE
     ref.p1_promote_stage_from_reconciliation(bigint) FROM PUBLIC;

--- a/LOR2DB/02_Reconciliation/reconciliation/migrations/0033_approve_stage_key_changes_with_stable_aliases.sql
+++ b/LOR2DB/02_Reconciliation/reconciliation/migrations/0033_approve_stage_key_changes_with_stable_aliases.sql
@@ -1,0 +1,506 @@
+/*
+Migration: 0033_approve_stage_key_changes_with_stable_aliases.sql
+Purpose:
+  Permit an operator-approved canonical StageID change when one or more stable
+  LOR bindings still retain previously accepted StageIDs. Preserve permanent
+  stage_id, remember each binding's accepted source StageID, expose complete
+  frozen evidence, and prevent the same accepted aliases from reopening on
+  every later reconciliation.
+*/
+
+BEGIN;
+
+ALTER TABLE ref.stage_lor_binding
+    ADD COLUMN IF NOT EXISTS accepted_source_stage_key text;
+
+/*
+  Migration 0029 intentionally suppresses provenance-only binding updates.
+  The accepted source StageID is durable business state, so include it in the
+  trigger's material-change comparison before backfilling the new column.
+*/
+CREATE OR REPLACE FUNCTION ref.trg_stage_lor_binding_require_change()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $function$
+BEGIN
+    IF NEW.stage_id IS NOT DISTINCT FROM OLD.stage_id
+       AND NEW.binding_type IS NOT DISTINCT FROM OLD.binding_type
+       AND NEW.preview_id IS NOT DISTINCT FROM OLD.preview_id
+       AND NEW.scene_id IS NOT DISTINCT FROM OLD.scene_id
+       AND NEW.source_name IS NOT DISTINCT FROM OLD.source_name
+       AND NEW.accepted_source_stage_key IS NOT DISTINCT FROM
+           OLD.accepted_source_stage_key THEN
+        RETURN NULL;
+    END IF;
+    RETURN NEW;
+END;
+$function$;
+
+UPDATE ref.stage_lor_binding AS b
+   SET accepted_source_stage_key = s.stage_key,
+       updated_at = now(),
+       updated_by = current_user
+FROM ref.stage AS s
+WHERE s.stage_id = b.stage_id
+  AND b.accepted_source_stage_key IS NULL;
+
+COMMENT ON COLUMN ref.stage_lor_binding.accepted_source_stage_key IS
+'Last operator-approved source StageID for this stable LOR preview/scene binding. It may differ from the permanent stage''s canonical stage_key.';
+
+CREATE OR REPLACE FUNCTION ops.f_stage_group_has_only_accepted_binding_keys(
+    p_lor_reconciliation_group_id bigint
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, ops, ref
+AS $function$
+    SELECT
+        g.entity_type = 'STAGE'
+        AND count(c.*) = g.member_count
+        AND count(c.*) > 0
+        AND count(*) FILTER (WHERE c.resolved_stage_id IS NULL) = 0
+        AND count(*) FILTER (WHERE b.stage_lor_binding_id IS NULL) = 0
+        AND count(*) FILTER (
+            WHERE b.accepted_source_stage_key IS DISTINCT FROM
+                c.source_stage_key
+        ) = 0
+        AND count(*) FILTER (WHERE c.classification_code IN (
+            'SOURCE_FILENAME_MISSING',
+            'BINDING_STAGE_KEY_CONFLICT',
+            'NEW_STAGE_REQUIRES_AUTHORITATIVE_DECISION'
+        )) = 0
+    FROM ops.lor_reconciliation_group AS g
+    JOIN ops.lor_reconciliation_stage_candidate AS c
+      ON c.lor_reconciliation_group_id = g.lor_reconciliation_group_id
+    LEFT JOIN ref.stage_lor_binding AS b
+      ON b.binding_type = c.binding_type
+     AND b.preview_id = c.preview_id
+     AND b.scene_id IS NOT DISTINCT FROM c.scene_id
+     AND b.stage_id = c.resolved_stage_id
+    WHERE g.lor_reconciliation_group_id = p_lor_reconciliation_group_id
+    GROUP BY g.lor_reconciliation_group_id, g.entity_type, g.member_count;
+$function$;
+
+CREATE OR REPLACE FUNCTION ops.f_stage_group_can_approve_change(
+    p_lor_reconciliation_group_id bigint
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, ops, ref
+AS $function$
+    SELECT
+        g.entity_type = 'STAGE'
+        AND g.decision_required
+        AND count(c.*) = g.member_count
+        AND count(c.*) > 0
+        AND count(DISTINCT c.resolved_stage_id) = 1
+        AND count(*) FILTER (WHERE c.resolved_stage_id IS NULL) = 0
+        AND count(*) FILTER (WHERE b.stage_lor_binding_id IS NULL) = 0
+        AND count(*) FILTER (
+            WHERE b.accepted_source_stage_key IS DISTINCT FROM
+                c.source_stage_key
+        ) > 0
+        AND count(DISTINCT c.proposed_stage_key) FILTER (
+            WHERE b.accepted_source_stage_key IS DISTINCT FROM
+                c.source_stage_key
+        ) = 1
+        AND count(*) FILTER (
+            WHERE c.stage_key_stage_id IS NOT NULL
+              AND c.stage_key_stage_id <> c.resolved_stage_id
+        ) = 0
+        AND count(*) FILTER (WHERE c.classification_code IN (
+            'SOURCE_FILENAME_MISSING',
+            'BINDING_STAGE_KEY_CONFLICT',
+            'NEW_STAGE_REQUIRES_AUTHORITATIVE_DECISION'
+        )) = 0
+    FROM ops.lor_reconciliation_group AS g
+    JOIN ops.lor_reconciliation_stage_candidate AS c
+      ON c.lor_reconciliation_group_id = g.lor_reconciliation_group_id
+    LEFT JOIN ref.stage_lor_binding AS b
+      ON b.binding_type = c.binding_type
+     AND b.preview_id = c.preview_id
+     AND b.scene_id IS NOT DISTINCT FROM c.scene_id
+     AND b.stage_id = c.resolved_stage_id
+    WHERE g.lor_reconciliation_group_id = p_lor_reconciliation_group_id
+    GROUP BY g.lor_reconciliation_group_id, g.entity_type,
+             g.decision_required, g.member_count;
+$function$;
+
+CREATE OR REPLACE VIEW ops.v_lor_reconciliation_group_review AS
+WITH latest_action AS (
+    SELECT DISTINCT ON (a.lor_reconciliation_group_id)
+        a.lor_reconciliation_group_id,
+        a.lor_reconciliation_action_id,
+        a.action_type,
+        a.reason,
+        a.action_payload,
+        a.acted_at,
+        a.acted_by,
+        a.acted_by_application
+    FROM ops.lor_reconciliation_action AS a
+    WHERE a.lor_reconciliation_group_id IS NOT NULL
+    ORDER BY a.lor_reconciliation_group_id, a.acted_at DESC,
+             a.lor_reconciliation_action_id DESC
+), accepted_binding_keys AS (
+    SELECT
+        g.lor_reconciliation_group_id,
+        ops.f_stage_group_has_only_accepted_binding_keys(
+            g.lor_reconciliation_group_id
+        ) AS all_keys_accepted
+    FROM ops.lor_reconciliation_group AS g
+    WHERE g.entity_type = 'STAGE'
+)
+SELECT
+    g.lor_reconciliation_group_id,
+    g.lor_reconciliation_run_id,
+    g.import_run_id,
+    g.entity_type,
+    g.logical_group_key,
+    g.group_kind,
+    g.member_count,
+    g.requires_atomic_decision,
+    g.decision_required AND NOT coalesce(abk.all_keys_accepted, false)
+        AS decision_required,
+    CASE WHEN coalesce(abk.all_keys_accepted, false)
+        THEN ARRAY[]::text[] ELSE g.allowed_action_types END
+        || CASE WHEN ops.f_stage_group_can_preserve_existing_metadata(
+                g.lor_reconciliation_group_id)
+            THEN ARRAY['PRESERVE_EXISTING_STAGE_METADATA']::text[]
+            ELSE ARRAY[]::text[] END
+        || CASE WHEN ops.f_stage_group_can_approve_change(
+                g.lor_reconciliation_group_id)
+            THEN ARRAY['APPROVE_STAGE_CHANGE']::text[]
+            ELSE ARRAY[]::text[] END
+        || CASE WHEN ops.f_stage_group_can_add_new_stage(
+                g.lor_reconciliation_group_id)
+            THEN ARRAY['ADD_NEW_STAGE']::text[]
+            ELSE ARRAY[]::text[] END
+        AS allowed_action_types,
+    CASE WHEN coalesce(abk.all_keys_accepted, false)
+        THEN 'Stable LOR bindings retain previously approved source StageIDs for this permanent stage.'
+        ELSE g.operator_message END AS operator_message,
+    la.lor_reconciliation_action_id AS effective_action_id,
+    la.action_type AS effective_action_type,
+    la.reason AS effective_reason,
+    la.acted_at,
+    la.acted_by,
+    la.acted_by_application,
+    CASE
+        WHEN la.action_type = 'DEFER' THEN 'DEFERRED'
+        WHEN la.action_type = 'CORRECT_SOURCE_REQUIRED' THEN 'BLOCKED'
+        WHEN la.action_type IS NOT NULL THEN 'APPROVED'
+        WHEN coalesce(abk.all_keys_accepted, false) THEN 'AUTO_APPROVED'
+        WHEN g.decision_required THEN 'UNRESOLVED'
+        ELSE 'AUTO_APPROVED'
+    END AS effective_resolution_state
+FROM ops.lor_reconciliation_group AS g
+LEFT JOIN latest_action AS la
+  ON la.lor_reconciliation_group_id = g.lor_reconciliation_group_id
+LEFT JOIN accepted_binding_keys AS abk
+  ON abk.lor_reconciliation_group_id = g.lor_reconciliation_group_id;
+
+CREATE OR REPLACE VIEW ops.v_lor_reconciliation_operator_stage_review AS
+SELECT
+    gr.lor_reconciliation_run_id,
+    gr.import_run_id,
+    gr.lor_reconciliation_group_id,
+    gr.logical_group_key,
+    gr.member_count,
+    gr.effective_resolution_state,
+    gr.effective_action_type,
+    gr.effective_reason,
+    c.lor_reconciliation_stage_candidate_id,
+    c.binding_type,
+    c.preview_id,
+    c.scene_id,
+    c.source_name,
+    c.classification_code,
+    c.changed_fields,
+    c.resolved_stage_id,
+    c.current_stage_key,
+    c.proposed_stage_key,
+    c.current_stage_name,
+    CASE WHEN c.metadata_authoritative
+        THEN ops.f_normalize_lor_stage_name(
+            c.source_name, c.proposed_stage_key)
+        ELSE c.proposed_stage_name END AS proposed_stage_name,
+    c.current_folder_name,
+    CASE WHEN c.metadata_authoritative
+        THEN c.proposed_stage_key || '-' ||
+            ops.f_normalize_lor_stage_name(
+                c.source_name, c.proposed_stage_key)
+        ELSE c.proposed_folder_name END AS proposed_folder_name,
+    c.operator_message,
+    c.source_evidence,
+    c.source_stage_key,
+    c.metadata_authoritative
+FROM ops.v_lor_reconciliation_group_review AS gr
+JOIN ops.lor_reconciliation_stage_candidate AS c
+  ON c.lor_reconciliation_group_id = gr.lor_reconciliation_group_id
+WHERE gr.decision_required
+   OR gr.effective_action_type IS NOT NULL;
+
+CREATE OR REPLACE FUNCTION ops.f_record_lor_stage_authority_action(
+    p_lor_reconciliation_run_id bigint,
+    p_lor_reconciliation_group_id bigint,
+    p_action_type text,
+    p_reason text,
+    p_acted_by_application text DEFAULT NULL
+)
+RETURNS bigint
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, ops, ref
+AS $function$
+DECLARE
+    v_import_run_id bigint;
+    v_status text;
+    v_action_id bigint;
+    v_counts record;
+    v_target_stage_key text;
+BEGIN
+    SELECT r.import_run_id, r.status
+      INTO v_import_run_id, v_status
+    FROM ops.lor_reconciliation_run AS r
+    WHERE r.lor_reconciliation_run_id = p_lor_reconciliation_run_id
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'Reconciliation run % does not exist',
+            p_lor_reconciliation_run_id;
+    END IF;
+    IF v_status NOT IN ('AWAITING_DECISIONS', 'READY_TO_FINISH') THEN
+        RAISE EXCEPTION 'Reconciliation run % does not accept decisions in status %',
+            p_lor_reconciliation_run_id, v_status;
+    END IF;
+    IF nullif(btrim(p_reason), '') IS NULL THEN
+        RAISE EXCEPTION 'A nonblank operator reason is required';
+    END IF;
+
+    IF p_action_type = 'APPROVE_STAGE_CHANGE' THEN
+        IF NOT coalesce(ops.f_stage_group_can_approve_change(
+            p_lor_reconciliation_group_id), false) THEN
+            RAISE EXCEPTION 'Stage group % does not contain one operator-selectable canonical StageID change',
+                p_lor_reconciliation_group_id;
+        END IF;
+
+        SELECT min(c.proposed_stage_key)
+          INTO v_target_stage_key
+        FROM ops.lor_reconciliation_stage_candidate AS c
+        JOIN ref.stage_lor_binding AS b
+          ON b.binding_type = c.binding_type
+         AND b.preview_id = c.preview_id
+         AND b.scene_id IS NOT DISTINCT FROM c.scene_id
+         AND b.stage_id = c.resolved_stage_id
+        WHERE c.lor_reconciliation_group_id =
+            p_lor_reconciliation_group_id
+          AND b.accepted_source_stage_key IS DISTINCT FROM
+            c.source_stage_key;
+    ELSIF p_action_type = 'ADD_NEW_STAGE' THEN
+        IF NOT coalesce(ops.f_stage_group_can_add_new_stage(
+            p_lor_reconciliation_group_id), false) THEN
+            RAISE EXCEPTION 'Stage group % does not contain one unambiguous new stage',
+                p_lor_reconciliation_group_id;
+        END IF;
+
+        SELECT min(c.proposed_stage_key)
+          INTO v_target_stage_key
+        FROM ops.lor_reconciliation_stage_candidate AS c
+        WHERE c.lor_reconciliation_group_id =
+            p_lor_reconciliation_group_id;
+    ELSE
+        RAISE EXCEPTION 'Action % is not a stage authority action', p_action_type;
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM ops.lor_reconciliation_group AS g
+        WHERE g.lor_reconciliation_group_id = p_lor_reconciliation_group_id
+          AND g.lor_reconciliation_run_id = p_lor_reconciliation_run_id
+          AND g.entity_type = 'STAGE'
+    ) THEN
+        RAISE EXCEPTION 'Stage group % does not belong to reconciliation run %',
+            p_lor_reconciliation_group_id, p_lor_reconciliation_run_id;
+    END IF;
+
+    INSERT INTO ops.lor_reconciliation_action (
+        lor_reconciliation_run_id, lor_reconciliation_group_id,
+        import_run_id, action_type, reason, action_payload,
+        acted_by_application
+    ) VALUES (
+        p_lor_reconciliation_run_id, p_lor_reconciliation_group_id,
+        v_import_run_id, p_action_type, btrim(p_reason),
+        jsonb_build_object(
+            'stage_authority_decision', true,
+            'target_stage_key', v_target_stage_key
+        ),
+        nullif(btrim(p_acted_by_application), '')
+    ) RETURNING lor_reconciliation_action_id INTO v_action_id;
+
+    SELECT * INTO v_counts
+    FROM ops.f_sync_lor_reconciliation_effective_counters(
+        p_lor_reconciliation_run_id
+    );
+
+    UPDATE ops.lor_reconciliation_run AS r
+       SET status = CASE WHEN v_counts.unresolved_count = 0
+                         THEN 'READY_TO_FINISH'
+                         ELSE 'AWAITING_DECISIONS' END,
+           resumed_at = now(),
+           paused_at = CASE WHEN v_counts.unresolved_count > 0
+                            THEN coalesce(r.paused_at, now())
+                            ELSE r.paused_at END
+     WHERE r.lor_reconciliation_run_id = p_lor_reconciliation_run_id;
+
+    RETURN v_action_id;
+END;
+$function$;
+
+ALTER PROCEDURE ref.p1_promote_stage_from_reconciliation(bigint)
+    RENAME TO p1_promote_stage_from_reconciliation_before_0033;
+
+CREATE OR REPLACE PROCEDURE ref.p1_promote_stage_from_reconciliation(
+    p_lor_reconciliation_run_id bigint
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, ops, lor_snap, ref
+AS $procedure$
+DECLARE
+    v_import_run_id bigint;
+    v_change record;
+    v_old_stage_key text;
+BEGIN
+    SELECT r.import_run_id INTO v_import_run_id
+    FROM ops.lor_reconciliation_run AS r
+    WHERE r.lor_reconciliation_run_id = p_lor_reconciliation_run_id
+    FOR UPDATE;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'Reconciliation run % does not exist',
+            p_lor_reconciliation_run_id;
+    END IF;
+
+    CALL ref.p1_promote_stage_from_reconciliation_before_0033(
+        p_lor_reconciliation_run_id
+    );
+
+    FOR v_change IN
+        SELECT
+            gr.lor_reconciliation_group_id,
+            min(c.resolved_stage_id) AS stage_id,
+            a.action_payload ->> 'target_stage_key' AS target_stage_key,
+            min(c.proposed_park_order) FILTER (
+                WHERE c.proposed_stage_key =
+                    a.action_payload ->> 'target_stage_key'
+            ) AS park_order,
+            min(c.proposed_sub_order) FILTER (
+                WHERE c.proposed_stage_key =
+                    a.action_payload ->> 'target_stage_key'
+            ) AS sub_order
+        FROM ops.v_lor_reconciliation_group_review AS gr
+        JOIN ops.lor_reconciliation_action AS a
+          ON a.lor_reconciliation_action_id = gr.effective_action_id
+        JOIN ops.lor_reconciliation_stage_candidate AS c
+          ON c.lor_reconciliation_group_id = gr.lor_reconciliation_group_id
+        WHERE gr.lor_reconciliation_run_id = p_lor_reconciliation_run_id
+          AND gr.effective_action_type = 'APPROVE_STAGE_CHANGE'
+          AND gr.effective_resolution_state = 'APPROVED'
+        GROUP BY gr.lor_reconciliation_group_id, a.action_payload
+    LOOP
+        IF nullif(btrim(v_change.target_stage_key), '') IS NULL THEN
+            RAISE EXCEPTION 'Approved stage group % has no target StageID',
+                v_change.lor_reconciliation_group_id;
+        END IF;
+
+        SELECT s.stage_key INTO v_old_stage_key
+        FROM ref.stage AS s
+        WHERE s.stage_id = v_change.stage_id
+        FOR UPDATE;
+
+        IF EXISTS (
+            SELECT 1 FROM ref.stage AS s
+            WHERE s.stage_key = v_change.target_stage_key
+              AND s.stage_id <> v_change.stage_id
+        ) THEN
+            RAISE EXCEPTION 'Approved StageID % already belongs to another permanent stage',
+                v_change.target_stage_key;
+        END IF;
+
+        UPDATE ref.stage AS s
+           SET stage_key = v_change.target_stage_key,
+               folder_name = CASE
+                   WHEN s.folder_name LIKE v_old_stage_key || '-%'
+                   THEN v_change.target_stage_key ||
+                        substr(s.folder_name, length(v_old_stage_key) + 1)
+                   ELSE s.folder_name
+               END,
+               park_order = v_change.park_order,
+               sub_order = v_change.sub_order,
+               updated_at = now(),
+               updated_by = current_user
+         WHERE s.stage_id = v_change.stage_id
+           AND (
+               s.stage_key IS DISTINCT FROM v_change.target_stage_key
+               OR s.park_order IS DISTINCT FROM v_change.park_order
+               OR s.sub_order IS DISTINCT FROM v_change.sub_order
+           );
+
+        IF FOUND THEN
+            INSERT INTO ops.lor_reconciliation_result (
+                lor_reconciliation_run_id, import_run_id, entity_type,
+                entity_key, result_class, reason_code,
+                operator_message, committed
+            ) VALUES (
+                p_lor_reconciliation_run_id, v_import_run_id, 'STAGE',
+                v_change.stage_id::text, 'UPDATED',
+                'P1_APPROVED_STAGE_KEY_CHANGE',
+                format(
+                    'UPDATED: Stage %s to canonical StageID %s and preserved permanent stage_id %s.',
+                    v_old_stage_key, v_change.target_stage_key,
+                    v_change.stage_id
+                ),
+                true
+            );
+        END IF;
+    END LOOP;
+
+    UPDATE ref.stage_lor_binding AS b
+       SET accepted_source_stage_key = c.source_stage_key,
+           updated_at = now(),
+           updated_by = current_user
+    FROM ops.lor_reconciliation_stage_candidate AS c
+    JOIN ops.v_lor_reconciliation_group_review AS gr
+      ON gr.lor_reconciliation_group_id = c.lor_reconciliation_group_id
+    WHERE gr.lor_reconciliation_run_id = p_lor_reconciliation_run_id
+      AND gr.effective_resolution_state IN ('AUTO_APPROVED', 'APPROVED')
+      AND b.binding_type = c.binding_type
+      AND b.preview_id = c.preview_id
+      AND b.scene_id IS NOT DISTINCT FROM c.scene_id
+      AND b.accepted_source_stage_key IS DISTINCT FROM c.source_stage_key;
+END;
+$procedure$;
+
+COMMENT ON PROCEDURE ref.p1_promote_stage_from_reconciliation(bigint) IS
+'Reconciliation-gated P1. Preserves permanent stage identity, applies explicitly approved canonical StageID/substage changes, remembers accepted per-binding source StageIDs, and delegates established/new-stage promotion to the preserved implementation.';
+
+REVOKE EXECUTE ON FUNCTION
+    ops.f_stage_group_has_only_accepted_binding_keys(bigint) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION
+    ops.f_stage_group_can_approve_change(bigint) FROM PUBLIC;
+REVOKE EXECUTE ON PROCEDURE
+    ref.p1_promote_stage_from_reconciliation_before_0033(bigint) FROM PUBLIC;
+REVOKE EXECUTE ON PROCEDURE
+    ref.p1_promote_stage_from_reconciliation(bigint) FROM PUBLIC;
+
+COMMIT;
+
+SELECT
+    '2026-08-16-approved-stage-key-aliases-v1'::text
+        AS installed_revision,
+    to_regprocedure(
+        'ops.f_stage_group_has_only_accepted_binding_keys(bigint)'
+    ) IS NOT NULL AS has_binding_key_acceptance_gate,
+    true AS complete_stage_evidence_view_installed;

--- a/LOR2DB/02_Reconciliation/reconciliation/validation/28_complete_stage_decision_evidence_validation.sql
+++ b/LOR2DB/02_Reconciliation/reconciliation/validation/28_complete_stage_decision_evidence_validation.sql
@@ -1,0 +1,50 @@
+/* Read-only acceptance checks for migration 0033. */
+
+DO $validation$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'ref'
+          AND table_name = 'stage_lor_binding'
+          AND column_name = 'accepted_source_stage_key'
+    ) OR to_regprocedure(
+        'ops.f_stage_group_has_only_accepted_binding_keys(bigint)'
+    ) IS NULL THEN
+        RAISE EXCEPTION
+            'Stage binding source-key acceptance objects are incomplete';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM ops.v_lor_reconciliation_group_review AS gr
+        LEFT JOIN ops.v_lor_reconciliation_operator_stage_review AS sr
+          ON sr.lor_reconciliation_group_id = gr.lor_reconciliation_group_id
+        WHERE gr.entity_type = 'STAGE'
+          AND gr.decision_required
+        GROUP BY gr.lor_reconciliation_group_id, gr.member_count
+        HAVING count(sr.lor_reconciliation_stage_candidate_id)
+            <> gr.member_count
+    ) THEN
+        RAISE EXCEPTION
+            'A decision-required stage group hides frozen evidence members';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM ops.v_lor_reconciliation_group_review AS gr
+        WHERE gr.entity_type = 'STAGE'
+          AND ops.f_stage_group_can_approve_change(
+              gr.lor_reconciliation_group_id)
+          AND NOT ('APPROVE_STAGE_CHANGE' = ANY(gr.allowed_action_types))
+    ) THEN
+        RAISE EXCEPTION
+            'An eligible canonical StageID change lacks an approval action';
+    END IF;
+END;
+$validation$;
+
+SELECT
+    'PASS'::text AS validation_status,
+    'Stage key changes preserve permanent identity, accepted aliases persist, and every decision group exposes complete frozen evidence.'::text
+        AS validation_detail;

--- a/LOR2DB/Application/README.md
+++ b/LOR2DB/Application/README.md
@@ -349,10 +349,13 @@ unit. Do not deploy only the static page or only `backend.py`.
 2. Apply
    `0032_add_safe_stage_authority_and_terminal_cancel.sql`, then run
    `27_safe_stage_authority_and_cancel_terminal_validation.sql`.
-3. Reapply `grant_lor_preflight_app.sql` V0.3.0 so the restricted API role can
-   invoke only the two stage decision recorders in addition to its existing
-   entry points.
-4. On the approved Windows host, deploy the canonical parser directory,
+3. Apply
+   `0033_approve_stage_key_changes_with_stable_aliases.sql`, then run
+   `28_complete_stage_decision_evidence_validation.sql`.
+4. Reapply `grant_lor_preflight_app.sql` V0.3.1 so the restricted API role can
+   read the evidence-gating predicates and invoke the stage decision recorders
+   in addition to its existing entry points.
+5. On the approved Windows host, deploy the canonical parser directory,
    including runner V1.3.0, version checker, parser V7.0.10, tests, and the root
    runner launcher. Retain the existing `runner-state.json` whose current
    approved LOR is 6.6.10; do not initialize over it. Run launcher `Install`

--- a/LOR2DB/Application/grant_lor_preflight_app.sql
+++ b/LOR2DB/Application/grant_lor_preflight_app.sql
@@ -1,7 +1,7 @@
 /* ============================================================================
 Object:       LOR preflight application least-privilege grants
 Filename:     grant_lor_preflight_app.sql
-Revision:     2026-08-14 V0.3.0
+Revision:     2026-08-16 V0.3.1
 
 Purpose:
   Grant the existing login role lor_preflight_app only the reads and secured
@@ -9,6 +9,9 @@ Purpose:
   publisher. This script does not create the login or store its password.
 
 Revision history:
+  2026-08-16  GAL / OpenAI  Granted the restricted API role the read-only
+                           stage evidence predicates required by the operator
+                           review views.
   2026-08-14  GAL / OpenAI  Added the evidence-gated stage authority action
                            recorder introduced by migration 0032.
   2026-08-06  GAL / OpenAI  Added current-snapshot read access and the unified
@@ -51,6 +54,11 @@ TO lor_preflight_app;
 GRANT SELECT ON lor_snap.v_current_run TO lor_preflight_app;
 
 GRANT EXECUTE ON FUNCTION
+    ops.f_normalize_lor_stage_name(text,text),
+    ops.f_stage_group_can_preserve_existing_metadata(bigint),
+    ops.f_stage_group_has_only_accepted_binding_keys(bigint),
+    ops.f_stage_group_can_approve_change(bigint),
+    ops.f_stage_group_can_add_new_stage(bigint),
     ops.f_record_lor_reconciliation_action(bigint,bigint,text,text,jsonb,text),
     ops.f_record_lor_stage_authority_action(bigint,bigint,text,text,text),
     ops.f_record_lor_stage_preserve_metadata_action(bigint,bigint,text,text),
@@ -68,5 +76,5 @@ TO lor_preflight_app;
 COMMIT;
 
 SELECT
-    '2026-08-14-lor-preflight-app-grants-v3' AS applied_revision,
+    '2026-08-16-lor-preflight-app-grants-v3.1' AS applied_revision,
     current_user AS applied_by;

--- a/LOR2DB/Application/test_stage_authority_migration.py
+++ b/LOR2DB/Application/test_stage_authority_migration.py
@@ -1,4 +1,4 @@
-"""Static safety contracts for reconciliation migration 0032.
+"""Static safety contracts for reconciliation stage-authority migrations.
 
 The transactional PostgreSQL validation script exercises the installed
 objects.  These fast repository tests prevent accidental removal of the
@@ -12,6 +12,10 @@ import unittest
 ROOT = Path(__file__).parents[1]
 MIGRATION = ROOT / "02_Reconciliation" / "reconciliation" / "migrations" / (
     "0032_add_safe_stage_authority_and_terminal_cancel.sql"
+)
+COMPLETE_EVIDENCE_MIGRATION = (
+    ROOT / "02_Reconciliation" / "reconciliation" / "migrations" /
+    "0033_approve_stage_key_changes_with_stable_aliases.sql"
 )
 GRANTS = ROOT / "Application" / "grant_lor_preflight_app.sql"
 
@@ -37,12 +41,35 @@ class StageAuthorityMigrationTests(unittest.TestCase):
         self.assertIn("RETURNING stage_id INTO v_stage_id", source)
         self.assertIn("INSERT INTO ref.stage_lor_binding", source)
 
-    def test_application_role_can_call_only_the_authority_recorder(self) -> None:
+    def test_application_role_can_read_stage_authority_evidence(self) -> None:
         source = GRANTS.read_text(encoding="utf-8")
-        self.assertIn(
+        required_functions = (
+            "ops.f_normalize_lor_stage_name(text,text)",
+            "ops.f_stage_group_can_preserve_existing_metadata(bigint)",
+            "ops.f_stage_group_has_only_accepted_binding_keys(bigint)",
+            "ops.f_stage_group_can_approve_change(bigint)",
+            "ops.f_stage_group_can_add_new_stage(bigint)",
             "ops.f_record_lor_stage_authority_action(bigint,bigint,text,text,text)",
+        )
+        for signature in required_functions:
+            with self.subTest(signature=signature):
+                self.assertIn(signature, source)
+
+    def test_decision_stage_view_includes_unchanged_group_members(self) -> None:
+        source = COMPLETE_EVIDENCE_MIGRATION.read_text(encoding="utf-8")
+        self.assertIn("WHERE gr.decision_required", source)
+        self.assertIn("ops.v_lor_reconciliation_operator_stage_review", source)
+
+    def test_approved_stage_key_change_persists_binding_aliases(self) -> None:
+        source = COMPLETE_EVIDENCE_MIGRATION.read_text(encoding="utf-8")
+        self.assertIn("accepted_source_stage_key", source)
+        self.assertIn(
+            "NEW.accepted_source_stage_key IS NOT DISTINCT FROM",
             source,
         )
+        self.assertIn("target_stage_key", source)
+        self.assertIn("P1_APPROVED_STAGE_KEY_CHANGE", source)
+        self.assertIn("preserved permanent stage_id", source)
 
     def test_cancelled_runs_receive_a_terminal_completion_timestamp(self) -> None:
         source = MIGRATION.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- allow a stable stage group to approve one unambiguous canonical StageID/substage change while preserving permanent `stage_id`
- persist accepted source StageID aliases per stable preview/scene binding so legitimate mixed aliases do not reopen every reconciliation
- expose every frozen member of a decision-required stage group
- grant the restricted application role the evidence predicates required by the review views

This is rule-based. It contains no hard-coded StageID, stage number, reconciliation run, or ingest ID.

## Validation
- 29 parser/runner tests passed
- 39 application tests passed
- 15 reporting tests passed
- migration, validation, current P1, and grant SQL parsed successfully as PostgreSQL