### PR TITLE
Soften production confirmation styling

### DIFF
--- a/LOR2DB/Application/README.md
+++ b/LOR2DB/Application/README.md
@@ -2,13 +2,14 @@
 
 | Document control | Value |
 |---|---|
-| Status | CURRENT code; web ingest workflow deployed; V0.6.1 action-clarity hotfix pending deployment |
+| Status | CURRENT code; web ingest workflow deployed; preflight browser V0.5.1 pending deployment |
 | Initial release / current revision | 2026-08-04 / 2026-08-16 |
 
 ## Revision history
 
 | Date | Change |
 |---|---|
+| 2026-08-16 | Changed the successful final production-application boundary from failure-red styling to an amber notice with standard blue confirmation controls. Cancellation and actual failures remain red. |
 | 2026-08-16 | Added ingest V0.4.1 / runner V1.5.1 recovery for a Windows console encoding failure after PostgreSQL commit. The exact completed SQLite digest is reused without creating a duplicate import run, and post-commit failures can no longer claim rollback. |
 | 2026-08-16 | Kept `Run parser` permanently available after successful runs and made `Review parser output` an additional action instead of a replacement. Corrected the Windows installer message so an unchanged protected token does not instruct the operator to pair the server again. |
 | 2026-08-15 | Added the complete browser-operated parser-to-ingest workflow. The idempotent parser remains repeatable until the operator approves the exact displayed SQLite digest. The Windows runner then performs the fixed digest-locked PostgreSQL ingest and exposes read-only console output on the same page. Ingest never starts reconciliation automatically. |

--- a/LOR2DB/Application/index.html
+++ b/LOR2DB/Application/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>LOR reconciliation preflight</title>
-  <link rel="stylesheet" href="preflight.css?v=0.5.0">
+  <link rel="stylesheet" href="preflight.css?v=0.5.1">
 </head>
 <body>
   <main id="app" class="shell" aria-live="polite">
@@ -26,6 +26,6 @@
     </form>
   </dialog>
 
-  <script src="preflight.js?v=0.5.0" defer></script>
+  <script src="preflight.js?v=0.5.1" defer></script>
 </body>
 </html>

--- a/LOR2DB/Application/preflight.css
+++ b/LOR2DB/Application/preflight.css
@@ -7,6 +7,9 @@
   --line: #d8dee5;
   --accent: #145a8d;
   --danger: #a12622;
+  --warning: #7a5100;
+  --warning-bg: #fff7df;
+  --warning-line: #d6a43a;
   --ok: #2c6e49;
 }
 * { box-sizing: border-box; }
@@ -51,6 +54,13 @@ select, textarea { border: 1px solid #aeb8c2; border-radius: 4px; background: #f
 .save-state.is-saved { color: var(--ok); font-weight: 650; }
 .save-state.is-unsaved { color: #9a5a00; font-weight: 650; }
 .error { color: var(--danger); font-weight: 650; }
+.production-warning {
+  border-left: 4px solid var(--warning-line);
+  background: var(--warning-bg);
+  color: var(--warning);
+  padding: 10px 12px;
+  font-weight: 650;
+}
 .eyebrow { color: var(--muted); font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
 .terminal.is-cancelled { border-top: 6px solid var(--danger); }
 .terminal-proof { display: flex; flex-wrap: wrap; gap: 12px; margin: 20px 0; }

--- a/LOR2DB/Application/preflight.js
+++ b/LOR2DB/Application/preflight.js
@@ -1,7 +1,7 @@
 /*
  * MSB Database - reusable LOR reconciliation preflight interface
  * Initial release: 2026-08-04 V0.1.0
- * Current version: 2026-08-14 V0.5.0
+ * Current version: 2026-08-16 V0.5.1
  *
  * The browser never writes PostgreSQL directly. All durable decisions and
  * lifecycle changes go through the same-origin secured API described in
@@ -237,7 +237,7 @@
 
   function renderFinalReview() {
     const applied = model.candidates.filter((candidate) => candidate.effective_action_type && candidate.effective_action_type !== "DEFER");
-    app.innerHTML = `<div class="card"><h1>Final application review</h1><p>Only the following recorded actions will be applied to production. Deferred items are excluded.</p><ul class="final-list">${applied.map((candidate) => `<li><strong>${esc(displayName(candidate))}</strong><br>${esc(actionLabel(candidate.effective_action_type))}<br><span class="muted">${esc(candidate.effective_reason)}</span></li>`).join("")}</ul><p class="error">Proceed is the production-write boundary. It invokes Finish for reconciliation run ${model.run_id}.</p><div class="footer-actions"><button id="back">Back to review</button><button id="proceed" class="danger">Proceed</button></div></div>`;
+    app.innerHTML = `<div class="card"><h1>Final application review</h1><p>Only the following recorded actions will be applied to production. Deferred items are excluded.</p><ul class="final-list">${applied.map((candidate) => `<li><strong>${esc(displayName(candidate))}</strong><br>${esc(actionLabel(candidate.effective_action_type))}<br><span class="muted">${esc(candidate.effective_reason)}</span></li>`).join("")}</ul><p class="production-warning">Proceed is the production-write boundary. It invokes Finish for reconciliation run ${model.run_id}.</p><div class="footer-actions"><button id="back">Back to review</button><button id="proceed" class="primary">Proceed</button></div></div>`;
     document.querySelector("#back").addEventListener("click", renderReview);
     document.querySelector("#proceed").addEventListener("click", confirmProceed);
   }
@@ -246,7 +246,7 @@
     dialogTitle.textContent = "Apply these changes to production?";
     dialogBody.textContent = `This will invoke Finish for reconciliation run ${model.run_id}. This action cannot be undone from this screen.`;
     dialogReasonWrap.hidden = true;
-    dialogConfirm.textContent = "Proceed with production update"; dialogConfirm.className = "danger";
+    dialogConfirm.textContent = "Proceed with production update"; dialogConfirm.className = "primary";
     dialogConfirm.onclick = async (event) => {
       event.preventDefault();
       try {

--- a/LOR2DB/Application/test_backend.py
+++ b/LOR2DB/Application/test_backend.py
@@ -68,6 +68,30 @@ class BackendSafetyTests(unittest.TestCase):
         self.assertIn("Complete stage evidence", source)
         self.assertIn("candidate.members.map", source)
 
+    def test_production_confirmation_is_a_warning_not_an_error(self) -> None:
+        application = Path(__file__).parent
+        source = (application / "preflight.js").read_text(encoding="utf-8")
+        styles = (application / "preflight.css").read_text(encoding="utf-8")
+
+        # Production application remains explicit without using failure-red styling.
+        self.assertIn('class="production-warning"', source)
+        self.assertIn('id="proceed" class="primary"', source)
+        self.assertIn(
+            'dialogConfirm.textContent = "Proceed with production update"; '
+            'dialogConfirm.className = "primary";',
+            source,
+        )
+        self.assertIn(".production-warning", styles)
+        self.assertIn(
+            'dialogConfirm.textContent = "Cancel reconciliation"; '
+            'dialogConfirm.className = "danger";',
+            source,
+        )
+        self.assertNotIn(
+            '<p class="error">Proceed is the production-write boundary.',
+            source,
+        )
+
     def test_cancel_endpoint_returns_terminal_proof_and_report_url(self) -> None:
         class Cursor:
             def __enter__(self):


### PR DESCRIPTION
## What changed

- replaces the red final production-boundary message with an amber warning notice
- changes the successful Proceed controls from red to the standard blue primary style
- keeps cancellation and actual failure states red
- bumps the preflight CSS/JavaScript cache version to V0.5.1
- documents the browser revision and adds a regression test

## Why

The final review and confirmation screens used the same red treatment as actual errors, which made a successful, intentional production update look like a failure.

## Validation

- `node --check LOR2DB/Application/preflight.js`
- `python -m unittest discover -s LOR2DB/Application -p "test_*.py"`
- 40 application tests passed
- `git diff --check`