### PR TITLE
Align LOR2DB operator and disaster recovery documentation

### DIFF
--- a/Docs/00_Project_Overview/00_LOR_System_Overview.md
+++ b/Docs/00_Project_Overview/00_LOR_System_Overview.md
@@ -4,7 +4,7 @@
 |---|---|
 | Status | ACTIVE — V7 scene-aware production workflow |
 | Owner | MSB Database Administrator |
-| Current revision | 2026-08-13 |
+| Current revision | 2026-08-17 |
 
 ## Purpose
 
@@ -27,37 +27,42 @@ The current workflow is V7. V6 parser and PostgreSQL ingest material is archived
 ```text
 Isolated programmer previews
     -> controlled dry-run comparison and reviewed merge
-    -> Office PC designated master during LOR 6.6.4/V7 development
+    -> Office PC designated master
     -> authoritative V7 preview exports
-    -> LOR2DB website / Windows V7 parser runner
+    -> Run and review the parser in the LOR2DB website
     -> Docs/01_LOR_System/02_Data_Extraction/Parser/parse_props_v7_scene_parser.py
     -> lor_output_v7_scene.db
-    -> LOR2DB/01_Ingest/postgres_run_ingest_v7.ps1
+    -> approve the exact SQLite digest in the LOR2DB website
+    -> digest-locked PostgreSQL ingest from the same page
     -> immutable lor_snap snapshot
-    -> https://my.sheboyganlights.org/lor2db/
-    -> persistent reconciliation and operator decisions
+    -> Start reconciliation in the LOR2DB website
+    -> persistent operator decisions and final review
     -> controlled P1-P4 promotion
     -> validation and immutable HTML report
 ```
 
-For the current release, the Office PC is the designated master during LOR
-6.6.4/V7 development. The Show PC held the master historically and must not be
+For the current release, the Office PC is the designated master for the
+approved LOR 6.6.10 preview set. The Show PC held the master historically and must not be
 treated as current authority until a deliberate handoff. The LOR2DB page runs
-the parser through the restricted Office PC runner. PostgreSQL ingest remains
-separate, manual, and locked to the exact reviewed SQLite SHA-256. The page
-detects the committed snapshot and never asks the operator for an ingest ID.
+the parser and the fixed PostgreSQL ingest through the restricted Office PC
+runner. They remain separate operator approvals: the parser may be repeated
+until the output looks correct, ingest is locked to the exact approved SQLite
+SHA-256, and reconciliation starts only after another explicit operator action.
+The page never asks the operator for an ingest ID.
 
 ## Current source and entry points
 
 - Parser: [`Docs/01_LOR_System/02_Data_Extraction/Parser/parse_props_v7_scene_parser.py`](../01_LOR_System/02_Data_Extraction/Parser/parse_props_v7_scene_parser.py).
 - XML version checker and runner: [`LOR Data Extraction`](../01_LOR_System/02_Data_Extraction/README.md).
 - SQLite snapshot: `lor_output_v7_scene.db`.
-- PostgreSQL ingest: [`LOR2DB/01_Ingest/postgres_run_ingest_v7.ps1`](../../LOR2DB/01_Ingest/postgres_run_ingest_v7.ps1).
+- Normal production workflow: [LOR2DB](https://my.sheboyganlights.org/lor2db/).
+- PostgreSQL ingest implementation and recovery entry point: [`LOR2DB/01_Ingest/postgres_run_ingest_v7.ps1`](../../LOR2DB/01_Ingest/postgres_run_ingest_v7.ps1).
 - Preview ownership and merge control: [Preview Merger](../01_LOR_System/03_Preview_Merger/README.md).
 - FormView executable application: [FormView](../../LOR/FormView/README.md).
 - Controlled production procedure: [LOR Production Import and Reconciliation Procedure](../../LOR2DB/02_Reconciliation/00_LOR_Production_Import_and_Reconciliation_Procedure.md).
 - Reconciliation landing page: [LOR2DB](https://my.sheboyganlights.org/lor2db/).
 - Manual recovery runbook: [LOR Manual Reconciliation Runbook](../../LOR2DB/02_Reconciliation/02_LOR_Manual_Reconciliation_Runbook.md).
+- Office PC service dependency and recovery: [Office PC Runner Operations and Disaster Recovery](../../LOR2DB/Application/Office_PC_Runner_Operations_and_Disaster_Recovery.md).
 
 ## Noncurrent material
 
@@ -65,5 +70,5 @@ Do not use `parse_props_v6.py`, `lor_output_v6.db`, or V6 workflow instructions 
 
 FormView's current `lor_output_v6.db` and `_v6` names are documented
 compatibility dependencies, not authorization to run the archived V6 parser.
-LOR 6.6.10 is the pending candidate and must follow the [LOR Preview Version
-Compatibility Review](../01_LOR_System/02_Data_Extraction/LOR_Preview_Version_Compatibility_Review.md).
+LOR 6.6.10 is the current approved version of record. Every later version must
+follow the [LOR Preview Version Compatibility Review](../01_LOR_System/02_Data_Extraction/LOR_Preview_Version_Compatibility_Review.md).

--- a/Docs/00_Project_Overview/01-Google_Drive_Document_Organization_Procedure.md
+++ b/Docs/00_Project_Overview/01-Google_Drive_Document_Organization_Procedure.md
@@ -23,7 +23,7 @@ Normal workflow:
 ```text
 Current LOR previews
         ↓
-run_parse_props.ps1
+Run and review the parser in LOR2DB
         ↓
 current V7 parser SQLite snapshot
         ↓

--- a/Docs/01_LOR_System/01_Preview_Authoring/B_Building_Preview_Howto.md
+++ b/Docs/01_LOR_System/01_Preview_Authoring/B_Building_Preview_Howto.md
@@ -37,10 +37,10 @@ The controlled path is:
 5. Run the comparison again and require `noop` to prove idempotence.
 6. Use only the approved master set as V7 parser input.
 
-Historically the Show PC held the master. During LOR 6.6.4/V7 development, the
-Office PC is the designated master. No programmer may overwrite it with their
-local preview. See the active
-[Preview Merger Reference](preview_merger_reference.md).
+Historically the Show PC held the master. The Office PC is the designated
+master for the approved LOR 6.6.10 preview set. No programmer may overwrite it
+with their local preview. See the active
+[Preview Merger documentation](../03_Preview_Merger/README.md).
 
 ---
 
@@ -977,10 +977,12 @@ Remove any temporary, draft, or unrelated images before finalizing.
 After **any changes** to previews, export the authoritative preview set from the
 approved Master PC and run the controlled V7 production workflow:
 
-1. V7 scene-aware parser.
-2. Protected PostgreSQL snapshot ingest.
-3. Reconciliation from `https://lortodb.sheboyganlights.org/lor2db/`.
-4. Finish, validation, and immutable report review.
+1. Open `https://my.sheboyganlights.org/lor2db/` and select **Run parser**.
+2. Review the parser output; correct the previews and rerun as often as needed.
+3. Confirm the exact parser output and select **Ingest to PostgreSQL**.
+4. Review the ingest console and select **Start reconciliation**.
+5. Record required decisions, complete final review, apply, and review the
+   immutable report.
 
 Use `LOR2DB/Reconciliation/00_LOR_Production_Import_and_Reconciliation_Procedure.md`
 for the current stop conditions and exact workflow. The V6 merger/parser/compare

--- a/Docs/01_LOR_System/02_Data_Extraction/Folder_Alignment/Folder_Alignment_Engineering_Design.md
+++ b/Docs/01_LOR_System/02_Data_Extraction/Folder_Alignment/Folder_Alignment_Engineering_Design.md
@@ -19,7 +19,7 @@ A separate narrow updater may add an approved missing `PreviewBackground` folder
 
 ```text
 LOR preview files
-    -> run_parse_props.ps1
+    -> repeatable parser run and review in the LOR2DB website
     -> lor_output_v7_scene.db
     -> run_folder_check.ps1
     -> Folder Alignment
@@ -27,6 +27,11 @@ LOR preview files
 ```
 
 PostgreSQL and LOR2DB are not working data sources for Folder Alignment. The current V7 parser SQLite output is deliberately used so LOR organization and document alignment can be inspected repeatedly before PostgreSQL ingest.
+
+The website is the normal parser entry point. The repository-root
+`run_parse_props.ps1` launcher is an engineering/recovery fallback only; either
+entry point must produce the same validated SQLite contract before Folder
+Alignment is run.
 
 The parser snapshot provenance in `parser_run` identifies the exact Preview folder used to build the current SQLite snapshot.
 

--- a/Docs/01_LOR_System/02_Data_Extraction/LOR_Preview_File_Structure_Specification.md
+++ b/Docs/01_LOR_System/02_Data_Extraction/LOR_Preview_File_Structure_Specification.md
@@ -3,8 +3,8 @@
 | Document control | Value |
 |---|---|
 | Status | CURRENT — reverse-engineered engineering reference |
-| Baseline | Approved Light-O-Rama `.lorprev` manifest; initialized from 6.6.4 |
-| Current revision | 2026-08-13 |
+| Baseline | Approved Light-O-Rama `.lorprev` manifest for LOR 6.6.10 |
+| Current revision | 2026-08-17 |
 | Owner | MSB Database Administrator |
 
 ## Purpose
@@ -29,7 +29,7 @@ Functional parser baseline:
 
 Known-good LOR preview baseline:
 
-`Light-O-Rama 6.6.4`
+`Light-O-Rama 6.6.10`
 
 The parser source is the implementation authority for materialization. The
 approved XML manifest is the compatibility authority for the complete exported

--- a/Docs/01_LOR_System/02_Data_Extraction/LOR_Preview_Parser_Architecture.md
+++ b/Docs/01_LOR_System/02_Data_Extraction/LOR_Preview_Parser_Architecture.md
@@ -5,7 +5,7 @@
 | Status | CURRENT — engineering architecture |
 | System | LOR Preview Parser / LOR2DB Ingest |
 | Functional baseline | `parse_props_v7_scene_parser.py` V7.0.10 |
-| Current revision | 2026-08-13 |
+| Current revision | 2026-08-17 |
 | Owner | MSB Database Administrator |
 
 ## Purpose
@@ -438,7 +438,9 @@ In particular, a changed RawPropID with the same physical display can be reconci
 
 ## Compatibility Contract
 
-The current functional baseline was developed and validated against the LOR 6.6.4 preview format.
+The current functional parser and approved compatibility manifest are validated
+against the LOR 6.6.10 preview format. The earlier 6.6.4 baseline remains
+historical evidence, not the current production authority.
 
 A newer LOR version must not be assumed compatible merely because the parser runs without raising an exception. Structural changes can cause silent omissions or different materialization.
 

--- a/Docs/01_LOR_System/02_Data_Extraction/LOR_Preview_Version_Compatibility_Review.md
+++ b/Docs/01_LOR_System/02_Data_Extraction/LOR_Preview_Version_Compatibility_Review.md
@@ -4,7 +4,7 @@
 |---|---|
 | Status | CURRENT — controlled engineering procedure |
 | Applies to | Any new Light-O-Rama release that can change `.lorprev` output |
-| Current revision | 2026-08-13 |
+| Current revision | 2026-08-17 |
 | Owner | MSB Database Administrator |
 
 ## Purpose
@@ -42,15 +42,19 @@ Use copied test files and a separate test output database.
 
 ## Operator Version Record
 
+Normal operation begins at the separate **Check new version** page reached from
+[LOR2DB](https://my.sheboyganlights.org/lor2db/). Do not use the routine parser
+page to approve a different Light-O-Rama software version.
+
 LOR2DB maintains two explicit fields:
 
 - **Current LOR version** — the approved production version of record;
 - **New LOR version** — the candidate being evaluated.
 
-The approved record identifies the versioned preview folder, for example
-`Database Previews V6.6.4`. A candidate such as 6.6.10 uses `Database Previews
-V6.6.10`. Approval changes the record; it does not rename or delete the
-previous versioned folder.
+The approved record currently identifies LOR 6.6.10 and `Database Previews
+V6.6.10`. A later candidate must use its own `Database Previews V<version>`
+folder. Approval changes the record; it does not rename or delete the previous
+versioned folder.
 
 ## Mandatory Automated Gate
 
@@ -97,7 +101,8 @@ comprehensive preview rather than manually inspecting all production previews.
 The automated positional inventory and critical ID/count scan still cover every
 file.
 
-For the 6.6.4 baseline, the selected deep preview is:
+For the historical 6.6.4-to-6.6.10 approval, the selected baseline deep preview
+was:
 
 `2026 Master Musical Preview v6.6 2026-07-30.lorprev`
 
@@ -529,15 +534,17 @@ If the new LOR version is approved:
 5. retain the comparison evidence for future LOR upgrades;
 6. update the approved LOR baseline only after the production transition is intentionally authorized.
 
-## Current Pending Review
+## Current Approved Version
 
-Light-O-Rama 6.6.10 is the next candidate. It must be exported into `Database
-Previews V6.6.10` and reviewed through the website checker/parser gates before
-replacing the approved 6.6.4 version record.
+Light-O-Rama 6.6.10 is the approved production version of record. Its approved
+preview source is `Database Previews V6.6.10`. No newer candidate is currently
+recorded. A later candidate must complete this entire isolated website workflow
+before it can replace 6.6.10.
 
 ## Revision History
 
 | Date | Author | Change |
 |---|---|---|
+| 2026-08-17 | GAL / OpenAI | Recorded LOR 6.6.10 as the approved production version and clarified that the separate website version-check page is the normal approval interface. |
 | 2026-08-13 | GAL / OpenAI | Added Current/New version records, complete all-preview XML manifests, the selected deep preview, blocking modification records/resolution, and website approval gates for the 6.6.10 review. |
 | 2026-08-08 | GAL / OpenAI | Created controlled LOR-version compatibility review procedure, regression checklist, decision model, and reusable ChatGPT engineering comparison prompt. |

--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/README.md
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/README.md
@@ -54,3 +54,4 @@ See:
 - [Version compatibility procedure](../LOR_Preview_Version_Compatibility_Review.md)
 - [SQLite output contract](../LOR_SQLite_Output_Database_Structure.md)
 - [LOR2DB ingest handoff](../../../../LOR2DB/01_Ingest/README.md)
+- [Office PC runner operations and disaster recovery](../../../../LOR2DB/Application/Office_PC_Runner_Operations_and_Disaster_Recovery.md)

--- a/Docs/01_LOR_System/02_Data_Extraction/README.md
+++ b/Docs/01_LOR_System/02_Data_Extraction/README.md
@@ -14,6 +14,7 @@ separate SQLite-to-PostgreSQL ingest.
 | Understand the `.lorprev` structure the parser depends on | [LOR Preview File Structure Specification](LOR_Preview_File_Structure_Specification.md) |
 | Evaluate and approve a new Light-O-Rama version | [LOR Preview Version Compatibility Review](LOR_Preview_Version_Compatibility_Review.md) |
 | Review the current parser/checker implementation | [Parser](Parser/) |
+| Install, restart, or recover the Office PC listener | [Office PC Runner Operations and Disaster Recovery](../../../LOR2DB/Application/Office_PC_Runner_Operations_and_Disaster_Recovery.md) |
 | Review the separate PostgreSQL ingest | [LOR2DB Ingest](../../../LOR2DB/01_Ingest/README.md) |
 
 ## Engineering Boundary
@@ -39,8 +40,8 @@ The parser owns interpretation of Light-O-Rama preview structure. PostgreSQL ing
 
 The current functional parser is
 `Parser/parse_props_v7_scene_parser.py` V7.0.10. The current approved LOR version
-is an operator-controlled record initialized from the known-good 6.6.4 preview
-set; it is not a hard-coded parser assumption.
+of record is 6.6.10. The approved version remains an operator-controlled record;
+it is not a hard-coded parser assumption.
 
 Every later Light-O-Rama version must pass the complete XML checker and the V7
 parser validation run before it can replace that approved record.

--- a/Docs/01_LOR_System/03_Preview_Merger/Preview_Merger_Architecture.md
+++ b/Docs/01_LOR_System/03_Preview_Merger/Preview_Merger_Architecture.md
@@ -5,7 +5,8 @@
 | Status | CURRENT — engineering architecture; implementation review still required |
 | System | LOR Preview Merger |
 | Current workflow model | Master Musical Preview |
-| Current revision | 2026-08-08 |
+| Current approved LOR version | 6.6.10 |
+| Current revision | 2026-08-17 |
 | Owner | MSB Database Administrator |
 
 ## Purpose
@@ -56,7 +57,9 @@ Programmers do not edit the controlled master preview directly. Each programmer 
 
 There must be one clearly designated master authority for the preview set.
 
-Historically the Show PC held the master preview set. During the LOR 6.6.4/V7 development period the Office PC became the designated master. Authority must be deliberately transferred; it must never be inferred from whichever copy appears newest.
+Historically the Show PC held the master preview set. The Office PC is now the
+designated master for approved LOR 6.6.10. Authority must be deliberately
+transferred; it must never be inferred from whichever copy appears newest.
 
 `Master_Musical_Preview` is the stable logical role for the musical-preview master. Dated exported files are snapshots, not permanent identities.
 
@@ -242,7 +245,7 @@ Known implementation issues include:
 - some launchers and report paths reflect older folder layouts;
 - the historical apply-policy defaults require review;
 - the Master Musical Preview simplification is not fully reflected in the old operator workflow;
-- LOR 6.6.8 compatibility has not yet been established.
+- every version after approved LOR 6.6.10 requires a new compatibility review.
 
 The presence of code in the active tree does not by itself make an `--apply` run production-approved.
 
@@ -250,14 +253,15 @@ The presence of code in the active tree does not by itself make an `--apply` run
 
 Before the Preview Merger is approved for this season's production programming workflow, engineering review must establish:
 
-1. the current master-preview authority and exact controlled source locations;
+1. safe integration with the current Office PC master authority and exact
+   controlled source locations;
 2. the Master Musical Preview workflow and which remaining previews are independently managed;
 3. the current comparison/winner policy;
 4. the required conflict and identity guardrails;
 5. the minimum audit evidence that must survive each comparison/apply;
 6. whether `preview_history.db` is retained, replaced, or reduced now that PostgreSQL/LOR2DB exists;
 7. current report locations and operator-facing report format;
-8. LOR 6.6.8 compatibility;
+8. compatibility handling for versions after approved LOR 6.6.10;
 9. dry-run and apply idempotency tests;
 10. the final operator procedure.
 

--- a/Docs/01_LOR_System/03_Preview_Merger/Preview_Merger_Operator_Procedure.md
+++ b/Docs/01_LOR_System/03_Preview_Merger/Preview_Merger_Operator_Procedure.md
@@ -5,7 +5,8 @@
 | Status | DRAFT — NOT YET APPROVED FOR PRODUCTION APPLY |
 | System | LOR Preview Merger |
 | Current workflow model | Master Musical Preview |
-| Current revision | 2026-08-08 |
+| Current approved LOR version | 6.6.10 |
+| Current revision | 2026-08-17 |
 | Owner | MSB Database Administrator |
 
 ## Purpose
@@ -76,12 +77,13 @@ Do not run a production apply merely because the launcher or `--apply` option ex
 
 Current engineering review still needs to confirm:
 
-- the exact controlled master location;
+- that merger apply targets the designated Office PC's controlled, versioned
+  master without overwriting unrelated approved previews;
 - which previews are independently managed under the Master Musical Preview model;
 - final winner/comparison policy;
 - current report locations;
 - audit/history implementation;
-- LOR 6.6.8 compatibility;
+- compatibility behavior for versions after approved LOR 6.6.10;
 - idempotent dry-run/apply behavior.
 
 ## Intended Operator Workflow

--- a/Docs/02_Production_Database/01_System_Architecture/02_LOR2DB_Ingest/README.md
+++ b/Docs/02_Production_Database/01_System_Architecture/02_LOR2DB_Ingest/README.md
@@ -14,13 +14,28 @@ LOR remains authoritative for show topology and wiring configuration. LOR2DB is 
 
 Data flow:
 
-`LOR -> parser -> snapshot -> PostgreSQL ingest -> reconciliation -> operational/reference data`
+`LOR -> Office PC parser/runner -> SQLite snapshot -> PostgreSQL ingest -> reconciliation -> operational/reference data`
+
+The authenticated browser does not execute Windows/G-drive work on the Linux
+web server. The Linux LOR2DB API calls a restricted listener on the designated
+Office PC for version checking, repeatable parser runs, and digest-locked
+ingest. That listener depends on the correct Windows account being logged in,
+the mapped `G:` drive, account-bound DPAPI credentials, its Scheduled Task,
+private-LAN firewall access from the database server, and the Linux pairing
+configuration.
+
+If the listener is unavailable, new version checks, parser runs, and browser
+ingests stop. Existing PostgreSQL data, reports, and an already-started
+reconciliation do not depend on that listener. The controlled installation,
+restart, and replacement-PC procedure is the [Office PC Runner Operations and
+Disaster Recovery runbook](../../../../LOR2DB/Application/Office_PC_Runner_Operations_and_Disaster_Recovery.md).
 
 ## Authoritative Sources
 
 - [LOR2DB project](../../../../LOR2DB/README.md)
 - [LOR2DB ingest](../../../../LOR2DB/01_Ingest/README.md)
 - [LOR2DB reconciliation](../../../../LOR2DB/02_Reconciliation/README.md)
+- [Office PC runner operations and disaster recovery](../../../../LOR2DB/Application/Office_PC_Runner_Operations_and_Disaster_Recovery.md)
 
 ## Boundaries
 

--- a/Docs/02_Production_Database/01_System_Architecture/README.md
+++ b/Docs/02_Production_Database/01_System_Architecture/README.md
@@ -14,6 +14,7 @@ Repository boundaries do not determine data authority. Dedicated applications an
 |---|---|
 | Understand shared PostgreSQL architecture and database-wide contracts | [01 — Database Foundation](01_Database_Foundation/README.md) |
 | Understand how LOR data enters PostgreSQL | [02 — LOR2DB Ingest](02_LOR2DB_Ingest/README.md) |
+| Recover the Office PC listener behind LOR2DB parser and ingest | [Office PC Runner Operations and Disaster Recovery](../../../LOR2DB/Application/Office_PC_Runner_Operations_and_Disaster_Recovery.md) |
 | Understand user onboarding, identity, roles, and audit attribution | [03 — People and Identity](03_People_and_Identity/README.md) |
 | Understand containers, display storage, KIT containers, and physical locations | [04 — Containers and Storage](04_Containers_and_Storage/README.md) |
 | Understand container/display testing | [05 — Testing System](05_Testing_System/README.md) |
@@ -95,7 +96,7 @@ The legacy Directus MVP documents `E_Directus_DB_Dev.md` and `F_Directus_UI_md` 
 
 The legacy `G_Work_Order_Design_Plan.md` has been reconciled into [06 — Work Orders](06_Work_Orders/README.md) and archived. The legacy `H_Asset_ID_Labeling_and_Scanning_Plan.md` has been reconciled into [07 — Labeling and Scanning](07_Labeling_and_Scanning/README.md) and archived.
 
-The legacy `D_Database_Structure.md` has now been fully reconciled into the current numbered subsystem architecture and removed from the active tree. Its historical reconciliation record is preserved at [`archive/architecture/D_Database_Structure.md`](../../../../archive/architecture/D_Database_Structure.md), while the complete original remains available in Git history.
+The legacy `D_Database_Structure.md` has now been fully reconciled into the current numbered subsystem architecture and removed from the active tree. Its historical reconciliation record is preserved at [`archive/architecture/D_Database_Structure.md`](../../../archive/architecture/D_Database_Structure.md), while the complete original remains available in Git history.
 
 One loose legacy architecture document remains active during the audit:
 

--- a/Docs/02_Production_Database/02_Operational_SOPs/LOR2DB/README.md
+++ b/Docs/02_Production_Database/02_Operational_SOPs/LOR2DB/README.md
@@ -1,0 +1,18 @@
+# LOR2DB Operator Procedures
+
+Use this area for the normal browser-operated workflow that moves approved
+Light-O-Rama preview changes into the Production Database.
+
+## What Do You Need To Do?
+
+| I want to... | Go to |
+|---|---|
+| Run the complete parser-to-report workflow | [Run an LOR Production Update](Run_an_LOR_Production_Update.md) |
+
+## Important Boundary
+
+The secured LOR2DB website is the normal operator interface. PowerShell,
+command-line ingest, and direct SQL reconciliation are engineering/recovery
+procedures and are not part of routine operation.
+
+For system design or recovery guidance, use the [LOR2DB technical portal](../../../../LOR2DB/README.md).

--- a/Docs/02_Production_Database/02_Operational_SOPs/LOR2DB/Run_an_LOR_Production_Update.md
+++ b/Docs/02_Production_Database/02_Operational_SOPs/LOR2DB/Run_an_LOR_Production_Update.md
@@ -1,0 +1,110 @@
+# Run an LOR Production Update
+
+[↑ LOR2DB Procedures](README.md)
+
+| Document Control | Value |
+|---|---|
+| Document Type | Operational SOP |
+| System | Production Database — LOR2DB |
+| Task | Parse approved LOR previews, ingest the reviewed snapshot, and reconcile production |
+| Audience | Authorized LOR2DB operators |
+| Status | CURRENT |
+| Owner | MSB Database Administrator |
+| Last Reviewed | 2026-08-17 |
+| Keywords | LOR2DB, parser, SQLite, ingest, reconciliation, production report |
+
+## Revision History
+
+| Date | Change |
+|---|---|
+| 2026-08-17 | Initial controlled browser procedure aligned to the deployed parser-to-report workflow validated by ingest 48 and reconciliation Run 7. |
+
+## Purpose
+
+Use this procedure after approved preview files have changed and those changes
+must be reviewed and applied to the Production Database.
+
+This procedure deliberately keeps three approvals separate:
+
+1. build and review the SQLite parser output;
+2. ingest that exact output into PostgreSQL; and
+3. reconcile and apply approved production changes.
+
+## Before You Start
+
+- Use an account authorized for LOR2DB.
+- Confirm the approved preview folder shown by LOR2DB is the intended source.
+- Make preview corrections in Light-O-Rama or the approved preview source—not
+  by manually editing SQLite or PostgreSQL.
+- Use **Check new version** instead if you are evaluating a different
+  Light-O-Rama software version.
+
+## Procedure
+
+1. Open [LOR2DB](https://my.sheboyganlights.org/lor2db/).
+2. Confirm the **Approved LOR version** and **Preview source folder**.
+3. Select **Run parser**.
+4. Review the parser console, validation status, counts, reports, SQLite path,
+   and SQLite SHA-256.
+5. If anything is wrong, correct the source previews and select **Run parser**
+   again. Repeat this step as many times as necessary. Each run rebuilds and
+   replaces the SQLite output; it does not ingest PostgreSQL.
+6. When the displayed output looks correct, select
+   **Parser output looks correct — ready for ingest**.
+7. Select **Ingest to PostgreSQL**. The ingest is locked to the exact SQLite
+   SHA-256 that you approved.
+8. Review the PostgreSQL ingest console. Continue only when the page reports
+   that the ingest completed and shows its PostgreSQL import run.
+9. Select **Start reconciliation**.
+10. Review every item requiring a decision. Use the complete evidence shown on
+    screen, choose the appropriate decision, optionally add a useful audit
+    comment, and select **Save decision**.
+11. When all decisions are saved, select **Continue to final review**.
+12. Verify the actions listed under **Final application review**. Select
+    **Back to review** if anything is incorrect.
+13. When the listed actions are correct, select **Proceed**, enter a concise
+    reason, and select **Proceed with production update**.
+14. Confirm the reconciliation completed, validation passed, and the immutable
+    final report opens.
+
+## Expected Result
+
+- The parser result is `PASSED`.
+- PostgreSQL contains one completed snapshot for the approved SQLite digest.
+- Reconciliation is terminal and validation is `PASSED`.
+- The report archive contains the immutable reconciliation report.
+- The dashboard no longer shows an unfinished run.
+
+## If Something Is Wrong
+
+- **Parser output is wrong:** correct the preview source and rerun the parser.
+  Do not ingest it.
+- **Runner unavailable:** confirm the Office PC is signed in, Google Drive has
+  restored `G:`, and the managed runner reports healthy. Do not substitute an
+  unreviewed file or path.
+- **Ingest fails before commit:** do not start reconciliation. Preserve the
+  console output and resolve the failure before retrying.
+- **Ingest console reports a failure after showing a completed import:** return
+  to the dashboard or refresh the parser page. Digest-idempotent recovery must
+  reuse the committed import instead of creating another snapshot.
+- **A reconciliation choice is missing:** do not force a different action.
+  Preserve the evidence and escalate the database rule or grant problem.
+- **You are not ready to apply production changes:** select **Back to review**.
+- **Cancellation is required:** select **Cancel reconciliation**, enter the
+  reason, and verify the terminal cancellation proof and report before closing
+  the browser. A cancelled run does not change production and its disposable
+  snapshot cannot be reused.
+- **The application is unavailable:** stop normal operation. Use the manual
+  runbook only as a controlled engineering/recovery procedure.
+
+## Related Documents
+
+- [LOR2DB technical portal](../../../../LOR2DB/README.md)
+- [LOR Production Import and Reconciliation Procedure](../../../../LOR2DB/02_Reconciliation/00_LOR_Production_Import_and_Reconciliation_Procedure.md)
+- [Manual Reconciliation Runbook — fallback only](../../../../LOR2DB/02_Reconciliation/02_LOR_Manual_Reconciliation_Runbook.md)
+- [LOR Preview Version Compatibility Review](../../../01_LOR_System/02_Data_Extraction/LOR_Preview_Version_Compatibility_Review.md)
+- [Office PC Runner Operations and Disaster Recovery](../../../../LOR2DB/Application/Office_PC_Runner_Operations_and_Disaster_Recovery.md)
+
+---
+
+[↑ LOR2DB Procedures](README.md)

--- a/Docs/02_Production_Database/02_Operational_SOPs/README.md
+++ b/Docs/02_Production_Database/02_Operational_SOPs/README.md
@@ -8,6 +8,7 @@ These procedures are for people performing day-to-day production database tasks.
 |---|---|
 | Create or maintain container records and display assignments | [Containers](Containers/README.md) |
 | Complete or maintain Production Database information about displays | [Displays](Displays/README.md) |
+| Run the LOR parser, ingest, and reconciliation workflow | [LOR2DB](LOR2DB/README.md) |
 | Print display or container labels | [Label Printing](Label_Printing/README.md) |
 | Test displays and record repairs | [Test Sessions](Test_Sessions/README.md) |
 | Create, review, assign, work, or complete Work Orders | [Work Orders](Work_Orders/README.md) |
@@ -18,6 +19,7 @@ These procedures are for people performing day-to-day production database tasks.
 |---|---|
 | [Containers](Containers/README.md) | Procedures for creating and maintaining containers, storage information, dimensions, labels, and display assignments |
 | [Displays](Displays/README.md) | Procedures for completing and maintaining Production Database display information |
+| [LOR2DB](LOR2DB/README.md) | Browser-operated LOR parser, PostgreSQL ingest, reconciliation, and reporting procedure |
 | [Label_Printing](Label_Printing/README.md) | Procedures for requesting display/container labels and first-line printing checks |
 | [Test_Sessions](Test_Sessions/README.md) | Container/display testing procedures and manager testing procedures |
 | [Work_Orders](Work_Orders/README.md) | Work-order request, triage, assignment, work, and completion procedures |

--- a/LOR/README.md
+++ b/LOR/README.md
@@ -8,7 +8,7 @@ LOR is the critical input-side system for the MSB production database. It includ
 programmer preview islands
     -> individual UserPreviewStaging folders
     -> controlled comparison and merge
-    -> Office PC designated master during 6.6.4/V7 development
+    -> Office PC designated master
     -> approved master preview set
     -> LOR2DB V7 parser and SQLite snapshot
     -> FormView (standalone SQLite application)
@@ -21,7 +21,7 @@ The Show PC historically held the master. It is not the current authority while 
 ## Production entry points
 
 1. Follow the [Preview Merger process](preview_merger/README.md) to establish the reviewed master input set. The process remains required, although the recovered implementation is blocked from production apply pending review.
-2. Continue to the [LOR2DB Ingest portal](../LOR2DB/01_Ingest/README.md) for the current V7 parser and PostgreSQL snapshot ingest.
+2. Continue to the [LOR2DB operator workflow](../Docs/02_Production_Database/02_Operational_SOPs/LOR2DB/Run_an_LOR_Production_Update.md) for the current V7 parser, review, and PostgreSQL snapshot ingest.
 3. Continue in LOR2DB. Ingest does not directly promote snapshot data into permanent production identities.
 
 ## FormView
@@ -32,7 +32,12 @@ See [FormView](FormView/README.md) for its build, deployment, launcher, data con
 
 ## Version compatibility
 
-The current V7 workflow was validated against LOR 6.6.4. LOR 6.6.8 requires a separate compatibility review before it can replace the known-good input baseline. The controlled checklist is maintained in the [LOR Preview Version Compatibility Review](../Docs/01_LOR_System/02_Data_Extraction/LOR_Preview_Version_Compatibility_Review.md). Do not assume parser, merger, or snapshot compatibility and do not modify production ingest or reconciliation until the review is complete.
+The current V7 workflow and approved XML manifest are validated for LOR 6.6.10.
+Every later LOR software version requires a separate compatibility review before
+it can replace that known-good input baseline. Use the website's **Check new
+version** workflow and the controlled [LOR Preview Version Compatibility
+Review](../Docs/01_LOR_System/02_Data_Extraction/LOR_Preview_Version_Compatibility_Review.md).
+Do not infer compatibility merely because the parser starts.
 
 ## Authoritative documentation
 
@@ -42,5 +47,6 @@ The current V7 workflow was validated against LOR 6.6.4. LOR 6.6.8 requires a se
 - [Data extraction engineering](../Docs/01_LOR_System/02_Data_Extraction/README.md)
 - [Preview Merger documentation](../Docs/01_LOR_System/03_Preview_Merger/README.md)
 - [LOR2DB Ingest](../LOR2DB/01_Ingest/README.md)
+- [Office PC runner operations and disaster recovery](../LOR2DB/Application/Office_PC_Runner_Operations_and_Disaster_Recovery.md)
 
 V6 and spreadsheet-era parser/ingest/report workflows are historical only and are stored under `archive/`. The Preview Merger's multi-programmer integrity process is active; it was not made obsolete by V7.

--- a/LOR/preview_merger/README.md
+++ b/LOR/preview_merger/README.md
@@ -4,8 +4,9 @@
 |---|---|
 | Process status | ACTIVE — required preview-integrity control |
 | Implementation status | REVIEW REQUIRED before production apply |
-| Current master location | Office PC during LOR 6.6.4/V7 development |
-| Current revision | 2026-08-06 |
+| Current master location | Office PC |
+| Current approved LOR version | 6.6.10 |
+| Current revision | 2026-08-17 |
 
 ## Purpose
 
@@ -22,8 +23,8 @@ multi-programmer integrity requirement.
 ## Master authority
 
 - Historically, the Show PC held the master preview set.
-- During the LOR 6.6.4 and V7 development period, the **Office PC is the
-  designated master**.
+- The **Office PC is the designated master** for the approved LOR 6.6.10
+  production preview set.
 - The Show PC must not be described or used as current authority until
   development is complete and responsibility is deliberately transferred.
 - `Master_Musical_Preview` is the stable logical role. Dated exported files are
@@ -61,7 +62,7 @@ Known blockers include:
   permissive apply profile. The intended production guardrails must be decided
   and validated before apply.
 - Some launchers and report paths reflect older folder layouts.
-- LOR 6.6.8 compatibility has not been established.
+- Any version after LOR 6.6.10 requires a new controlled compatibility review.
 
 Until those blockers are closed, the ownership, isolation, dry-run review, and
 controlled-master rules remain mandatory, but the recovered script must not be
@@ -83,24 +84,24 @@ assumed safe merely because it exists in the active tree.
 Current Preview Merger engineering and operator documentation is maintained in the
 [Preview Merger documentation portal](../../Docs/01_LOR_System/03_Preview_Merger/README.md).
 
-## LOR 6.6.8 compatibility boundary
+## New LOR version compatibility boundary
 
-LOR 6.6.8 is a separate compatibility project. Do not update the master set,
-production parser, PostgreSQL ingest, or reconciliation based on an assumption
-that 6.6.8 is schema-compatible.
+Every version after approved LOR 6.6.10 is a separate compatibility project.
+Do not update the master set, production parser, PostgreSQL ingest, or
+reconciliation based on an assumption that a later release is schema-compatible.
 
 The compatibility branch must:
 
-1. Preserve known-good LOR 6.6.4 previews and V7 outputs as the baseline.
-2. Export representative 6.6.8 previews to a separate test location.
+1. Preserve the approved LOR 6.6.10 preview manifest and V7 outputs as the baseline.
+2. Export representative previews from the new version to a separate versioned location.
 3. Compare XML elements, attributes, identifiers, scenes, preview-level versus
    sequence-level scene behavior, props, subprops, DMX, backgrounds, and channel
    data.
-4. Run the V7 parser only against copied 6.6.8 test inputs.
+4. Run the V7 parser only against the isolated candidate inputs.
 5. Compare SQLite schema, row counts, identities, relationships, warnings,
    omissions, collisions, and unassigned records with the baseline.
 6. Review Preview Merger field/signature logic against any XML changes.
-7. Preserve the V7 snapshot contract and LOR 6.6.4 compatibility unless a
+7. Preserve the V7 snapshot contract and LOR 6.6.10 compatibility unless a
    controlled database change is explicitly approved.
 8. Leave production ingest and reconciliation unchanged until compatibility is
    demonstrated and documented.

--- a/LOR2DB/01_Ingest/README.md
+++ b/LOR2DB/01_Ingest/README.md
@@ -13,12 +13,11 @@ The normal sequence is:
 
 1. In LOR2DB, confirm **Current LOR version** and use **Run parser**.
 2. Inspect the generated SQLite repeatedly as needed; parser runs never ingest.
-3. Mark the exact displayed SQLite SHA-256 as ready for ingest only after its
-   console, counts, reports, and data look correct.
-4. Apply migration `0031_preserve_lor_sqlite_authority_chain.sql` before the
-   first V0.4.0 ingest.
-5. Use **Ingest to PostgreSQL** on the same page and review its console output.
-6. Continue to [LOR2DB Reconciliation](../02_Reconciliation/README.md).
+3. Select **Parser output looks correct — ready for ingest** only after the
+   console, counts, reports, SHA-256, and data look correct.
+4. Use **Ingest to PostgreSQL** on the same page and review its console output.
+5. Select **Start reconciliation** only after the completed PostgreSQL import is
+   shown, then continue to [LOR2DB Reconciliation](../02_Reconciliation/README.md).
 
 The ingest rejects a modified/replaced SQLite file and rejects any snapshot
 that was not produced in `PRODUCTION` mode with `ValidationStatus=PASSED`.
@@ -35,6 +34,10 @@ The exact engineering rules behind the parser are documented under [LOR Data Ext
 | `postgres_run_ingest_v7.ps1` | Operator entry point for the PostgreSQL ingest step |
 | `postgres_ingest_from_lor_sqlite_v7.py` | Loads the parser output into the PostgreSQL snapshot schema |
 | `requirements.txt` | Python dependencies required by the ingest programs |
+
+The PowerShell entry point is retained for engineering and recovery use. Normal
+operators use the secured LOR2DB parser page; they do not enter the SQLite path,
+digest, database command, or `import_run_id` manually.
 
 ## Related Systems
 

--- a/LOR2DB/02_Reconciliation/00_LOR_Production_Import_and_Reconciliation_Procedure.md
+++ b/LOR2DB/02_Reconciliation/00_LOR_Production_Import_and_Reconciliation_Procedure.md
@@ -2,12 +2,12 @@
 
 | Document control | Value |
 |---|---|
-| Repository path | `LOR2DB/Reconciliation/00_LOR_Production_Import_and_Reconciliation_Procedure.md` |
+| Repository path | `LOR2DB/02_Reconciliation/00_LOR_Production_Import_and_Reconciliation_Procedure.md` |
 | Document type | Controlled production procedure |
-| Status | ACTIVE — V0.5.0 combined stage/cancellation/parser-runner deployment pending acceptance |
+| Status | CURRENT — browser parser, ingest, reconciliation, cancellation, and reporting production validated |
 | Owner / author | GAL |
 | Initial release | 2026-07-31 |
-| Current revision | 2026-08-14 |
+| Current revision | 2026-08-17 |
 
 ## Purpose
 
@@ -30,6 +30,7 @@ The parser and snapshot ingest do **not** update production reference data by th
 
 | Date | Author | Revision |
 |---|---|---|
+| 2026-08-17 | GAL / OpenAI | Aligned the controlled procedure to the deployed browser workflow validated through ingest 48 and reconciliation Run 7: repeatable parser review, explicit digest approval, web PostgreSQL ingest with console output, separate Start reconciliation action, evidence-gated stage decisions, final application review, and immutable reporting. Added the Office PC runner operations/disaster-recovery dependency. |
 | 2026-08-14 | GAL / OpenAI | Recorded the approved LOR 6.6.10 / parser V7.0.10 / digest-locked ingest 47 authority chain and cancelled reconciliation Run 6. Added evidence-gated existing/new stage approval paths, complete stage-group evidence, terminal cancellation confirmation/report/archive outcomes, and the combined Version Check / Run Parser deployment boundary. |
 | 2026-08-13 | GAL / OpenAI | Added the website-accessible V7 parser and complete XML version checker through a restricted Windows/G-drive runner. Added Current/New LOR version management, atomic SQLite publication, required finding resolution, and exact reviewed-SQLite SHA-256 ingest enforcement. Ingest remains separate and manual. |
 | 2026-08-06 | GAL / OpenAI | Recorded completed production reconciliation Run 4, the subsequent `0029` true-no-op correction, application grants V0.2.0, backend V0.3.0, and successful `/lor2db/` deployment validation. Parser and snapshot ingest remain manual until the controlled app-server runner is implemented. |
@@ -48,29 +49,34 @@ The parser and snapshot ingest do **not** update production reference data by th
 | 2026-07-31 | GAL / OpenAI | Linked the full P1/P2/P3 promotion design and established controlled orchestration as the required final production execution model. |
 | 2026-07-31 | GAL | Initial procedure draft. Documents authoritative-preview controls, V7 parsing, PostgreSQL ingest, reconciliation requirements, and the P1/P2/P3 gate. |
 
-## Current Operator Workflow and Future Parser/Ingest Integration
+## Current Operator Workflow
 
-The active executable procedure is:
+The normal operator procedure is:
 
-`LOR2DB/Reconciliation/02_LOR_Manual_Reconciliation_Runbook.md`
+[`Docs/02_Production_Database/02_Operational_SOPs/LOR2DB/Run_an_LOR_Production_Update.md`](../../Docs/02_Production_Database/02_Operational_SOPs/LOR2DB/Run_an_LOR_Production_Update.md)
 
-It contains the exact SQL and PowerShell commands, decision templates, result checks, production-write warning, publication sequence, and recovery rules. It remains the authoritative fallback and recovery sequence.
+The SQL and PowerShell runbook in
+`02_LOR_Manual_Reconciliation_Runbook.md` is retained only for controlled
+engineering fallback and recovery when the secured application cannot perform
+the normal workflow.
 
 The secured reconciliation application is implemented under `LOR2DB/Application/`. The `/lor2db/` landing page reports the latest committed snapshot and reconciliation state, links the immutable report, starts reconciliation only when the latest snapshot is eligible, and routes an open run back to its persisted review. It calls the same installed boundaries and preserves the same safeguards.
 
-The LOR2DB page now invokes the approved parser through a restricted Windows
-runner on the approved Master PC. PostgreSQL snapshot ingest remains a separate
-manual action. The operator must review the parser result and supply the exact
-displayed SQLite SHA-256 to ingest. After ingest commits, the page detects the
-snapshot automatically. The operator never enters an `import_run_id`.
+The LOR2DB page invokes the approved parser and fixed digest-locked ingest
+through a restricted Windows runner on the approved Master PC. The parser may
+be run repeatedly until its console, counts, reports, digest, and SQLite output
+look correct. The operator then approves that exact displayed SHA-256 before
+the browser enables ingest. Ingest and reconciliation each remain separate,
+explicit actions. The operator never enters an `import_run_id`.
 
 ```text
 Run V7 parser from LOR2DB through the approved Master PC runner
-    -> inspect SQLite and record its SHA-256
-    -> run the password-protected, digest-locked PostgreSQL snapshot ingest manually
-    -> open /lor2db/
-    -> review the detected latest completed snapshot
-    -> select Start reconciliation when enabled
+    -> review console, counts, reports, SQLite, and SHA-256
+    -> correct previews and repeat parser as many times as necessary
+    -> approve the exact parser output for ingest
+    -> select Ingest to PostgreSQL
+    -> review the ingest console and completed import run
+    -> select Start reconciliation
     -> create the persistent reconciliation run
     -> build the stage, display, scene, and scene-membership candidate sets once
     -> run preflight checks and classifications
@@ -86,7 +92,10 @@ If no operator decisions are required, the run enters `READY_TO_FINISH`. Finish 
 
 If decisions are required, the workflow pauses in operator review. The operator records the applicable decision for each candidate and then chooses one of two workflow actions:
 
-- **Finish Reconciliation** — promote every passing or approved candidate, leave deferred and unresolved candidates unchanged in production, validate the committed results, publish the report, and complete the reconciliation.
+- **Proceed with production update** — invoke Finish, promote every passing or
+  approved candidate, leave deferred and unresolved candidates unchanged in
+  production, validate the committed results, publish the report, and complete
+  the reconciliation.
 - **Cancel Reconciliation** — apply no production changes, delete the entire latest snapshot and its uncommitted reconciliation working state, publish a cancellation report, and close the reconciliation as `CANCELLED`.
 
 The operator never selects or enters an `import_run_id`. Start captures the latest committed snapshot exactly once. A newer ingest cannot replace the snapshot already captured by an open reconciliation run.
@@ -134,23 +143,24 @@ The three documents describe one workflow at different levels and must not defin
 
 | Procedure component | Status |
 |---|---|
-| Master PC and preview-folder controls | Current approved LOR state is 6.6.10; Current/New versioned-folder controls are implemented; Windows runner V1.2.0 deployment acceptance pending |
+| Master PC and preview-folder controls | Current approved LOR state is 6.6.10; Current/New versioned-folder controls and exact folder paths are production deployed |
 | `Docs/01_LOR_System/02_Data_Extraction/Parser/parse_props_v7_scene_parser.py` | V7.0.10 production SQLite completed and validated against all 33 current 6.6.10 previews |
-| `LOR2DB/01_Ingest/postgres_run_ingest_v7.ps1` | V0.4.0 and migration `0031` production-applied; digest-locked ingest 47 completed successfully |
-| Latest-ingest capture and frozen preflight | Installed and production validated; manual operation documented in `02_LOR_Manual_Reconciliation_Runbook.md` |
+| Windows operator runner | V1.5.1 installed as the logged-in-user Scheduled Task; DPAPI-protected runner and PostgreSQL credentials; backend-to-runner health production validated |
+| PostgreSQL ingest | V0.4.1 digest-locked and digest-idempotent; browser ingest 48 completed successfully and retry reused the committed snapshot |
+| Latest-ingest capture and frozen preflight | Installed and production validated through reconciliation Run 7; manual runbook retained only for recovery |
 | Persistent reconciliation-run and display-candidate tables | Installed and live-validated from `reconciliation/0014_create_lor_reconciliation_decision_layer.sql` on 2026-08-02 |
 | Persistent stage candidate and binding tables | Installed from `0015` and rollback-validated by `11`; multi-preview metadata preservation installed from `0016` and rollback-validated by `12` |
 | Persistent scene and scene-membership candidate tables | Installed from `0018` and rollback-validated by `14` |
-| Operator decision database contract | Installed and live-validated for append-only group decisions, atomic reassociation assignments, `DEFER`, and review views; exercised by the application through Run 4 |
-| Operator decision application interface | Existing interface deployed and production-exercised through Run 6; V0.5.0 complete stage evidence and safe stage decisions pending combined deployment acceptance |
-| Finish and cancel workflow actions | Installed from `0019`; Finish validated through Run 5 and Cancel production-validated by Run 6. V0.5.0 terminal cancellation confirmation/report/archive UX pending deployment acceptance |
-| P1 | Existing-stage P1 installed and controlled by Finish; migration `0032` evidence-gated stage change/new-stage extension pending installation and validation `27` |
+| Operator decision database contract | Installed through migration `0033`; complete frozen evidence, stable stage aliases, append-only decisions, reassociation, `DEFER`, `APPROVE_STAGE_CHANGE`, and `ADD_NEW_STAGE` validated |
+| Operator decision application interface | Complete stage evidence and evidence-gated stage decisions production-exercised by Run 7 |
+| Finish and cancel workflow actions | Finish production-validated through Run 7; terminal Cancel proof, snapshot removal, cancellation report, and archive Outcome production-validated by Run 6 |
+| P1 | Controlled by Finish; migration `0032` safe stage authority and migration `0033` stable-alias stage-key changes installed and validated by `27` and `28` |
 | P2 | Installed from `0017` and rollback-validated by `13`; legacy procedure remains prohibited |
 | P3/P4 | Installed from `0018` and rollback-validated by `14`; these remain internal engine phases |
-| Controlled manual workflow | Active and documented in `02_LOR_Manual_Reconciliation_Runbook.md` |
-| `/lor2db/` snapshot/reconciliation landing page | Deployed and production validated on 2026-08-06 against snapshot 45 and completed Run 4 |
-| Website parser invocation | Implemented through restricted Windows runner V1.2.0; combined API/static/runner deployment acceptance pending. Ingest intentionally remains separate and manual. |
-| Timestamped HTML report publication | V0.4.2 installed and production validated; V0.5.0 cancelled outcome/banner/action corrections pending combined deployment acceptance |
+| Normal browser workflow | Parser → review/repeat → approve digest → ingest → review console → Start reconciliation → decisions → final review → production update → report; production validated through Run 7 |
+| Manual SQL/PowerShell workflow | Active fallback/recovery only; documented in `02_LOR_Manual_Reconciliation_Runbook.md` |
+| `/lor2db/` landing and parser pages | Backend V0.6.1 deployed; separate routine parser and infrequent version-check workflows; parser and ingest consoles production validated |
+| Timestamped HTML report publication | Report framework V0.5.0 production validated for completed and cancelled outcomes |
 | True no-op protection | Migration `0029` V4 installed; validation `25` and the seven-part post-install definition/guard check passed on 2026-08-05 |
 
 ## Production Validation Record — Reconciliation Run 4
@@ -183,10 +193,31 @@ promotion was committed, captured snapshot 47 was removed, and the current
 database snapshot returned to reconciled import 46 / Run 5. The immutable
 report is `lor-reconciliation-20260814-011807-run-6.html`.
 
-Run 6 exposed two application defects corrected by the V0.5.0 release: the
+Run 6 exposed two application defects corrected and subsequently deployed: the
 browser reloaded the editable preflight instead of showing terminal proof, and
 the archive/report presentation did not clearly label cancellation. It also
-confirmed the need for evidence-gated stage decisions in migration `0032`.
+confirmed the need for evidence-gated stage decisions in migrations `0032` and
+`0033`.
+
+## Production Validation Record — Ingest 48 and Reconciliation Run 7
+
+The complete browser-operated workflow was production exercised on 2026-08-16.
+
+| Field | Recorded result |
+|---|---|
+| Approved source | LOR 6.6.10; parser V7.0.10 |
+| Parser result | `PASSED`; 33 previews, 92 raw LOR Scene rows, 1157 props, 1312 subprops, 508 DMX channels, 2260 scene/prop rows |
+| Reviewed SQLite SHA-256 | `4c8802764872ea041a243ab6933243871d57b5e6372ca56dd3b60881707314ae` |
+| PostgreSQL ingest | import 48; ingest V0.4.0 provenance; completed 2026-08-16 14:38 UTC |
+| Recovery behavior | A Windows console encoding error occurred after commit; runner V1.5.1 / ingest V0.4.1 recovered the exact digest by returning existing import 48 without creating a duplicate snapshot |
+| Reconciliation | Run 7 captured import 48 and completed with validation `PASSED` |
+| Stage decisions | Approved a general evidence-gated substage StageID change while preserving permanent stage identity; added Stage 40 as a new permanent stage |
+| Exceptions | Zero blocked, deferred, unresolved, or failed items at completion |
+| Report | `lor-reconciliation-20260816-164810-run-7.html` |
+
+Run 7 validates the normal sequence from repeatable browser parser through
+digest approval, browser ingest, reconciliation decisions, final application
+review, production update, validation, and immutable report publication.
 
 ## Production Application Deployment Record — 2026-08-06
 
@@ -223,11 +254,11 @@ Record the current Master PC before beginning:
 
 | Field | Value |
 |---|---|
-| Computer name | |
-| Operator | |
-| LOR version | |
-| Date verified | |
-| Master preview folder | |
+| Computer name | `MSB-OFFICE-PC` |
+| Operator | Greg |
+| LOR version | 6.6.10 |
+| Date verified | 2026-08-16 |
+| Master preview folder | `G:\Shared drives\MSB Database\Database Previews V6.6.10` |
 
 ### Transferring the Master PC Role
 
@@ -354,17 +385,26 @@ Validate:
 
 ### 3. Run Parser and Snapshot Ingest
 
-For the current release, run the approved V7 parser and PostgreSQL snapshot
-ingest manually using the commands and checks in:
+Open `https://my.sheboyganlights.org/lor2db/` and use the normal browser
+workflow:
 
-`LOR2DB/Reconciliation/02_LOR_Manual_Reconciliation_Runbook.md`
+1. Select **Run parser**.
+2. Review the parser console, counts, reports, SQLite path, and SHA-256.
+3. Correct the preview source and repeat the parser as many times as needed.
+4. When that exact output looks correct, select
+   **Parser output looks correct — ready for ingest**.
+5. Select **Ingest to PostgreSQL**.
+6. Review the ingest console and require a completed PostgreSQL import run.
 
-Stop if either command fails or produces implausible counts. Do not reconstruct
-commands from this policy overview or run P1–P4 directly.
+Stop if either operation fails or produces implausible counts. Running the
+parser does not start ingest, and ingest does not start reconciliation. Do not
+reconstruct command-line alternatives from this policy overview or run P1–P4
+directly. The manual runbook is for controlled recovery only.
 
 ### 3A. Start Reconciliation from lor2db
 
-Open `https://lortodb.sheboyganlights.org/lor2db/` after the snapshot ingest commits.
+Remain on the parser page after the snapshot ingest commits, or return to
+`https://my.sheboyganlights.org/lor2db/`.
 Verify that the displayed ingest, parser/ingest versions, timestamps, and row
 counts match the run just completed.
 
@@ -383,9 +423,9 @@ Start must:
 4. create the persistent reconciliation run and frozen candidate sets;
 5. return the operator to the persisted review for that run.
 
-The future app-server parser/ingest phase may precede this action only after its
-Python environment and secured runner are implemented and validated. Passwords
-must never be stored in reconciliation records, browser content, or reports.
+The browser uses only the configured Office PC runner and fixed ingest command.
+Passwords must never be stored in reconciliation records, browser content, or
+reports.
 
 ### 4. Reconciliation Start Behavior
 
@@ -450,24 +490,25 @@ A deferred candidate or a candidate without a completed decision is blocked from
 
 The reusable operator screen is published under:
 
-`https://lortodb.sheboyganlights.org/lor2db/preflight/?run={reconciliation_run_id}`
+`https://my.sheboyganlights.org/lor2db/preflight/?run={reconciliation_run_id}`
 
 It presents each persisted preflight check and its frozen evidence on the left,
-with **Accept**, **Change**, and **Defer** controls on the same line. Accept is
-available only when the engine proposes one unambiguous production action.
+with the allowed decision choices and complete frozen evidence on the same
+screen. An approval choice appears only when the engine can prove that action
+is safe for the complete logical group.
 Every saved selection is recorded through the installed append-only decision
 functions by a same-origin authenticated backend; browser state is never the
 record of authority.
 
-After all required decisions are recorded, **Continue** opens a final review of
-only accepted or changed-and-approved production actions. Deferred items are
-excluded. **Back to Review** returns without writing production. **Proceed**
-requires a second confirmation and is the only screen action that may invoke
-Finish. **Cancel Reconciliation** also requires confirmation and a reason and
-never invokes Finish.
+After all required decisions are recorded, **Continue to final review** opens a final review of
+only approved production actions. Deferred items are excluded. **Back to
+review** returns without writing production. **Proceed** requires a second
+confirmation, a reason, and selection of **Proceed with production update**;
+this is the only screen action that may invoke Finish. **Cancel reconciliation**
+also requires confirmation and a reason and never invokes Finish.
 
 The browser template and implemented backend live in `LOR2DB/Application/`.
-Run 4 completed through this interface. The manual SQL runbook remains the
+Run 7 completed through this interface against ingest 48. The manual SQL runbook remains the
 recovery procedure; it is not the normal operator path after landing-page
 deployment.
 
@@ -661,13 +702,22 @@ Stop the workflow immediately if:
 
 The operator-facing application for the current release must provide:
 
+- a routine **Run parser** action that remains available after successful runs;
+- read-only parser console output, validation, counts, reports, output path, and
+  SQLite SHA-256;
+- unlimited deliberate parser reruns before ingest, with one runner operation
+  accepted at a time;
+- a separate **Check new version** workflow for infrequent LOR software-version
+  approval;
+- exact-digest parser-output approval before **Ingest to PostgreSQL** is enabled;
+- read-only PostgreSQL ingest console output and digest-idempotent recovery;
 - current snapshot parser/ingest provenance and row counts;
 - current persistent reconciliation run, status, validation, and exception counts;
-- **Start reconciliation** only for an eligible manually ingested snapshot;
-- **Open reconciliation** for an existing active run;
+- **Start reconciliation** only for an eligible completed browser ingest;
+- **Continue previous reconciliation** for an existing active run;
 - decision screens only for candidates requiring operator action;
 - explicit approve and defer actions;
-- one **Finish Reconciliation** action;
+- one final application review and **Proceed with production update** action;
 - one **Cancel Reconciliation** action;
 - automatic promotion of passing candidates;
 - blocking of deferred and unresolved candidates without blocking unrelated passing work;
@@ -678,14 +728,16 @@ The operator-facing application for the current release must provide:
 - a clickable report link;
 - permissions preventing routine direct execution of P1/P2/P3.
 
-The secured page may run the parser but must not combine parser and ingest into
-one action. Ingest remains the distinct digest-locked authority handoff and
-must not weaken any validation, credential, or procedure-execution boundary.
+The secured page must not combine parser and ingest into one action and must not
+combine ingest and reconciliation Start into one action. Ingest remains the
+distinct digest-locked authority handoff and must not weaken any validation,
+credential, or procedure-execution boundary.
 
 ## Related Files and Objects
 
 - `Docs/01_LOR_System/02_Data_Extraction/Parser/parse_props_v7_scene_parser.py`
 - `LOR2DB/01_Ingest/postgres_run_ingest_v7.ps1`
+- `run_lor_runner.ps1`
 - `lor_snap.import_run`
 - `ref.display`
 - `ref.display_status`
@@ -698,39 +750,14 @@ must not weaken any validation, credential, or procedure-execution boundary.
 This controlled procedure is one part of the controlled documentation set:
 
 - **Production policy — this document:** `00_LOR_Production_Import_and_Reconciliation_Procedure.md`
-- **Executable manual runbook:** `02_LOR_Manual_Reconciliation_Runbook.md`
+- **Normal operator SOP:** `../../Docs/02_Production_Database/02_Operational_SOPs/LOR2DB/Run_an_LOR_Production_Update.md`
+- **Engineering fallback runbook:** `02_LOR_Manual_Reconciliation_Runbook.md`
 - **Production-promotion architecture:** `01_LOR_Production_Promotion_Pipeline_Design.md`
 - **Reconciliation SQL engineering design:** `reconciliation/LOR_Display_Reconciliation_SQL_Design.md`
+- **Office PC runner operations and recovery:** `../Application/Office_PC_Runner_Operations_and_Disaster_Recovery.md`
 
-Use the pipeline design to understand the architecture and procedure boundaries. Use the reconciliation SQL design when building or modifying the database implementation. All three documents must remain synchronized.
-
-## Post-Merge Feature Handoff
-
-The V7 parser, snapshot ingest, reconciliation engine, secured browser workflow,
-and Run 4 acceptance are complete for this feature. Do not reopen their design
-when starting either follow-on feature unless new evidence demonstrates a
-defect.
-
-### Prompt: clean recycled displays from open test sessions
-
-> Start a new feature from current `main` to correct unfinished container test
-> sessions that still reference displays changed to `RECYCLED`. Inspect the
-> test-session schema and application flow before changing records. Remove
-> recycled displays only from unfinished sessions; preserve all completed test
-> history; preserve active checks in mixed containers such as QV; and close or
-> cancel an unfinished session when removal leaves it empty, including the four
-> PVC Igloo sessions. Do not delete display identities or change their
-> reconciled lifecycle status. Implement, validate, document, and publish on a
-> dedicated feature branch.
-
-### Prompt: add secured parser and ingest execution to lor2db
-
-> Start a new feature from current `main` to add a secured app-server Python
-> runner before reconciliation on the `lor2db` page. The current V7 parser and
-> PostgreSQL ingest remain authoritative and manual until this feature is fully
-> validated. Preserve every parser and ingest preflight gate; execute only
-> configured approved commands; capture complete logs and provenance; never
-> accept an operator-entered `import_run_id`; never expose credentials,
-> arbitrary shell commands, or direct P1-P4 execution; and preserve the rule
-> that an open reconciliation retains its captured snapshot. Implement,
-> validate, document, and publish on a dedicated feature branch.
+Use the pipeline design to understand the architecture and procedure boundaries.
+Use the reconciliation SQL design when building or modifying the database
+implementation. Use the Office PC runbook for listener installation, restart,
+credential recovery, or transfer to another computer. These documents must
+remain synchronized with this procedure.

--- a/LOR2DB/02_Reconciliation/01_LOR_Production_Promotion_Pipeline_Design.md
+++ b/LOR2DB/02_Reconciliation/01_LOR_Production_Promotion_Pipeline_Design.md
@@ -2,12 +2,12 @@
 
 | Document control | Value |
 |---|---|
-| Repository path | `LOR2DB/Reconciliation/01_LOR_Production_Promotion_Pipeline_Design.md` |
+| Repository path | `LOR2DB/02_Reconciliation/01_LOR_Production_Promotion_Pipeline_Design.md` |
 | Document type | Database design specification |
-| Status | IMPLEMENTED AND PRODUCTION VALIDATED — Run 4 complete |
+| Status | IMPLEMENTED AND PRODUCTION VALIDATED — Run 7 complete |
 | Owner | MSB Database Administrator |
 | Initial release | 2026-07-31 |
-| Current revision | 2026-08-06 |
+| Current revision | 2026-08-17 |
 
 ## Purpose
 
@@ -30,6 +30,7 @@ in `reconciliation/LOR_Display_Reconciliation_SQL_Design.md`.
 
 | Date | Author | Change |
 |---|---|---|
+| 2026-08-17 | GAL / OpenAI | Aligned the design with the browser-operated parser, digest approval, ingest console, explicit reconciliation start, Run 7 production acceptance, and the Office PC listener service boundary. |
 | 2026-08-06 | GAL / OpenAI | Recorded completed P1-P4 implementation, production reconciliation Run 4, post-write validation, immutable report publication, and production acceptance of the secured lor2db workflow. |
 | 2026-08-03 | GAL / OpenAI | Implemented the repository P3/P4 checkpoint: frozen scene and physical-membership candidates, captured-source revalidation, guarded current-state synchronization, permanent display identity resolution after P2, and rollback validation. Production promotion remains disabled. |
 | 2026-08-03 | GAL / OpenAI | Added reconciliation-safe P2 and rollback validation: frozen action consumption, exact captured raw-source revalidation, nonphysical guards, atomic chained reassociation, exact write authority, and same-run idempotency checks. Production promotion remains disabled. |
@@ -49,12 +50,16 @@ The production import is one stateful workflow even though parser, ingest,
 preflight, operator review, promotion, validation, and reporting are separate
 implementation phases.
 
-The finished operator experience is:
+The implemented operator experience is:
 
 ```text
-Start LOR Production Import
-    -> parser
-    -> password-protected snapshot ingest
+Open the authenticated LOR2DB website
+    -> run parser one or more times
+    -> review parser console, counts, reports, SQLite, and SHA-256
+    -> approve the exact SQLite digest for ingest
+    -> digest-locked snapshot ingest through the Office PC runner
+    -> review ingest console
+    -> explicitly Start reconciliation
     -> capture latest completed ingest
     -> build persistent reconciliation working sets
     -> automatic preflight
@@ -64,6 +69,13 @@ Start LOR Production Import
     -> generate and publish timestamped HTML report
     -> complete
 ```
+
+The browser communicates with the Linux API, which calls the restricted Office
+PC listener for version checking, parser execution, and ingest. Reconciliation
+itself is database-controlled and remains available after an ingest even if the
+Office PC listener later goes offline. Installation, restart, credential, IP,
+and replacement-PC recovery are defined in
+[`../Application/Office_PC_Runner_Operations_and_Disaster_Recovery.md`](../Application/Office_PC_Runner_Operations_and_Disaster_Recovery.md).
 
 If no operator decisions are required, the workflow continues automatically
 through promotion, validation, report publication, and completion. If review is

--- a/LOR2DB/02_Reconciliation/02_LOR_Manual_Reconciliation_Runbook.md
+++ b/LOR2DB/02_Reconciliation/02_LOR_Manual_Reconciliation_Runbook.md
@@ -4,11 +4,11 @@
 |---|---|
 | Status | ACTIVE FALLBACK — secured operator application is the normal workflow |
 | Owner | GAL |
-| Initial release / current revision | 2026-08-04 / 2026-08-06 |
+| Initial release / current revision | 2026-08-04 / 2026-08-17 |
 
 The reusable screen and its secured backend are defined in
 `LOR2DB/Application/` and were deployed and production validated with Run 4.
-Normal operation begins at `https://lortodb.sheboyganlights.org/lor2db/`. This
+Normal operation begins at `https://my.sheboyganlights.org/lor2db/`. This
 runbook is retained only for controlled fallback and recovery when the secured
 application cannot perform the normal workflow.
 
@@ -142,6 +142,23 @@ SELECT ops.f_record_lor_stage_preserve_metadata_action(
     'Manual reconciliation via SQL client'
 ) AS action_id;
 ```
+
+Evidence-gated existing StageID change or new permanent stage, only when the
+selected action appears in the group's `allowed_action_types`:
+
+```sql
+SELECT ops.f_record_lor_stage_authority_action(
+    :run_id,
+    :group_id,
+    'APPROVE_STAGE_CHANGE', -- or ADD_NEW_STAGE
+    'Specific operator reason supported by the complete frozen stage evidence.',
+    'Manual reconciliation via SQL client'
+) AS action_id;
+```
+
+Never substitute either stage-authority action for a contradictory group. The
+database evidence gates must return true, and every frozen group member must be
+reviewed before recording the action.
 
 For display reassociation, first retrieve exact candidate IDs and possible permanent identities:
 
@@ -364,6 +381,7 @@ The run advances to `REPORTING`; publish its cancellation report using Step 9. C
 
 ## Related Documents
 
-- `00_LOR_Production_Import_and_Reconciliation_Procedure.md`
-- `01_LOR_Production_Promotion_Pipeline_Design.md`
-- `reconciliation/LOR_Display_Reconciliation_SQL_Design.md`
+- [Normal LOR2DB operator SOP](../../Docs/02_Production_Database/02_Operational_SOPs/LOR2DB/Run_an_LOR_Production_Update.md)
+- [LOR Production Import and Reconciliation Procedure](00_LOR_Production_Import_and_Reconciliation_Procedure.md)
+- [Production Promotion Pipeline Design](01_LOR_Production_Promotion_Pipeline_Design.md)
+- [Reconciliation SQL Design](reconciliation/LOR_Display_Reconciliation_SQL_Design.md)

--- a/LOR2DB/02_Reconciliation/README.md
+++ b/LOR2DB/02_Reconciliation/README.md
@@ -8,12 +8,16 @@ It is part of the **LOR2DB technical workflow**. Operational Directus SOPs are m
 
 | I want to... | Go to |
 |---|---|
-| Run the normal production reconciliation workflow | [00_LOR_Production_Import_and_Reconciliation_Procedure.md](00_LOR_Production_Import_and_Reconciliation_Procedure.md) |
+| Run the normal production update | [Operator SOP](../../Docs/02_Production_Database/02_Operational_SOPs/LOR2DB/Run_an_LOR_Production_Update.md) |
+| Administer the full production workflow | [00_LOR_Production_Import_and_Reconciliation_Procedure.md](00_LOR_Production_Import_and_Reconciliation_Procedure.md) |
 | Understand how the production workflow is organized | [01_LOR_Production_Promotion_Pipeline_Design.md](01_LOR_Production_Promotion_Pipeline_Design.md) |
 | Recover when the normal application cannot be used | [02_LOR_Manual_Reconciliation_Runbook.md](02_LOR_Manual_Reconciliation_Runbook.md) |
 | View the reconciliation engineering documentation | [reconciliation/README.md](reconciliation/README.md) |
 
-For normal operation, begin with the Production Import and Reconciliation Procedure. The secured LOR2DB application is the normal operator interface. The manual reconciliation procedure is intended only for controlled recovery situations.
+For normal operation, begin with the Operator SOP. The secured LOR2DB
+application is the normal operator interface. The controlled production
+procedure supplies administrative detail, and the manual reconciliation
+procedure is intended only for controlled recovery situations.
 
 ## Folder Guide
 

--- a/LOR2DB/02_Reconciliation/reconciliation/LOR_Display_Reconciliation_SQL_Design.md
+++ b/LOR2DB/02_Reconciliation/reconciliation/LOR_Display_Reconciliation_SQL_Design.md
@@ -299,18 +299,17 @@ The operator interface is a run-driven view of the persisted reconciliation
 state, not a generated SQL workflow and not a browser-only form.
 
 - The active route is
-  `https://lortodb.sheboyganlights.org/lor2db/preflight/?run={reconciliation_run_id}`.
-- Cloudflare authentication protects the entire `lortodb.sheboyganlights.org`
+  `https://my.sheboyganlights.org/lor2db/preflight/?run={reconciliation_run_id}`.
+- Cloudflare authentication protects the entire `my.sheboyganlights.org`
   route. Application authorization must further restrict reconciliation access
   to the smaller approved operator group.
 - One reusable template renders display, stage, scene, and scene-display groups
   from the installed persisted review views.
 - Every line shows its frozen evidence and only the action types allowed for its
   logical group.
-- **Accept** resolves to the single proposed production action. It is disabled
-  when reconciliation cannot propose one safe action, such as deciding whether
-  a missing active display is retired or recycled.
-- **Change** exposes the other allowed actions; **Defer** records `DEFER`.
+- Each decision list exposes only actions proven safe for that complete frozen
+  logical group. Approval is absent when the group evidence is contradictory or
+  incomplete. **Defer** records `DEFER` without changing production.
 - Saving calls the existing append-only reconciliation action function through
   a same-origin secured backend. Reopening the page displays the persisted
   effective decision rather than browser state.

--- a/LOR2DB/02_Reconciliation/reconciliation/README.md
+++ b/LOR2DB/02_Reconciliation/reconciliation/README.md
@@ -46,9 +46,11 @@ is authoritative for the named object only.
 
 ## Operator preflight suite
 
-Run files in `operator_queries/preflight/` individually in numeric order when a
-manual SQL preflight is required. They select the latest committed ingest and
-do not call P1, P2, P3, P4, or Finish.
+The secured LOR2DB website is the normal preflight and decision interface. Run
+files in `operator_queries/preflight/` individually in numeric order only when
+an authorized engineering investigation or manual recovery requires SQL
+evidence. They select the latest committed ingest and do not call P1, P2, P3,
+P4, or Finish.
 
 1. `01_latest_ingest_context.sql`
 2. `02_latest_ingest_p1_stage_preflight.sql`

--- a/LOR2DB/Application/Office_PC_Runner_Operations_and_Disaster_Recovery.md
+++ b/LOR2DB/Application/Office_PC_Runner_Operations_and_Disaster_Recovery.md
@@ -1,0 +1,404 @@
+# Office PC Runner Operations and Disaster Recovery
+
+| Document control | Value |
+|---|---|
+| Repository path | `LOR2DB/Application/Office_PC_Runner_Operations_and_Disaster_Recovery.md` |
+| Document type | Engineering operations and recovery runbook |
+| Status | CURRENT |
+| Owner | MSB Database Administrator |
+| Initial release / current revision | 2026-08-17 / 2026-08-17 |
+
+## Revision History
+
+| Date | Change |
+|---|---|
+| 2026-08-17 | Initial controlled runbook for installation, restart, credential recovery, network failure, and replacement-PC transfer. |
+
+## Purpose
+
+This runbook defines the Office PC dependency behind the browser-operated LOR
+parser, version checker, and PostgreSQL ingest. It covers normal status and
+restart actions, Windows recovery, credential recovery, and transfer to a
+replacement computer.
+
+This is not a normal operator procedure. Authorized operators use the LOR2DB
+website. Use this document only to maintain or recover the engineering service
+boundary behind that website.
+
+## Dependency Summary
+
+The production LOR2DB application spans two computers and the shared Google
+Drive:
+
+```text
+Authenticated browser
+    -> Linux LOR2DB API on msb-prod-db (192.168.5.9:8784)
+    -> authenticated HTTP request from 192.168.5.9
+    -> Office PC runner (192.168.5.55:8791)
+    -> approved repository code and account-bound DPAPI credentials
+    -> G:\ Shared Drive previews, state, reports, and SQLite output
+```
+
+The Office PC runner is required for:
+
+- LOR-version candidate detection and compatibility checks;
+- routine production parser execution and console capture; and
+- the fixed digest-locked PostgreSQL ingest.
+
+The Office PC runner is not required for:
+
+- reviewing or finishing an already-started reconciliation;
+- applying its database-controlled P1–P4 phases;
+- publishing a reconciliation report;
+- viewing an existing report; or
+- normal PostgreSQL and Directus operation.
+
+If the runner is offline, do not assume PostgreSQL or an open reconciliation is
+down. The parser/version/ingest controls are unavailable, but an already
+committed snapshot and an already-started reconciliation remain on the Linux
+and PostgreSQL side.
+
+## Production Components
+
+| Component | Production requirement |
+|---|---|
+| Windows host | Designated Office PC; current address `192.168.5.55` |
+| Windows account | Greg's logged-in account; owns the mapped `G:` drive and DPAPI secrets |
+| Repository | Current reviewed `main` checkout with a working `.venv` |
+| Launcher | Repository-root `run_lor_runner.ps1` |
+| Scheduled Task | `MSB LOR Operator Runner`, triggered at that user's logon |
+| Listener | `192.168.5.55:8791`, private LAN only |
+| Firewall | Inbound TCP 8791, Private profile, remote address `192.168.5.9` only |
+| State | `G:\Shared drives\MSB Database\LOR Version Reviews\runner-state.json` |
+| SQLite output | `G:\Shared drives\MSB Database\database\lor_output_v7_scene.db` |
+| Runner token | `%LOCALAPPDATA%\MSB\LORRunner\runner-token.dpapi` |
+| PostgreSQL ingest password | `%LOCALAPPDATA%\MSB\LORRunner\postgres-ingest-password.dpapi` |
+| Service log | `%LOCALAPPDATA%\MSB\LORRunner\runner-service.log` |
+| Linux environment | `/etc/msb/lor-preflight-api.env`, mode `0640`, owner `root`, group `msbadmin` |
+| Linux API service | `lor-preflight-api.service`, user `lor-preflight`, group `msbadmin` |
+
+Both DPAPI files are bound to the Windows account that created them. Treat them
+as local encrypted state, not portable backups. Copying them to another PC or
+running the task under another account will not recover their plaintext.
+
+## Credential Prompts Are Different
+
+Three prompts can appear during installation. They are not interchangeable:
+
+| Prompt or command | Credential required | Purpose |
+|---|---|---|
+| `Install` or `ConfigureIngest` asks for the PostgreSQL ingest password | PostgreSQL database account `msbadmin` password | Lets the fixed ingest child connect to PostgreSQL |
+| `PairServer` invokes `ssh msbadmin@192.168.5.9` | Linux server account `msbadmin` password | Transfers the new pairing token to the server |
+| Linux command begins with `sudo` | Linux server account `msbadmin` password | Authorizes protected environment installation or service restart |
+
+Never use the runner bearer token at any of these password prompts.
+
+## Initial Installation or Rebuild
+
+Use these steps for the first controlled install on a PC or after rebuilding
+Windows. A replacement PC must also follow the transfer controls later in this
+document.
+
+1. Sign in as the Windows account that will permanently run the listener.
+2. Clone or update the repository and create the repository-root `.venv`.
+   Install the parser and fixed-ingest dependencies and pass the release's
+   parser/application/reporting tests.
+3. Confirm the authoritative Shared Drive state already exists. Do not create a
+   replacement state file:
+
+   ```powershell
+   $statePath = "G:\Shared drives\MSB Database\LOR Version Reviews\runner-state.json"
+   Test-Path -LiteralPath $statePath
+   $state = Get-Content -LiteralPath $statePath -Raw | ConvertFrom-Json
+   Test-Path -LiteralPath $state.current_preview_folder
+   Test-Path -LiteralPath $state.current_manifest_path
+   ```
+
+   All three checks must return `True`, and the state must show the expected
+   approved LOR version and preview folder.
+4. In an elevated PowerShell window, install the inbound Private-profile
+   firewall rule for TCP 8791, restricted to remote address `192.168.5.9`. The
+   replacement-PC procedure contains the exact command.
+5. Return to a normal PowerShell window under the permanent runner account and
+   run from the repository root:
+
+   ```powershell
+   .\run_lor_runner.ps1 -Action Install
+   .\run_lor_runner.ps1 -Action Status
+   ```
+
+   `Install` creates or retains the DPAPI runner token, requests the PostgreSQL
+   ingest password only when needed, registers the logged-in-user Scheduled
+   Task, and starts the listener.
+6. If `Install` says a new token was generated, run `PairServer`, install the
+   pending token on Linux, and restart the API as described in the replacement
+   procedure. If it says the existing server pairing remains valid, do not pair
+   again.
+7. Require a healthy Windows `Status`, a passing Linux backend-to-runner check,
+   and the expected runner version on the LOR2DB dashboard before returning the
+   service to operators.
+
+## Normal Status Check
+
+Run this from a normal PowerShell window in the repository root on the Office
+PC:
+
+```powershell
+.\run_lor_runner.ps1 -Action Status
+```
+
+A healthy result must show:
+
+- Scheduled Task state `Running`;
+- protected runner token `AVAILABLE`;
+- protected PostgreSQL ingest credential `AVAILABLE`;
+- runner health `ok`; and
+- runner version `V1.5.1` or the later version documented by the deployed
+  release.
+
+The displayed credential fingerprint is not a secret. It is safe to use when
+confirming that Windows and Linux hold the same pairing token. Never display or
+copy the token itself.
+
+## Normal Restart or Repository Upgrade
+
+Do not restart while the parser or ingest is running.
+
+1. Pull the reviewed repository change on the Office PC.
+2. Run the release's required Python tests and PowerShell syntax check.
+3. From the repository root, run:
+
+   ```powershell
+   .\run_lor_runner.ps1 -Action Install
+   ```
+
+4. When an existing protected token is retained, do not run `PairServer`.
+5. Run `Status` and require a healthy local result.
+6. Confirm the LOR2DB dashboard shows the same runner version.
+
+`Install` safely stops only the managed runner process whose command line
+matches this repository, listener address, and port. It refuses to stop an
+unrelated process and refuses to reinstall during a recorded parser or ingest
+operation.
+
+For a deliberate stop or start:
+
+```powershell
+.\run_lor_runner.ps1 -Action Stop
+.\run_lor_runner.ps1 -Action Start
+.\run_lor_runner.ps1 -Action Status
+```
+
+Normally the Scheduled Task starts the runner automatically at user logon.
+
+## After a Reboot or Windows Update
+
+1. Sign in to the same Windows account used to install the task.
+2. Wait for Google Drive to restore the `G:` mapping.
+3. Confirm the current preview folder, manifest, and `runner-state.json` are
+   available.
+4. Run `Status`.
+5. If the task is not running, run `Start` and check `Status` again.
+6. If startup repeatedly fails, review:
+
+   ```powershell
+   Get-Content "$env:LOCALAPPDATA\MSB\LORRunner\runner-service.log" -Tail 60
+   ```
+
+Screen locking does not stop the task. Logging out does. The task requires an
+interactive logon because the mapped Shared Drive belongs to that user
+session.
+
+## Restore the PostgreSQL Ingest Credential
+
+Use this when the PostgreSQL password changed, the DPAPI ingest file is missing,
+or Windows reports that it cannot decrypt the stored credential:
+
+```powershell
+.\run_lor_runner.ps1 -Action ConfigureIngest
+```
+
+Enter the PostgreSQL `msbadmin` password at the secure prompt. The launcher
+stores it with account-bound DPAPI, restarts the managed runner, and never sends
+the password to the browser or Linux API. Finish with `Status`.
+
+## Replace or Transfer the Office PC
+
+Changing the Office PC is a controlled service transfer. The following items
+break until the transfer is completed:
+
+- the Linux API's configured runner IP and bearer token;
+- the Windows firewall rule if the replacement uses a different address;
+- the Scheduled Task, local repository, Python environment, and service log;
+- both account-bound DPAPI credential files; and
+- access to the approved `G:` paths if Google Drive is not installed and mapped
+  for the new logged-in account.
+
+The shared `runner-state.json`, approved manifest, preview folders, parser
+reports, and SQLite output remain recoverable because they live on the Shared
+Drive. Do not initialize a replacement runner state over the existing file.
+
+### Transfer procedure
+
+1. Stop the old runner after confirming no parser or ingest is running:
+
+   ```powershell
+   .\run_lor_runner.ps1 -Action Stop
+   ```
+
+   If the old PC is unavailable, keep it powered off or disconnected from the
+   network. Do not allow it to return with the old listener active after the
+   replacement is paired.
+
+2. Preserve the existing Shared Drive data, especially:
+
+   - `LOR Version Reviews\runner-state.json`;
+   - the current approved manifest;
+   - the approved versioned preview folder;
+   - parser/version reports; and
+   - `database\lor_output_v7_scene.db`.
+
+3. On the replacement PC, install Git, Python, Google Drive, and the approved
+   LOR software version. Clone the repository, recreate the repository-root
+   `.venv`, install the Python dependencies required by the parser and fixed
+   PostgreSQL ingest, and pass the release's parser/application/reporting test
+   commands before installing the service.
+4. Sign in as the Windows account that will permanently run the service and
+   confirm every path referenced by the existing `runner-state.json` resolves.
+5. Give the replacement a reserved private IPv4 address. If it will not retain
+   `192.168.5.55`, record the new address for the Linux pairing step.
+6. In an elevated PowerShell window, create an inbound firewall rule restricted
+   to the database server:
+
+   ```powershell
+   New-NetFirewallRule `
+       -DisplayName "MSB LOR Runner 8791" `
+       -Direction Inbound `
+       -Protocol TCP `
+       -LocalPort 8791 `
+       -RemoteAddress 192.168.5.9 `
+       -Action Allow `
+       -Profile Private
+   ```
+
+7. In a normal PowerShell window under the permanent runner account, install
+   the runner. Supply the replacement PC's address when it differs:
+
+   ```powershell
+   .\run_lor_runner.ps1 `
+       -Action Install `
+       -RunnerHost 192.168.5.55
+   ```
+
+   `Install` generates a new runner token and prompts once for the PostgreSQL
+   ingest password because DPAPI files are not portable.
+8. Pair the newly generated token to Linux:
+
+   ```powershell
+   .\run_lor_runner.ps1 `
+       -Action PairServer `
+       -RunnerHost 192.168.5.55
+   ```
+
+9. On `msb-prod-db`, install the pending pairing. Use the replacement PC's
+   actual address. A permanent repository clone is not required on the server,
+   but the installer must be the reviewed file from the same deployed release.
+
+   If a current repository checkout or release staging tree is already present,
+   run its reviewed installer by path:
+
+   ```bash
+   sudo python3 LOR2DB/Application/install_lor_runner_pairing.py \
+     --runner-url http://192.168.5.55:8791
+   sudo systemctl restart lor-preflight-api.service
+   ```
+
+   If the server has no checkout, transfer only
+   `LOR2DB/Application/install_lor_runner_pairing.py` from the reviewed Windows
+   checkout into an operator-owned mode-`0700` staging directory, compare its
+   SHA-256 on both computers, and invoke that verified file by absolute path.
+   Do not download an unreviewed copy directly onto production.
+
+10. Confirm that the non-secret fingerprint printed on Linux matches Windows.
+11. Run Windows `Status`, verify Linux API health, and confirm the LOR2DB
+    dashboard reports the expected runner version.
+12. Run a parser only after checking that the approved LOR version and preview
+    source shown by the website are unchanged. Do not perform an ingest merely
+    to test the replacement.
+13. Remove or disable the old listener and its firewall rule before returning
+    the old PC to unrelated use.
+
+If the previous PC failed during a parser or ingest, treat the operation as
+interrupted. Check the website's durable operation record and, for ingest, the
+completed SQLite digest in PostgreSQL before retrying. A console or network
+failure after database commit must reuse the existing import rather than create
+a duplicate snapshot.
+
+Replace `192.168.5.55` in these commands with the reserved replacement address
+when the address changes. Do not leave the Linux environment pointed at the old
+computer.
+
+## Linux Verification Without Exposing the Token
+
+Run the following on `msb-prod-db`. It reads the protected environment as the
+service account and prints only runner status and version:
+
+```bash
+sudo -u lor-preflight /opt/lor-preflight/.venv/bin/python - <<'PY'
+import os
+import sys
+from pathlib import Path
+
+for line in Path("/etc/msb/lor-preflight-api.env").read_text(
+    encoding="utf-8"
+).splitlines():
+    line = line.strip()
+    if not line or line.startswith("#") or "=" not in line:
+        continue
+    key, value = line.split("=", 1)
+    if key in {"LOR_RUNNER_URL", "LOR_RUNNER_TOKEN"}:
+        os.environ[key] = value
+
+sys.path.insert(0, "/opt/lor-preflight")
+import backend
+
+health = backend.runner_request("health")
+print("Backend-to-runner status:", health.get("status"))
+print("Backend-to-runner version:", health.get("version"))
+PY
+```
+
+## Failure Matrix
+
+| Symptom | Likely boundary | Safe action |
+|---|---|---|
+| Dashboard says runner unavailable after reboot | No interactive logon or `G:` not restored | Sign in, restore `G:`, then run `Status` |
+| Scheduled Task is `Ready`, no listener exists | Task exited during prerequisite or credential check | Review service log, fix the named prerequisite, run `Start` |
+| Port 8791 belongs to an unrelated process | Listener conflict | Do not kill it through the launcher; identify and resolve the conflict |
+| Local health passes but Linux times out | Firewall, wrong runner IP, or network path | Verify Private profile, firewall remote address, listener address, and Linux `LOR_RUNNER_URL` |
+| Linux receives `401` | Windows and Linux pairing tokens differ | Run `PairServer`, install the pending token on Linux, restart the API, and compare fingerprints |
+| Protected token cannot be decrypted | Different Windows account or damaged DPAPI file | Reinstall with `-RotateToken`, pair Linux again, and verify fingerprints |
+| Ingest credential cannot be decrypted | Different account, missing file, or password change | Run `ConfigureIngest` |
+| State or current manifest is missing | Shared Drive or incorrect state path | Stop; restore the authoritative Shared Drive file. Never initialize over production state |
+| Runner stopped during parser/ingest | Windows logout, update, process failure, or network loss | Confirm no child process remains; restart runner; interrupted work must be reviewed and deliberately rerun |
+
+## Security and Recovery Rules
+
+- Never paste the bearer token into chat, shell history, documentation, or a
+  browser request.
+- Never copy DPAPI files to another computer or Windows account as a recovery
+  method.
+- Never broaden port 8791 to the Internet or the full LAN. Restrict it to
+  `192.168.5.9` on the Private profile.
+- Never initialize over the existing production `runner-state.json`.
+- Never perform a production ingest merely as a connectivity test.
+- Never rotate the runner token unless Linux will be paired again immediately.
+- Back up `/etc/msb/lor-preflight-api.env` before manual recovery changes; the
+  pairing installer already creates a timestamped backup.
+
+## Related Documents
+
+- [LOR Preflight Operator Interface](README.md)
+- [LOR Parser and Compatibility Tools](../../Docs/01_LOR_System/02_Data_Extraction/Parser/README.md)
+- [LOR2DB Ingest](../01_Ingest/README.md)
+- [LOR Production Import and Reconciliation Procedure](../02_Reconciliation/00_LOR_Production_Import_and_Reconciliation_Procedure.md)

--- a/LOR2DB/Application/README.md
+++ b/LOR2DB/Application/README.md
@@ -2,8 +2,8 @@
 
 | Document control | Value |
 |---|---|
-| Status | CURRENT code; web ingest workflow deployed; preflight browser V0.5.1 pending deployment |
-| Initial release / current revision | 2026-08-04 / 2026-08-16 |
+| Status | CURRENT — production deployed and validated through reconciliation Run 7 |
+| Initial release / current revision | 2026-08-04 / 2026-08-17 |
 
 ## Revision history
 
@@ -103,8 +103,11 @@ approved-version baseline, candidate parser, and SQLite comparison in order.
 Approval returns to the landing page with the new approved version and folder
 and marks the production parser as requiring a deliberate rebuild.
 
-PostgreSQL ingest remains separate and manual. No browser page starts ingest,
-and the Linux API never executes a user-supplied path or command.
+PostgreSQL ingest remains a separate, explicit operator approval. The parser
+page starts only the fixed digest-locked ingest operation after the operator
+approves the exact displayed SQLite SHA-256. The browser cannot supply a path,
+command, database account, or executable, and ingest never starts
+reconciliation automatically.
 
 ## LOR version-check workspace
 
@@ -135,7 +138,8 @@ The infrequent version workflow is intentionally gated:
    rebuild.
 10. Use the normal parser page to run the current parser in `PRODUCTION` mode.
    Inspect the resulting SQLite as often as needed; no ingest is automatic.
-11. Supply its displayed SHA-256 to the separate manual PostgreSQL ingest.
+11. Review the production parser output, approve its displayed SHA-256, and use
+    **Ingest to PostgreSQL** on the parser page.
 
 The raw SQLite `scenes` count is labeled **raw LOR Scene rows**. Operational
 true Scenes are classified by Folder Alignment naming rules and are not a
@@ -184,8 +188,14 @@ publish port 8791 to the Internet.
 The task runs while Greg remains logged in, including while the screen is
 locked. After a Windows update or reboot, the runner remains unavailable until
 Greg signs in and `G:` is restored. This is an explicit availability boundary:
-the website reports the runner offline, while command-line parser operation,
-the existing SQLite snapshot, PostgreSQL, and reconciliation remain unaffected.
+the website reports the runner offline, while the existing SQLite snapshot,
+PostgreSQL, and any already-started reconciliation remain unaffected.
+
+Installation, restart, credential recovery, network requirements, and transfer
+to a replacement Office PC are controlled by the
+[Office PC Runner Operations and Disaster Recovery](Office_PC_Runner_Operations_and_Disaster_Recovery.md)
+runbook. Do not improvise token transfer or copy DPAPI files to another account
+or computer.
 
 ## Required API
 
@@ -325,7 +335,8 @@ the browser or Linux API.
    application tests plus PowerShell and JavaScript syntax checks.
 3. Run `run_lor_runner.ps1 -Action Install`. Retain the existing runner token,
    enter the PostgreSQL `msbadmin` password once at the secure prompt, and
-   verify runner V1.5.0. Do not run `PairServer`.
+   verify runner V1.5.1. Do not run `PairServer` when the existing protected
+   token is retained.
 4. Deploy backend V0.6.1, restart `lor-preflight-api.service`, and verify its
    health response plus the existing backend-to-runner connection.
 5. Publish the complete `landing/` tree, including `parser/` and

--- a/LOR2DB/README.md
+++ b/LOR2DB/README.md
@@ -10,10 +10,11 @@ Cloudflare authentication is required, just as it is for [my.sheboyganlights.org
 
 ![LOR2DB landing page](../Docs/images/lor2db_landing_page.jpg)
 
-The landing page shows the approved/current and candidate LOR versions, XML
-compatibility and parser controls, the current PostgreSQL snapshot,
-reconciliation status, and the current reconciliation report. Use **Report
-archive** to view all completed reconciliation reports, newest first.
+The landing page separates the routine parser workflow, the infrequent LOR
+version-approval workflow, and reconciliation status. Use **Run parser** for
+normal preview changes. Use **Check new version** only when evaluating a
+different Light-O-Rama software version. Use **Report archive** to view
+completed and cancelled reconciliation reports, newest first.
 
 **Completed reconciliation reports:** [Open the report archive](https://my.sheboyganlights.org/lor2db/reports/)
 
@@ -21,9 +22,10 @@ For production reconciliation procedures and recovery guidance, go to [Reconcili
 
 ## What Do You Need To Do?
 
-- [Run/check the parser and then perform the separate PostgreSQL ingest](01_Ingest/README.md)
+- [Run the repeatable parser, approve its output, and ingest it from the web interface](01_Ingest/README.md)
 - [Run or understand reconciliation](02_Reconciliation/README.md)
 - [Work on the LOR2DB application](Application/README.md)
+- [Install, restart, or recover the Office PC runner](Application/Office_PC_Runner_Operations_and_Disaster_Recovery.md)
 - [View and understand reconciliation reports](03_Reporting/README.md)
 
 ## Folder Guide

--- a/readme.md
+++ b/readme.md
@@ -18,47 +18,41 @@ V7 is the current supported breakpoint. Superseded V6, spreadsheet, Excel-report
 
 ## Production LOR-to-database flow
 
-The repository root provides two operator launchers for the two separate manual
-data steps:
-
-```powershell
-.\run_parse_props.ps1
-.\run_ingest.ps1
-```
-
-They are intentionally separate. Running the parser does **not** automatically ingest anything into PostgreSQL.
-
-The restricted website runner has its own root management launcher:
-
-```powershell
-.\run_lor_runner.ps1 -Action Status
-```
-
-`run_lor_runner.ps1` installs and starts the internal Windows service boundary;
-it does not run the parser merely because the runner starts. Its protected
-token is generated once, stored with Windows DPAPI, and paired to the Linux API
-through SSH without copying the secret through operator commands.
+The normal production workflow is operated from the secured
+[LOR2DB website](https://my.sheboyganlights.org/lor2db/). The parser remains a
+separate, repeatable approval step: operators may correct previews and run it
+as many times as necessary before approving one exact SQLite output for ingest.
+The browser then performs the fixed digest-locked PostgreSQL ingest, displays
+its console output, and enables reconciliation only after ingest succeeds.
 
 ```text
 Authoritative LOR previews
-    -> run_parse_props.ps1
+    -> Run parser in LOR2DB
     -> Docs/01_LOR_System/02_Data_Extraction/Parser/parse_props_v7_scene_parser.py
     -> lor_output_v7_scene.db
 
        STOP / REVIEW CHECKPOINT
-       Inspect the SQLite snapshot.
+       Review the parser console, counts, reports, digest, and SQLite snapshot.
        Correct LOR source data and rerun the parser as many times as needed.
 
-    -> run_ingest.ps1
-    -> LOR2DB/01_Ingest/postgres_run_ingest_v7.ps1
+    -> Confirm "Parser output looks correct — ready for ingest"
+    -> Ingest to PostgreSQL in LOR2DB
     -> LOR2DB/01_Ingest/postgres_ingest_from_lor_sqlite_v7.py
     -> immutable lor_snap snapshot
-    -> LOR2DB reconciliation and operator decisions
+    -> Start reconciliation in LOR2DB
+    -> operator decisions and final application review
     -> controlled P1-P4 promotion
     -> validation and immutable HTML report
 ```
 
-The parser and PostgreSQL snapshot ingest remain manual and independent. `run_parse_props.ps1` is the root entry point for rebuilding the SQLite snapshot. `run_ingest.ps1` is used only after that SQLite snapshot has been reviewed and accepted for ingest.
+Running the parser never starts ingest automatically. Running ingest never
+starts reconciliation automatically. Each boundary requires a separate,
+explicit operator action in the browser.
+
+The repository-root `run_parse_props.ps1` and `run_ingest.ps1` launchers remain
+available only for controlled engineering or recovery use. The root
+`run_lor_runner.ps1` manages the restricted Windows runner service; normal
+operators do not use it to perform a production data update.
 
 Operators never enter or select an `import_run_id`; LOR2DB captures the latest completed ingest at reconciliation start and preserves it for the entire run.
 
@@ -71,6 +65,7 @@ Operators never enter or select an `import_run_id`; LOR2DB captures the latest c
 - [LOR subsystem](LOR/README.md)
 - [PostgreSQL database subsystem](Database/README.md)
 - [LOR2DB subsystem](LOR2DB/README.md)
+- [Office PC runner operations and disaster recovery](LOR2DB/Application/Office_PC_Runner_Operations_and_Disaster_Recovery.md)
 - [Documentation standards and maintenance](System_Documentation/README.md)
 
 Selected operator manuals are linked from the Production Committee landing page. Backend engineering documents remain authoritative here even when they are not exposed on that page.


### PR DESCRIPTION
## Summary

- Aligns operator documentation with the completed browser workflow: run and review the parser repeatedly, approve ingest, watch ingest output, then start reconciliation.
- Adds a dedicated production-update SOP and updates the documentation indexes and architecture references.
- Documents the Office PC runner as a production dependency, including installation, scheduled-task operation, restart/status checks, DPAPI-protected credentials, API pairing, firewall/network requirements, and recovery when replacing or rebuilding the Office PC.
- Updates the current deployed-state references for the approved LOR/parser/ingest/reconciliation workflow.

## Validation

- 29 Markdown files reviewed and updated
- 188 relative documentation links validated
- Markdown code fences and structure checked
- `git diff --check` passed
- stale active-workflow reference scan passed

Documentation only; no runtime code changes.