### PR TITLE
Fix reconciliation completion readiness and navigation

### DIFF
--- a/LOR2DB/02_Reconciliation/00_LOR_Production_Import_and_Reconciliation_Procedure.md
+++ b/LOR2DB/02_Reconciliation/00_LOR_Production_Import_and_Reconciliation_Procedure.md
@@ -442,6 +442,11 @@ Immediately after a successful ingest, the workflow must:
 
 The operator does not enter an ingest number.
 
+After every persisted decision, the database recalculates the effective
+unresolved, deferred, and blocked counts. When the last required decision is
+saved and no blocked group remains, the same transaction advances the run to
+`READY_TO_FINISH`; the operator must not run a manual counter or status update.
+
 ### 5. Review Candidates Requiring Decisions
 
 Exact matches and other candidates requiring no operator action are not shown as decisions and are not listed as production changes in the final report.

--- a/LOR2DB/02_Reconciliation/02_LOR_Manual_Reconciliation_Runbook.md
+++ b/LOR2DB/02_Reconciliation/02_LOR_Manual_Reconciliation_Runbook.md
@@ -225,6 +225,10 @@ WHERE lor_reconciliation_run_id = :run_id;
 ```
 
 `READY_TO_FINISH` means every decision-required group has an action. Deferred or source-correction groups remain exceptions and will be left unchanged.
+Migration `0034` synchronizes these counters and this lifecycle state whenever
+an action is saved. If the website reports that all decisions are recorded but
+the final-review button remains disabled, stop and investigate; do not manually
+change the run status during normal operation.
 
 ## 6. Pre-Finish Gate — Read Only
 

--- a/LOR2DB/02_Reconciliation/reconciliation/README.md
+++ b/LOR2DB/02_Reconciliation/reconciliation/README.md
@@ -11,8 +11,8 @@ change, or merely reports evidence.
 | Path | Contents | Execution rule |
 |---|---|---|
 | `current_procedures/` | Canonical standalone P1, P2, P3, and P4 definitions matching the latest accepted migration chain | Inspection or explicitly authorized repair only; these files do not call promotion |
-| `migrations/` | Immutable installation history `0011` through `0033` | Run only the specifically authorized next migration; never rerun the folder as a batch |
-| `validation/` | Validation `10` through `28` | Follow each file's header; several are transaction-wrapped rollback tests |
+| `migrations/` | Immutable installation history `0011` through `0034` | Run only the specifically authorized next migration; never rerun the folder as a batch |
+| `validation/` | Validation `10` through `29` | Follow each file's header; several are transaction-wrapped rollback tests |
 | `operator_queries/preflight/` | Read-only latest-ingest reports `01` through `09` | Run individually; no operator-supplied `import_run_id` |
 | `incidents/` | Production incident report and its incident-specific forensic SQL | Historical evidence; not part of routine reconciliation |
 
@@ -67,7 +67,7 @@ is retained only as incident evidence. It is not step 8A of the normal workflow.
 
 ## Migration and validation status
 
-The current installation chain is `0011` through `0033`.
+The current installation chain is `0011` through `0034`.
 Migration `0029` must be revision
 `2026-08-05-true-noop-reconciliation-writes-v4`; its corresponding validation
 is `validation/25_true_noop_reconciliation_write_validation.sql`. Migration
@@ -79,6 +79,10 @@ Migration `0033` applies operator-approved canonical StageID/substage changes
 without replacing permanent stage identity, records accepted StageID aliases
 for stable bindings, exposes every frozen decision-group member, and is paired
 with `validation/28_complete_stage_decision_evidence_validation.sql`.
+Migration `0034` synchronizes effective counters and decision-state readiness
+after every persisted action, repairs already-open runs whose saved decisions
+and lifecycle diverged, and is paired with
+`validation/29_decision_readiness_sync_validation.sql`.
 
 Do not infer that a numbered validation is harmless from its filename alone.
 Read its header. In particular,

--- a/LOR2DB/02_Reconciliation/reconciliation/migrations/0034_sync_readiness_after_every_decision.sql
+++ b/LOR2DB/02_Reconciliation/reconciliation/migrations/0034_sync_readiness_after_every_decision.sql
@@ -1,0 +1,196 @@
+/* ============================================================================
+File:       0034_sync_readiness_after_every_decision.sql
+Migration:  Synchronize run readiness after every recorded decision
+
+Purpose:
+  Keep the durable run counters and lifecycle status aligned with the effective
+  logical-group decisions.  Every decision recorder writes to
+  ops.lor_reconciliation_action, so one AFTER INSERT trigger closes the gap
+  between a visibly saved decision and READY_TO_FINISH.
+
+Safety:
+  - Does not call Finish or any P1-P4 promotion procedure.
+  - Does not change production Stage, Display, Scene, or Scene/Display rows.
+  - Repairs only open decision-state runs from their persisted effective state.
+
+Revision History:
+  2026-08-17  GAL / OpenAI  Initial readiness synchronization.
+============================================================================ */
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION ops.f_sync_lor_reconciliation_effective_counters(
+    p_lor_reconciliation_run_id bigint
+)
+RETURNS TABLE (
+    unresolved_count integer,
+    deferred_count integer,
+    blocked_count integer
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, ops
+AS $function$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM ops.lor_reconciliation_run AS r
+        WHERE r.lor_reconciliation_run_id = p_lor_reconciliation_run_id
+    ) THEN
+        RAISE EXCEPTION 'Reconciliation run % does not exist',
+            p_lor_reconciliation_run_id;
+    END IF;
+
+    RETURN QUERY
+    WITH effective_counts AS (
+        SELECT
+            count(*) FILTER (
+                WHERE gr.effective_resolution_state = 'UNRESOLVED'
+            )::integer AS unresolved_count,
+            count(*) FILTER (
+                WHERE gr.effective_resolution_state = 'DEFERRED'
+            )::integer AS deferred_count,
+            count(*) FILTER (
+                WHERE gr.effective_resolution_state = 'BLOCKED'
+            )::integer AS blocked_count
+        FROM ops.v_lor_reconciliation_group_review AS gr
+        WHERE gr.lor_reconciliation_run_id =
+            p_lor_reconciliation_run_id
+    ), updated AS (
+        UPDATE ops.lor_reconciliation_run AS r
+           SET unresolved_count = ec.unresolved_count,
+               deferred_count = ec.deferred_count,
+               blocked_count = ec.blocked_count,
+               status = CASE
+                   WHEN r.status IN (
+                       'AWAITING_DECISIONS', 'READY_TO_FINISH'
+                   ) THEN CASE
+                       WHEN ec.unresolved_count = 0
+                        AND ec.blocked_count = 0
+                           THEN 'READY_TO_FINISH'
+                       ELSE 'AWAITING_DECISIONS'
+                   END
+                   ELSE r.status
+               END,
+               resumed_at = CASE
+                   WHEN r.status IN (
+                       'AWAITING_DECISIONS', 'READY_TO_FINISH'
+                   )
+                    AND ec.unresolved_count = 0
+                    AND ec.blocked_count = 0
+                       THEN now()
+                   ELSE r.resumed_at
+               END,
+               paused_at = CASE
+                   WHEN r.status IN (
+                       'AWAITING_DECISIONS', 'READY_TO_FINISH'
+                   )
+                    AND ec.unresolved_count = 0
+                    AND ec.blocked_count = 0
+                       THEN NULL
+                   WHEN r.status IN (
+                       'AWAITING_DECISIONS', 'READY_TO_FINISH'
+                   ) THEN coalesce(r.paused_at, now())
+                   ELSE r.paused_at
+               END
+          FROM effective_counts AS ec
+         WHERE r.lor_reconciliation_run_id =
+            p_lor_reconciliation_run_id
+        RETURNING
+            r.unresolved_count,
+            r.deferred_count,
+            r.blocked_count
+    )
+    SELECT
+        u.unresolved_count,
+        u.deferred_count,
+        u.blocked_count
+    FROM updated AS u;
+END;
+$function$;
+
+COMMENT ON FUNCTION
+    ops.f_sync_lor_reconciliation_effective_counters(bigint) IS
+'Synchronizes one run counters and decision-state readiness from effective logical-group state; never performs promotion.';
+
+REVOKE EXECUTE ON FUNCTION
+    ops.f_sync_lor_reconciliation_effective_counters(bigint) FROM PUBLIC;
+
+CREATE OR REPLACE FUNCTION
+    ops.f_sync_lor_reconciliation_readiness_after_action()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, ops
+AS $trigger$
+DECLARE
+    v_status text;
+BEGIN
+    SELECT r.status
+      INTO v_status
+    FROM ops.lor_reconciliation_run AS r
+    WHERE r.lor_reconciliation_run_id = NEW.lor_reconciliation_run_id;
+
+    /* PREFLIGHT can insert automatic actions while groups are still forming. */
+    IF v_status IN ('AWAITING_DECISIONS', 'READY_TO_FINISH') THEN
+        PERFORM *
+        FROM ops.f_sync_lor_reconciliation_effective_counters(
+            NEW.lor_reconciliation_run_id
+        );
+    END IF;
+
+    RETURN NEW;
+END;
+$trigger$;
+
+COMMENT ON FUNCTION
+    ops.f_sync_lor_reconciliation_readiness_after_action() IS
+'Refreshes an open run lifecycle after any persisted operator or automatic action; skips PREFLIGHT while groups are still forming.';
+
+REVOKE EXECUTE ON FUNCTION
+    ops.f_sync_lor_reconciliation_readiness_after_action() FROM PUBLIC;
+
+DROP TRIGGER IF EXISTS trg_sync_lor_reconciliation_readiness_after_action
+    ON ops.lor_reconciliation_action;
+
+CREATE TRIGGER trg_sync_lor_reconciliation_readiness_after_action
+AFTER INSERT ON ops.lor_reconciliation_action
+FOR EACH ROW
+EXECUTE FUNCTION
+    ops.f_sync_lor_reconciliation_readiness_after_action();
+
+/* Repair any open run whose saved decisions and lifecycle state diverged. */
+DO $migration$
+DECLARE
+    v_run_id bigint;
+BEGIN
+    FOR v_run_id IN
+        SELECT r.lor_reconciliation_run_id
+        FROM ops.lor_reconciliation_run AS r
+        WHERE r.status IN ('AWAITING_DECISIONS', 'READY_TO_FINISH')
+        ORDER BY r.lor_reconciliation_run_id
+    LOOP
+        PERFORM *
+        FROM ops.f_sync_lor_reconciliation_effective_counters(v_run_id);
+    END LOOP;
+END;
+$migration$;
+
+COMMIT;
+
+SELECT
+    '2026-08-17-decision-readiness-sync-v1'::text AS installed_revision,
+    to_regprocedure(
+        'ops.f_sync_lor_reconciliation_readiness_after_action()'
+    ) IS NOT NULL AS readiness_trigger_function_installed,
+    EXISTS (
+        SELECT 1
+        FROM pg_trigger AS t
+        JOIN pg_class AS c ON c.oid = t.tgrelid
+        JOIN pg_namespace AS n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'ops'
+          AND c.relname = 'lor_reconciliation_action'
+          AND t.tgname =
+              'trg_sync_lor_reconciliation_readiness_after_action'
+          AND NOT t.tgisinternal
+    ) AS readiness_trigger_installed;

--- a/LOR2DB/02_Reconciliation/reconciliation/validation/29_decision_readiness_sync_validation.sql
+++ b/LOR2DB/02_Reconciliation/reconciliation/validation/29_decision_readiness_sync_validation.sql
@@ -1,0 +1,90 @@
+/* ============================================================================
+Validation: Decision readiness synchronization
+
+Purpose:
+  Prove that every saved reconciliation action refreshes effective counters and
+  the READY_TO_FINISH/AWAITING_DECISIONS lifecycle without promotion.
+
+Safety:
+  Read-only. Does not alter reconciliation or production data.
+============================================================================ */
+
+DO $validation$
+DECLARE
+    v_sync_definition text;
+BEGIN
+    IF to_regprocedure(
+        'ops.f_sync_lor_reconciliation_effective_counters(bigint)'
+    ) IS NULL OR to_regprocedure(
+        'ops.f_sync_lor_reconciliation_readiness_after_action()'
+    ) IS NULL THEN
+        RAISE EXCEPTION
+            'Decision readiness synchronization functions are incomplete';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_trigger AS t
+        JOIN pg_class AS c ON c.oid = t.tgrelid
+        JOIN pg_namespace AS n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'ops'
+          AND c.relname = 'lor_reconciliation_action'
+          AND t.tgname =
+              'trg_sync_lor_reconciliation_readiness_after_action'
+          AND NOT t.tgisinternal
+    ) THEN
+        RAISE EXCEPTION 'Decision readiness trigger is not installed';
+    END IF;
+
+    SELECT pg_get_functiondef(
+        'ops.f_sync_lor_reconciliation_effective_counters(bigint)'::regprocedure
+    ) INTO v_sync_definition;
+
+    IF v_sync_definition NOT ILIKE '%effective_resolution_state%'
+       OR v_sync_definition NOT ILIKE '%READY_TO_FINISH%'
+       OR v_sync_definition ~* 'p[1234]_promote' THEN
+        RAISE EXCEPTION
+            'Effective counter sync does not enforce the safe readiness contract';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM ops.lor_reconciliation_run AS r
+        CROSS JOIN LATERAL (
+            SELECT
+                count(*) FILTER (
+                    WHERE gr.effective_resolution_state = 'UNRESOLVED'
+                )::integer AS unresolved_count,
+                count(*) FILTER (
+                    WHERE gr.effective_resolution_state = 'DEFERRED'
+                )::integer AS deferred_count,
+                count(*) FILTER (
+                    WHERE gr.effective_resolution_state = 'BLOCKED'
+                )::integer AS blocked_count
+            FROM ops.v_lor_reconciliation_group_review AS gr
+            WHERE gr.lor_reconciliation_run_id =
+                r.lor_reconciliation_run_id
+        ) AS ec
+        WHERE r.status IN ('AWAITING_DECISIONS', 'READY_TO_FINISH')
+          AND (
+              r.unresolved_count <> ec.unresolved_count
+              OR r.deferred_count <> ec.deferred_count
+              OR r.blocked_count <> ec.blocked_count
+              OR r.status <> CASE
+                  WHEN ec.unresolved_count = 0
+                   AND ec.blocked_count = 0
+                      THEN 'READY_TO_FINISH'
+                  ELSE 'AWAITING_DECISIONS'
+              END
+          )
+    ) THEN
+        RAISE EXCEPTION
+            'An open run lifecycle disagrees with its effective decisions';
+    END IF;
+END;
+$validation$;
+
+SELECT
+    'PASS'::text AS validation_status,
+    'Every saved decision refreshes counters and final-review readiness.'::text
+        AS validation_detail;

--- a/LOR2DB/03_Reporting/publish_lor_reconciliation_report.py
+++ b/LOR2DB/03_Reporting/publish_lor_reconciliation_report.py
@@ -3,7 +3,7 @@ MSB Database - LOR Reconciliation Report Publisher
 publish_lor_reconciliation_report.py
 
 Initial Release : 2026-08-03  V0.1.0
-Current Version : 2026-08-17  V0.5.1
+Current Version : 2026-08-17  V0.5.2
 Author          : GAL / OpenAI
 
 Purpose:
@@ -21,6 +21,10 @@ Operation:
       revised without changing the production audit row.
 
 Revision History:
+    2026-08-17  GAL / OpenAI  V0.5.2
+        Added explicit navigation from published reports and the report archive
+        back to the LOR2DB dashboard.
+
     2026-08-17  GAL / OpenAI  V0.5.1
         Sorted the source Preview manifest by Stage and replaced the misleading
         Preview-level BackgroundFile column with Scene background coverage.
@@ -52,7 +56,7 @@ from pathlib import Path
 from typing import Any, Iterable, Sequence
 
 
-REPORT_VERSION = "V0.5.1"
+REPORT_VERSION = "V0.5.2"
 DEFAULT_OUTPUT_DIR = r"\\192.168.5.4\web\my\lor2db\reports"
 REPORT_FILENAME = re.compile(
     r"^lor-reconciliation-(?P<stamp>\d{8}-\d{6})-run-(?P<run>\d+)"
@@ -248,8 +252,8 @@ def refresh_report_index(output_dir: str) -> Path:
     generated = datetime.now().astimezone()
     document = f"""<!doctype html><html lang="en"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1"><title>LOR Reconciliation Reports</title>
-<style>body{{font:14px/1.4 Arial,sans-serif;color:#1f2937;max-width:1400px;margin:24px auto;padding:0 18px}}h1{{margin-bottom:4px}}.meta{{color:#475569}}table{{width:100%;border-collapse:collapse;margin-top:18px}}th,td{{border:1px solid #cbd5e1;padding:8px;text-align:left;vertical-align:top}}th{{background:#e2e8f0}}tr:nth-child(even) td{{background:#f8fafc}}a{{color:#075985}}.empty{{font-style:italic;color:#475569}}</style></head><body>
-<h1>LOR Reconciliation Reports</h1><p class="meta">Index refreshed {html.escape(display(generated))} · {len(entries)} report(s)</p>
+<style>body{{font:14px/1.4 Arial,sans-serif;color:#1f2937;max-width:1400px;margin:24px auto;padding:0 18px}}h1{{margin-bottom:4px}}.report-nav{{float:right;padding:9px 13px;border:1px solid #94a3b8;border-radius:4px;text-decoration:none}}.meta{{color:#475569}}table{{width:100%;border-collapse:collapse;margin-top:18px}}th,td{{border:1px solid #cbd5e1;padding:8px;text-align:left;vertical-align:top}}th{{background:#e2e8f0}}tr:nth-child(even) td{{background:#f8fafc}}a{{color:#075985}}.empty{{font-style:italic;color:#475569}}@media print{{.report-nav{{display:none}}}}</style></head><body>
+<a class="report-nav" href="../">Return to LOR2DB dashboard</a><h1>LOR Reconciliation Reports</h1><p class="meta">Index refreshed {html.escape(display(generated))} · {len(entries)} report(s)</p>
 <table><thead><tr><th>Report</th><th>Type</th><th>Outcome</th><th>Reconciliation run</th><th>Captured ingest</th><th>Generated</th><th>Framework</th></tr></thead><tbody>{rows_html}</tbody></table>
 </body></html>"""
     destination = directory / "index.html"
@@ -512,8 +516,8 @@ def render_report(data: dict[str, Any], generated_at: datetime) -> str:
         )
     return f"""<!doctype html><html lang="en"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1"><title>{html.escape(title)}</title>
-<style>body{{font:14px/1.4 Arial,sans-serif;color:#1f2937;max-width:1400px;margin:24px auto;padding:0 18px}}h1{{margin-bottom:4px}}h2{{border-bottom:2px solid #334155;padding-bottom:5px;margin-top:30px}}h3{{margin-top:20px}}.meta{{color:#475569}}.action{{display:inline-block;padding:6px 10px;border-radius:4px}}.none{{background:#dcfce7}}.required{{background:#fef3c7}}.cancelled-banner{{margin:18px 0;padding:14px;border:2px solid #991b1b;background:#fee2e2;color:#7f1d1d}}.not-applicable{{padding:10px;background:#e2e8f0}}table{{width:100%;border-collapse:collapse;margin:10px 0 18px}}th,td{{border:1px solid #cbd5e1;padding:6px 8px;text-align:left;vertical-align:top}}th{{background:#e2e8f0}}tr:nth-child(even) td{{background:#f8fafc}}.empty td{{font-style:italic;color:#475569}}@media print{{body{{margin:0;max-width:none}}section{{break-inside:avoid}}}}</style></head><body data-report-outcome="{html.escape(final_status, quote=True)}">
-<h1>{html.escape(title)}</h1><p class="meta">Generated {html.escape(display(generated_at))} · Report framework {REPORT_VERSION} · Captured ingest {r["import_run_id"]}</p>{banner}{body}</body></html>"""
+<style>body{{font:14px/1.4 Arial,sans-serif;color:#1f2937;max-width:1400px;margin:24px auto;padding:0 18px}}h1{{margin-bottom:4px}}h2{{border-bottom:2px solid #334155;padding-bottom:5px;margin-top:30px}}h3{{margin-top:20px}}.report-nav{{float:right;padding:9px 13px;border:1px solid #94a3b8;border-radius:4px;color:#075985;text-decoration:none}}.meta{{color:#475569}}.action{{display:inline-block;padding:6px 10px;border-radius:4px}}.none{{background:#dcfce7}}.required{{background:#fef3c7}}.cancelled-banner{{margin:18px 0;padding:14px;border:2px solid #991b1b;background:#fee2e2;color:#7f1d1d}}.not-applicable{{padding:10px;background:#e2e8f0}}table{{width:100%;border-collapse:collapse;margin:10px 0 18px}}th,td{{border:1px solid #cbd5e1;padding:6px 8px;text-align:left;vertical-align:top}}th{{background:#e2e8f0}}tr:nth-child(even) td{{background:#f8fafc}}.empty td{{font-style:italic;color:#475569}}@media print{{body{{margin:0;max-width:none}}section{{break-inside:avoid}}.report-nav{{display:none}}}}</style></head><body data-report-outcome="{html.escape(final_status, quote=True)}">
+<a class="report-nav" href="../">Return to LOR2DB dashboard</a><h1>{html.escape(title)}</h1><p class="meta">Generated {html.escape(display(generated_at))} · Report framework {REPORT_VERSION} · Captured ingest {r["import_run_id"]}</p>{banner}{body}</body></html>"""
 
 
 def publish(conn: Any, run_id: int, output_dir: str, base_url: str | None) -> Path:

--- a/LOR2DB/03_Reporting/test_publish_lor_reconciliation_report.py
+++ b/LOR2DB/03_Reporting/test_publish_lor_reconciliation_report.py
@@ -96,6 +96,11 @@ class ReportRenderingTests(unittest.TestCase):
         self.assertIn("No blocked, deferred, unresolved, or failed items.", output)
         self.assertIn("No operator decisions were required.", output)
 
+    def test_report_has_dashboard_navigation(self):
+        output = REPORT.render_report(self.base_data(), datetime.now(timezone.utc))
+
+        self.assertIn('href="../">Return to LOR2DB dashboard</a>', output)
+
     def test_name_change_produces_label_action(self):
         data = self.base_data()
         data["names"] = [{
@@ -212,7 +217,7 @@ class ReportRenderingTests(unittest.TestCase):
                 REPORT.render_evaluation_copy(object(), 101, output_dir)
 
     def test_report_framework_version_identifies_evaluation_copy_release(self):
-        self.assertEqual(REPORT.REPORT_VERSION, "V0.5.1")
+        self.assertEqual(REPORT.REPORT_VERSION, "V0.5.2")
 
     def test_cancelled_report_is_terminal_and_has_no_required_actions(self):
         data = self.base_data()
@@ -272,6 +277,7 @@ class ReportRenderingTests(unittest.TestCase):
             self.assertIn("Captured ingest", index)
             self.assertIn("Outcome", index)
             self.assertIn("CANCELLED", index)
+            self.assertIn("Return to LOR2DB dashboard", index)
             self.assertLess(index.index(evaluation.name), index.index(published.name))
 
     def test_index_ignores_unrecognized_html_files(self):

--- a/LOR2DB/Application/README.md
+++ b/LOR2DB/Application/README.md
@@ -260,7 +260,10 @@ relationship, allowed action, and optimistic `expected_action_id`; then calls
 the appropriate protected recorder. Display/scene decisions use
 `ops.f_record_lor_reconciliation_action`; evidence-gated stage decisions use
 `ops.f_record_lor_stage_authority_action`, and the existing multi-preview
-preservation choice uses its dedicated stage recorder. It returns the complete
+preservation choice uses its dedicated stage recorder. Migration `0034` uses
+the persisted action as the common synchronization point: it recalculates the
+effective counters and changes an open run to `READY_TO_FINISH` only when no
+unresolved or blocked group remains. The endpoint then returns the complete
 refreshed run document as `{ "run": { ... } }`.
 
 Stage candidates include the complete frozen `members` array and the browser

--- a/LOR2DB/Application/preflight.js
+++ b/LOR2DB/Application/preflight.js
@@ -1,7 +1,7 @@
 /*
  * MSB Database - reusable LOR reconciliation preflight interface
  * Initial release: 2026-08-04 V0.1.0
- * Current version: 2026-08-16 V0.5.1
+ * Current version: 2026-08-17 V0.5.2
  *
  * The browser never writes PostgreSQL directly. All durable decisions and
  * lifecycle changes go through the same-origin secured API described in
@@ -90,7 +90,9 @@
   function openPublishedReport(result) {
     // The API returns the immutable URL written to the completed run. Keep the
     // report archive only as a defensive fallback for older API responses.
-    location.href = result.report_url || "../reports/";
+    // Replace the approval workflow in browser history. After Finish, Back
+    // must not reopen a stale pre-production decision or confirmation screen.
+    location.replace(result.report_url || "../reports/");
   }
 
   function renderCandidate(candidate) {

--- a/LOR2DB/Application/test_backend.py
+++ b/LOR2DB/Application/test_backend.py
@@ -52,6 +52,8 @@ class BackendSafetyTests(unittest.TestCase):
     def test_browser_opens_run_report_with_archive_fallback(self) -> None:
         source = Path(__file__).with_name("preflight.js").read_text(encoding="utf-8")
         self.assertIn('result.report_url || "../reports/"', source)
+        self.assertIn('location.replace(result.report_url || "../reports/")', source)
+        self.assertNotIn('location.href = result.report_url || "../reports/"', source)
         self.assertEqual(source.count("openPublishedReport(result);"), 2)
 
     def test_browser_renders_terminal_cancellation_proof(self) -> None:

--- a/LOR2DB/Application/test_decision_readiness_migration.py
+++ b/LOR2DB/Application/test_decision_readiness_migration.py
@@ -1,0 +1,65 @@
+"""Static safety contracts for decision-readiness synchronization."""
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).parents[1]
+MIGRATION = ROOT / "02_Reconciliation" / "reconciliation" / "migrations" / (
+    "0034_sync_readiness_after_every_decision.sql"
+)
+VALIDATION = ROOT / "02_Reconciliation" / "reconciliation" / "validation" / (
+    "29_decision_readiness_sync_validation.sql"
+)
+
+
+class DecisionReadinessMigrationTests(unittest.TestCase):
+    def test_every_action_refreshes_readiness(self) -> None:
+        source = MIGRATION.read_text(encoding="utf-8")
+        self.assertIn("AFTER INSERT ON ops.lor_reconciliation_action", source)
+        self.assertIn("trg_sync_lor_reconciliation_readiness_after_action", source)
+        self.assertIn("effective_resolution_state = 'UNRESOLVED'", source)
+        self.assertIn("THEN 'READY_TO_FINISH'", source)
+
+    def test_preflight_is_not_advanced_while_groups_are_forming(self) -> None:
+        source = MIGRATION.read_text(encoding="utf-8")
+        self.assertIn(
+            "IF v_status IN ('AWAITING_DECISIONS', 'READY_TO_FINISH')",
+            source,
+        )
+        self.assertNotIn("IF v_status IN ('PREFLIGHT'", source)
+
+    def test_migration_repairs_existing_open_runs(self) -> None:
+        source = MIGRATION.read_text(encoding="utf-8")
+        self.assertIn("Repair any open run", source)
+        self.assertIn("FOR v_run_id IN", source)
+        self.assertIn(
+            "ops.f_sync_lor_reconciliation_effective_counters(v_run_id)",
+            source,
+        )
+
+    def test_sync_never_calls_promotion(self) -> None:
+        source = MIGRATION.read_text(encoding="utf-8").lower()
+        for procedure in (
+            "p1_promote",
+            "p2_promote",
+            "p3_promote",
+            "p4_promote",
+            "p_finish_lor_reconciliation",
+        ):
+            with self.subTest(procedure=procedure):
+                self.assertNotIn(procedure, source)
+
+    def test_validation_is_read_only_and_checks_lifecycle(self) -> None:
+        source = VALIDATION.read_text(encoding="utf-8")
+        self.assertIn(
+            "An open run lifecycle disagrees with its effective decisions",
+            source,
+        )
+        self.assertIn("READY_TO_FINISH", source)
+        self.assertNotIn("UPDATE ops.", source)
+        self.assertNotIn("CALL ops.", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Synchronizes reconciliation counters and lifecycle state after every saved operator decision.
- Advances eligible runs to `READY_TO_FINISH` without requiring a manual refresh or database repair.
- Repairs existing open decision-state runs when migration 0034 is installed.
- Adds read-only validation 29 for the readiness trigger and lifecycle contract.
- Adds explicit dashboard links to completed reconciliation reports and the report archive.
- Uses browser history replacement after completion so Back does not reopen the stale final-approval screen.
- Updates the operator and engineering documentation.

## Root cause

Saving an operator action updated the effective decision, but did not recalculate the parent run's stored unresolved counters and lifecycle status. The browser therefore showed every decision as saved while the run still remained `AWAITING_DECISIONS`. Completed-report navigation also used normal history navigation and generated reports had no direct dashboard link.

## Safety

- The readiness trigger does not call Finish or any P1-P4 promotion procedure.
- Production writes still occur only through the existing explicit Finish boundary.
- `PREFLIGHT` runs are not advanced while decision groups are being formed.
- The branch is based on main commit `8d70590`, preserving the new documentation and image folders.

## Validation

- Application tests: 45 passed.
- Reporting tests: 18 passed.
- Decision-readiness migration contracts: 5 passed.
- Python compilation: passed.
- Git whitespace validation: passed.