### PR TITLE
Refresh preflight navigation script after completion fix

### DIFF
--- a/LOR2DB/Application/index.html
+++ b/LOR2DB/Application/index.html
@@ -26,6 +26,6 @@
     </form>
   </dialog>
 
-  <script src="preflight.js?v=0.5.1" defer></script>
+  <script src="preflight.js?v=0.5.2" defer></script>
 </body>
 </html>

--- a/LOR2DB/Application/test_backend.py
+++ b/LOR2DB/Application/test_backend.py
@@ -56,6 +56,11 @@ class BackendSafetyTests(unittest.TestCase):
         self.assertNotIn('location.href = result.report_url || "../reports/"', source)
         self.assertEqual(source.count("openPublishedReport(result);"), 2)
 
+    def test_preflight_page_loads_current_navigation_script(self) -> None:
+        source = Path(__file__).with_name("index.html").read_text(encoding="utf-8")
+        self.assertIn('src="preflight.js?v=0.5.2"', source)
+        self.assertNotIn('src="preflight.js?v=0.5.1"', source)
+
     def test_browser_renders_terminal_cancellation_proof(self) -> None:
         source = Path(__file__).with_name("preflight.js").read_text(encoding="utf-8")
         self.assertIn("Reconciliation cancelled", source)


### PR DESCRIPTION
## What changed

- Updates the reconciliation preflight page to request `preflight.js?v=0.5.2`.
- Adds a regression test that prevents the HTML cache key from falling behind the JavaScript release.

## Why

PR #24 updated the navigation script to V0.5.2 but the page still requested the V0.5.1 cache key. A browser or proxy could therefore retain the previous script and reopen the stale approval page after completion.

## Validation

- Application tests: 46 passed.
- Git whitespace validation: passed.