### PR TITLE
Repair distinct LOR substages and reporting

### DIFF
--- a/LOR2DB/02_Reconciliation/02_LOR_Manual_Reconciliation_Runbook.md
+++ b/LOR2DB/02_Reconciliation/02_LOR_Manual_Reconciliation_Runbook.md
@@ -230,6 +230,16 @@ an action is saved. If the website reports that all decisions are recorded but
 the final-review button remains disabled, stop and investigate; do not manually
 change the run status during normal operation.
 
+### Main stage and substage identity
+
+Stage keys such as `05` and `05a` (likewise `07` and `07a`) are separate
+permanent stages. If the frozen evidence contains both keys at the same time,
+do not approve a canonical rename. The interface must offer creation of the
+new substage and P1 must move only bindings whose captured source key matches
+that new substage. The main-stage bindings and displays remain assigned to the
+main stage. Migration `0035` enforces this rule and preserves the captured
+snapshot/frozen evidence unchanged.
+
 ## 6. Pre-Finish Gate — Read Only
 
 ```sql

--- a/LOR2DB/02_Reconciliation/reconciliation/README.md
+++ b/LOR2DB/02_Reconciliation/reconciliation/README.md
@@ -11,8 +11,8 @@ change, or merely reports evidence.
 | Path | Contents | Execution rule |
 |---|---|---|
 | `current_procedures/` | Canonical standalone P1, P2, P3, and P4 definitions matching the latest accepted migration chain | Inspection or explicitly authorized repair only; these files do not call promotion |
-| `migrations/` | Immutable installation history `0011` through `0034` | Run only the specifically authorized next migration; never rerun the folder as a batch |
-| `validation/` | Validation `10` through `29` | Follow each file's header; several are transaction-wrapped rollback tests |
+| `migrations/` | Immutable installation history `0011` through `0035` | Run only the specifically authorized next migration; never rerun the folder as a batch |
+| `validation/` | Validation `10` through `30` | Follow each file's header; several are transaction-wrapped rollback tests |
 | `operator_queries/preflight/` | Read-only latest-ingest reports `01` through `09` | Run individually; no operator-supplied `import_run_id` |
 | `incidents/` | Production incident report and its incident-specific forensic SQL | Historical evidence; not part of routine reconciliation |
 
@@ -22,8 +22,8 @@ The root Markdown files are this index and the current design specification.
 
 | Phase | Database object | Canonical file | Definition lineage |
 |---|---|---|---|
-| P1 | `ref.p1_promote_stage_from_reconciliation(bigint)` | `current_procedures/P1_stage_promotion.sql` | Existing-stage definition from `0016`/`0029 v4`, wrapped by `0032` for new-stage creation and by `0033` for approved canonical StageID/substage changes and accepted binding aliases |
-| P2 | `ref.p2_promote_display_from_reconciliation(bigint)` | `current_procedures/P2_display_promotion.sql` | Full definition from `0017`; unchanged by `0029` |
+| P1 | `ref.p1_promote_stage_from_reconciliation(bigint)` | `current_procedures/P1_stage_promotion.sql` | Migration `0035` distinguishes simultaneous main/substage keys, moves only the approved new-key bindings, and requires unanimous evidence for a true rename |
+| P2 | `ref.p2_promote_display_from_reconciliation(bigint)` | `current_procedures/P2_display_promotion.sql` | Migration `0035` resolves P1-created stages by source key and refuses unresolved/null stage assignments |
 | P3 | `ref.p3_promote_scene_from_reconciliation(bigint)` | `current_procedures/P3_scene_promotion.sql` | Full definition from `0018`, then no-op correction from `0029 v4` |
 | P4 | `ref.p4_promote_scene_display_from_reconciliation(bigint)` | `current_procedures/P4_scene_display_promotion.sql` | Full definition from `0018`, then no-op correction from `0029 v4` |
 
@@ -67,7 +67,7 @@ is retained only as incident evidence. It is not step 8A of the normal workflow.
 
 ## Migration and validation status
 
-The current installation chain is `0011` through `0034`.
+The current installation chain is `0011` through `0035`.
 Migration `0029` must be revision
 `2026-08-05-true-noop-reconciliation-writes-v4`; its corresponding validation
 is `validation/25_true_noop_reconciliation_write_validation.sql`. Migration
@@ -83,6 +83,12 @@ Migration `0034` synchronizes effective counters and decision-state readiness
 after every persisted action, repairs already-open runs whose saved decisions
 and lifecycle diverged, and is paired with
 `validation/29_decision_readiness_sync_validation.sql`.
+Migration `0035` repairs the Stage 05/05a collapse without changing captured
+snapshot or frozen candidate evidence. It establishes the general rule that
+simultaneous source keys such as `NN` and `NNa` are distinct permanent stages,
+not a rename of one stage. It also prevents P2 from clearing a production
+`stage_id` when a source key cannot be resolved. Validate it with
+`validation/30_distinct_substage_and_stage_assignment_validation.sql`.
 
 Do not infer that a numbered validation is harmless from its filename alone.
 Read its header. In particular,
@@ -96,6 +102,10 @@ not an installation script.
 - Start captures the latest committed ingest internally and freezes evidence.
 - Operators and Directus users do not select `import_run_id`.
 - Contradictory stage evidence cannot expose an approval action.
+- Main and substage source keys (`NN` and `NNa`) retain separate permanent
+  stage identities, bindings, and display assignments.
+- Captured `lor_snap` rows and frozen reconciliation candidates are never
+  rewritten to repair a production-reference defect.
 - A new permanent stage is inserted only by P1 after an explicit, evidence-
   gated `ADD_NEW_STAGE` decision.
 - P1-P4 are internal and execute only through authorized Finish processing.

--- a/LOR2DB/02_Reconciliation/reconciliation/current_procedures/P1_stage_promotion.sql
+++ b/LOR2DB/02_Reconciliation/reconciliation/current_procedures/P1_stage_promotion.sql
@@ -1,17 +1,15 @@
 /* ============================================================================
 Object:       Current P1 stage promotion entry procedure
-Revision:     2026-08-16-after-0033
+Revision:     2026-08-17-distinct-substage-safe-p1-v2
 
 Purpose:
-  Canonical repair/inspection definition of the public P1 entry procedure
-  installed by migration 0033. The migration 0032 implementation remains
-  `ref.p1_promote_stage_from_reconciliation_before_0033(bigint)`.
+  Canonical inspection/repair definition installed by migration 0035. It
+  treats simultaneous main/substage source keys as distinct stages and permits
+  a true canonical rename only when every stable binding agrees.
 
 Safety:
-  Installing this definition does not call P1 or modify production rows. Finish
-  calls P1 only after all operator decisions have been recorded. Explicitly
-  approved canonical StageID changes preserve permanent stage_id, and accepted
-  per-binding source StageIDs prevent the same alias from reopening later.
+  Installing this definition replaces P1 only. It does not call P1, start a
+  reconciliation, or modify production rows.
 ============================================================================ */
 
 BEGIN;
@@ -25,7 +23,10 @@ SET search_path = pg_catalog, ops, lor_snap, ref
 AS $procedure$
 DECLARE
     v_import_run_id bigint;
+    v_group record;
+    v_binding record;
     v_change record;
+    v_stage_id integer;
     v_old_stage_key text;
 BEGIN
     SELECT r.import_run_id INTO v_import_run_id
@@ -37,21 +38,36 @@ BEGIN
             p_lor_reconciliation_run_id;
     END IF;
 
-    CALL ref.p1_promote_stage_from_reconciliation_before_0033(
-        p_lor_reconciliation_run_id
-    );
-
-    FOR v_change IN
+    FOR v_group IN
         SELECT
             gr.lor_reconciliation_group_id,
-            min(c.resolved_stage_id) AS stage_id,
-            a.action_payload ->> 'target_stage_key' AS target_stage_key,
+            a.action_payload ->> 'target_stage_key' AS stage_key,
+            coalesce(
+                min(ops.f_normalize_lor_stage_name(
+                    c.source_name, c.source_stage_key
+                )) FILTER (
+                    WHERE c.source_stage_key =
+                        a.action_payload ->> 'target_stage_key'
+                      AND c.metadata_authoritative
+                ),
+                'RGB Plus Stage ' ||
+                    (a.action_payload ->> 'target_stage_key') || ' ' ||
+                    min(regexp_replace(
+                        ops.f_normalize_lor_stage_name(
+                            c.source_name, c.source_stage_key
+                        ),
+                        '-[[:alnum:]]{1,4}$', ''
+                    )) FILTER (
+                        WHERE c.source_stage_key =
+                            a.action_payload ->> 'target_stage_key'
+                    )
+            ) AS stage_name,
             min(c.proposed_park_order) FILTER (
-                WHERE c.proposed_stage_key =
+                WHERE c.source_stage_key =
                     a.action_payload ->> 'target_stage_key'
             ) AS park_order,
             min(c.proposed_sub_order) FILTER (
-                WHERE c.proposed_stage_key =
+                WHERE c.source_stage_key =
                     a.action_payload ->> 'target_stage_key'
             ) AS sub_order
         FROM ops.v_lor_reconciliation_group_review AS gr
@@ -60,28 +76,121 @@ BEGIN
         JOIN ops.lor_reconciliation_stage_candidate AS c
           ON c.lor_reconciliation_group_id = gr.lor_reconciliation_group_id
         WHERE gr.lor_reconciliation_run_id = p_lor_reconciliation_run_id
-          AND gr.effective_action_type = 'APPROVE_STAGE_CHANGE'
+          AND gr.effective_action_type = 'ADD_NEW_STAGE'
           AND gr.effective_resolution_state = 'APPROVED'
+          AND ops.f_stage_group_can_add_new_stage(
+                gr.lor_reconciliation_group_id)
         GROUP BY gr.lor_reconciliation_group_id, a.action_payload
     LOOP
-        IF nullif(btrim(v_change.target_stage_key), '') IS NULL THEN
-            RAISE EXCEPTION 'Approved stage group % has no target StageID',
-                v_change.lor_reconciliation_group_id;
+        IF nullif(btrim(v_group.stage_key), '') IS NULL THEN
+            RAISE EXCEPTION 'Approved new-stage group % has no target StageID',
+                v_group.lor_reconciliation_group_id;
+        END IF;
+        IF EXISTS (
+            SELECT 1 FROM ref.stage AS s WHERE s.stage_key = v_group.stage_key
+        ) THEN
+            RAISE EXCEPTION 'Approved new StageID % already exists',
+                v_group.stage_key;
         END IF;
 
+        INSERT INTO ref.stage (
+            stage_key, stage_name, folder_name, park_order, sub_order
+        ) VALUES (
+            v_group.stage_key, v_group.stage_name,
+            v_group.stage_key || '-' || v_group.stage_name,
+            v_group.park_order, v_group.sub_order
+        ) RETURNING stage_id INTO v_stage_id;
+
+        INSERT INTO ops.lor_reconciliation_result (
+            lor_reconciliation_run_id, import_run_id, entity_type,
+            entity_key, result_class, reason_code, operator_message, committed
+        ) VALUES (
+            p_lor_reconciliation_run_id, v_import_run_id, 'STAGE',
+            v_stage_id::text, 'ADDED', 'P1_ADD_NEW_STAGE',
+            format('ADDED: Stage %s as permanent stage_id %s.',
+                v_group.stage_key, v_stage_id), true
+        );
+
+        FOR v_binding IN
+            SELECT c.*
+            FROM ops.lor_reconciliation_stage_candidate AS c
+            WHERE c.lor_reconciliation_group_id =
+                v_group.lor_reconciliation_group_id
+              AND c.source_stage_key = v_group.stage_key
+            ORDER BY c.lor_reconciliation_stage_candidate_id
+        LOOP
+            IF v_binding.binding_type = 'PREVIEW' THEN
+                UPDATE ref.stage_lor_binding AS b
+                   SET stage_id = v_stage_id,
+                       source_name = v_binding.source_name,
+                       last_seen_import_run_id = v_import_run_id,
+                       accepted_source_stage_key = v_group.stage_key,
+                       updated_at = now(), updated_by = current_user
+                 WHERE b.binding_type = 'PREVIEW'
+                   AND b.preview_id = v_binding.preview_id;
+                IF NOT FOUND THEN
+                    INSERT INTO ref.stage_lor_binding (
+                        stage_id, binding_type, preview_id, scene_id,
+                        source_name, first_seen_import_run_id,
+                        last_seen_import_run_id, accepted_source_stage_key
+                    ) VALUES (
+                        v_stage_id, 'PREVIEW', v_binding.preview_id, NULL,
+                        v_binding.source_name, v_import_run_id,
+                        v_import_run_id, v_group.stage_key
+                    );
+                END IF;
+            ELSE
+                INSERT INTO ref.stage_lor_binding (
+                    stage_id, binding_type, preview_id, scene_id, source_name,
+                    first_seen_import_run_id, last_seen_import_run_id,
+                    accepted_source_stage_key
+                ) VALUES (
+                    v_stage_id, 'SCENE', v_binding.preview_id,
+                    v_binding.scene_id, v_binding.source_name,
+                    v_import_run_id, v_import_run_id, v_group.stage_key
+                )
+                ON CONFLICT (preview_id, scene_id)
+                    WHERE binding_type = 'SCENE'
+                DO UPDATE SET
+                    stage_id = EXCLUDED.stage_id,
+                    source_name = EXCLUDED.source_name,
+                    last_seen_import_run_id = EXCLUDED.last_seen_import_run_id,
+                    accepted_source_stage_key =
+                        EXCLUDED.accepted_source_stage_key,
+                    updated_at = now(), updated_by = current_user;
+            END IF;
+        END LOOP;
+    END LOOP;
+
+    /* Original existing-stage behavior remains authoritative for ordinary
+       exact bindings, preservation decisions, and new stable bindings. */
+    CALL ref.p1_promote_stage_from_reconciliation_before_0032(
+        p_lor_reconciliation_run_id
+    );
+
+    FOR v_change IN
+        SELECT
+            gr.lor_reconciliation_group_id,
+            min(c.resolved_stage_id) AS stage_id,
+            a.action_payload ->> 'target_stage_key' AS target_stage_key,
+            min(c.proposed_park_order) AS park_order,
+            min(c.proposed_sub_order) AS sub_order
+        FROM ops.v_lor_reconciliation_group_review AS gr
+        JOIN ops.lor_reconciliation_action AS a
+          ON a.lor_reconciliation_action_id = gr.effective_action_id
+        JOIN ops.lor_reconciliation_stage_candidate AS c
+          ON c.lor_reconciliation_group_id = gr.lor_reconciliation_group_id
+        WHERE gr.lor_reconciliation_run_id = p_lor_reconciliation_run_id
+          AND gr.effective_action_type = 'APPROVE_STAGE_CHANGE'
+          AND gr.effective_resolution_state = 'APPROVED'
+          AND ops.f_stage_group_can_approve_change(
+                gr.lor_reconciliation_group_id)
+        GROUP BY gr.lor_reconciliation_group_id, a.action_payload
+    LOOP
         SELECT s.stage_key INTO v_old_stage_key
         FROM ref.stage AS s
         WHERE s.stage_id = v_change.stage_id
         FOR UPDATE;
-
-        IF EXISTS (
-            SELECT 1 FROM ref.stage AS s
-            WHERE s.stage_key = v_change.target_stage_key
-              AND s.stage_id <> v_change.stage_id
-        ) THEN
-            RAISE EXCEPTION 'Approved StageID % already belongs to another permanent stage',
-                v_change.target_stage_key;
-        END IF;
 
         UPDATE ref.stage AS s
            SET stage_key = v_change.target_stage_key,
@@ -93,38 +202,25 @@ BEGIN
                END,
                park_order = v_change.park_order,
                sub_order = v_change.sub_order,
-               updated_at = now(),
-               updated_by = current_user
-         WHERE s.stage_id = v_change.stage_id
-           AND (
-               s.stage_key IS DISTINCT FROM v_change.target_stage_key
-               OR s.park_order IS DISTINCT FROM v_change.park_order
-               OR s.sub_order IS DISTINCT FROM v_change.sub_order
-           );
+               updated_at = now(), updated_by = current_user
+         WHERE s.stage_id = v_change.stage_id;
 
-        IF FOUND THEN
-            INSERT INTO ops.lor_reconciliation_result (
-                lor_reconciliation_run_id, import_run_id, entity_type,
-                entity_key, result_class, reason_code,
-                operator_message, committed
-            ) VALUES (
-                p_lor_reconciliation_run_id, v_import_run_id, 'STAGE',
-                v_change.stage_id::text, 'UPDATED',
-                'P1_APPROVED_STAGE_KEY_CHANGE',
-                format(
-                    'UPDATED: Stage %s to canonical StageID %s and preserved permanent stage_id %s.',
-                    v_old_stage_key, v_change.target_stage_key,
-                    v_change.stage_id
-                ),
-                true
-            );
-        END IF;
+        INSERT INTO ops.lor_reconciliation_result (
+            lor_reconciliation_run_id, import_run_id, entity_type,
+            entity_key, result_class, reason_code, operator_message, committed
+        ) VALUES (
+            p_lor_reconciliation_run_id, v_import_run_id, 'STAGE',
+            v_change.stage_id::text, 'UPDATED',
+            'P1_APPROVED_STAGE_KEY_CHANGE',
+            format('UPDATED: Stage %s to canonical StageID %s and preserved permanent stage_id %s.',
+                v_old_stage_key, v_change.target_stage_key,
+                v_change.stage_id), true
+        );
     END LOOP;
 
     UPDATE ref.stage_lor_binding AS b
        SET accepted_source_stage_key = c.source_stage_key,
-           updated_at = now(),
-           updated_by = current_user
+           updated_at = now(), updated_by = current_user
     FROM ops.lor_reconciliation_stage_candidate AS c
     JOIN ops.v_lor_reconciliation_group_review AS gr
       ON gr.lor_reconciliation_group_id = c.lor_reconciliation_group_id
@@ -138,7 +234,8 @@ END;
 $procedure$;
 
 COMMENT ON PROCEDURE ref.p1_promote_stage_from_reconciliation(bigint) IS
-'Reconciliation-gated P1. Preserves permanent stage identity, applies explicitly approved canonical StageID/substage changes, remembers accepted per-binding source StageIDs, and delegates established/new-stage promotion to the preserved implementation.';
+'Reconciliation-gated P1. Treats simultaneous main/substage keys as distinct permanent stages, requires unanimous evidence for a true canonical rename, and preserves stable bindings.';
+
 
 REVOKE EXECUTE ON PROCEDURE
     ref.p1_promote_stage_from_reconciliation(bigint) FROM PUBLIC;

--- a/LOR2DB/02_Reconciliation/reconciliation/current_procedures/P2_display_promotion.sql
+++ b/LOR2DB/02_Reconciliation/reconciliation/current_procedures/P2_display_promotion.sql
@@ -2,7 +2,7 @@
 Object group: Current installed reconciliation promotion procedures
 Repository:   LOR2DB/Reconciliation/reconciliation/current_procedures/
 Filename:     P2_display_promotion.sql
-Revision:     2026-08-03-reconciliation-safe-p2-v1
+Revision:     2026-08-17-stage-safe-p2-v2
 
 Purpose:
   Canonical standalone definition of the P2 procedure currently installed in
@@ -88,6 +88,8 @@ BEGIN
     )
     SELECT
         c.*,
+        coalesce(stage_by_key.stage_id, c.proposed_stage_id)
+            AS effective_stage_id,
         la.lor_reconciliation_action_id,
         la.action_type,
         CASE
@@ -103,6 +105,8 @@ BEGIN
       ON aa.lor_reconciliation_action_id = la.lor_reconciliation_action_id
      AND aa.lor_reconciliation_display_candidate_id =
             c.lor_reconciliation_display_candidate_id
+    LEFT JOIN ref.stage AS stage_by_key
+      ON stage_by_key.stage_key = nullif(btrim(c.proposed_stage_key), '')
     WHERE c.lor_reconciliation_run_id = p_lor_reconciliation_run_id
       AND c.candidate_class = 'PHYSICAL_DISPLAY'
       AND (
@@ -119,6 +123,17 @@ BEGIN
           AND p.target_display_id IS NULL
     ) THEN
         RAISE EXCEPTION 'An approved reassociation is missing a frozen target mapping';
+    END IF;
+
+    /* A stage created by P1 in this same Finish transaction is resolved by
+       source StageID here.  Never turn a known assignment into NULL merely
+       because the frozen preflight row predates that permanent stage. */
+    IF EXISTS (
+        SELECT 1 FROM pg_temp._lor_p2_plan AS p
+        WHERE nullif(btrim(p.proposed_stage_key), '') IS NOT NULL
+          AND p.effective_stage_id IS NULL
+    ) THEN
+        RAISE EXCEPTION 'P2 cannot resolve one or more approved source StageIDs to permanent stages';
     END IF;
 
     /* Final write guard: every source-backed plan row must still match Run N. */
@@ -185,7 +200,7 @@ BEGIN
                 stage_id, string_type
             ) VALUES (
                 v_row.lor_prop_id, v_row.proposed_display_name, 'LOR',
-                v_active_status_id, v_row.proposed_stage_id,
+                v_active_status_id, v_row.effective_stage_id,
                 v_row.proposed_string_type
             ) RETURNING display_id INTO v_display_id;
 
@@ -225,13 +240,13 @@ BEGIN
             UPDATE ref.display AS d
                SET lor_prop_id = v_row.lor_prop_id,
                    display_name = v_row.proposed_display_name,
-                   stage_id = v_row.proposed_stage_id,
+                   stage_id = v_row.effective_stage_id,
                    string_type = v_row.proposed_string_type
              WHERE d.display_id = v_display_id
                AND (
                    d.lor_prop_id IS DISTINCT FROM v_row.lor_prop_id
                    OR d.display_name IS DISTINCT FROM v_row.proposed_display_name
-                   OR d.stage_id IS DISTINCT FROM v_row.proposed_stage_id
+                   OR d.stage_id IS DISTINCT FROM v_row.effective_stage_id
                    OR d.string_type IS DISTINCT FROM v_row.proposed_string_type
                );
         END IF;
@@ -261,7 +276,7 @@ END;
 $procedure$;
 
 COMMENT ON PROCEDURE ref.p2_promote_display_from_reconciliation(bigint) IS
-'Internal reconciliation-gated P2. Revalidates exact raw source rows, rejects nonphysical names, preserves display_id and production-owned metadata, and applies only approved atomic groups. Canonical revision 2026-08-03-reconciliation-safe-p2-v1.';
+'Internal reconciliation-gated P2. Resolves P1-created stages by approved source StageID, refuses unresolved stage assignments, preserves display_id and production-owned metadata, and applies only approved atomic groups. Canonical revision 2026-08-17-stage-safe-p2-v2.';
 
 REVOKE EXECUTE ON PROCEDURE
     ref.p2_promote_display_from_reconciliation(bigint) FROM PUBLIC;

--- a/LOR2DB/02_Reconciliation/reconciliation/migrations/0035_repair_distinct_substages_and_protect_display_stage.sql
+++ b/LOR2DB/02_Reconciliation/reconciliation/migrations/0035_repair_distinct_substages_and_protect_display_stage.sql
@@ -1,0 +1,878 @@
+/* ============================================================================
+Migration: 0035_repair_distinct_substages_and_protect_display_stage.sql
+
+Purpose:
+  Repair the Stage 05/05a production split damaged by reconciliation run 7/8,
+  and prevent a permanent stage from being renamed when its frozen evidence
+  simultaneously contains the existing main key and a distinct substage key.
+
+Safety:
+  - The data repair runs only when the complete, known damaged state matches.
+  - Run 7/8 frozen candidates and immutable reports remain unchanged as audit
+    evidence of the incident.
+  - A canonical stage rename now requires every member to present one key.
+  - P2 resolves a stage by the approved source key at Finish time and refuses
+    to clear a non-null production stage assignment.
+============================================================================ */
+
+BEGIN;
+
+/* A rename is valid only when every member of the permanent stage agrees on
+   the same source key.  Mixed 05/05a (or NN/NNa) evidence is not a rename. */
+CREATE OR REPLACE FUNCTION ops.f_stage_group_can_approve_change(
+    p_lor_reconciliation_group_id bigint
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, ops, ref
+AS $function$
+    SELECT
+        g.entity_type = 'STAGE'
+        AND g.decision_required
+        AND count(c.*) = g.member_count
+        AND count(c.*) > 0
+        AND count(DISTINCT c.resolved_stage_id) = 1
+        AND count(*) FILTER (WHERE c.resolved_stage_id IS NULL) = 0
+        AND count(*) FILTER (WHERE b.stage_lor_binding_id IS NULL) = 0
+        AND count(DISTINCT c.source_stage_key) = 1
+        AND count(*) FILTER (
+            WHERE b.accepted_source_stage_key IS DISTINCT FROM
+                c.source_stage_key
+        ) > 0
+        AND count(*) FILTER (
+            WHERE c.stage_key_stage_id IS NOT NULL
+              AND c.stage_key_stage_id <> c.resolved_stage_id
+        ) = 0
+        AND count(*) FILTER (WHERE c.classification_code IN (
+            'SOURCE_FILENAME_MISSING',
+            'BINDING_STAGE_KEY_CONFLICT',
+            'NEW_STAGE_REQUIRES_AUTHORITATIVE_DECISION'
+        )) = 0
+    FROM ops.lor_reconciliation_group AS g
+    JOIN ops.lor_reconciliation_stage_candidate AS c
+      ON c.lor_reconciliation_group_id = g.lor_reconciliation_group_id
+    LEFT JOIN ref.stage_lor_binding AS b
+      ON b.binding_type = c.binding_type
+     AND b.preview_id = c.preview_id
+     AND b.scene_id IS NOT DISTINCT FROM c.scene_id
+     AND b.stage_id = c.resolved_stage_id
+    WHERE g.lor_reconciliation_group_id = p_lor_reconciliation_group_id
+    GROUP BY g.lor_reconciliation_group_id, g.entity_type,
+             g.decision_required, g.member_count;
+$function$;
+
+/* Return the one source key that represents a new permanent stage.  This is
+   either an entirely unresolved one-key group, or the noncanonical key in a
+   two-key group whose other key still equals the resolved permanent stage. */
+CREATE OR REPLACE FUNCTION ops.f_stage_group_new_stage_key(
+    p_lor_reconciliation_group_id bigint
+)
+RETURNS text
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, ops, ref
+AS $function$
+    WITH evidence AS (
+        SELECT c.*, s.stage_key AS resolved_stage_key
+        FROM ops.lor_reconciliation_stage_candidate AS c
+        LEFT JOIN ref.stage AS s ON s.stage_id = c.resolved_stage_id
+        WHERE c.lor_reconciliation_group_id = p_lor_reconciliation_group_id
+    ), candidate_key AS (
+        SELECT CASE
+            WHEN count(*) FILTER (WHERE resolved_stage_id IS NOT NULL) = 0
+             AND count(DISTINCT source_stage_key) = 1
+                THEN min(source_stage_key)
+            WHEN count(DISTINCT resolved_stage_id) = 1
+             AND count(*) FILTER (WHERE resolved_stage_id IS NULL) = 0
+             AND count(DISTINCT source_stage_key) = 2
+             AND count(*) FILTER (
+                    WHERE source_stage_key = resolved_stage_key
+                 ) > 0
+             AND count(DISTINCT source_stage_key) FILTER (
+                    WHERE source_stage_key IS DISTINCT FROM resolved_stage_key
+                 ) = 1
+                THEN min(source_stage_key) FILTER (
+                    WHERE source_stage_key IS DISTINCT FROM resolved_stage_key
+                )
+            ELSE NULL
+        END AS stage_key
+        FROM evidence
+    )
+    SELECT ck.stage_key
+    FROM candidate_key AS ck
+    WHERE ck.stage_key IS NOT NULL
+      AND NOT EXISTS (
+          SELECT 1 FROM ref.stage AS s WHERE s.stage_key = ck.stage_key
+      );
+$function$;
+
+CREATE OR REPLACE FUNCTION ops.f_stage_group_can_add_new_stage(
+    p_lor_reconciliation_group_id bigint
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, ops, ref
+AS $function$
+    WITH target AS (
+        SELECT ops.f_stage_group_new_stage_key(
+            p_lor_reconciliation_group_id
+        ) AS stage_key
+    )
+    SELECT
+        g.entity_type = 'STAGE'
+        AND g.decision_required
+        AND t.stage_key IS NOT NULL
+        AND count(c.*) = g.member_count
+        AND count(c.*) > 0
+        AND count(*) FILTER (WHERE c.source_stage_key = t.stage_key) > 0
+        AND count(DISTINCT c.proposed_park_order) FILTER (
+            WHERE c.source_stage_key = t.stage_key
+        ) = 1
+        AND count(DISTINCT c.proposed_sub_order) FILTER (
+            WHERE c.source_stage_key = t.stage_key
+        ) = 1
+        AND count(*) FILTER (
+            WHERE c.source_stage_key = t.stage_key
+              AND c.classification_code IN (
+                  'SOURCE_FILENAME_MISSING', 'BINDING_STAGE_KEY_CONFLICT'
+              )
+        ) = 0
+    FROM ops.lor_reconciliation_group AS g
+    JOIN ops.lor_reconciliation_stage_candidate AS c
+      ON c.lor_reconciliation_group_id = g.lor_reconciliation_group_id
+    CROSS JOIN target AS t
+    WHERE g.lor_reconciliation_group_id = p_lor_reconciliation_group_id
+    GROUP BY g.lor_reconciliation_group_id, g.entity_type,
+             g.decision_required, g.member_count, t.stage_key;
+$function$;
+
+/* Record the exact new source key.  The P1 wrapper below consumes this frozen
+   payload and moves only bindings/candidates carrying that key. */
+CREATE OR REPLACE FUNCTION ops.f_record_lor_stage_authority_action(
+    p_lor_reconciliation_run_id bigint,
+    p_lor_reconciliation_group_id bigint,
+    p_action_type text,
+    p_reason text,
+    p_acted_by_application text DEFAULT NULL
+)
+RETURNS bigint
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, ops, ref
+AS $function$
+DECLARE
+    v_import_run_id bigint;
+    v_status text;
+    v_action_id bigint;
+    v_counts record;
+    v_target_stage_key text;
+BEGIN
+    SELECT r.import_run_id, r.status
+      INTO v_import_run_id, v_status
+    FROM ops.lor_reconciliation_run AS r
+    WHERE r.lor_reconciliation_run_id = p_lor_reconciliation_run_id
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'Reconciliation run % does not exist',
+            p_lor_reconciliation_run_id;
+    END IF;
+    IF v_status NOT IN ('AWAITING_DECISIONS', 'READY_TO_FINISH') THEN
+        RAISE EXCEPTION 'Reconciliation run % does not accept decisions in status %',
+            p_lor_reconciliation_run_id, v_status;
+    END IF;
+    IF nullif(btrim(p_reason), '') IS NULL THEN
+        RAISE EXCEPTION 'A nonblank operator reason is required';
+    END IF;
+
+    IF p_action_type = 'APPROVE_STAGE_CHANGE' THEN
+        IF NOT coalesce(ops.f_stage_group_can_approve_change(
+            p_lor_reconciliation_group_id), false) THEN
+            RAISE EXCEPTION 'Stage group % is not a unanimous canonical StageID change',
+                p_lor_reconciliation_group_id;
+        END IF;
+        SELECT min(c.source_stage_key) INTO v_target_stage_key
+        FROM ops.lor_reconciliation_stage_candidate AS c
+        WHERE c.lor_reconciliation_group_id =
+            p_lor_reconciliation_group_id;
+    ELSIF p_action_type = 'ADD_NEW_STAGE' THEN
+        IF NOT coalesce(ops.f_stage_group_can_add_new_stage(
+            p_lor_reconciliation_group_id), false) THEN
+            RAISE EXCEPTION 'Stage group % does not contain one distinct new stage',
+                p_lor_reconciliation_group_id;
+        END IF;
+        v_target_stage_key := ops.f_stage_group_new_stage_key(
+            p_lor_reconciliation_group_id
+        );
+    ELSE
+        RAISE EXCEPTION 'Action % is not a stage authority action', p_action_type;
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM ops.lor_reconciliation_group AS g
+        WHERE g.lor_reconciliation_group_id = p_lor_reconciliation_group_id
+          AND g.lor_reconciliation_run_id = p_lor_reconciliation_run_id
+          AND g.entity_type = 'STAGE'
+    ) THEN
+        RAISE EXCEPTION 'Stage group % does not belong to reconciliation run %',
+            p_lor_reconciliation_group_id, p_lor_reconciliation_run_id;
+    END IF;
+
+    INSERT INTO ops.lor_reconciliation_action (
+        lor_reconciliation_run_id, lor_reconciliation_group_id,
+        import_run_id, action_type, reason, action_payload,
+        acted_by_application
+    ) VALUES (
+        p_lor_reconciliation_run_id, p_lor_reconciliation_group_id,
+        v_import_run_id, p_action_type, btrim(p_reason),
+        jsonb_build_object(
+            'stage_authority_decision', true,
+            'target_stage_key', v_target_stage_key
+        ),
+        nullif(btrim(p_acted_by_application), '')
+    ) RETURNING lor_reconciliation_action_id INTO v_action_id;
+
+    SELECT * INTO v_counts
+    FROM ops.f_sync_lor_reconciliation_effective_counters(
+        p_lor_reconciliation_run_id
+    );
+
+    UPDATE ops.lor_reconciliation_run AS r
+       SET status = CASE WHEN v_counts.unresolved_count = 0
+                          AND v_counts.blocked_count = 0
+                         THEN 'READY_TO_FINISH'
+                         ELSE 'AWAITING_DECISIONS' END,
+           resumed_at = now(),
+           paused_at = CASE WHEN v_counts.unresolved_count > 0
+                            THEN coalesce(r.paused_at, now())
+                            ELSE r.paused_at END
+     WHERE r.lor_reconciliation_run_id = p_lor_reconciliation_run_id;
+
+    RETURN v_action_id;
+END;
+$function$;
+
+/* Consume ADD_NEW_STAGE without delegating it through the pre-0032 wrapper,
+   because that historical wrapper correctly rejected stable bindings but did
+   not know about an operator-approved split. */
+CREATE OR REPLACE PROCEDURE ref.p1_promote_stage_from_reconciliation(
+    p_lor_reconciliation_run_id bigint
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, ops, lor_snap, ref
+AS $procedure$
+DECLARE
+    v_import_run_id bigint;
+    v_group record;
+    v_binding record;
+    v_change record;
+    v_stage_id integer;
+    v_old_stage_key text;
+BEGIN
+    SELECT r.import_run_id INTO v_import_run_id
+    FROM ops.lor_reconciliation_run AS r
+    WHERE r.lor_reconciliation_run_id = p_lor_reconciliation_run_id
+    FOR UPDATE;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'Reconciliation run % does not exist',
+            p_lor_reconciliation_run_id;
+    END IF;
+
+    FOR v_group IN
+        SELECT
+            gr.lor_reconciliation_group_id,
+            a.action_payload ->> 'target_stage_key' AS stage_key,
+            coalesce(
+                min(ops.f_normalize_lor_stage_name(
+                    c.source_name, c.source_stage_key
+                )) FILTER (
+                    WHERE c.source_stage_key =
+                        a.action_payload ->> 'target_stage_key'
+                      AND c.metadata_authoritative
+                ),
+                'RGB Plus Stage ' ||
+                    (a.action_payload ->> 'target_stage_key') || ' ' ||
+                    min(regexp_replace(
+                        ops.f_normalize_lor_stage_name(
+                            c.source_name, c.source_stage_key
+                        ),
+                        '-[[:alnum:]]{1,4}$', ''
+                    )) FILTER (
+                        WHERE c.source_stage_key =
+                            a.action_payload ->> 'target_stage_key'
+                    )
+            ) AS stage_name,
+            min(c.proposed_park_order) FILTER (
+                WHERE c.source_stage_key =
+                    a.action_payload ->> 'target_stage_key'
+            ) AS park_order,
+            min(c.proposed_sub_order) FILTER (
+                WHERE c.source_stage_key =
+                    a.action_payload ->> 'target_stage_key'
+            ) AS sub_order
+        FROM ops.v_lor_reconciliation_group_review AS gr
+        JOIN ops.lor_reconciliation_action AS a
+          ON a.lor_reconciliation_action_id = gr.effective_action_id
+        JOIN ops.lor_reconciliation_stage_candidate AS c
+          ON c.lor_reconciliation_group_id = gr.lor_reconciliation_group_id
+        WHERE gr.lor_reconciliation_run_id = p_lor_reconciliation_run_id
+          AND gr.effective_action_type = 'ADD_NEW_STAGE'
+          AND gr.effective_resolution_state = 'APPROVED'
+          AND ops.f_stage_group_can_add_new_stage(
+                gr.lor_reconciliation_group_id)
+        GROUP BY gr.lor_reconciliation_group_id, a.action_payload
+    LOOP
+        IF nullif(btrim(v_group.stage_key), '') IS NULL THEN
+            RAISE EXCEPTION 'Approved new-stage group % has no target StageID',
+                v_group.lor_reconciliation_group_id;
+        END IF;
+        IF EXISTS (
+            SELECT 1 FROM ref.stage AS s WHERE s.stage_key = v_group.stage_key
+        ) THEN
+            RAISE EXCEPTION 'Approved new StageID % already exists',
+                v_group.stage_key;
+        END IF;
+
+        INSERT INTO ref.stage (
+            stage_key, stage_name, folder_name, park_order, sub_order
+        ) VALUES (
+            v_group.stage_key, v_group.stage_name,
+            v_group.stage_key || '-' || v_group.stage_name,
+            v_group.park_order, v_group.sub_order
+        ) RETURNING stage_id INTO v_stage_id;
+
+        INSERT INTO ops.lor_reconciliation_result (
+            lor_reconciliation_run_id, import_run_id, entity_type,
+            entity_key, result_class, reason_code, operator_message, committed
+        ) VALUES (
+            p_lor_reconciliation_run_id, v_import_run_id, 'STAGE',
+            v_stage_id::text, 'ADDED', 'P1_ADD_NEW_STAGE',
+            format('ADDED: Stage %s as permanent stage_id %s.',
+                v_group.stage_key, v_stage_id), true
+        );
+
+        FOR v_binding IN
+            SELECT c.*
+            FROM ops.lor_reconciliation_stage_candidate AS c
+            WHERE c.lor_reconciliation_group_id =
+                v_group.lor_reconciliation_group_id
+              AND c.source_stage_key = v_group.stage_key
+            ORDER BY c.lor_reconciliation_stage_candidate_id
+        LOOP
+            IF v_binding.binding_type = 'PREVIEW' THEN
+                UPDATE ref.stage_lor_binding AS b
+                   SET stage_id = v_stage_id,
+                       source_name = v_binding.source_name,
+                       last_seen_import_run_id = v_import_run_id,
+                       accepted_source_stage_key = v_group.stage_key,
+                       updated_at = now(), updated_by = current_user
+                 WHERE b.binding_type = 'PREVIEW'
+                   AND b.preview_id = v_binding.preview_id;
+                IF NOT FOUND THEN
+                    INSERT INTO ref.stage_lor_binding (
+                        stage_id, binding_type, preview_id, scene_id,
+                        source_name, first_seen_import_run_id,
+                        last_seen_import_run_id, accepted_source_stage_key
+                    ) VALUES (
+                        v_stage_id, 'PREVIEW', v_binding.preview_id, NULL,
+                        v_binding.source_name, v_import_run_id,
+                        v_import_run_id, v_group.stage_key
+                    );
+                END IF;
+            ELSE
+                INSERT INTO ref.stage_lor_binding (
+                    stage_id, binding_type, preview_id, scene_id, source_name,
+                    first_seen_import_run_id, last_seen_import_run_id,
+                    accepted_source_stage_key
+                ) VALUES (
+                    v_stage_id, 'SCENE', v_binding.preview_id,
+                    v_binding.scene_id, v_binding.source_name,
+                    v_import_run_id, v_import_run_id, v_group.stage_key
+                )
+                ON CONFLICT (preview_id, scene_id)
+                    WHERE binding_type = 'SCENE'
+                DO UPDATE SET
+                    stage_id = EXCLUDED.stage_id,
+                    source_name = EXCLUDED.source_name,
+                    last_seen_import_run_id = EXCLUDED.last_seen_import_run_id,
+                    accepted_source_stage_key =
+                        EXCLUDED.accepted_source_stage_key,
+                    updated_at = now(), updated_by = current_user;
+            END IF;
+        END LOOP;
+    END LOOP;
+
+    /* Original existing-stage behavior remains authoritative for ordinary
+       exact bindings, preservation decisions, and new stable bindings. */
+    CALL ref.p1_promote_stage_from_reconciliation_before_0032(
+        p_lor_reconciliation_run_id
+    );
+
+    FOR v_change IN
+        SELECT
+            gr.lor_reconciliation_group_id,
+            min(c.resolved_stage_id) AS stage_id,
+            a.action_payload ->> 'target_stage_key' AS target_stage_key,
+            min(c.proposed_park_order) AS park_order,
+            min(c.proposed_sub_order) AS sub_order
+        FROM ops.v_lor_reconciliation_group_review AS gr
+        JOIN ops.lor_reconciliation_action AS a
+          ON a.lor_reconciliation_action_id = gr.effective_action_id
+        JOIN ops.lor_reconciliation_stage_candidate AS c
+          ON c.lor_reconciliation_group_id = gr.lor_reconciliation_group_id
+        WHERE gr.lor_reconciliation_run_id = p_lor_reconciliation_run_id
+          AND gr.effective_action_type = 'APPROVE_STAGE_CHANGE'
+          AND gr.effective_resolution_state = 'APPROVED'
+          AND ops.f_stage_group_can_approve_change(
+                gr.lor_reconciliation_group_id)
+        GROUP BY gr.lor_reconciliation_group_id, a.action_payload
+    LOOP
+        SELECT s.stage_key INTO v_old_stage_key
+        FROM ref.stage AS s
+        WHERE s.stage_id = v_change.stage_id
+        FOR UPDATE;
+
+        UPDATE ref.stage AS s
+           SET stage_key = v_change.target_stage_key,
+               folder_name = CASE
+                   WHEN s.folder_name LIKE v_old_stage_key || '-%'
+                   THEN v_change.target_stage_key ||
+                        substr(s.folder_name, length(v_old_stage_key) + 1)
+                   ELSE s.folder_name
+               END,
+               park_order = v_change.park_order,
+               sub_order = v_change.sub_order,
+               updated_at = now(), updated_by = current_user
+         WHERE s.stage_id = v_change.stage_id;
+
+        INSERT INTO ops.lor_reconciliation_result (
+            lor_reconciliation_run_id, import_run_id, entity_type,
+            entity_key, result_class, reason_code, operator_message, committed
+        ) VALUES (
+            p_lor_reconciliation_run_id, v_import_run_id, 'STAGE',
+            v_change.stage_id::text, 'UPDATED',
+            'P1_APPROVED_STAGE_KEY_CHANGE',
+            format('UPDATED: Stage %s to canonical StageID %s and preserved permanent stage_id %s.',
+                v_old_stage_key, v_change.target_stage_key,
+                v_change.stage_id), true
+        );
+    END LOOP;
+
+    UPDATE ref.stage_lor_binding AS b
+       SET accepted_source_stage_key = c.source_stage_key,
+           updated_at = now(), updated_by = current_user
+    FROM ops.lor_reconciliation_stage_candidate AS c
+    JOIN ops.v_lor_reconciliation_group_review AS gr
+      ON gr.lor_reconciliation_group_id = c.lor_reconciliation_group_id
+    WHERE gr.lor_reconciliation_run_id = p_lor_reconciliation_run_id
+      AND gr.effective_resolution_state IN ('AUTO_APPROVED', 'APPROVED')
+      AND b.binding_type = c.binding_type
+      AND b.preview_id = c.preview_id
+      AND b.scene_id IS NOT DISTINCT FROM c.scene_id
+      AND b.accepted_source_stage_key IS DISTINCT FROM c.source_stage_key;
+END;
+$procedure$;
+
+COMMENT ON PROCEDURE ref.p1_promote_stage_from_reconciliation(bigint) IS
+'Reconciliation-gated P1. Treats simultaneous main/substage keys as distinct permanent stages, requires unanimous evidence for a true canonical rename, and preserves stable bindings.';
+
+/* P2 resolves P1-created stages by source key and refuses unresolved stage
+   assignments instead of turning a permanent stage_id into NULL. */
+CREATE OR REPLACE PROCEDURE ref.p2_promote_display_from_reconciliation(
+    p_lor_reconciliation_run_id bigint
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, ops, lor_snap, ref
+AS $procedure$
+DECLARE
+    v_import_run_id bigint;
+    v_status text;
+    v_active_status_id integer;
+    v_retired_status_id integer;
+    v_recycled_status_id integer;
+    v_bad_source integer;
+    v_row record;
+    v_display_id bigint;
+    v_old_name text;
+    v_old_uuid text;
+    v_old_stage integer;
+    v_old_string_type text;
+    v_old_status integer;
+BEGIN
+    SELECT r.import_run_id, r.status
+      INTO v_import_run_id, v_status
+    FROM ops.lor_reconciliation_run AS r
+    WHERE r.lor_reconciliation_run_id = p_lor_reconciliation_run_id
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'Reconciliation run % does not exist',
+            p_lor_reconciliation_run_id;
+    END IF;
+
+    IF v_status NOT IN ('READY_TO_FINISH', 'PROMOTING') THEN
+        RAISE EXCEPTION 'Reconciliation run % is %, not ready for P2',
+            p_lor_reconciliation_run_id, v_status;
+    END IF;
+
+    SELECT ds.display_status_id INTO v_active_status_id
+    FROM ref.display_status AS ds
+    WHERE upper(btrim(ds.display_status_name)) = 'ACTIVE';
+    SELECT ds.display_status_id INTO v_retired_status_id
+    FROM ref.display_status AS ds
+    WHERE upper(btrim(ds.display_status_name)) = 'RETIRED';
+    SELECT ds.display_status_id INTO v_recycled_status_id
+    FROM ref.display_status AS ds
+    WHERE upper(btrim(ds.display_status_name)) = 'RECYCLED';
+
+    IF v_active_status_id IS NULL OR v_retired_status_id IS NULL
+       OR v_recycled_status_id IS NULL THEN
+        RAISE EXCEPTION 'ACTIVE, RETIRED, and RECYCLED display statuses are required';
+    END IF;
+
+    /* Permit idempotency validation to call P2 twice in one transaction. */
+    DROP TABLE IF EXISTS pg_temp._lor_p2_plan;
+
+    /* Build the complete effective write plan once from frozen state. */
+    CREATE TEMP TABLE pg_temp._lor_p2_plan ON COMMIT DROP AS
+    WITH latest_action AS (
+        SELECT DISTINCT ON (a.lor_reconciliation_group_id)
+            a.lor_reconciliation_group_id,
+            a.lor_reconciliation_action_id,
+            a.action_type
+        FROM ops.lor_reconciliation_action AS a
+        WHERE a.lor_reconciliation_run_id = p_lor_reconciliation_run_id
+          AND a.lor_reconciliation_group_id IS NOT NULL
+        ORDER BY a.lor_reconciliation_group_id,
+                 a.acted_at DESC,
+                 a.lor_reconciliation_action_id DESC
+    )
+    SELECT
+        c.*,
+        coalesce(stage_by_key.stage_id, c.proposed_stage_id)
+            AS effective_stage_id,
+        la.lor_reconciliation_action_id,
+        la.action_type,
+        CASE
+            WHEN la.action_type = 'REASSOCIATE_DISPLAY' THEN aa.target_display_id
+            ELSE c.display_id
+        END AS target_display_id
+    FROM ops.lor_reconciliation_display_candidate AS c
+    JOIN ops.lor_reconciliation_group AS g
+      ON g.lor_reconciliation_group_id = c.lor_reconciliation_group_id
+    LEFT JOIN latest_action AS la
+      ON la.lor_reconciliation_group_id = c.lor_reconciliation_group_id
+    LEFT JOIN ops.lor_reconciliation_action_assignment AS aa
+      ON aa.lor_reconciliation_action_id = la.lor_reconciliation_action_id
+     AND aa.lor_reconciliation_display_candidate_id =
+            c.lor_reconciliation_display_candidate_id
+    LEFT JOIN ref.stage AS stage_by_key
+      ON stage_by_key.stage_key = nullif(btrim(c.proposed_stage_key), '')
+    WHERE c.lor_reconciliation_run_id = p_lor_reconciliation_run_id
+      AND c.candidate_class = 'PHYSICAL_DISPLAY'
+      AND (
+          (NOT g.decision_required AND c.initial_resolution_state = 'AUTO_APPROVED')
+          OR la.action_type IN (
+              'RENAME_DISPLAY', 'UPDATE_LOR_LINK', 'REASSOCIATE_DISPLAY',
+              'ADD_NEW_DISPLAY', 'SET_RETIRED', 'SET_RECYCLED'
+          )
+      );
+
+    IF EXISTS (
+        SELECT 1 FROM pg_temp._lor_p2_plan AS p
+        WHERE p.action_type = 'REASSOCIATE_DISPLAY'
+          AND p.target_display_id IS NULL
+    ) THEN
+        RAISE EXCEPTION 'An approved reassociation is missing a frozen target mapping';
+    END IF;
+
+    /* A stage created by P1 in this same Finish transaction is resolved by
+       source StageID here.  Never turn a known assignment into NULL merely
+       because the frozen preflight row predates that permanent stage. */
+    IF EXISTS (
+        SELECT 1 FROM pg_temp._lor_p2_plan AS p
+        WHERE nullif(btrim(p.proposed_stage_key), '') IS NOT NULL
+          AND p.effective_stage_id IS NULL
+    ) THEN
+        RAISE EXCEPTION 'P2 cannot resolve one or more approved source StageIDs to permanent stages';
+    END IF;
+
+    /* Final write guard: every source-backed plan row must still match Run N. */
+    SELECT count(*) INTO v_bad_source
+    FROM pg_temp._lor_p2_plan AS p
+    WHERE p.source_prop_id IS NOT NULL
+      AND NOT EXISTS (
+          SELECT 1
+          FROM lor_snap.props AS raw
+          WHERE raw.import_run_id = v_import_run_id
+            AND raw.prop_id = p.source_prop_id
+            AND raw.raw_prop_id = p.lor_prop_id
+            AND nullif(btrim(raw.lor_comment), '') IS NOT NULL
+            AND btrim(raw.lor_comment) = p.proposed_display_name
+            AND raw.string_type IS NOT DISTINCT FROM p.proposed_string_type
+      );
+
+    IF v_bad_source > 0 THEN
+        RAISE EXCEPTION '% P2 candidates fail the captured raw-source guard for import_run_id %',
+            v_bad_source, v_import_run_id;
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM pg_temp._lor_p2_plan AS p
+        WHERE p.source_prop_id IS NOT NULL
+          AND (
+              p.proposed_display_name IS NULL
+              OR upper(btrim(p.proposed_display_name)) LIKE '%SPARE%'
+              OR upper(btrim(p.proposed_display_name)) LIKE '%PHANTOM%'
+          )
+    ) THEN
+        RAISE EXCEPTION 'P2 plan contains a blank, SPARE, or PHANTOM display';
+    END IF;
+
+    /*
+      Immediate unique indexes make a chained rename/UUID swap impossible in
+      one direct update. Vacate only the approved reassociation targets inside
+      this transaction, then assign all final values below. A failure rolls the
+      complete group and its temporary values back.
+    */
+    UPDATE ref.display AS d
+       SET display_name = format('__LOR_RECON_%s_%s__',
+                                 p_lor_reconciliation_run_id, d.display_id),
+           lor_prop_id = format('__LOR_RECON_UUID_%s_%s__',
+                                p_lor_reconciliation_run_id, d.display_id)
+    WHERE EXISTS (
+        SELECT 1
+        FROM pg_temp._lor_p2_plan AS p
+        WHERE p.action_type = 'REASSOCIATE_DISPLAY'
+          AND p.target_display_id = d.display_id
+          AND (
+              d.display_name IS DISTINCT FROM p.proposed_display_name
+              OR d.lor_prop_id IS DISTINCT FROM p.lor_prop_id
+          )
+    );
+
+    FOR v_row IN
+        SELECT * FROM pg_temp._lor_p2_plan
+        ORDER BY lor_reconciliation_display_candidate_id
+    LOOP
+        IF v_row.action_type = 'ADD_NEW_DISPLAY' THEN
+            INSERT INTO ref.display (
+                lor_prop_id, display_name, inventory_type, display_status_id,
+                stage_id, string_type
+            ) VALUES (
+                v_row.lor_prop_id, v_row.proposed_display_name, 'LOR',
+                v_active_status_id, v_row.effective_stage_id,
+                v_row.proposed_string_type
+            ) RETURNING display_id INTO v_display_id;
+
+            INSERT INTO ops.lor_reconciliation_result (
+                lor_reconciliation_run_id, import_run_id, entity_type,
+                entity_key, result_class, reason_code, operator_message, committed
+            ) VALUES (
+                p_lor_reconciliation_run_id, v_import_run_id, 'DISPLAY',
+                v_display_id::text, 'ADDED', 'P2_ADD_NEW_DISPLAY',
+                format('ADDED: display_id %s as %s.',
+                       v_display_id, v_row.proposed_display_name), true
+            );
+            CONTINUE;
+        END IF;
+
+        v_display_id := v_row.target_display_id;
+        SELECT d.display_name, d.lor_prop_id, d.stage_id, d.string_type,
+               d.display_status_id
+          INTO v_old_name, v_old_uuid, v_old_stage, v_old_string_type,
+               v_old_status
+        FROM ref.display AS d
+        WHERE d.display_id = v_display_id;
+
+        IF NOT FOUND THEN
+            RAISE EXCEPTION 'P2 target display_id % does not exist', v_display_id;
+        END IF;
+
+        IF v_row.action_type = 'SET_RETIRED' THEN
+            UPDATE ref.display SET display_status_id = v_retired_status_id
+            WHERE display_id = v_display_id
+              AND display_status_id IS DISTINCT FROM v_retired_status_id;
+        ELSIF v_row.action_type = 'SET_RECYCLED' THEN
+            UPDATE ref.display SET display_status_id = v_recycled_status_id
+            WHERE display_id = v_display_id
+              AND display_status_id IS DISTINCT FROM v_recycled_status_id;
+        ELSE
+            UPDATE ref.display AS d
+               SET lor_prop_id = v_row.lor_prop_id,
+                   display_name = v_row.proposed_display_name,
+                   stage_id = v_row.effective_stage_id,
+                   string_type = v_row.proposed_string_type
+             WHERE d.display_id = v_display_id
+               AND (
+                   d.lor_prop_id IS DISTINCT FROM v_row.lor_prop_id
+                   OR d.display_name IS DISTINCT FROM v_row.proposed_display_name
+                   OR d.stage_id IS DISTINCT FROM v_row.effective_stage_id
+                   OR d.string_type IS DISTINCT FROM v_row.proposed_string_type
+               );
+        END IF;
+
+        IF FOUND THEN
+            INSERT INTO ops.lor_reconciliation_result (
+                lor_reconciliation_run_id, import_run_id, entity_type,
+                entity_key, result_class, reason_code, operator_message, committed
+            ) VALUES (
+                p_lor_reconciliation_run_id, v_import_run_id, 'DISPLAY',
+                v_display_id::text,
+                CASE
+                    WHEN v_row.action_type = 'REASSOCIATE_DISPLAY' THEN 'REASSOCIATED'
+                    WHEN v_row.action_type IN ('SET_RETIRED', 'SET_RECYCLED')
+                        THEN 'STATUS_CHANGED'
+                    ELSE 'UPDATED'
+                END,
+                'P2_' || coalesce(v_row.action_type, 'AUTO_APPROVED'),
+                format('P2 applied approved fields to display_id %s (%s).',
+                       v_display_id,
+                       coalesce(v_row.proposed_display_name, v_old_name)),
+                true
+            );
+        END IF;
+    END LOOP;
+END;
+$procedure$;
+
+COMMENT ON PROCEDURE ref.p2_promote_display_from_reconciliation(bigint) IS
+'Internal reconciliation-gated P2. Resolves P1-created stages by approved source StageID, refuses unresolved stage assignments, preserves display_id and production-owned metadata, and applies only approved atomic groups. Canonical revision 2026-08-17-stage-safe-p2-v2.';
+
+/* Known-state repair.  The assertions prevent this from becoming a broad or
+   guessed production edit. */
+DO $repair$
+DECLARE
+    v_new_stage_id integer;
+    v_restored_count integer;
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM ref.stage AS s
+        WHERE s.stage_key = '05'
+          AND s.stage_name = 'RGB Plus Stage 05 Festive Trees Traditional'
+    ) AND EXISTS (
+        SELECT 1 FROM ref.stage AS s WHERE s.stage_key = '05a'
+    ) THEN
+        RAISE NOTICE 'Stage 05/05a repair is already present; data repair skipped';
+        RETURN;
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM ref.stage AS s
+        WHERE s.stage_id = 35
+          AND s.stage_key = '05a'
+          AND s.stage_name = 'RGB Plus Stage 05 Festive Trees Traditional'
+          AND s.park_order = 5
+          AND s.sub_order = 1
+    ) OR EXISTS (
+        SELECT 1 FROM ref.stage AS s
+        WHERE s.stage_key IN ('05', '05a') AND s.stage_id <> 35
+    ) THEN
+        RAISE EXCEPTION 'Stage 05/05a repair guard failed: permanent-stage state is not the known damaged state';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM ref.stage_lor_binding AS b
+        WHERE b.stage_lor_binding_id = 142 AND b.stage_id = 35
+          AND b.binding_type = 'SCENE'
+          AND b.scene_id = 'd4eeafb3-c355-44df-ab9e-e7566b29e0e7'
+          AND b.accepted_source_stage_key = '05'
+    ) OR NOT EXISTS (
+        SELECT 1 FROM ref.stage_lor_binding AS b
+        WHERE b.stage_lor_binding_id = 143 AND b.stage_id = 35
+          AND b.binding_type = 'SCENE'
+          AND b.scene_id = 'd57761f7-3527-4b00-a8ce-2eeb70eb3d8c'
+          AND b.accepted_source_stage_key = '05a'
+    ) THEN
+        RAISE EXCEPTION 'Stage 05/05a repair guard failed: stable bindings 142/143 do not match incident evidence';
+    END IF;
+
+    IF (
+        SELECT count(DISTINCT c.display_id)
+        FROM ops.lor_reconciliation_display_candidate AS c
+        WHERE c.lor_reconciliation_run_id = 8
+          AND c.current_stage_id = 35
+          AND c.proposed_stage_id IS NULL
+          AND 'stage_id' = ANY(c.changed_fields)
+          AND c.display_id IS NOT NULL
+    ) <> 50 THEN
+        RAISE EXCEPTION 'Stage 05/05a repair guard failed: run 8 does not expose the expected 50 cleared Stage 05 displays';
+    END IF;
+
+    UPDATE ref.stage
+       SET stage_key = '05',
+           folder_name = '05-RGB Plus Stage 05 Festive Trees Traditional',
+           park_order = 5,
+           sub_order = 0,
+           updated_at = now(),
+           updated_by = current_user
+     WHERE stage_id = 35;
+
+    INSERT INTO ref.stage (
+        stage_key, stage_name, folder_name, park_order, sub_order
+    ) VALUES (
+        '05a', 'RGB Plus Stage 05a Mega Star',
+        '05a-RGB Plus Stage 05a Mega Star', 5, 1
+    ) RETURNING stage_id INTO v_new_stage_id;
+
+    UPDATE ref.stage_lor_binding
+       SET stage_id = v_new_stage_id,
+           accepted_source_stage_key = '05a',
+           updated_at = now(), updated_by = current_user
+     WHERE stage_lor_binding_id = 143;
+
+    UPDATE ref.display AS d
+       SET stage_id = 35,
+           updated_at = now(), updated_by = current_user
+     WHERE d.stage_id IS NULL
+       AND EXISTS (
+           SELECT 1
+           FROM ops.lor_reconciliation_display_candidate AS c
+           WHERE c.lor_reconciliation_run_id = 8
+             AND c.display_id = d.display_id
+             AND c.current_stage_id = 35
+             AND c.proposed_stage_id IS NULL
+             AND 'stage_id' = ANY(c.changed_fields)
+       );
+    GET DIAGNOSTICS v_restored_count = ROW_COUNT;
+    IF v_restored_count <> 50 THEN
+        RAISE EXCEPTION 'Stage 05 repair restored % displays, expected exactly 50',
+            v_restored_count;
+    END IF;
+
+    UPDATE ref.display
+       SET stage_id = v_new_stage_id,
+           updated_at = now(), updated_by = current_user
+     WHERE display_id = 869
+       AND display_name = 'FT-MegaStar';
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'Stage 05a repair did not find display_id 869 FT-MegaStar';
+    END IF;
+END;
+$repair$;
+
+REVOKE EXECUTE ON FUNCTION
+    ops.f_stage_group_new_stage_key(bigint) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION
+    ops.f_stage_group_can_approve_change(bigint) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION
+    ops.f_stage_group_can_add_new_stage(bigint) FROM PUBLIC;
+REVOKE EXECUTE ON PROCEDURE
+    ref.p1_promote_stage_from_reconciliation(bigint) FROM PUBLIC;
+REVOKE EXECUTE ON PROCEDURE
+    ref.p2_promote_display_from_reconciliation(bigint) FROM PUBLIC;
+
+COMMIT;
+
+SELECT
+    '2026-08-17-distinct-substages-and-stage05-repair-v1'::text
+        AS installed_revision,
+    (SELECT stage_id FROM ref.stage WHERE stage_key = '05') AS stage_05_id,
+    (SELECT stage_id FROM ref.stage WHERE stage_key = '05a') AS stage_05a_id;

--- a/LOR2DB/02_Reconciliation/reconciliation/validation/30_distinct_substage_and_stage_assignment_validation.sql
+++ b/LOR2DB/02_Reconciliation/reconciliation/validation/30_distinct_substage_and_stage_assignment_validation.sql
@@ -1,0 +1,102 @@
+/* ============================================================================
+Validation: Distinct substages and protected display-stage assignments
+
+Safety: Read-only.  This script changes no production or audit data.
+============================================================================ */
+
+DO $validation$
+DECLARE
+    v_stage_05 integer;
+    v_stage_05a integer;
+    v_p2_definition text;
+BEGIN
+    SELECT s.stage_id INTO STRICT v_stage_05
+    FROM ref.stage AS s
+    WHERE s.stage_key = '05'
+      AND s.stage_name = 'RGB Plus Stage 05 Festive Trees Traditional'
+      AND s.folder_name = '05-RGB Plus Stage 05 Festive Trees Traditional'
+      AND s.park_order = 5
+      AND s.sub_order = 0;
+
+    SELECT s.stage_id INTO STRICT v_stage_05a
+    FROM ref.stage AS s
+    WHERE s.stage_key = '05a'
+      AND s.stage_name = 'RGB Plus Stage 05a Mega Star'
+      AND s.folder_name = '05a-RGB Plus Stage 05a Mega Star'
+      AND s.park_order = 5
+      AND s.sub_order = 1;
+
+    IF v_stage_05 = v_stage_05a OR v_stage_05 <> 35 THEN
+        RAISE EXCEPTION 'Stage 05 and 05a do not have distinct permanent identities';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM ops.lor_reconciliation_stage_candidate AS c
+        WHERE c.lor_reconciliation_run_id = 8
+          AND c.source_stage_key = '05'
+    ) OR NOT EXISTS (
+        SELECT 1
+        FROM ops.lor_reconciliation_stage_candidate AS c
+        WHERE c.lor_reconciliation_run_id = 8
+          AND c.source_stage_key = '05a'
+    ) THEN
+        RAISE EXCEPTION 'Frozen snapshot evidence no longer retains both source keys 05 and 05a';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM ref.stage_lor_binding AS b
+        WHERE b.stage_lor_binding_id = 142
+          AND b.stage_id = v_stage_05
+          AND b.accepted_source_stage_key = '05'
+    ) OR NOT EXISTS (
+        SELECT 1 FROM ref.stage_lor_binding AS b
+        WHERE b.stage_lor_binding_id = 143
+          AND b.stage_id = v_stage_05a
+          AND b.accepted_source_stage_key = '05a'
+    ) THEN
+        RAISE EXCEPTION 'Stage 05/05a stable bindings are not separated';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM ops.lor_reconciliation_display_candidate AS c
+        JOIN ref.display AS d ON d.display_id = c.display_id
+        WHERE c.lor_reconciliation_run_id = 8
+          AND c.current_stage_id = 35
+          AND c.proposed_stage_id IS NULL
+          AND 'stage_id' = ANY(c.changed_fields)
+          AND d.stage_id IS DISTINCT FROM v_stage_05
+    ) THEN
+        RAISE EXCEPTION 'At least one run 8 Stage 05 display was not restored';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM ref.display AS d
+        WHERE d.display_id = 869
+          AND d.display_name = 'FT-MegaStar'
+          AND d.stage_id = v_stage_05a
+    ) THEN
+        RAISE EXCEPTION 'FT-MegaStar is not assigned to permanent Stage 05a';
+    END IF;
+
+    IF ops.f_stage_group_can_approve_change(14721) THEN
+        RAISE EXCEPTION 'Mixed 05/05a evidence is still incorrectly approvable as a rename';
+    END IF;
+
+    SELECT pg_get_functiondef(
+        'ref.p2_promote_display_from_reconciliation(bigint)'::regprocedure
+    ) INTO v_p2_definition;
+
+    IF v_p2_definition NOT ILIKE '%effective_stage_id%'
+       OR v_p2_definition NOT ILIKE '%cannot resolve one or more approved source StageIDs%'
+       OR v_p2_definition ILIKE '%stage_id = v_row.proposed_stage_id%' THEN
+        RAISE EXCEPTION 'P2 stage-assignment protection is not installed';
+    END IF;
+END;
+$validation$;
+
+SELECT
+    'PASS'::text AS validation_status,
+    'Stage 05 and 05a are distinct, exact affected displays are repaired, and P2 cannot clear unresolved stage assignments.'::text
+        AS validation_detail;

--- a/LOR2DB/03_Reporting/README.md
+++ b/LOR2DB/03_Reporting/README.md
@@ -13,6 +13,11 @@ The LOR2DB Reporting subsystem provides permanent reconciliation reports for eac
 
 Cloudflare authentication is required to access the LOR2DB application and published reconciliation report archive.
 
+Report framework V0.6.0 lists every captured Scene-level background path,
+sorts manifests and committed changes by natural Stage order (`05`, `05a`,
+`06`, ...), and shows the exact frozen fields changed by automatic display
+promotion. Evaluated no-op rows do not appear as production changes.
+
 ---
 
 # Google Drive Folder Alignment Report

--- a/LOR2DB/03_Reporting/publish_lor_reconciliation_report.py
+++ b/LOR2DB/03_Reporting/publish_lor_reconciliation_report.py
@@ -3,7 +3,7 @@ MSB Database - LOR Reconciliation Report Publisher
 publish_lor_reconciliation_report.py
 
 Initial Release : 2026-08-03  V0.1.0
-Current Version : 2026-08-17  V0.5.2
+Current Version : 2026-08-17  V0.6.0
 Author          : GAL / OpenAI
 
 Purpose:
@@ -21,6 +21,10 @@ Operation:
       revised without changing the production audit row.
 
 Revision History:
+    2026-08-17  GAL / OpenAI  V0.6.0
+        Show every captured Scene background path, sort production changes in
+        natural Stage order, and expose the exact frozen fields changed by P2.
+
     2026-08-17  GAL / OpenAI  V0.5.2
         Added explicit navigation from published reports and the report archive
         back to the LOR2DB dashboard.
@@ -56,7 +60,7 @@ from pathlib import Path
 from typing import Any, Iterable, Sequence
 
 
-REPORT_VERSION = "V0.5.2"
+REPORT_VERSION = "V0.6.0"
 DEFAULT_OUTPUT_DIR = r"\\192.168.5.4\web\my\lor2db\reports"
 REPORT_FILENAME = re.compile(
     r"^lor-reconciliation-(?P<stamp>\d{8}-\d{6})-run-(?P<run>\d+)"
@@ -115,6 +119,8 @@ def humanize_changes(data: dict[str, Any]) -> list[dict[str, Any]]:
     scenes = data.get("scene_names", {})
     previews = data.get("preview_names", {})
     stages = data.get("stage_names", {})
+    stage_keys = data.get("stage_keys", {})
+    display_evidence = data.get("display_change_evidence", {})
     readable = []
 
     for source in data["changes"]:
@@ -125,6 +131,27 @@ def humanize_changes(data: dict[str, Any]) -> list[dict[str, Any]]:
 
         if entity_type == "DISPLAY" and key.isdigit():
             row["entity_key"] = f"{key}-{displays.get(key, 'Unknown display')}"
+            evidence = display_evidence.get(key, {})
+            row["report_stage_id"] = (
+                evidence.get("proposed_stage_key")
+                or stage_keys.get(str(evidence.get("current_stage_id") or ""))
+            )
+            row["changed_fields_display"] = display(
+                evidence.get("changed_fields") or []
+            )
+            if "stage_id" in (evidence.get("changed_fields") or []):
+                before_key = stage_keys.get(
+                    str(evidence.get("current_stage_id") or ""), "Unassigned"
+                )
+                after_key = evidence.get("proposed_stage_key") or "Unassigned"
+                row["before_after"] = f"Stage {before_key} -> Stage {after_key}"
+            elif "display_name" in (evidence.get("changed_fields") or []):
+                row["before_after"] = (
+                    f'{evidence.get("current_display_name") or "—"} -> '
+                    f'{evidence.get("proposed_display_name") or "—"}'
+                )
+            else:
+                row["before_after"] = "—"
 
         elif entity_type == "SCENE" and len(parts) >= 3:
             scene = scenes.get((parts[1], parts[2]), {})
@@ -136,6 +163,7 @@ def humanize_changes(data: dict[str, Any]) -> list[dict[str, Any]]:
                 target += f' / stage "{stage_name}"'
             row["entity_key"] = f"SCENE: {scene_name}"
             row["operator_message"] = f'Synchronized scene "{scene_name}" to {target}.'
+            row["report_stage_id"] = scene.get("report_stage_id")
 
         elif entity_type == "SCENE_DISPLAY":
             match = re.search(r"display_id\s+(\d+)", str(row.get("operator_message") or ""))
@@ -148,6 +176,11 @@ def humanize_changes(data: dict[str, Any]) -> list[dict[str, Any]]:
             )
             row["entity_key"] = f"{display_key} -> SCENE: {scene_name}"
             row["operator_message"] = f'Synchronized display {display_key} to scene "{scene_name}".'
+            row["report_stage_id"] = scene.get("report_stage_id")
+
+        elif entity_type == "STAGE" and key.isdigit():
+            row["report_stage_id"] = stage_keys.get(key)
+            row["entity_key"] = f"{key}-{stages.get(key, 'Unknown stage')}"
 
         elif entity_type == "STAGE" and len(parts) >= 2:
             source_name = previews.get(parts[1]) if parts[0] == "PREVIEW" else None
@@ -161,9 +194,16 @@ def humanize_changes(data: dict[str, Any]) -> list[dict[str, Any]]:
                 f'Synchronized {parts[0].lower()} "{source_name or "Unnamed source"}" '
                 f'to stage "{stage_name}".'
             )
+            row["report_stage_id"] = scene.get("report_stage_id") if parts[0] == "SCENE" else None
 
         readable.append(row)
-    return readable
+    return sorted(
+        readable,
+        key=lambda item: stage_sort_key(item) + (
+            str(item.get("entity_type") or ""),
+            str(item.get("entity_key") or ""),
+        ),
+    )
 
 
 def table(columns: Sequence[tuple[str, str]], data: Iterable[dict[str, Any]], empty: str) -> str:
@@ -311,6 +351,18 @@ def collect_report_data(conn: Any, run_id: int) -> dict[str, Any]:
                    "After" AS after_name, "Follow-up" AS action_required
             FROM ops.f_lor_reconciliation_display_name_changes_report(%s)
         """, (run_id,))
+        display_evidence_rows = rows(cur, """
+            SELECT DISTINCT ON (c.display_id)
+                   c.display_id, c.changed_fields,
+                   c.current_display_name, c.proposed_display_name,
+                   c.current_stage_id, c.proposed_stage_id,
+                   c.proposed_stage_key
+            FROM ops.lor_reconciliation_display_candidate AS c
+            WHERE c.lor_reconciliation_run_id = %s
+              AND c.display_id IS NOT NULL
+            ORDER BY c.display_id,
+                     c.lor_reconciliation_display_candidate_id DESC
+        """, (run_id,))
         problems = rows(cur, """
             /* Current problems come from effective state, not historical flags. */
             SELECT gr.entity_type, gr.logical_group_key AS entity_key,
@@ -351,7 +403,7 @@ def collect_report_data(conn: Any, run_id: int) -> dict[str, Any]:
             ORDER BY recorded_at, lor_reconciliation_result_id
         """, (run_id,))
         display_rows = rows(cur, "SELECT display_id, display_name FROM ref.display", ())
-        stage_rows = rows(cur, "SELECT stage_id, stage_name FROM ref.stage", ())
+        stage_rows = rows(cur, "SELECT stage_id, stage_key, stage_name FROM ref.stage", ())
         scene_rows = rows(cur, """
             SELECT s.preview_id, s.scene_id, s.scene_name, p.preview_name,
                    p.stage_id AS preview_stage_id,
@@ -379,6 +431,10 @@ def collect_report_data(conn: Any, run_id: int) -> dict[str, Any]:
             "validations": validations,
             "display_names": {str(x["display_id"]): x["display_name"] for x in display_rows},
             "stage_names": {str(x["stage_id"]): x["stage_name"] for x in stage_rows},
+            "stage_keys": {str(x["stage_id"]): x["stage_key"] for x in stage_rows},
+            "display_change_evidence": {
+                str(x["display_id"]): x for x in display_evidence_rows
+            },
             "preview_names": {str(x["preview_id"]): x["preview_name"] for x in previews},
             "scene_names": {(str(x["preview_id"]), str(x["scene_id"])): x for x in scene_rows}}
 
@@ -420,15 +476,6 @@ def render_report(data: dict[str, Any], generated_at: datetime) -> str:
         row for row in scene_backgrounds
         if str(row.get("background_file") or "").strip()
     ]
-    missing_backgrounds = [
-        {
-            "report_stage_id": row.get("report_stage_id"),
-            "preview_name": row.get("preview_name"),
-            "scene_name": row.get("scene_name"),
-        }
-        for row in scene_backgrounds
-        if not str(row.get("background_file") or "").strip()
-    ]
     coverage = (
         f'<h3>Scene background coverage</h3>'
         f'<p><strong>{len(assigned_backgrounds)} of {len(scene_backgrounds)} Scenes</strong> '
@@ -437,18 +484,34 @@ def render_report(data: dict[str, Any], generated_at: datetime) -> str:
         + table([
             ("report_stage_id", "Stage"),
             ("preview_name", "Preview name"),
-            ("scene_name", "Scene without an assigned background"),
-        ], missing_backgrounds, "Every captured Scene has an assigned background file.")
+            ("scene_name", "Scene"),
+            ("background_file", "Background file"),
+        ], scene_backgrounds, "No captured Scene rows were recorded.")
     )
     manifest = f'<p><strong>Source folder:</strong> {html.escape(display(r["source_preview_folder"]))}</p>' + table([
         ("source_filename", "Preview filename"), ("preview_revision", "Revision"),
         ("preview_name", "Preview name"), ("stage_id", "Stage"),
         ("brightness", "Brightness"),
     ], previews, "No frozen preview manifest rows were recorded.") + coverage
+    name_rows = []
+    for source in data["names"]:
+        row = dict(source)
+        evidence = data.get("display_change_evidence", {}).get(
+            str(row.get("display_id")), {}
+        )
+        row["report_stage_id"] = (
+            evidence.get("proposed_stage_key")
+            or data.get("stage_keys", {}).get(
+                str(evidence.get("current_stage_id") or "")
+            )
+        )
+        name_rows.append(row)
+    name_rows.sort(key=stage_sort_key)
     name_table = table([
+        ("report_stage_id", "Stage"),
         ("display_id", "Display_id"), ("before_name", "Before"),
         ("after_name", "After"), ("action_required", "Action Required"),
-    ], data["names"], "No display-name changes were committed.")
+    ], name_rows, "No display-name changes were committed.")
     changed_name_ids = {str(n["display_id"]) for n in data["names"]}
     other_change_data = dict(data)
     other_change_data["changes"] = [x for x in data["changes"] if not (
@@ -456,8 +519,11 @@ def render_report(data: dict[str, Any], generated_at: datetime) -> str:
     )]
     readable_changes = humanize_changes(other_change_data)
     other_changes = table([
+        ("report_stage_id", "Stage"),
         ("entity_type", "Object"), ("entity_key", "Permanent key"),
         ("result_class", "Change"), ("reason_code", "Reason"),
+        ("changed_fields_display", "Fields changed"),
+        ("before_after", "Before -> After"),
         ("operator_message", "Detail"),
     ], readable_changes, "No other production changes were committed.")
     changes_body = '<h3>Display Name Changes</h3>' + name_table + '<h3>Other Changes</h3>' + other_changes

--- a/LOR2DB/03_Reporting/test_publish_lor_reconciliation_report.py
+++ b/LOR2DB/03_Reporting/test_publish_lor_reconciliation_report.py
@@ -72,7 +72,8 @@ class ReportRenderingTests(unittest.TestCase):
             }],
             "changes": [], "names": [], "problems": [],
             "display_names": {}, "preview_names": {"preview-uuid": "Stage 01"},
-            "stage_names": {}, "scene_names": {},
+            "stage_names": {}, "stage_keys": {}, "scene_names": {},
+            "display_change_evidence": {},
             "decisions": [],
             "validations": [{
                 "validation_check": "FINISH_POST_WRITE_VALIDATION_PASSED",
@@ -145,10 +146,10 @@ class ReportRenderingTests(unittest.TestCase):
         output = REPORT.render_report(self.base_data(), datetime.now(timezone.utc))
 
         self.assertIn("1 of 2 Scenes", output)
-        self.assertIn("Scene without an assigned background", output)
+        self.assertIn("Scene", output)
         self.assertIn("Scene without background", output)
-        self.assertNotIn("G:\\Backgrounds\\stage-01.jpg", output)
-        self.assertNotIn("<th>Background file</th>", output)
+        self.assertIn("G:\\Backgrounds\\stage-01.jpg", output)
+        self.assertIn("<th>Background file</th>", output)
 
     def test_changes_use_human_readable_display_and_scene_keys(self):
         data = self.base_data()
@@ -217,7 +218,32 @@ class ReportRenderingTests(unittest.TestCase):
                 REPORT.render_evaluation_copy(object(), 101, output_dir)
 
     def test_report_framework_version_identifies_evaluation_copy_release(self):
-        self.assertEqual(REPORT.REPORT_VERSION, "V0.5.2")
+        self.assertEqual(REPORT.REPORT_VERSION, "V0.6.0")
+
+    def test_changes_are_sorted_in_natural_stage_order_and_show_exact_fields(self):
+        data = self.base_data()
+        data["display_names"] = {"10": "Stage Ten", "2": "Stage Two"}
+        data["stage_keys"] = {"2": "02", "10": "10"}
+        data["display_change_evidence"] = {
+            "10": {"display_id": 10, "changed_fields": ["stage_id"],
+                   "current_stage_id": 2, "proposed_stage_key": "10"},
+            "2": {"display_id": 2, "changed_fields": ["string_type"],
+                  "current_stage_id": 2, "proposed_stage_key": "02"},
+        }
+        data["changes"] = [
+            {"entity_type": "DISPLAY", "entity_key": "10",
+             "result_class": "UPDATED", "reason_code": "P2_AUTO_APPROVED",
+             "operator_message": "ten", "recorded_at": None},
+            {"entity_type": "DISPLAY", "entity_key": "2",
+             "result_class": "UPDATED", "reason_code": "P2_AUTO_APPROVED",
+             "operator_message": "two", "recorded_at": None},
+        ]
+
+        output = REPORT.render_report(data, datetime.now(timezone.utc))
+
+        self.assertLess(output.index("2-Stage Two"), output.index("10-Stage Ten"))
+        self.assertIn("string_type", output)
+        self.assertIn("Stage 02 -&gt; Stage 10", output)
 
     def test_cancelled_report_is_terminal_and_has_no_required_actions(self):
         data = self.base_data()

--- a/LOR2DB/Application/test_distinct_substage_repair.py
+++ b/LOR2DB/Application/test_distinct_substage_repair.py
@@ -1,0 +1,79 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+MIGRATION = (
+    ROOT / "02_Reconciliation" / "reconciliation" / "migrations"
+    / "0035_repair_distinct_substages_and_protect_display_stage.sql"
+)
+VALIDATION = (
+    ROOT / "02_Reconciliation" / "reconciliation" / "validation"
+    / "30_distinct_substage_and_stage_assignment_validation.sql"
+)
+P1 = (
+    ROOT / "02_Reconciliation" / "reconciliation" / "current_procedures"
+    / "P1_stage_promotion.sql"
+)
+P2 = (
+    ROOT / "02_Reconciliation" / "reconciliation" / "current_procedures"
+    / "P2_display_promotion.sql"
+)
+
+
+class DistinctSubstageRepairTests(unittest.TestCase):
+    def test_true_rename_requires_one_source_key(self):
+        source = MIGRATION.read_text(encoding="utf-8")
+        approve = source.split(
+            "CREATE OR REPLACE FUNCTION ops.f_stage_group_can_approve_change", 1
+        )[1].split(
+            "CREATE OR REPLACE FUNCTION ops.f_stage_group_new_stage_key", 1
+        )[0]
+        self.assertIn("count(DISTINCT c.source_stage_key) = 1", approve)
+
+    def test_new_substage_target_excludes_the_current_stage_key(self):
+        source = MIGRATION.read_text(encoding="utf-8")
+        target = source.split(
+            "CREATE OR REPLACE FUNCTION ops.f_stage_group_new_stage_key", 1
+        )[1].split(
+            "CREATE OR REPLACE FUNCTION ops.f_stage_group_can_add_new_stage", 1
+        )[0]
+        self.assertIn("count(DISTINCT source_stage_key) = 2", target)
+        self.assertIn(
+            "source_stage_key IS DISTINCT FROM resolved_stage_key", target
+        )
+
+    def test_repair_is_exact_and_does_not_rewrite_snapshot_evidence(self):
+        source = MIGRATION.read_text(encoding="utf-8")
+        repair = source.split("DO $repair$", 1)[1]
+        self.assertIn("v_restored_count <> 50", repair)
+        self.assertIn("stage_lor_binding_id = 142", repair)
+        self.assertIn("stage_lor_binding_id = 143", repair)
+        self.assertNotIn("UPDATE lor_snap.", repair)
+        self.assertNotIn("UPDATE ops.lor_reconciliation_stage_candidate", repair)
+        self.assertNotIn("UPDATE ops.lor_reconciliation_display_candidate", repair)
+
+    def test_p1_moves_only_the_target_source_key(self):
+        source = P1.read_text(encoding="utf-8")
+        self.assertIn("c.source_stage_key = v_group.stage_key", source)
+        self.assertIn("accepted_source_stage_key", source)
+
+    def test_p2_resolves_stage_by_key_and_rejects_null_resolution(self):
+        source = P2.read_text(encoding="utf-8")
+        self.assertIn("AS effective_stage_id", source)
+        self.assertIn("stage_by_key.stage_key", source)
+        self.assertIn(
+            "P2 cannot resolve one or more approved source StageIDs", source
+        )
+        self.assertNotIn("stage_id = v_row.proposed_stage_id", source)
+
+    def test_validation_checks_frozen_keys_and_repaired_assignments(self):
+        source = VALIDATION.read_text(encoding="utf-8")
+        self.assertIn("source_stage_key = '05'", source)
+        self.assertIn("source_stage_key = '05a'", source)
+        self.assertIn("display_id = 869", source)
+        self.assertNotIn("UPDATE ", source.upper())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Repairs the Stage 05 / 05a production corruption by restoring permanent Stage 05, creating a distinct permanent Stage 05a, restoring the 50 Stage 05 display assignments, and moving only the Mega Star binding/display to 05a.
- Preserves `lor_snap` and the frozen evidence for reconciliation runs 7 and 8.
- Generalizes the rule for `NN` / `NNa` substages so mixed source keys create distinct stages; only unanimous evidence can authorize a true stage-key rename.
- Prevents P2 from clearing unchanged stage assignments and resolves approved stage targets dynamically.
- Updates the reconciliation report to show scene background paths, sort in stage order, and report only fields that actually changed.
- Updates operator and engineering documentation.

## Root cause

The prior stage-authority procedure treated mixed source keys such as `05` and `05a` as one canonical stage rename. Frozen proposed stage IDs then allowed P2 to clear 50 valid Stage 05 assignments.

## Validation

- 37 relevant unit tests passed.
- GitHub branch comparison matches the exact 10-file diff from local commit `d927ab9`.
- Includes migration `0035_repair_distinct_substages_and_protect_display_stage.sql` and validation `30_distinct_substage_and_stage_assignment_validation.sql`.

## Deployment note

Apply migration 0035 and run validation 30. Per operator direction, no backup step is included for the already-corrupted database.