### PR TITLE
Complete Stage 05a permanent Scene repair

### DIFF
--- a/LOR2DB/02_Reconciliation/reconciliation/README.md
+++ b/LOR2DB/02_Reconciliation/reconciliation/README.md
@@ -11,8 +11,8 @@ change, or merely reports evidence.
 | Path | Contents | Execution rule |
 |---|---|---|
 | `current_procedures/` | Canonical standalone P1, P2, P3, and P4 definitions matching the latest accepted migration chain | Inspection or explicitly authorized repair only; these files do not call promotion |
-| `migrations/` | Immutable installation history `0011` through `0035` | Run only the specifically authorized next migration; never rerun the folder as a batch |
-| `validation/` | Validation `10` through `30` | Follow each file's header; several are transaction-wrapped rollback tests |
+| `migrations/` | Immutable installation history `0011` through `0036` | Run only the specifically authorized next migration; never rerun the folder as a batch |
+| `validation/` | Validation `10` through `31` | Follow each file's header; several are transaction-wrapped rollback tests |
 | `operator_queries/preflight/` | Read-only latest-ingest reports `01` through `09` | Run individually; no operator-supplied `import_run_id` |
 | `incidents/` | Production incident report and its incident-specific forensic SQL | Historical evidence; not part of routine reconciliation |
 
@@ -67,7 +67,7 @@ is retained only as incident evidence. It is not step 8A of the normal workflow.
 
 ## Migration and validation status
 
-The current installation chain is `0011` through `0035`.
+The current installation chain is `0011` through `0036`.
 Migration `0029` must be revision
 `2026-08-05-true-noop-reconciliation-writes-v4`; its corresponding validation
 is `validation/25_true_noop_reconciliation_write_validation.sql`. Migration
@@ -89,6 +89,10 @@ simultaneous source keys such as `NN` and `NNa` are distinct permanent stages,
 not a rename of one stage. It also prevents P2 from clearing a production
 `stage_id` when a source key cannot be resolved. Validate it with
 `validation/30_distinct_substage_and_stage_assignment_validation.sql`.
+Migration `0036` completes the incident repair by moving the existing Mega Star
+permanent Scene from Stage 05 to the distinct Stage 05a identity. It changes no
+snapshot or frozen reconciliation evidence and is paired with
+`validation/31_complete_stage05a_scene_repair_validation.sql`.
 
 Do not infer that a numbered validation is harmless from its filename alone.
 Read its header. In particular,

--- a/LOR2DB/02_Reconciliation/reconciliation/migrations/0036_complete_stage05a_scene_repair.sql
+++ b/LOR2DB/02_Reconciliation/reconciliation/migrations/0036_complete_stage05a_scene_repair.sql
@@ -1,0 +1,117 @@
+/* ============================================================================
+Migration: 0036_complete_stage05a_scene_repair.sql
+
+Purpose:
+  Complete the Stage 05/05a production-reference repair begun by migration
+  0035.  Migration 0035 separated the permanent stages, binding, and display,
+  but left the already-existing Mega Star ref.lor_scene row assigned to Stage
+  05.  This guarded follow-up moves only that permanent Scene to Stage 05a.
+
+Safety:
+  - The repair accepts only the exact known Stage, binding, display, and Scene
+    identities.
+  - It is idempotent when the Scene is already assigned to Stage 05a.
+  - Captured lor_snap data and frozen reconciliation evidence are untouched.
+============================================================================ */
+
+BEGIN;
+
+DO $repair$
+DECLARE
+    v_stage_05 integer;
+    v_stage_05a integer;
+    v_current_scene_stage integer;
+    v_updated_count integer;
+BEGIN
+    SELECT s.stage_id INTO STRICT v_stage_05
+    FROM ref.stage AS s
+    WHERE s.stage_id = 35
+      AND s.stage_key = '05'
+      AND s.stage_name = 'RGB Plus Stage 05 Festive Trees Traditional'
+      AND s.folder_name = '05-RGB Plus Stage 05 Festive Trees Traditional'
+      AND s.park_order = 5
+      AND s.sub_order = 0;
+
+    SELECT s.stage_id INTO STRICT v_stage_05a
+    FROM ref.stage AS s
+    WHERE s.stage_key = '05a'
+      AND s.stage_name = 'RGB Plus Stage 05a Mega Star'
+      AND s.folder_name = '05a-RGB Plus Stage 05a Mega Star'
+      AND s.park_order = 5
+      AND s.sub_order = 1;
+
+    IF v_stage_05 = v_stage_05a THEN
+        RAISE EXCEPTION 'Stage 05 and 05a do not have distinct permanent identities';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM ref.stage_lor_binding AS b
+        WHERE b.stage_lor_binding_id = 143
+          AND b.stage_id = v_stage_05a
+          AND b.binding_type = 'SCENE'
+          AND b.preview_id = 'fcf5c29c-8d51-46c5-9ad0-cc47a97c75bd'
+          AND b.scene_id = 'd57761f7-3527-4b00-a8ce-2eeb70eb3d8c'
+          AND b.accepted_source_stage_key = '05a'
+    ) THEN
+        RAISE EXCEPTION 'Stage 05a Scene binding does not match the repaired incident identity';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM ref.display AS d
+        WHERE d.display_id = 869
+          AND d.display_name = 'FT-MegaStar'
+          AND d.stage_id = v_stage_05a
+    ) THEN
+        RAISE EXCEPTION 'FT-MegaStar is not assigned to the repaired Stage 05a identity';
+    END IF;
+
+    SELECT ls.stage_id INTO STRICT v_current_scene_stage
+    FROM ref.lor_scene AS ls
+    WHERE ls.preview_uuid = 'fcf5c29c-8d51-46c5-9ad0-cc47a97c75bd'
+      AND ls.scene_uuid = 'd57761f7-3527-4b00-a8ce-2eeb70eb3d8c'
+      AND ls.scene_name = '05a-Mega Star-MS';
+
+    IF v_current_scene_stage = v_stage_05a THEN
+        RAISE NOTICE 'Stage 05a permanent Scene repair is already present; repair skipped';
+        RETURN;
+    END IF;
+
+    IF v_current_scene_stage <> v_stage_05 THEN
+        RAISE EXCEPTION
+            'Stage 05a Scene repair guard failed: current stage_id is %, expected %',
+            v_current_scene_stage, v_stage_05;
+    END IF;
+
+    UPDATE ref.lor_scene AS ls
+       SET stage_id = v_stage_05a,
+           updated_at = now(),
+           updated_by = current_user
+     WHERE ls.preview_uuid = 'fcf5c29c-8d51-46c5-9ad0-cc47a97c75bd'
+       AND ls.scene_uuid = 'd57761f7-3527-4b00-a8ce-2eeb70eb3d8c'
+       AND ls.scene_name = '05a-Mega Star-MS'
+       AND ls.stage_id = v_stage_05;
+
+    GET DIAGNOSTICS v_updated_count = ROW_COUNT;
+    IF v_updated_count <> 1 THEN
+        RAISE EXCEPTION
+            'Stage 05a Scene repair changed % rows, expected exactly 1',
+            v_updated_count;
+    END IF;
+END;
+$repair$;
+
+COMMIT;
+
+SELECT
+    '2026-08-17-complete-stage05a-scene-repair-v1'::text
+        AS installed_revision,
+    s.stage_id AS stage_05a_id,
+    ls.lor_scene_id,
+    ls.scene_name
+FROM ref.lor_scene AS ls
+JOIN ref.stage AS s ON s.stage_id = ls.stage_id
+WHERE ls.preview_uuid = 'fcf5c29c-8d51-46c5-9ad0-cc47a97c75bd'
+  AND ls.scene_uuid = 'd57761f7-3527-4b00-a8ce-2eeb70eb3d8c'
+  AND s.stage_key = '05a';

--- a/LOR2DB/02_Reconciliation/reconciliation/validation/31_complete_stage05a_scene_repair_validation.sql
+++ b/LOR2DB/02_Reconciliation/reconciliation/validation/31_complete_stage05a_scene_repair_validation.sql
@@ -1,0 +1,77 @@
+/* ============================================================================
+Validation: Complete Stage 05a Scene repair
+
+Safety: Read-only.  This script changes no production or audit data.
+============================================================================ */
+
+DO $validation$
+DECLARE
+    v_stage_05 integer;
+    v_stage_05a integer;
+BEGIN
+    SELECT s.stage_id INTO STRICT v_stage_05
+    FROM ref.stage AS s
+    WHERE s.stage_id = 35
+      AND s.stage_key = '05';
+
+    SELECT s.stage_id INTO STRICT v_stage_05a
+    FROM ref.stage AS s
+    WHERE s.stage_key = '05a'
+      AND s.stage_name = 'RGB Plus Stage 05a Mega Star'
+      AND s.folder_name = '05a-RGB Plus Stage 05a Mega Star'
+      AND s.park_order = 5
+      AND s.sub_order = 1;
+
+    IF v_stage_05 = v_stage_05a THEN
+        RAISE EXCEPTION 'Stage 05 and 05a do not have distinct permanent identities';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM ref.stage_lor_binding AS b
+        WHERE b.stage_lor_binding_id = 143
+          AND b.stage_id = v_stage_05a
+          AND b.scene_id = 'd57761f7-3527-4b00-a8ce-2eeb70eb3d8c'
+          AND b.accepted_source_stage_key = '05a'
+    ) THEN
+        RAISE EXCEPTION 'Stage 05a binding is not assigned to the permanent Stage 05a identity';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM ref.display AS d
+        WHERE d.display_id = 869
+          AND d.display_name = 'FT-MegaStar'
+          AND d.stage_id = v_stage_05a
+    ) THEN
+        RAISE EXCEPTION 'FT-MegaStar is not assigned to permanent Stage 05a';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM ref.lor_scene AS ls
+        WHERE ls.preview_uuid = 'fcf5c29c-8d51-46c5-9ad0-cc47a97c75bd'
+          AND ls.scene_uuid = 'd57761f7-3527-4b00-a8ce-2eeb70eb3d8c'
+          AND ls.scene_name = '05a-Mega Star-MS'
+          AND ls.stage_id = v_stage_05a
+    ) THEN
+        RAISE EXCEPTION 'Mega Star permanent Scene is not assigned to Stage 05a';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM ref.lor_scene AS ls
+        WHERE ls.preview_uuid = 'fcf5c29c-8d51-46c5-9ad0-cc47a97c75bd'
+          AND ls.scene_uuid = 'd4eeafb3-c355-44df-ab9e-e7566b29e0e7'
+          AND ls.scene_name = '05-Festive Trees-FT'
+          AND ls.stage_id = v_stage_05
+    ) THEN
+        RAISE EXCEPTION 'Festive Trees permanent Scene is not preserved on Stage 05';
+    END IF;
+END;
+$validation$;
+
+SELECT
+    'PASS'::text AS validation_status,
+    'Stage 05a binding, display, and permanent Scene share one distinct stage identity; Stage 05 remains separate.'::text
+        AS validation_detail;

--- a/LOR2DB/Application/test_distinct_substage_repair.py
+++ b/LOR2DB/Application/test_distinct_substage_repair.py
@@ -11,6 +11,14 @@ VALIDATION = (
     ROOT / "02_Reconciliation" / "reconciliation" / "validation"
     / "30_distinct_substage_and_stage_assignment_validation.sql"
 )
+FOLLOWUP_MIGRATION = (
+    ROOT / "02_Reconciliation" / "reconciliation" / "migrations"
+    / "0036_complete_stage05a_scene_repair.sql"
+)
+FOLLOWUP_VALIDATION = (
+    ROOT / "02_Reconciliation" / "reconciliation" / "validation"
+    / "31_complete_stage05a_scene_repair_validation.sql"
+)
 P1 = (
     ROOT / "02_Reconciliation" / "reconciliation" / "current_procedures"
     / "P1_stage_promotion.sql"
@@ -72,6 +80,23 @@ class DistinctSubstageRepairTests(unittest.TestCase):
         self.assertIn("source_stage_key = '05'", source)
         self.assertIn("source_stage_key = '05a'", source)
         self.assertIn("display_id = 869", source)
+        self.assertNotIn("UPDATE ", source.upper())
+
+    def test_followup_moves_only_the_exact_permanent_scene(self):
+        source = FOLLOWUP_MIGRATION.read_text(encoding="utf-8")
+        repair = source.split("DO $repair$", 1)[1]
+        self.assertIn("UPDATE ref.lor_scene", repair)
+        self.assertIn("d57761f7-3527-4b00-a8ce-2eeb70eb3d8c", repair)
+        self.assertIn("05a-Mega Star-MS", repair)
+        self.assertIn("v_updated_count <> 1", repair)
+        self.assertNotIn("UPDATE lor_snap.", repair)
+        self.assertNotIn("UPDATE ops.lor_reconciliation_", repair)
+
+    def test_followup_validation_checks_scene_and_remains_read_only(self):
+        source = FOLLOWUP_VALIDATION.read_text(encoding="utf-8")
+        self.assertIn("FROM ref.lor_scene", source)
+        self.assertIn("ls.stage_id = v_stage_05a", source)
+        self.assertIn("ls.stage_id = v_stage_05", source)
         self.assertNotIn("UPDATE ", source.upper())
 
 


### PR DESCRIPTION
## What changed

- Adds guarded migration `0036` to move the existing Mega Star permanent Scene from Stage 05 to the distinct Stage 05a identity.
- Adds read-only validation `31` confirming the Stage 05a binding, display, and Scene share one permanent stage while the Festive Trees Scene remains on Stage 05.
- Updates reconciliation migration documentation and targeted tests.

## Why

Migration `0035` correctly separated Stages `05` and `05a`, moved binding `143`, restored the 50 Stage 05 displays, and assigned `FT-MegaStar` to Stage 05a. Run 9 preflight then proved that `ref.lor_scene` for `05a-Mega Star-MS` still referenced Stage 05. Letting Run 9 apply that delayed repair would misattribute an incident repair to an unchanged reconciliation.

## Safety

The migration accepts only the exact known Stage, binding, display, preview, Scene, and current-stage identities. It changes exactly one `ref.lor_scene` row, is idempotent after repair, and does not rewrite `lor_snap` or frozen reconciliation candidates.

## Validation

- 43 dependency-complete application/reporting tests passed.
- All four published files were compared byte-for-byte with the local correction.
- Branch comparison: four intended files only; zero commits behind `main`.