### PR TITLE
Fix restricted report evidence access

### DIFF
--- a/LOR2DB/03_Reporting/README.md
+++ b/LOR2DB/03_Reporting/README.md
@@ -13,10 +13,12 @@ The LOR2DB Reporting subsystem provides permanent reconciliation reports for eac
 
 Cloudflare authentication is required to access the LOR2DB application and published reconciliation report archive.
 
-Report framework V0.6.0 lists every captured Scene-level background path,
+Report framework V0.6.1 lists every captured Scene-level background path,
 sorts manifests and committed changes by natural Stage order (`05`, `05a`,
 `06`, ...), and shows the exact frozen fields changed by automatic display
-promotion. Evaluated no-op rows do not appear as production changes.
+promotion. Evaluated no-op rows do not appear as production changes. The
+publisher reads that evidence through the restricted operator-review view and
+does not require direct access to internal candidate tables.
 
 ---
 

--- a/LOR2DB/03_Reporting/publish_lor_reconciliation_report.py
+++ b/LOR2DB/03_Reporting/publish_lor_reconciliation_report.py
@@ -3,7 +3,7 @@ MSB Database - LOR Reconciliation Report Publisher
 publish_lor_reconciliation_report.py
 
 Initial Release : 2026-08-03  V0.1.0
-Current Version : 2026-08-17  V0.6.0
+Current Version : 2026-08-17  V0.6.1
 Author          : GAL / OpenAI
 
 Purpose:
@@ -21,6 +21,10 @@ Operation:
       revised without changing the production audit row.
 
 Revision History:
+    2026-08-17  GAL / OpenAI  V0.6.1
+        Read display-change evidence through the approved restricted review
+        view instead of requiring direct candidate-table access.
+
     2026-08-17  GAL / OpenAI  V0.6.0
         Show every captured Scene background path, sort production changes in
         natural Stage order, and expose the exact frozen fields changed by P2.
@@ -60,7 +64,7 @@ from pathlib import Path
 from typing import Any, Iterable, Sequence
 
 
-REPORT_VERSION = "V0.6.0"
+REPORT_VERSION = "V0.6.1"
 DEFAULT_OUTPUT_DIR = r"\\192.168.5.4\web\my\lor2db\reports"
 REPORT_FILENAME = re.compile(
     r"^lor-reconciliation-(?P<stamp>\d{8}-\d{6})-run-(?P<run>\d+)"
@@ -134,15 +138,13 @@ def humanize_changes(data: dict[str, Any]) -> list[dict[str, Any]]:
             evidence = display_evidence.get(key, {})
             row["report_stage_id"] = (
                 evidence.get("proposed_stage_key")
-                or stage_keys.get(str(evidence.get("current_stage_id") or ""))
+                or evidence.get("current_stage_key")
             )
             row["changed_fields_display"] = display(
                 evidence.get("changed_fields") or []
             )
             if "stage_id" in (evidence.get("changed_fields") or []):
-                before_key = stage_keys.get(
-                    str(evidence.get("current_stage_id") or ""), "Unassigned"
-                )
+                before_key = evidence.get("current_stage_key") or "Unassigned"
                 after_key = evidence.get("proposed_stage_key") or "Unassigned"
                 row["before_after"] = f"Stage {before_key} -> Stage {after_key}"
             elif "display_name" in (evidence.get("changed_fields") or []):
@@ -355,9 +357,9 @@ def collect_report_data(conn: Any, run_id: int) -> dict[str, Any]:
             SELECT DISTINCT ON (c.display_id)
                    c.display_id, c.changed_fields,
                    c.current_display_name, c.proposed_display_name,
-                   c.current_stage_id, c.proposed_stage_id,
+                   c.current_stage_key,
                    c.proposed_stage_key
-            FROM ops.lor_reconciliation_display_candidate AS c
+            FROM ops.v_lor_reconciliation_operator_display_review AS c
             WHERE c.lor_reconciliation_run_id = %s
               AND c.display_id IS NOT NULL
             ORDER BY c.display_id,
@@ -501,9 +503,7 @@ def render_report(data: dict[str, Any], generated_at: datetime) -> str:
         )
         row["report_stage_id"] = (
             evidence.get("proposed_stage_key")
-            or data.get("stage_keys", {}).get(
-                str(evidence.get("current_stage_id") or "")
-            )
+            or evidence.get("current_stage_key")
         )
         name_rows.append(row)
     name_rows.sort(key=stage_sort_key)

--- a/LOR2DB/03_Reporting/test_publish_lor_reconciliation_report.py
+++ b/LOR2DB/03_Reporting/test_publish_lor_reconciliation_report.py
@@ -187,6 +187,17 @@ class ReportRenderingTests(unittest.TestCase):
         self.assertIn("effective_resolution_state", problem_query)
         self.assertNotIn("is_blocking", problem_query)
 
+    def test_display_evidence_uses_restricted_review_view(self):
+        source = MODULE_PATH.read_text(encoding="utf-8")
+        evidence_query = source.split("display_evidence_rows = rows(cur,", 1)[1].split(
+            "problems = rows(cur,", 1
+        )[0]
+
+        self.assertIn(
+            "ops.v_lor_reconciliation_operator_display_review", evidence_query
+        )
+        self.assertNotIn("ops.lor_reconciliation_display_candidate", evidence_query)
+
     def test_evaluation_copy_renders_completed_run_without_database_write(self):
         data = self.base_data()
         data["run"]["status"] = "COMPLETED"
@@ -218,7 +229,7 @@ class ReportRenderingTests(unittest.TestCase):
                 REPORT.render_evaluation_copy(object(), 101, output_dir)
 
     def test_report_framework_version_identifies_evaluation_copy_release(self):
-        self.assertEqual(REPORT.REPORT_VERSION, "V0.6.0")
+        self.assertEqual(REPORT.REPORT_VERSION, "V0.6.1")
 
     def test_changes_are_sorted_in_natural_stage_order_and_show_exact_fields(self):
         data = self.base_data()
@@ -226,9 +237,9 @@ class ReportRenderingTests(unittest.TestCase):
         data["stage_keys"] = {"2": "02", "10": "10"}
         data["display_change_evidence"] = {
             "10": {"display_id": 10, "changed_fields": ["stage_id"],
-                   "current_stage_id": 2, "proposed_stage_key": "10"},
+                   "current_stage_key": "02", "proposed_stage_key": "10"},
             "2": {"display_id": 2, "changed_fields": ["string_type"],
-                  "current_stage_id": 2, "proposed_stage_key": "02"},
+                  "current_stage_key": "02", "proposed_stage_key": "02"},
         }
         data["changes"] = [
             {"entity_type": "DISPLAY", "entity_key": "10",


### PR DESCRIPTION
## What changed

- Updates the reconciliation report publisher to read display-change evidence through `ops.v_lor_reconciliation_operator_display_review`.
- Removes the V0.6.0 direct read of the internal `ops.lor_reconciliation_display_candidate` table.
- Releases report framework V0.6.1 and adds a regression test for the least-privilege query boundary.

## Root cause

V0.6.0 added exact display-change reporting using a direct candidate-table query. The production publisher runs as restricted role `lor_preflight_app`, which intentionally has access to approved review views but not internal candidate tables. Run 9 completed its database lifecycle and then correctly stopped in `REPORTING` when publication received `permission denied`.

## Impact and recovery

This is report-only. Finish and P1-P4 already completed and will not rerun. After V0.6.1 is deployed, the existing **Retry report publication** action will publish Run 9 and transition it to its terminal status.

## Validation

- 44 relevant application/reporting tests passed.
- All three published files match the local correction exactly.
- Branch comparison contains only the intended three report files and is zero commits behind `main`.