### PR TITLE
Reconcile Preview Authoring operator docs and documentation governance

### DIFF
--- a/Docs/00_Project_Overview/01-Google_Drive_Document_Organization_Procedure.md
+++ b/Docs/00_Project_Overview/01-Google_Drive_Document_Organization_Procedure.md
@@ -111,10 +111,10 @@ Future Procedure paths require markers on:
 Procedures
 Procedures\Inspection
 Procedures\Setup
+Procedures\Setup\images
 Procedures\Takedown
+Procedures\Takedown\images
 ```
-
-If the future Procedure application directly reads another folder such as `Procedures\Setup\images`, that folder must be marked before it becomes part of the application path.
 
 `SourceDocs` and `Archive` are excluded working/history areas and are not normal field-application marker targets.
 
@@ -132,7 +132,9 @@ Stage / Scene root                    <- marked structural scope
 ├── Procedures/                       <- marked application path
 │   ├── Inspection/                   <- marked application branch
 │   ├── Setup/                        <- marked application branch
+│   │   └── images/                   <- marked procedure-image branch
 │   └── Takedown/                     <- marked application branch
+│       └── images/                   <- marked procedure-image branch
 ├── Wiring/                           <- marked application path
 │   ├── BackgroundStage/              <- marked published branch
 │   └── MusicalStage/                 <- marked published branch
@@ -335,11 +337,11 @@ Example target state:
             Front Entrance Setup.pdf
 ```
 
-The Stage/Sub-stage/Scene root, `Procedures`, and `Setup` folders are part of the future Procedure application path and must carry their required markers.
+The Stage/Sub-stage/Scene root, `Procedures`, `Setup`, and `Setup\images` folders are part of the future Procedure application path and must carry their required markers.
 
 `Archive` contains superseded or historical source material and must not be treated as current field authority.
 
-`images` contains image assets used by the Setup instructions. If the future Procedure application reads this folder directly, it must be marked before application use.
+`images` contains image assets used by the Setup instructions and is a required marked application folder.
 
 `SourceDocs` contains Setup working/source material and is not intended for direct field presentation.
 
@@ -365,6 +367,12 @@ For Setup, once the correct Stage, Sub-stage, or Scene is resolved, the applicat
 
 ```text
 <Stage, Sub-stage, or Scene>\Procedures\Setup
+```
+
+and the related current instruction images under:
+
+```text
+<Stage, Sub-stage, or Scene>\Procedures\Setup\images
 ```
 
 Every directory used in that application path must have the required marker before the application treats it as current field content.
@@ -403,7 +411,7 @@ The durable database/document-ID relationship is a separate engineering problem.
 10. Continue until the Stage/Sub-stage/Scene legacy material has been reconciled.
 11. Re-run Folder Alignment when a fresh snapshot of migration progress is needed.
 12. In the procedure-audit phase, process each archived legacy document through the controlled Setup Instruction template.
-13. After review/approval, publish the current field PDF in the applicable marked `Procedures\Setup` folder.
+13. After review/approval, publish the current field PDF in the applicable marked `Procedures\Setup` folder and keep its current images in the marked `Procedures\Setup\images` folder.
 14. Keep the superseded source in `Archive`.
 
 ---
@@ -454,7 +462,7 @@ FormView remains the fallback/reference while the browser-based FieldWiring syst
 
 1. Use the current Documentation Alignment Worklist as the migration roadmap.
 2. Keep the established Stage/Sub-stage/Scene folder structure and do not rename an aligned Stage/Sub-stage/Scene root during ordinary cleanup.
-3. Keep the required marker in every folder used by the new FieldWiring or future Procedure application path.
+3. Keep the required marker in every folder used by the new FieldWiring or future Procedure application path, including `Setup\images` and `Takedown\images`.
 4. Do not rename the controlled `PreviewBackground`, `Procedures`, `Wiring`, or task-branch folders used by the applications.
 5. Preserve loose files and unmarked legacy folders until they have been deliberately reviewed; applications must ignore them for current discovery.
 6. Treat `SourceDocs` and `Archive` as excluded working/history areas, not normal field-presentation folders.
@@ -464,11 +472,12 @@ FormView remains the fallback/reference while the browser-based FieldWiring syst
 10. Do not publish an archived legacy `.gdoc` as though it were the current field instruction.
 11. Audit and reformat the legacy procedure using the controlled Setup Instruction template before publishing a current version.
 12. Keep the current field PDF or other approved presentation directly available from the marked `Procedures\Setup` folder.
-13. Exclude `Archive` and `SourceDocs` material from normal field-user navigation.
-14. Do not delete useful historical engineering material merely to make the folder tree look clean.
-15. Do not assume every Display requires a Setup procedure.
-16. Do not assume every file in the legacy Setup repository is actually a procedure.
-17. When uncertain, preserve the material and flag it for review instead of guessing.
+13. Keep current Setup/Takedown instruction images in their marked task-local `images` folders.
+14. Exclude `Archive` and `SourceDocs` material from normal field-user navigation.
+15. Do not delete useful historical engineering material merely to make the folder tree look clean.
+16. Do not assume every Display requires a Setup procedure.
+17. Do not assume every file in the legacy Setup repository is actually a procedure.
+18. When uncertain, preserve the material and flag it for review instead of guessing.
 
 ---
 
@@ -477,7 +486,7 @@ FormView remains the fallback/reference while the browser-based FieldWiring syst
 The migration phase is progressing correctly when:
 
 - the current aligned Stage/Sub-stage/Scene folder names remain stable;
-- required markers are present throughout the controlled FieldWiring/Procedure application paths;
+- required markers are present throughout the controlled FieldWiring/Procedure application paths, including the task-local `images` folders;
 - applications can ignore unmarked legacy material and use only the controlled marked paths;
 - the unresolved central legacy Setup backlog becomes smaller;
 - reviewed legacy procedures appear under the correct Stage/Sub-stage/Scene `Procedures\Setup\Archive` folders;

--- a/Docs/00_Project_Overview/01-Google_Drive_Document_Organization_Procedure.md
+++ b/Docs/00_Project_Overview/01-Google_Drive_Document_Organization_Procedure.md
@@ -78,45 +78,72 @@ Images needed for `Setup` or `Takedown` must be placed in the `images` folder un
 
 `Procedures\Inspection` is intentionally unstructured.
 
-## Protected Names and the Database-Source Boundary
+## Protected Names and the Application Marker Path
 
 The current Stage, Sub-stage, and Scene folder names are part of the LOR/Production Database/Google Drive alignment. **Do not rename them during ordinary cleanup.** Renaming a current structured root can break stored LOR `BackgroundFile` pointers, database path evidence, and application resolution.
 
-The following helper-folder names are also protected because they are part of the application-facing contract:
-
-```text
-PreviewBackground
-Procedures
-Wiring
-```
-
-Do not rename those helper folders.
-
-Each active database/application source helper folder contains:
+The standard marker is:
 
 ```text
 _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
 ```
 
-The marker defines the current application-source boundary. For current database-backed discovery, **only content inside approved marked source folders is considered**. Loose files and unmarked legacy folders elsewhere under a Stage or Scene are not current application-source content merely because they are physically nearby.
+The current rule is:
+
+> **Every folder used by the new FieldWiring system or future Procedure system as part of its controlled application path must contain the marker.**
+
+This includes the Stage/Sub-stage/Scene root itself and the application-facing folders below it.
+
+Current FieldWiring paths require markers on:
+
+```text
+<Stage / Sub-stage / Scene root>
+Wiring
+Wiring\BackgroundStage
+Wiring\MusicalStage
+PreviewBackground   when used as a current LOR/application source
+```
+
+Future Procedure paths require markers on:
+
+```text
+<Stage / Sub-stage / Scene root>
+Procedures
+Procedures\Inspection
+Procedures\Setup
+Procedures\Takedown
+```
+
+If the future Procedure application directly reads another folder such as `Procedures\Setup\images`, that folder must be marked before it becomes part of the application path.
+
+`SourceDocs` and `Archive` are excluded working/history areas and are not normal field-application marker targets.
+
+`Photos` is general documentation and is not currently part of the FieldWiring/Procedure application path.
+
+The marker defines the controlled application path. Loose files and unmarked legacy folders elsewhere under a Stage or Scene are not current application content merely because they are physically nearby.
 
 This rule is intentionally compatible with gradual cleanup. Existing Stage and Scene folders contain many years of loose files, legacy folders, and other engineering material. Do not move, rename, or delete that material just to make the root look like the current scaffold. Preserve it until its purpose and correct destination are understood.
 
 Conceptually:
 
 ```text
-Stage / Scene root
-├── PreviewBackground/   <- marked current DB/application source
-├── Procedures/          <- marked current DB/application source
-├── Wiring/              <- marked current DB/application source
-├── Photos/              <- general documentation; not DB source currently
-├── legacy folder(s)     <- preserve; ignored by application discovery
-└── loose legacy files   <- preserve; ignored by application discovery
+Stage / Scene root                    <- marked structural scope
+├── PreviewBackground/                <- marked when used by application/LOR
+├── Procedures/                       <- marked application path
+│   ├── Inspection/                   <- marked application branch
+│   ├── Setup/                        <- marked application branch
+│   └── Takedown/                     <- marked application branch
+├── Wiring/                           <- marked application path
+│   ├── BackgroundStage/              <- marked published branch
+│   └── MusicalStage/                 <- marked published branch
+├── Photos/                           <- general documentation; not app source currently
+├── legacy folder(s)                  <- preserve; ignored by application discovery
+└── loose legacy files                <- preserve; ignored by application discovery
 ```
 
-As legacy material is reviewed, it may be deliberately moved into the appropriate marked source structure. Until then, applications must ignore it rather than guess based on filename, folder name, or proximity.
+As legacy material is reviewed, it may be deliberately moved into the appropriate marked structure. Until then, applications must ignore it rather than guess based on filename, folder name, or proximity.
 
-See [MSB Database Source Folder Marker — Operator Procedure](03-MSB_DB_Source_Folder_Marker_Operator_Procedure.md) for marker use, local notes, and the automated population utility.
+See [MSB Database Source Folder Marker — Operator Procedure](03-MSB_DB_Source_Folder_Marker_Operator_Procedure.md) for the current marker rule.
 
 ## When a Scene Should Be Used
 
@@ -184,7 +211,7 @@ A Display may exist directly under a Stage or under a Scene/Sub-stage. A Display
 
 Do not redesign the Stage/Sub-stage/Scene hierarchy while performing document cleanup.
 
-Not every LOR Display needs its own Google Drive folder, and not every Display needs its own Setup procedure. Shared Stage or Scene instructions should remain shared rather than being duplicated under every Display.
+Not every Display needs its own Setup procedure. Shared Stage or Scene instructions should remain shared rather than being duplicated under every Display.
 
 ---
 
@@ -308,9 +335,11 @@ Example target state:
             Front Entrance Setup.pdf
 ```
 
+The Stage/Sub-stage/Scene root, `Procedures`, and `Setup` folders are part of the future Procedure application path and must carry their required markers.
+
 `Archive` contains superseded or historical source material and must not be treated as current field authority.
 
-`images` contains image assets used by the Setup instructions.
+`images` contains image assets used by the Setup instructions. If the future Procedure application reads this folder directly, it must be marked before application use.
 
 `SourceDocs` contains Setup working/source material and is not intended for direct field presentation.
 
@@ -322,7 +351,7 @@ Do not delete the archived legacy Google Doc merely because a current PDF has be
 
 # Future Setup Application Discovery
 
-The Setup application should use the same general location-resolution principle already proven by FormView for Wiring:
+The Setup application should use the same general location-resolution principle already proven by the field-wiring work:
 
 ```text
 structured Stage / Sub-stage / Scene identity
@@ -338,7 +367,7 @@ For Setup, once the correct Stage, Sub-stage, or Scene is resolved, the applicat
 <Stage, Sub-stage, or Scene>\Procedures\Setup
 ```
 
-The `Procedures` source root must be an approved marked database-source folder before the application treats its content as current application-source material.
+Every directory used in that application path must have the required marker before the application treats it as current field content.
 
 Archive and SourceDocs content must be excluded from normal field presentation.
 
@@ -364,8 +393,8 @@ The durable database/document-ID relationship is a separate engineering problem.
 
 1. Run or open the current Documentation Alignment Worklist.
 2. Select one Stage and preserve its current aligned Stage folder name.
-3. Preserve the marked `PreviewBackground`, `Procedures`, and `Wiring` helper-folder names.
-4. Treat material outside the marked source folders as legacy/general engineering material unless and until it is deliberately aligned.
+3. Preserve the controlled Stage/Sub-stage/Scene structure and required application-path markers.
+4. Treat material outside the controlled marked application paths as legacy/general engineering material unless and until it is deliberately aligned.
 5. Review the remaining legacy Setup files reported from `000-Instructions\0 - Setup Procedures`.
 6. Human-review the legacy file and determine its correct Stage, Sub-stage, or Scene ownership.
 7. If ownership is understood, move the original legacy `.gdoc` into that Stage/Sub-stage/Scene `Procedures\Setup\Archive` folder.
@@ -374,7 +403,7 @@ The durable database/document-ID relationship is a separate engineering problem.
 10. Continue until the Stage/Sub-stage/Scene legacy material has been reconciled.
 11. Re-run Folder Alignment when a fresh snapshot of migration progress is needed.
 12. In the procedure-audit phase, process each archived legacy document through the controlled Setup Instruction template.
-13. After review/approval, publish the current field PDF in the applicable `Procedures\Setup` folder.
+13. After review/approval, publish the current field PDF in the applicable marked `Procedures\Setup` folder.
 14. Keep the superseded source in `Archive`.
 
 ---
@@ -411,9 +440,13 @@ Wiring\MusicalStage
 
 with working/source material under the corresponding `SourceDocs` location.
 
-The `Wiring` root is a protected marked database-source folder. Do not rename it. FieldWiring should consider published wiring only through the marked `Wiring` source structure and must ignore unrelated loose Stage/Scene files and unmarked legacy folders.
+The Stage/Sub-stage/Scene root, `Wiring`, and selected published `BackgroundStage` / `MusicalStage` branch are all part of the FieldWiring application path and must carry the required marker.
 
-The existing FormView architecture remains the precedent for resolving standardized field documentation from structured Stage/LOR context.
+`SourceDocs` remains excluded working/source material.
+
+FieldWiring must ignore unrelated loose Stage/Scene files and unmarked legacy folders.
+
+FormView remains the fallback/reference while the browser-based FieldWiring system completes deployment and field acceptance.
 
 ---
 
@@ -421,20 +454,21 @@ The existing FormView architecture remains the precedent for resolving standardi
 
 1. Use the current Documentation Alignment Worklist as the migration roadmap.
 2. Keep the established Stage/Sub-stage/Scene folder structure and do not rename an aligned Stage/Sub-stage/Scene root during ordinary cleanup.
-3. Do not rename the marked `PreviewBackground`, `Procedures`, or `Wiring` helper folders.
-4. Treat only approved marked source folders as current database/application source locations.
+3. Keep the required marker in every folder used by the new FieldWiring or future Procedure application path.
+4. Do not rename the controlled `PreviewBackground`, `Procedures`, `Wiring`, or task-branch folders used by the applications.
 5. Preserve loose files and unmarked legacy folders until they have been deliberately reviewed; applications must ignore them for current discovery.
-6. Treat the central `000-Instructions\0 - Setup Procedures` tree as the unresolved legacy backlog.
-7. A human-audited move into `Procedures\Setup\Archive` establishes the accepted Stage/Sub-stage/Scene ownership of that legacy document.
-8. Do not rely on fuzzy filename matching once the document has been human-assigned to an Archive location.
-9. Do not publish an archived legacy `.gdoc` as though it were the current field instruction.
-10. Audit and reformat the legacy procedure using the controlled Setup Instruction template before publishing a current version.
-11. Keep the current field PDF or other approved presentation directly available from `Procedures\Setup`.
-12. Exclude `Archive` and `SourceDocs` material from normal field-user navigation.
-13. Do not delete useful historical engineering material merely to make the folder tree look clean.
-14. Do not assume every Display requires a Setup procedure.
-15. Do not assume every file in the legacy Setup repository is actually a procedure.
-16. When uncertain, preserve the material and flag it for review instead of guessing.
+6. Treat `SourceDocs` and `Archive` as excluded working/history areas, not normal field-presentation folders.
+7. Treat the central `000-Instructions\0 - Setup Procedures` tree as the unresolved legacy backlog.
+8. A human-audited move into `Procedures\Setup\Archive` establishes the accepted Stage/Sub-stage/Scene ownership of that legacy document.
+9. Do not rely on fuzzy filename matching once the document has been human-assigned to an Archive location.
+10. Do not publish an archived legacy `.gdoc` as though it were the current field instruction.
+11. Audit and reformat the legacy procedure using the controlled Setup Instruction template before publishing a current version.
+12. Keep the current field PDF or other approved presentation directly available from the marked `Procedures\Setup` folder.
+13. Exclude `Archive` and `SourceDocs` material from normal field-user navigation.
+14. Do not delete useful historical engineering material merely to make the folder tree look clean.
+15. Do not assume every Display requires a Setup procedure.
+16. Do not assume every file in the legacy Setup repository is actually a procedure.
+17. When uncertain, preserve the material and flag it for review instead of guessing.
 
 ---
 
@@ -442,8 +476,9 @@ The existing FormView architecture remains the precedent for resolving standardi
 
 The migration phase is progressing correctly when:
 
-- the current aligned Stage/Sub-stage/Scene and marked source-folder names remain stable;
-- applications can ignore unmarked legacy material and use only the controlled marked source structure;
+- the current aligned Stage/Sub-stage/Scene folder names remain stable;
+- required markers are present throughout the controlled FieldWiring/Procedure application paths;
+- applications can ignore unmarked legacy material and use only the controlled marked paths;
 - the unresolved central legacy Setup backlog becomes smaller;
 - reviewed legacy procedures appear under the correct Stage/Sub-stage/Scene `Procedures\Setup\Archive` folders;
 - Folder Alignment can verify those human-audited locations without fuzzy ownership inference;
@@ -457,8 +492,10 @@ The end goal is simple: a volunteer should eventually be able to scan a Display 
 ## Related Documents
 
 - [Google Drive Folder Structure](00-Google_Drive.md) — engineering architecture and folder-location contract.
-- [MSB Database Source Folder Marker — Operator Procedure](03-MSB_DB_Source_Folder_Marker_Operator_Procedure.md) — identifies the current database/application source boundary inside existing Stage/Scene trees.
+- [Google Drive Path Resolution Contract](02-Google_Drive_Path_Resolution_Contract.md) — governing field-application folder/path/marker rules.
+- [MSB Database Source Folder Marker — Operator Procedure](03-MSB_DB_Source_Folder_Marker_Operator_Procedure.md) — marker placement for the controlled field-application paths.
 - [LOR System Documentation](../01_LOR_System/README.md) — LOR-side system documentation.
-- [FormView](../01_LOR_System/04_FormView/README.md) — proven field-wiring application and location-resolution precedent.
+- [FormView](../01_LOR_System/04_FormView/README.md) — fallback/reference field-wiring application.
+- [FieldWiring Engineering](../02_Production_Database/01_System_Architecture/09_Wiring_System/README.md) — current browser-based wiring system engineering handoff.
 - [Stage Setup Documentation Standard](../../System_Documentation/Project_Rules/Stage_Setup_Documentation_Standard.md) — governance for controlled field-facing Setup Instructions.
 - [Stage Setup Instruction Template](../../System_Documentation/Templates/Stage_Setup_Instruction_Template.md) — controlled draft formatting structure for current Setup Instructions.

--- a/Docs/00_Project_Overview/02-Google_Drive_Path_Resolution_Contract.md
+++ b/Docs/00_Project_Overview/02-Google_Drive_Path_Resolution_Contract.md
@@ -3,10 +3,10 @@
 | Document control | Value |
 |---|---|
 | Status | DRAFT — governing filesystem/path contract |
-| Current revision | 2026-08-17 |
+| Current revision | 2026-08-22 |
 | Owner | MSB Database Administrator |
 | Applies to | Folder Alignment, Field Context Resolution, FieldWiring, Setup, Takedown, Inspection, future field-document applications |
-| Code/schema status | Documentation only; no code or schema change authorized |
+| Code/schema status | Documentation contract; current FieldWiring release candidate does not yet enforce every required child-branch marker |
 
 ## Purpose
 
@@ -95,7 +95,61 @@ Display folders intentionally use a smaller standard structure:
 
 A Display does not automatically receive standardized `Wiring` or `Procedures` branches.
 
-Not every Display requires its own Google Drive folder, and not every Display requires its own `PreviewBackground` image.
+Not every Display requires its own `PreviewBackground` image.
+
+## Controlled Marker Path
+
+The standard marker is:
+
+```text
+_MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
+```
+
+The governing rule is:
+
+> **Every folder that FieldWiring or the future Procedure system uses as part of its controlled application path must contain the marker.**
+
+The marker therefore applies to both the structured scope and the application-facing branches below it.
+
+For current Stage/Sub-stage/Scene field-document paths, required marker locations include:
+
+```text
+<Stage / Sub-stage / Scene>\
+├── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
+│
+├── PreviewBackground\
+│   └── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
+│
+├── Procedures\
+│   ├── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
+│   ├── Inspection\
+│   │   └── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
+│   ├── Setup\
+│   │   └── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
+│   └── Takedown\
+│       └── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
+│
+└── Wiring\
+    ├── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
+    ├── BackgroundStage\
+    │   └── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
+    └── MusicalStage\
+        └── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
+```
+
+A current Display/shared-folder `PreviewBackground` that is used as LOR/application path evidence must also be marked.
+
+`SourceDocs` and `Archive` are excluded working/history boundaries and are not part of normal field traversal or presentation. They are not field-application marker targets unless an approved future design changes that role.
+
+If the future Procedure system directly consumes another folder such as a Setup/Takedown `images` folder, that folder must be marked before it becomes part of the application path.
+
+`Photos` is not currently part of the FieldWiring or Procedure application path.
+
+### Current FieldWiring implementation gap
+
+The FieldWiring release-candidate image resolver currently validates the structured Stage/Scene root and checks markers on `Wiring` and `PreviewBackground`, but it does not yet require a marker on the selected `BackgroundStage` / `MusicalStage` child branch.
+
+That is an implementation gap against this current contract. Do not weaken the folder/marker documentation to match the incomplete enforcement. The FieldWiring engineering work must be updated separately before final deployment acceptance.
 
 ## Naming Rules for Documentation Scope
 
@@ -493,14 +547,17 @@ A downstream resolver should apply this contract conservatively:
 6. classify the owner and parent hierarchy using the Stage/Sub-stage/Scene/Display naming rules;
 7. if the immediate owner is a Display/group, climb through the actual parent hierarchy to the nearest valid Scene/Sub-stage/Stage root for shared Wiring/Procedure discovery;
 8. if no usable explicit path evidence exists, use the current database hierarchy and deterministic naming rules to resolve the applicable structured scope;
-9. append only the standardized relative branch owned by the selected task;
-10. if path evidence, naming, and current relationships conflict or remain ambiguous, report the condition instead of guessing.
+9. verify the required markers along the controlled application path;
+10. append only the standardized relative branch owned by the selected task;
+11. if path evidence, naming, markers, and current relationships conflict or remain ambiguous, report the condition instead of guessing.
 
 The resolver must not require a Display-level background merely because the entry point was a Display.
 
 ## Task Branches After Scope Resolution
 
 After resolving the documentation root, the task determines the relative branch.
+
+Every directory used in the selected application path must satisfy the marker rule above.
 
 ### Field Wiring
 
@@ -552,7 +609,7 @@ permanent Display identity
 
 A QR code must not embed the Google Drive path.
 
-Where a browser/service cannot consume a mounted-drive path directly, the service may resolve the same hierarchy through a controlled Google Drive/file-serving mechanism. That mechanism must preserve the scope and branch rules in this contract.
+Where a browser/service cannot consume a mounted-drive path directly, the service may resolve the same hierarchy through a controlled Google Drive/file-serving mechanism. That mechanism must preserve the scope, branch, and marker rules in this contract.
 
 ## Relationship to Folder Alignment
 
@@ -565,8 +622,8 @@ Folder Alignment should:
 - classify Stage/Sub-stage/Scene/Display scopes using this contract;
 - recognize both `PreviewBackground` and deliberate direct Wiring path evidence;
 - report path/name/hierarchy conflicts;
-- validate required standardized helper folders where applicable; and
-- remain read-only except for separately controlled additive helper-folder updaters.
+- validate required markers and standardized helper folders where applicable; and
+- remain read-only except for separately controlled additive helper-folder/marker updaters.
 
 When this document and Folder Alignment implementation disagree, the discrepancy must be reviewed explicitly. Do not silently treat Folder Alignment implementation behavior as a new filesystem standard.
 
@@ -575,6 +632,7 @@ When this document and Folder Alignment implementation disagree, the discrepancy
 Path resolution must:
 
 - preserve the existing Stage/Sub-stage/Scene/Display hierarchy;
+- require the marker on every directory used as part of the current field-application path;
 - treat `PreviewBackground` as an infrastructure/helper folder, never as the scope itself;
 - not require every Display to have `PreviewBackground`;
 - accept deliberate direct Wiring paths as valid current evidence;
@@ -590,6 +648,8 @@ Path resolution must:
 
 - [Google Drive Folder Structure](00-Google_Drive.md)
 - [Google Drive Document Organization Procedure](01-Google_Drive_Document_Organization_Procedure.md)
+- [MSB Database Source Folder Marker — Operator Procedure](03-MSB_DB_Source_Folder_Marker_Operator_Procedure.md)
+- [Stage / Sub-stage / Scene Folder Scaffold](04-Stage_Substage_Scene_Folder_Scaffold.md)
 - [Folder Alignment Engineering Design](../01_LOR_System/02_Data_Extraction/Folder_Alignment/Folder_Alignment_Engineering_Design.md)
 - [LOR Preview Parser Architecture](../01_LOR_System/02_Data_Extraction/LOR_Preview_Parser_Architecture.md)
 - [Shared Field Context Resolution Contract](../02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/Field_Context_Resolution_Contract.md)

--- a/Docs/00_Project_Overview/02-Google_Drive_Path_Resolution_Contract.md
+++ b/Docs/00_Project_Overview/02-Google_Drive_Path_Resolution_Contract.md
@@ -125,9 +125,13 @@ For current Stage/Sub-stage/Scene field-document paths, required marker location
 │   ├── Inspection\
 │   │   └── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
 │   ├── Setup\
-│   │   └── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
+│   │   ├── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
+│   │   └── images\
+│   │       └── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
 │   └── Takedown\
-│       └── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
+│       ├── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
+│       └── images\
+│           └── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
 │
 └── Wiring\
     ├── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
@@ -141,7 +145,7 @@ A current Display/shared-folder `PreviewBackground` that is used as LOR/applicat
 
 `SourceDocs` and `Archive` are excluded working/history boundaries and are not part of normal field traversal or presentation. They are not field-application marker targets unless an approved future design changes that role.
 
-If the future Procedure system directly consumes another folder such as a Setup/Takedown `images` folder, that folder must be marked before it becomes part of the application path.
+`Setup\images` and `Takedown\images` are part of the future Procedure content path and must be marked.
 
 `Photos` is not currently part of the FieldWiring or Procedure application path.
 
@@ -579,10 +583,22 @@ A direct Wiring `BackgroundFile` path may already identify the applicable branch
 <documentation root>\Procedures\Setup
 ```
 
+Published Setup images use the marked:
+
+```text
+<documentation root>\Procedures\Setup\images
+```
+
 ### Takedown
 
 ```text
 <documentation root>\Procedures\Takedown
+```
+
+Published Takedown images use the marked:
+
+```text
+<documentation root>\Procedures\Takedown\images
 ```
 
 ### Inspection

--- a/Docs/00_Project_Overview/03-MSB_DB_Source_Folder_Marker_Operator_Procedure.md
+++ b/Docs/00_Project_Overview/03-MSB_DB_Source_Folder_Marker_Operator_Procedure.md
@@ -119,22 +119,18 @@ Procedures\
 │   ├── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
 │   ├── Archive\
 │   ├── images\
+│   │   └── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
 │   └── SourceDocs\
 │
 └── Takedown\
     ├── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
     ├── Archive\
     ├── images\
+    │   └── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
     └── SourceDocs\
 ```
 
-`Procedures`, `Inspection`, `Setup`, and `Takedown` are controlled application folders and must be marked.
-
-### Procedure image folders
-
-If the field Procedure system directly reads an `images` folder as part of published field content, that `images` folder must also contain the marker before it is used by the application.
-
-This follows the same rule: **if the application uses the folder, mark it.**
+`Procedures`, `Inspection`, `Setup`, `Setup\images`, `Takedown`, and `Takedown\images` are controlled application folders and must be marked.
 
 ### Archive and SourceDocs are excluded
 
@@ -183,7 +179,7 @@ Do not place passwords, credentials, API keys, or private personal information i
 
 ---
 
-# Existing Automated Marker Utility — Important
+# Existing Marker Utilities — Important
 
 The existing marker-population utility was written around an earlier, narrower marker rule.
 
@@ -191,7 +187,9 @@ Do **not** assume that running the current utility proves the complete FieldWiri
 
 The utility must be reviewed and updated separately so its targets match this current rule before it is used as the authority for full marker population.
 
-Until that engineering work is complete, visually verify the required markers when creating or reviewing a new controlled Stage/Sub-stage/Scene structure.
+The existing `remove_misplaced_msb_db_scope_root_markers.ps1` utility was created during an intermediate design that treated Stage/Sub-stage/Scene root markers as incorrect. **Do not run that utility under the current architecture.** Current field systems require the structural marker on those roots.
+
+Until the marker tooling is updated and revalidated, visually verify the required markers when creating or reviewing a controlled Stage/Sub-stage/Scene structure.
 
 ---
 
@@ -204,8 +202,8 @@ For a Stage/Sub-stage/Scene used by the field systems, verify:
 - [ ] `Wiring` is marked;
 - [ ] each active published `BackgroundStage` / `MusicalStage` branch is marked;
 - [ ] `Procedures` is marked;
-- [ ] active `Inspection`, `Setup`, and `Takedown` branches are marked;
-- [ ] any additional folder directly consumed by the field application is marked;
+- [ ] `Inspection`, `Setup`, `Setup\images`, `Takedown`, and `Takedown\images` are marked;
+- [ ] any additional folder directly consumed by a field application is marked;
 - [ ] `SourceDocs` and `Archive` remain excluded from normal field presentation; and
 - [ ] marker files have not been renamed or deleted.
 

--- a/Docs/00_Project_Overview/03-MSB_DB_Source_Folder_Marker_Operator_Procedure.md
+++ b/Docs/00_Project_Overview/03-MSB_DB_Source_Folder_Marker_Operator_Procedure.md
@@ -2,13 +2,9 @@
 
 ## Purpose
 
-Use this procedure when working with the standardized Google Drive helper folders used by the MSB Production Database and database-backed applications.
+Use this procedure when working with Google Drive folders that are part of the new FieldWiring system or the future Setup/Takedown/Inspection system.
 
-The marker file identifies a **specific helper folder whose contents are used as a database/application source location**. It exists to make those folders obvious to people browsing Google Drive without renaming the established Stage, Sub-stage, Scene, Display, or helper-folder structure.
-
-The marker is human-readable guidance and may also be used by applications as supporting confirmation. It does **not** replace Production Database identity, current LOR relationships, Scene/Preview path evidence, or the Google Drive path-resolution contract.
-
----
+The marker file tells people and applications that a folder is part of the controlled MSB field-document system.
 
 ## Standard File Name
 
@@ -18,224 +14,205 @@ Use this exact file name:
 _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
 ```
 
-Do not shorten, rename, or delete the marker after it has been placed in an approved source folder.
-
----
-
-## Standard Opening Text
-
-Every marker begins with:
-
-```text
-MSB DATABASE SOURCE FOLDER
-READ ME — DO NOT DELETE
-
-This file identifies this folder as a source location used by the
-MSB Production Database or an MSB database-backed application
-```
-
-Keep this opening text unchanged.
-
-The rest of the marker is personalized for the folder type and may include local notes.
-
----
-
-# Approved Marker Locations
-
-The current approved database/application source folders are:
-
-```text
-PreviewBackground
-Procedures
-Wiring
-```
-
-The marker belongs at the **root of those source helper folders**.
-
-Example:
-
-```text
-<Stage, Sub-stage, or Scene>/
-├── PreviewBackground/
-│   └── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
-│
-├── Procedures/
-│   └── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
-│
-├── Wiring/
-│   └── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
-│
-└── Photos/
-    └── no database-source marker at this time
-```
-
-## Stage / Sub-stage / Scene roots are NOT marker locations
-
-Do **not** place the database-source marker directly in a Stage, Sub-stage, or Scene root merely because that scope contains database-linked material.
-
-For example, this is **not** correct:
-
-```text
-15-Church-Bells-CH/
-└── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt   <- DO NOT PLACE HERE
-```
-
-The Stage/Scene root may contain many other engineering, historical, fabrication, photo, and legacy folders that are not database/application source folders. The marker is intentionally used only on the helper folders that participate in the current database/application source contract.
-
-## Photos is not marked
-
-Do not add the marker to `Photos` at this time. The current Production Database/application contract does not use the Stage/Scene `Photos` helper as a database source folder.
-
-## Child folders are not separately marked by default
-
-Do not add extra copies inside:
-
-```text
-BackgroundStage
-MusicalStage
-Setup
-Takedown
-Inspection
-SourceDocs
-Archive
-images
-```
-
-unless a future approved application contract specifically makes that child folder its own separately controlled database source.
-
-`PreviewBackground` may legitimately exist beneath a Display/shared folder and may carry its own marker because LOR may reference that folder directly.
-
-If another helper folder becomes a database/application source in the future, update the governing documentation first and then add the marker to that helper folder.
-
----
-
-# Folder-Specific Marker Content
-
-## PreviewBackground
-
-The marker explains that the folder contains current LOR Preview/Scene background images and path/context evidence used by database-backed applications.
-
-Referenced images must not be casually renamed, moved, or deleted without deliberately updating the LOR reference and alignment.
-
-## Procedures
-
-The marker explains that the folder is the controlled source root for field procedures associated with the applicable Stage, Sub-stage, or Scene.
-
-`Archive` and `SourceDocs` remain excluded from normal field presentation.
-
-## Wiring
-
-The marker explains that the folder is the controlled source root for published field wiring information.
-
-Published field wiring branches are:
-
-```text
-Wiring\BackgroundStage
-Wiring\MusicalStage
-```
-
-`SourceDocs` is working/source material and is a hard exclusion boundary for FieldWiring and normal field applications.
-
----
-
-# Local Notes Are Allowed
-
-Each marker contains a `LOCAL NOTES (optional)` section.
-
-Use it for short factual information such as:
-
-- pending Folder Alignment work;
-- stale Scene/background pointers;
-- known legacy exceptions;
-- why a Scene currently falls back to a Stage/Substage source; or
-- other information a future maintainer should know before changing the folder.
-
-Example:
-
-```text
-LOCAL NOTES (optional)
-
-Notes:
-2026-08-19 GL — Musical Scene pointer still uses the old folder suffix.
-Do not remove the current folder until the next LOR/parser alignment run is complete.
-```
-
-Do not place credentials, passwords, API keys, or private personal information in the marker.
-
-The population utility never overwrites an existing exact marker, so local notes are preserved.
-
----
-
-# Automated Population Utility
-
-Use:
-
-```text
-Utilities\populate_msb_db_source_folder_markers.ps1
-```
-
-The utility is preview-only by default.
-
-It targets only:
-
-- existing `PreviewBackground` folders;
-- existing `Procedures` folders at Stage/Sub-stage/Scene scope; and
-- existing `Wiring` folders at Stage/Sub-stage/Scene scope.
-
-It does **not** target Stage/Sub-stage/Scene roots and does not mark `Photos`.
-
-It does not create, rename, move, or delete folders. It does not overwrite an existing exact marker.
-
-### Preview all current Stages
-
-```powershell
-.\Utilities\populate_msb_db_source_folder_markers.ps1
-```
-
-### Preview one Stage
-
-```powershell
-.\Utilities\populate_msb_db_source_folder_markers.ps1 -StageFilter '15-*'
-```
-
-### Apply after review
-
-```powershell
-.\Utilities\populate_msb_db_source_folder_markers.ps1 -Apply
-```
-
-Review any `REVIEW_EXISTING_MARKER` result manually.
-
----
-
-# Application Behavior
-
-The marker `.txt` file itself is never field content and must not be listed as a Wiring image, Setup/Takedown/Inspection instruction, or other published document.
-
-Applications may use the presence of the marker as supporting confirmation that an approved helper folder participates in the current database/application source contract.
-
-The marker does not replace database/LOR identity authority.
-
-Inside marked source folders, task-specific exclusions still apply. Examples:
-
-- FieldWiring exposes only the applicable published `BackgroundStage` or `MusicalStage` branch;
-- `SourceDocs` is excluded;
-- Procedure `Archive` and source branches are excluded from normal field presentation; and
-- the marker file itself is ignored as content.
-
-A missing expected marker is an alignment/review condition. It does not authorize an application to search neighboring legacy material for a substitute.
+Do not shorten, rename, move, or delete the marker.
 
 ---
 
 # Simple Rule
 
-> Put `_MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt` only in the root of an approved database/application source helper folder. Today those are `PreviewBackground`, `Procedures`, and `Wiring`. Do not put it in the Stage/Scene root or `Photos`.
+> **Every folder that the new FieldWiring system or future Procedure system uses must contain the marker.**
+
+The marker is not limited to only the top-level `PreviewBackground`, `Procedures`, or `Wiring` folders.
+
+If the application follows a folder as part of its controlled path, that folder must be marked.
+
+Working/archive folders that the field applications are specifically forbidden to use are excluded.
 
 ---
 
-## More Information
+# Current Required Marker Locations
+
+## Stage / Sub-stage / Scene roots
+
+Every current Stage, formal Sub-stage, and Scene documentation root used by the field systems must contain the marker directly in the root.
+
+Example:
+
+```text
+15-Church-Bells-CH\
+├── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
+├── PreviewBackground\
+├── Procedures\
+├── Wiring\
+└── Photos\
+```
+
+The root marker identifies and protects the structured Stage/Sub-stage/Scene location.
+
+Do not rename or move a marked Stage/Sub-stage/Scene root as ordinary cleanup.
+
+---
+
+## Preview backgrounds
+
+Any `PreviewBackground` folder used as a current LOR/application source must contain the marker.
+
+This includes an applicable Stage, Sub-stage, Scene, Display, or shared-group `PreviewBackground` folder.
+
+```text
+PreviewBackground\
+├── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
+└── current background images
+```
+
+Referenced background images must not be casually renamed, moved, or deleted because LOR may point directly to them.
+
+---
+
+## FieldWiring folders
+
+Every folder used in the published FieldWiring path must be marked.
+
+Current wiring paths include:
+
+```text
+Wiring\
+├── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
+│
+├── BackgroundStage\
+│   ├── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
+│   ├── published wiring images
+│   └── SourceDocs\
+│
+└── MusicalStage\
+    ├── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
+    ├── published wiring images
+    └── SourceDocs\
+```
+
+The marker in `Wiring` identifies the controlled Wiring source root.
+
+The marker in `BackgroundStage` or `MusicalStage` identifies the actual published branch used by FieldWiring.
+
+### `SourceDocs` is excluded
+
+Do **not** treat `SourceDocs` as a field-application source folder.
+
+It contains working/source material and is specifically excluded from FieldWiring. It does not require a field-source marker unless a future approved design changes that rule.
+
+---
+
+## Procedure folders
+
+The future Procedure system follows the same rule: every folder used by the application must be marked.
+
+Current controlled procedure paths include:
+
+```text
+Procedures\
+├── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
+│
+├── Inspection\
+│   └── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
+│
+├── Setup\
+│   ├── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
+│   ├── Archive\
+│   ├── images\
+│   └── SourceDocs\
+│
+└── Takedown\
+    ├── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
+    ├── Archive\
+    ├── images\
+    └── SourceDocs\
+```
+
+`Procedures`, `Inspection`, `Setup`, and `Takedown` are controlled application folders and must be marked.
+
+### Procedure image folders
+
+If the field Procedure system directly reads an `images` folder as part of published field content, that `images` folder must also contain the marker before it is used by the application.
+
+This follows the same rule: **if the application uses the folder, mark it.**
+
+### Archive and SourceDocs are excluded
+
+`Archive` and `SourceDocs` are not normal field-presentation folders.
+
+Do not mark them as field-application source folders unless a later approved design intentionally changes their role.
+
+---
+
+# Photos
+
+`Photos` is general engineering documentation and is not currently part of the FieldWiring or Procedure application path.
+
+Do not add a field-source marker to `Photos` merely because the folder exists.
+
+If a future field application begins using `Photos` directly, update the governing documentation first and then mark the applicable folder before the application consumes it.
+
+---
+
+# What the Marker Means
+
+The marker means:
+
+> This folder is part of the controlled MSB field-document/application structure. Do not casually rename, move, delete, or repurpose it.
+
+The marker does **not** mean that the folder name itself is permanent Production Database identity.
+
+The Production Database and current LOR relationships still provide the durable identities and relationships used by the applications.
+
+---
+
+# Local Notes Are Allowed
+
+Each marker may contain a `LOCAL NOTES` section.
+
+Use it for short factual information such as:
+
+- a known legacy exception;
+- pending Folder Alignment work;
+- a stale LOR background pointer that still needs correction;
+- a missing field image;
+- a temporary migration condition; or
+- another warning a future maintainer should see before changing the folder.
+
+Do not place passwords, credentials, API keys, or private personal information in a marker.
+
+---
+
+# Existing Automated Marker Utility — Important
+
+The existing marker-population utility was written around an earlier, narrower marker rule.
+
+Do **not** assume that running the current utility proves the complete FieldWiring/future-Procedure marker structure is correct.
+
+The utility must be reviewed and updated separately so its targets match this current rule before it is used as the authority for full marker population.
+
+Until that engineering work is complete, visually verify the required markers when creating or reviewing a new controlled Stage/Sub-stage/Scene structure.
+
+---
+
+# Before You Finish
+
+For a Stage/Sub-stage/Scene used by the field systems, verify:
+
+- [ ] the Stage/Sub-stage/Scene root is marked;
+- [ ] every active `PreviewBackground` source folder is marked;
+- [ ] `Wiring` is marked;
+- [ ] each active published `BackgroundStage` / `MusicalStage` branch is marked;
+- [ ] `Procedures` is marked;
+- [ ] active `Inspection`, `Setup`, and `Takedown` branches are marked;
+- [ ] any additional folder directly consumed by the field application is marked;
+- [ ] `SourceDocs` and `Archive` remain excluded from normal field presentation; and
+- [ ] marker files have not been renamed or deleted.
+
+## Related Documents
 
 - [Google Drive Folder Structure](00-Google_Drive.md)
 - [Google Drive Document Organization Procedure](01-Google_Drive_Document_Organization_Procedure.md)
 - [Google Drive Path Resolution Contract](02-Google_Drive_Path_Resolution_Contract.md)
-- [FieldWiring Drive Context Resolver Engineering Design](../02_Production_Database/01_System_Architecture/09_Wiring_System/FieldWiring_Drive_Context_Resolver_Engineering_Design.md)
+- [Stage / Sub-stage / Scene Folder Scaffold](04-Stage_Substage_Scene_Folder_Scaffold.md)
+- [FieldWiring Engineering](../02_Production_Database/01_System_Architecture/09_Wiring_System/README.md)

--- a/Docs/00_Project_Overview/04-Stage_Substage_Scene_Folder_Scaffold.md
+++ b/Docs/00_Project_Overview/04-Stage_Substage_Scene_Folder_Scaffold.md
@@ -88,12 +88,14 @@ Use this structure for every newly created Stage, Sub-stage, or Scene documentat
 │   │   ├── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
 │   │   ├── Archive/
 │   │   ├── images/
+│   │   │   └── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
 │   │   └── SourceDocs/
 │   │
 │   ├── Takedown/
 │   │   ├── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
 │   │   ├── Archive/
 │   │   ├── images/
+│   │   │   └── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
 │   │   └── SourceDocs/
 │   │
 │   └── SourceDocs/
@@ -133,12 +135,12 @@ For the scaffold above, markers are required in:
 3. `Procedures`;
 4. `Procedures\Inspection`;
 5. `Procedures\Setup`;
-6. `Procedures\Takedown`;
-7. `Wiring`;
-8. `Wiring\BackgroundStage`; and
-9. `Wiring\MusicalStage`.
-
-If the future Procedure application directly consumes another folder, such as a Setup/Takedown `images` folder, that folder must be marked before it becomes part of the application path.
+6. `Procedures\Setup\images`;
+7. `Procedures\Takedown`;
+8. `Procedures\Takedown\images`;
+9. `Wiring`;
+10. `Wiring\BackgroundStage`; and
+11. `Wiring\MusicalStage`.
 
 `SourceDocs` and `Archive` are working/history folders excluded from normal field presentation and are not field-application marker targets unless a future approved design changes their role.
 
@@ -201,6 +203,8 @@ Procedures\Takedown
 
 The `Procedures` root and the applicable task branch must be marked.
 
+Setup/Takedown `images` folders are part of the future procedure content path and must also be marked.
+
 `Archive` and `SourceDocs` are not normal field-facing content.
 
 ## Photos
@@ -219,7 +223,7 @@ When a new Scene documentation folder is approved:
 - [ ] Create the complete scaffold, not only the one helper folder needed today.
 - [ ] Add the marker to the Scene root.
 - [ ] Add the marker to `PreviewBackground`.
-- [ ] Add the marker to `Procedures` and the active procedure branches.
+- [ ] Add the marker to `Procedures`, `Inspection`, `Setup`, `Setup\images`, `Takedown`, and `Takedown\images`.
 - [ ] Add the marker to `Wiring` and the active `BackgroundStage` / `MusicalStage` branches.
 - [ ] Do not mark `SourceDocs` or `Archive` as normal field sources.
 - [ ] Do not rename the standard helper folders.

--- a/Docs/00_Project_Overview/04-Stage_Substage_Scene_Folder_Scaffold.md
+++ b/Docs/00_Project_Overview/04-Stage_Substage_Scene_Folder_Scaffold.md
@@ -71,39 +71,50 @@ Use this structure for every newly created Stage, Sub-stage, or Scene documentat
 │   ├── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
 │   └── archive/
 │
+├── Photos/
+│   ├── Current/
+│   ├── Historical/
+│   ├── Reference/
+│   ├── Setup/
+│   └── Takedown/
+│
 ├── Procedures/
 │   ├── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
+│   │
 │   ├── Inspection/
+│   │   └── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
+│   │
 │   ├── Setup/
+│   │   ├── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
 │   │   ├── Archive/
 │   │   ├── images/
 │   │   └── SourceDocs/
+│   │
 │   ├── Takedown/
+│   │   ├── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
 │   │   ├── Archive/
 │   │   ├── images/
 │   │   └── SourceDocs/
+│   │
 │   └── SourceDocs/
 │
-├── Wiring/
-│   ├── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
-│   ├── BackgroundStage/
-│   │   └── SourceDocs/
-│   └── MusicalStage/
-│       └── SourceDocs/
-│
-└── Photos/
-    ├── Current/
-    ├── Historical/
-    ├── Reference/
-    ├── Setup/
-    └── Takedown/
+└── Wiring/
+    ├── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
+    │
+    ├── BackgroundStage/
+    │   ├── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
+    │   └── SourceDocs/
+    │
+    └── MusicalStage/
+        ├── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
+        └── SourceDocs/
 ```
 
-`desktop.ini` or other Windows-generated metadata is not part of the controlled scaffold contract and does not need to be copied deliberately.
+`desktop.ini` or other Windows-generated metadata is not part of the controlled scaffold and does not need to be copied deliberately.
 
 ---
 
-# Marker Placement
+# Marker Placement Rule
 
 The standard marker filename is:
 
@@ -111,18 +122,27 @@ The standard marker filename is:
 _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
 ```
 
-A marker is required in:
+The current rule is:
+
+> **Every folder used by the new FieldWiring system or future Procedure system must contain the marker.**
+
+For the scaffold above, markers are required in:
 
 1. the Stage / Sub-stage / Scene root;
 2. `PreviewBackground`;
-3. `Procedures`; and
-4. `Wiring`.
+3. `Procedures`;
+4. `Procedures\Inspection`;
+5. `Procedures\Setup`;
+6. `Procedures\Takedown`;
+7. `Wiring`;
+8. `Wiring\BackgroundStage`; and
+9. `Wiring\MusicalStage`.
 
-Do **not** place a database-source marker in `Photos` at this time.
+If the future Procedure application directly consumes another folder, such as a Setup/Takedown `images` folder, that folder must be marked before it becomes part of the application path.
 
-The root marker protects and identifies the aligned structural scope. The helper-folder markers identify the current database/application source folders.
+`SourceDocs` and `Archive` are working/history folders excluded from normal field presentation and are not field-application marker targets unless a future approved design changes their role.
 
-Use the personalized marker text for each location. Local notes may be added in the marker's `LOCAL NOTES` section when useful.
+`Photos` is not currently part of the FieldWiring/Procedure application source path and is not marked by this scaffold.
 
 See [MSB Database Source Folder Marker — Operator Procedure](03-MSB_DB_Source_Folder_Marker_Operator_Procedure.md).
 
@@ -137,12 +157,12 @@ An **existing** Stage/Sub-stage/Scene root may already contain years of loose fi
 For existing folders:
 
 - preserve the aligned root name;
-- preserve the marked helper-folder names;
-- use marked `PreviewBackground`, `Procedures`, and `Wiring` as the current application-source boundary;
+- preserve the controlled field-application folder names;
+- add/maintain the required markers as the folder becomes part of the new FieldWiring/Procedure system;
 - preserve unrelated legacy material until it can be reviewed; and
-- allow applications to ignore unmarked legacy material.
+- allow applications to ignore material outside the controlled marked paths.
 
-This is what allows gradual cleanup without breaking LOR paths or current database-backed applications.
+This allows gradual cleanup without breaking LOR paths or current field applications.
 
 ---
 
@@ -152,28 +172,40 @@ This is what allows gradual cleanup without breaking LOR paths or current databa
 
 Use `PreviewBackground` for current images intentionally used as LOR Preview/Scene background references.
 
-For **new authoring**, choose the Scene/Preview `BackgroundFile` from an approved marked source location. Do not create new LOR references into loose legacy material when a controlled source folder is available.
+For new authoring, choose the Scene/Preview `BackgroundFile` from an approved marked location. Do not create new LOR references into loose legacy material when a controlled source folder is available.
 
 ## Wiring
 
-Published FieldWiring images belong directly in the applicable branch:
+Published FieldWiring images belong directly in the applicable marked branch:
 
 ```text
 Wiring\BackgroundStage
 Wiring\MusicalStage
 ```
 
+Both the `Wiring` root and the published child branch must be marked.
+
 `SourceDocs` is working/source material and is not normal field-facing content.
 
-**Do not point a new Scene background into `SourceDocs`.** Existing legacy pointers may remain temporarily while alignment work continues, but new authoring should use `PreviewBackground` or a directly published Wiring image.
+Do not point a new Scene background into `SourceDocs`. Existing legacy pointers may remain temporarily while alignment work continues, but new authoring should use `PreviewBackground` or a directly published Wiring image.
 
 ## Procedures
 
-Published field procedure material belongs in the approved procedure branch. `Archive` and `SourceDocs` are not normal field-facing content.
+Published field procedure material belongs in the applicable marked procedure branch:
+
+```text
+Procedures\Inspection
+Procedures\Setup
+Procedures\Takedown
+```
+
+The `Procedures` root and the applicable task branch must be marked.
+
+`Archive` and `SourceDocs` are not normal field-facing content.
 
 ## Photos
 
-`Photos` remains general documentation and is not currently a Production Database/application source folder.
+`Photos` remains general documentation and is not currently a FieldWiring/Procedure application source folder.
 
 ---
 
@@ -185,9 +217,11 @@ When a new Scene documentation folder is approved:
 - [ ] Confirm the owning Stage or Sub-stage.
 - [ ] Name the folder using the current `NN-Scene Name` / `NNa-Scene Name` rule.
 - [ ] Create the complete scaffold, not only the one helper folder needed today.
-- [ ] Add the structural root marker.
-- [ ] Add the personalized markers to `PreviewBackground`, `Procedures`, and `Wiring`.
-- [ ] Do not mark `Photos`.
+- [ ] Add the marker to the Scene root.
+- [ ] Add the marker to `PreviewBackground`.
+- [ ] Add the marker to `Procedures` and the active procedure branches.
+- [ ] Add the marker to `Wiring` and the active `BackgroundStage` / `MusicalStage` branches.
+- [ ] Do not mark `SourceDocs` or `Archive` as normal field sources.
 - [ ] Do not rename the standard helper folders.
 - [ ] Put new LOR background references only in approved marked source locations.
 - [ ] Never use `SourceDocs` as a normal field-document or new LOR background endpoint.
@@ -198,7 +232,7 @@ When a new Scene documentation folder is approved:
 
 # Simple Rule
 
-> If a new Stage, Sub-stage, or Scene documentation folder is needed, create it from the complete scaffold immediately. Do not invent a partial folder structure and plan to fix it later.
+> If a new Stage, Sub-stage, or Scene documentation folder is needed, create the complete controlled scaffold immediately and mark every folder used by the field applications. Do not invent a partial folder structure and plan to fix it later.
 
 ---
 

--- a/Docs/01_LOR_System/01_Preview_Authoring/A_Naming_Conventions.md
+++ b/Docs/01_LOR_System/01_Preview_Authoring/A_Naming_Conventions.md
@@ -1,465 +1,318 @@
 # Prop and Display Naming Conventions
 
-- Filename: A_Naming_Conventions.md
-- version: 2026-08-02
-- author: Greg Liebig / Engineering Innovations, LLC
+| Document Control | Value |
+|---|---|
+| Document Type | Operator Procedure |
+| System | LOR Preview Authoring |
+| Task | Name Displays and channels correctly |
+| Audience | Preview authors and programmers |
+| Status | CURRENT |
+| Owner | MSB Production Crew |
+| Last Reviewed | 2026-08-22 |
+
+## Purpose
+
+Use these rules when creating or editing channels and Displays in LOR.
+
+Correct naming keeps channels together in the LOR grid and keeps the physical Display name consistent with labels, inventory, and field wiring.
 
 ---
 
-These conventions ensure consistent naming across:
+# 1. LOR Uses Two Different Name Fields
 
-- **LOR sequencing (Channel Grid)**
-- **Display database records (Postgres / SQLite)**
-- **Physical labels used in the field**
-- **Field wiring exports**
+| LOR field | What it is used for |
+|---|---|
+| **Name** | Channel name used for programming and sorting in the LOR grid |
+| **Comment** | Physical MSB Display Name |
 
-If naming rules are not followed, channels scatter in the grid, wiring reports drift from reality, and physical labels no longer match database records.
-
-This document prevents chaos.
+Do not use the **Name** field as the physical Display Name.
 
 ---
 
-## 1. Two Separate Naming Layers in LOR
+# 2. Name Field — Channel Naming
 
-LOR uses two different fields that serve different purposes:
+Use this general format:
 
-| Field | Meaning | Purpose | Spaces Allowed | Used as Database Key |
-|-------|---------|---------|----------------|----------------------|
-| **Name** | Channel Name | Channel grid sorting and programming | Yes | No |
-| **Comment** | Display Name | Physical display identifier | No | Yes |
-
-These fields must not be confused.
-
----
-
-## 2. LOR Name Field (Channel Naming Convention)
-
-The **Name field controls alphabetical sorting inside the LOR grid.**
-
-- LOR sorts strictly alphabetically.  
-- Improper numbering or inconsistent formatting causes channels to scatter.
-
-### 2.1 Required Structure
-
-Recommended format:
-
-`<SC> <UID>-<CH> <Channel Group>  <Optional Attribute>`
+```text
+<Stage Code> <Controller ID>-<Channel> <Description>
+```
 
 Example:
 
-`TC 7B-01 Hippo Box`
+```text
+TC 7B-01 Hippo Box
+```
 
----
+## Stage Code
 
-### 2.2 UID and Channel Rules (CRITICAL)
-
-**SC** Stage Code
-
-- SC is Stage Code
-- 2 Character Abbreviation
-- Examples:
-  - FT = Festive Trees
-  - FC = Food Collection
-  - WW = Winter Wonderand
-
-**UID** Contriller Unit ID (HEX)
-
-- Controller ID in HEX
-- Uppercase
-- No leading zero padding
-- Example: `7B`, `1F`, `20`
-
-**Channel**
-- Is the plug used on an A/C Controller
-- Always 2-digit padded
-- `01–16`
-- Even if wiring exports show a single digit
-
-Correct:
-- `7B-01`
-- `7B-02`
-- `7B-10`
-
-Incorrect:
-- `7B-1`
-- `7B-2`
-
-**Channel Group**
-
-- Often Used when building a preview with additional detail
-- `Uses the same channel as` in the Preview channel grid
-  - This allows the additional detail on the preview drawing to use the same physical channel without conflict
-- Again used to keep channels sorted together
-- Usually used with with additional Attributes
-
-**Optional Attributes**
-
-- Helpful when building animations
-- Used to describe an Action of a Channel group
-- Examples:
-  - Lid Open
-  - Lid Closed
-  - Arm Up
-  - Arm Down
-
-If channels are not padded, alphabetical sorting breaks:
-
-Wrong order:
-
-- 7B-1
-- 7B-10
-- 7B-11
-- 7B-2
-
-Correct order:
-
-- 7B-01
-- 7B-02
-- 7B-03
-- 7B-10
-
----
-
-### 2.3 Real Example (Hippo + Carolers)
-
-![Channel Grid Example](/Docs/images/naming_conventions_channel_grid.png)
-
-This grid shows:
-
-- One multi-state animated display (Hippo)
-- Three physical panels (CarolerPanel-01..03)
-- Proper grouping by padded channel numbers
-
-The naming works because:
-- All channels begin with consistent stage prefix
-- Channels are padded
-- Related elements sort together
-
-### 2.4 Unused Channels (SPARE Rule — REQUIRED)
-
-Any unused channel on a controller must be explicitly added to the preview.
-
-Do NOT leave gaps.
-
-Unused channels must:
-
-- Follow the exact same naming structure
-- Use the same Stage and Group prefix
-- Use correct HEX UID
-- Use 2-digit padded channel number
-- End with the word `Spare`
-
-Example:
-
-TC 7B-11 Spare  
-TC 7B-12 Spare  
-
-Why this is required:
-
-- Makes unused capacity immediately visible in the Channel Grid
-- Prevents accidental reuse of a channel already assumed to be empty
-- Keeps controllers fully documented
-- Allows quick identification of expansion space during programming
-
-Unused channels must remain in the preview even if no physical wiring exists.
-
-When a Spare channel is later assigned to a display:
-- Rename the channel
-- Update wiring documentation
-- Remove the `Spare` designation
-
-### 2.5 Vacated Channels After Moving a Display (CRITICAL)
-
-When a display is moved to another preview, controller, or channel range, do
-not convert its former channel definition into a spare by only renaming it or
-hiding it.
-
-LOR can retain the moved display's PropClass UUID on the old channel. Hidden
-channels are still stored in the preview and are still processed by the parser.
-For a multi-channel prop, the parser uses the lowest channel when constructing
-the prop identity. A stale UUID on that channel can therefore make the new
-display and the old SPARE appear to be the same LOR object.
-
-Required procedure for each vacated channel:
-
-1. Delete the obsolete display channel/prop definition.
-2. Recreate the unused channel as a new SPARE channel.
-3. Use the required channel name and the `SPARE` Comment value.
-4. Keep the recreated SPARE visible so the unused controller capacity can be
-   verified in the preview.
-5. Export, parse, ingest, and confirm that reconciliation reports no shared
-   `raw_prop_id` across different display comments or previews.
-
-Do not:
-
-- rename the former display channel to SPARE and leave the original object in
-  place;
-- hide the former display channel and assume the parser will ignore it;
-- approve reconciliation while a UUID collision remains unresolved.
-
-#### Verified Example — Olaf Move
-
-`IT-Olaf` was moved from Stage 13 Winter Wonderland controller `3E`, channels
-`01-05`, to Stage 14 Icicle Tunnel controller `3F`, channels `11-15`. The old
-`WW 3E-01` channel had been renamed `SPARE` and hidden, but it retained Olaf's
-UUID. Ingest Run 41 exposed the same `raw_prop_id` on `SPARE` and `IT-Olaf`.
-Deleting and recreating `WW 3E-01` assigned the spare a new identity, and Run
-42 confirmed that the collision was gone.
-
-This check is required for every moved display. A stale identity could collide
-with another physical display, not only a spare.
-  
----
-
-## 3. Comment Field (Display Identifier)
-
-The **Comment field defines the Display Name** used for:
-
-- Physical labels
-- Database joins
-- Wiring exports
-- Inventory tracking
-- Maintenance records
-
-This is the true identity of the physical display.
-
----
-
-### 3.1 Comment Field [Display Name] Rules
-
-- No spaces allowed
-- Must start with 2-letter stage abbreviation
-- Use hyphen as structural separator
-- Use a hyphen after the Actual Display Name (CamelCase)
-- Must remain stable over time
+Use the two-letter Stage abbreviation.
 
 Examples:
 
-Standard stages:
-- `FC-Arch-01`means Food Collection Arch #1
-- `RA-Arch-DS-01`means Racing Arches, Driver Side #1
-- `EC-Elf-P2-06`means Elf Choir, Elf, Pattern 2, #6
+- `FT` = Festive Trees
+- `FC` = Food Collection
+- `WW` = Winter Wonderland
 
-GG stage (Controller Unit ID's specifically allowed):
-- `GG-Elden-20-01` means Glistening Grove, Elden (version 1), UID 20 #1
-- `GG-Elden-20-04` means Glistening Grove, Elden (version 1), UID 20 #4
-- `GG-EldenV2-30-01` means Glistening Grove, Elden (version 2), UID 30 #1
-- `GG-EldenV2-30-02` means Glistening Grove, Elden (version 2), UID 30 #2
+## Controller ID
+
+Use the controller Unit ID exactly as assigned.
+
+Examples:
+
+```text
+7B
+1F
+20
+```
+
+Use uppercase letters. Do not add unnecessary leading zeroes.
+
+## Channel Number
+
+Always use two digits for AC controller channels.
+
+Correct:
+
+```text
+7B-01
+7B-02
+7B-10
+```
+
+Incorrect:
+
+```text
+7B-1
+7B-2
+```
+
+The two-digit format keeps channels in the correct order when LOR sorts them alphabetically.
+
+## Extra Description
+
+Add a short description when it helps identify what the channel controls.
+
+Examples:
+
+```text
+TC 7B-01 Hippo Box
+TC 7B-04 Hippo Body Mid
+TC 7B-05 Hippo Body Full Head
+```
+
+For animated Displays, descriptions such as `Lid Open`, `Lid Closed`, `Arm Up`, or `Arm Down` can make programming easier.
 
 ---
 
-### 3.2 Displays vs Sub-Props
+# 3. Unused Channels — SPARE
 
-| Term | Definition |
-|------|------------|
-| **Display** | One physical panel or unit |
-| **Sub-Prop** | Logical motion element within a display |
+Every unused controller channel must still appear in the Preview.
 
-All sub-props must share the **exact same Comment value** as their parent display.
+Do not leave unexplained gaps.
 
 Example:
 
-| Channel Name | Comment [Display Name]|
-|--------------|---------|
+```text
+TC 7B-11 Spare
+TC 7B-12 Spare
+```
+
+For an unused channel:
+
+1. Use the normal Stage, Controller ID, and two-digit channel format.
+2. End the channel Name with `Spare`.
+3. Use `SPARE` in the Comment field.
+4. Keep the channel visible in the Preview.
+
+This makes unused controller capacity easy to see and prevents someone from accidentally assuming a used channel is available.
+
+---
+
+# 4. When a Display Is Moved to Different Channels
+
+When a Display is moved away from an old channel, **do not simply rename the old Display channel to SPARE and do not just hide it**.
+
+LOR can keep information from the old Display attached to that channel even after the name is changed. That can cause problems later.
+
+For every channel that becomes unused:
+
+1. Delete the old Display channel/Prop from that location.
+2. Create a new SPARE channel in its place.
+3. Use the normal channel naming format.
+4. Use `SPARE` in the Comment field.
+5. Keep the new SPARE visible.
+
+The important rule is:
+
+> **Moved Display: delete the old channel object and create a new SPARE. Do not just rename or hide the old one.**
+
+If you are unsure whether the old Display object was properly removed, stop and ask before exporting the Preview.
+
+---
+
+# 5. Comment Field — Physical Display Name
+
+The **Comment** field contains the physical MSB Display Name.
+
+Examples:
+
+```text
+FC-Arch-01
+RA-Arch-DS-01
+EC-Elf-P2-06
+TC-ChristmasHippo
+```
+
+The Comment value should match the name used on the physical Display label and in field documentation.
+
+## Display Name Rules
+
+- No spaces.
+- Start with the two-letter Stage code.
+- Use hyphens to separate meaningful parts.
+- Keep the name stable unless the physical Display identity is intentionally being changed.
+
+General format:
+
+```text
+<Stage Code>-<DisplayName>-<Optional Variation>-<Optional Number>-<Optional Color>
+```
+
+Examples:
+
+```text
+IT-EntryArchWrap-DS
+IT-SteelEntryArch-PS
+FC-CarCounterArch-Grn
+EC-Elf-P2-06
+WF-MiniTree-G-04
+GG-Elden-20-01
+```
+
+Do not run attributes together when a hyphen is needed.
+
+Wrong:
+
+```text
+EntryArchWrapDS
+SteelEntryArchPS
+CarCounterArchGrn
+```
+
+Correct:
+
+```text
+IT-EntryArchWrap-DS
+IT-SteelEntryArch-PS
+FC-CarCounterArch-Grn
+```
+
+---
+
+# 6. One Physical Display with Several Channels
+
+Several channels may belong to one physical Display.
+
+All of those channels must use the **same Comment value**.
+
+Example:
+
+| Channel Name | Comment |
+|---|---|
 | `TC 7B-01 Hippo Box` | `TC-ChristmasHippo` |
 | `TC 7B-04 Hippo Body Mid` | `TC-ChristmasHippo` |
 | `TC 7B-05 Hippo Body Full Head` | `TC-ChristmasHippo` |
 
----
-
-### 3.3 Example – Multi-Panel Display (Caroler)
-
-![Visualization Example](/Docs/images/naming_conventions_visualization.png)
-
-Three physical displays (panels):
-
-- `TC-CarolerPanel-01`
-- `TC-CarolerPanel-02`
-- `TC-CarolerPanel-03`
-
-Each has its own Comment value. TC is the Stage Code for Traditional Christmas
-
-Even if programming groups them visually, they remain separate physical units in inventory and wiring.
+The channel Names can be different because they describe different parts of the Display. The Comment stays the same because they belong to the same physical Display.
 
 ---
 
-## 4. Display Name Format (put into Comment field)
+# 7. Several Physical Displays Must Have Separate Names
 
-Display names must be structured so that:
-
-The first hyphen separates Stage from DisplayName
-Subsequent hyphens separate functional attributes
-No attribute codes may be appended directly to DisplayName without a hyphen
-
-Prohibited:
-
-EntryArchWrapDS
-SteelEntryArchPS
-CarCounterArchGrn
-
-Required (Stage Code-Display Name-Attributes):
-
-- IT-EntryArchWrap-DS
-- IT-SteelEntryArch-PS
-- FC-CarCounterArch-Grn
-
-`<Stage Code>-<DisplayName>-<Variation>-<Sequence>-<Color>`
-
-| Segment | Meaning |
-|----------|---------|
-| Stage | Two-letter stage code |
-| DisplayName | CamelCase, no spaces |
-| Variation | Optional location/version identifier |
-| Sequence | Always 2-digit padded |
-| Color | Optional suffix |
-
-More Examples:
-
-- `EC-Elf-P2-06`
-- `RA-Arch-DS-01`
-- `WF-MiniTree-G-04`
-- `GG-Elden-20-01`
-- `DF-Wrap-DS-A-02G`
-
----
-
-### 4.1 DeviceType = Undetermined (Inventory-Only Displays)
-
-![Undetermined DeviceType Example](/Docs/images/DisplayTypeNone.png)
-
-In the LOR preview editor, DeviceType is set to:
-
-Undetermined
-
-During SQLite parsing and Postgres ingestion, this becomes:
-
-DeviceType = None
-
-Operationally, both represent the same thing:
-
-A physical inventory item with no controller assignment and no channel grid usage.
-
-`<Stage Code>-<DisplayName>-<Variation>-<Sequence>-<Color>`
-
----
-
-#### Use Cases
-
-- Physical duplicates of programmed displays
-- Arch supports
-- Wrap stands
-- Frame stands
-- Future expansion inventory
-- Volunteer Trailer Steps
-- Igloo wagon for No Left Turn
-- Additional displays were we duplicate the controllers for programming simplification like Emojis
-
----
-
-#### Quantity Creation (Max Circuits per Unit)
-
-When creating inventory-only items:
-
-- Set "Max Circuits per Unit" equal to the required quantity.
-- LOR automatically generates suffixed records:
-  - `-01`, `-02`, `-03`, etc.
+If several physical panels or units are separate items in storage and setup, each one needs its own Display Name.
 
 Example:
 
-Comment:
-`FC-WrapStand`
+```text
+TC-CarolerPanel-01
+TC-CarolerPanel-02
+TC-CarolerPanel-03
+```
 
-Max Circuits per Unit:
-`32`
-
-Generated records:
-- `FC-WrapStand-01`
-- `FC-WrapStand-02`
-- ...
-- `FC-WrapStand-32`
-
-If Max Circuits per Unit = 1:
-- No suffix is added.
+Even if they are programmed together, they are still separate physical Displays.
 
 ---
 
-#### ⚠️ Critical Warning
+# 8. Inventory-Only Displays in LOR
 
-The default value for "Max Circuits per Unit" is 16.
+Some physical items need to be listed even though they have no controller or channel assignment.
 
-If not changed intentionally, LOR will create 16 inventory records automatically.
+In LOR, use **Undetermined** for these items.
 
-This will:
+Examples may include:
 
-- Inflate inventory counts
-- Pollute the database
-- Require manual cleanup
+- spare physical duplicates;
+- supports or stands;
+- future expansion pieces; and
+- other physical items that need to exist in inventory but are not wired in the Preview.
 
-Always verify this value before saving.
+These items still need a valid Display Name in the Comment field.
 
----
+## Creating Several Identical Inventory Items
 
-#### Rules
+When LOR uses **Max Circuits per Unit** to create several physical items, set the quantity intentionally.
 
-Inventory-only entries:
+Example:
 
-- Must follow full Comment naming rules
-- Must not contain Network, UID, or ChannelGrid
-- Must represent real physical inventory
+```text
+Comment: FC-WrapStand
+Max Circuits per Unit: 32
+```
 
-These entries appear in database ingestion but do not affect wiring exports.
+LOR can create:
 
----
+```text
+FC-WrapStand-01
+FC-WrapStand-02
+...
+FC-WrapStand-32
+```
 
-## 5. Field Wiring Alignment
+### Important
 
-![Field Wiring Example](/Docs/images/naming_conventions_field_wiring.png)
+The default value may be larger than the number you actually need.
 
-Field wiring exports rely on the Comment value.
-
-If Comment naming is incorrect:
-- Wiring sheets become inaccurate
-- Displays cannot be located in the field
-- Maintenance records break
-
----
-
-## 6. Inventory and Physical Labels
-
-Every display label must:
-
-- Match the Comment field exactly
-- Be permanently attached to the display
-- Match database and wiring documentation
-
-The Comment value is the backbone of:
-
-- Physical inventory
-- Storage tracking
-- Repair history
-- Field setup instructions
+Always check **Max Circuits per Unit** before saving so you do not accidentally create extra inventory items.
 
 ---
 
-## ✅ Summary
+# Before You Finish
 
-| Field | Controls | Critical Rule |
-|--------|----------|--------------|
-| Name | Programming & Grid Sorting | Pad channels to 2 digits |
-| Comment | Physical Identity | No spaces, stable, structured |
+- [ ] Every channel uses the correct Stage code.
+- [ ] Controller IDs are correct.
+- [ ] AC channels use two digits.
+- [ ] Unused channels are shown as SPARE.
+- [ ] Moved Displays were removed from their old channels and new SPARE channels were created.
+- [ ] Every physical Display has the correct Comment value.
+- [ ] Channels belonging to one physical Display use the same Comment.
+- [ ] Separate physical Displays have separate Display Names.
+- [ ] Inventory-only quantities were checked before saving.
 
-Naming consistency prevents:
+## Expected Result
 
-- Channel grid chaos
-- Lost programming
-- Wiring mismatches
-- Inventory drift
+The LOR grid is easy to read, channels sort correctly, and each physical Display has one clear name that matches field documentation.
 
----
+## Related Operator Documents
 
-> **Revision History**
-> - GAL 26-03-24 — Added images back in and fixed some typos
-> - GAL 26-03-17 — Clarified Section 4 due to label printing conflicts
-> - GAL 26-02-22 — Major clarification: separated Name vs Comment logic, added UID padding rule, added real-world examples with grid and wiring screenshots
-> - GAL 25-10-30 — Formatting cleanup
-> - GAL 25-10-29 — Initial merge  
+- [Building a Preview](B_Building_Preview_Howto.md)
+- [Building the Master Musical Preview](E_Master_Musical_Preview_Howto.md)
+- [Preview Authoring Home](README.md)
+
+## Related Engineering
+
+- [Historical LOR Naming Data Contract](C_LOR_Naming_Data_Contract.md)
+- [LOR Parser Architecture](../02_Data_Extraction/LOR_Preview_Parser_Architecture.md)
+
+## Revision History
+
+- 2026-08-22 — Rewritten for Preview authors in plain language. Parser, UUID, SQLite, PostgreSQL, and reconciliation details were removed from the operator instructions while preserving the required naming and SPARE rules.

--- a/Docs/01_LOR_System/01_Preview_Authoring/B_Building_Preview_Howto.md
+++ b/Docs/01_LOR_System/01_Preview_Authoring/B_Building_Preview_Howto.md
@@ -1,997 +1,308 @@
 ---
-title: Building a Preview (Operator How-To)
-version: See Changelog
+title: Building a Preview
+status: CURRENT
+revision: 2026-08-22
 author: Greg Liebig / Engineering Innovations, LLC
 ---
 
-# Building a Preview (Operator How-To)
+# Building a Preview
 
-This guide explains how to build, edit, and export a preview in **Light‑O‑Rama (LOR)** for integration with the MSB Database. 
-This is a multi-step process where:
-1. A concept is dreamed up
-2. Drawings/sketches created to describe the concept
-3. [Display Design-Approval Form](https://docs.google.com/spreadsheets/d/1Pw91W724KTUcvG1HdSYsTuLY1Mo-2JRPdKq7nziDz8M/edit?usp=sharing)
-    - Is used to document the display including
-      - Controller
-      - Stage
-      - Channels
-      - Colors
-      - Lighting types
-4. After the drawings are finalized a preview must be created in LOR
-   - This is done on the programmer's PC
-   - Channel Namimg conventions must be used
-   - When Finished the final preview is exported to the individual's preview folder
-   - G:\Shared drives\MSB Database\UserPreviewStaging\username
+| Document Control | Value |
+|---|---|
+| Document Type | Operator Procedure |
+| System | LOR Preview Authoring |
+| Task | Build or update an LOR Preview |
+| Audience | Preview authors and programmers |
+| Status | CURRENT |
+| Owner | MSB Production Crew |
+| Last Reviewed | 2026-08-22 |
 
-## Preview ownership and master protection
+## Purpose
 
-Each programmer's preview is an isolated working copy. Exporting it to the
-individual staging folder does not authorize direct replacement of the master.
+Use this procedure when creating a new LOR Preview or changing an existing one.
 
-The controlled path is:
+You do not need to understand the parser or database systems to complete this task.
 
-1. Export to `UserPreviewStaging\<username>`.
-2. Run and review the Preview Merger dry comparison.
-3. Resolve identifier, revision, semantic, comment, or ownership conflicts.
-4. Apply only reviewed changes through the controlled merge process.
-5. Run the comparison again and require `noop` to prove idempotence.
-6. Use only the approved master set as V7 parser input.
+## Before You Start
 
-Historically the Show PC held the master. The Office PC is the designated
-master for the approved LOR 6.6.10 preview set. No programmer may overwrite it
-with their local preview. See the active
-[Preview Merger documentation](../03_Preview_Merger/README.md).
+Have the following ready:
+
+- the approved Display Design Worksheet or other approved design information;
+- the correct Stage and controller/channel assignments;
+- the current approved Preview if you are editing an existing one; and
+- any artwork or background image needed to build the Preview.
+
+The existing Display Design Worksheet is the design starting point. This procedure does not replace or redesign it.
 
 ---
 
-## Folder Layout — Wiring Images and Examples
+# 1. Get the Current Preview Before Editing
+
+If you are changing an existing Preview, first follow:
+
+[Preview Import Workflow](Preview_Import_Workflow.md)
+
+Do not edit the approved master files directly.
+
+Make all changes in your own LOR working copy.
+
+---
+
+# 2. Use the Existing Google Drive Folder Structure
+
+Engineering files are stored under:
+
+```text
+G:\Shared drives\Display Folders\
 ```
-G:
-└── Shared drives
-└── Display Folders
-└── 21-Polar Bear Playground-PB -> **Each Stage has single unique folder**
-└── Wiring -> **Folder used to store all images needed for LOR Previews**
-├── BackgroundStage -> **Only store images here needed for the Field Wiring Instructions here for Background Previews**
-│ ├── Show Background Stage 21 PolarBears-Tagged.jpg
-│ ├── Show Background Stage 21 Sliding Penguins-Tagged.jpg
-│ └── SourceDocs **Location to build the background images for Field Wiring Instructions**
-│ ├── polar_bears_map.drawio
-│ ├── polar_bears_wiring.pspimage
-│ └── sliding_penguins_layout.jpg
-│
-├── MusicalStage -> **Only store images here needed for the Field Wiring Instructions here for Musical Previews**
-│ ├── Show Musical Stage 21 PolarBears-Tagged.jpg
-│ ├── Show Musical Stage 21 Sliding Penguins-Wired.jpg
-│ └── SourceDocs **Location to build the background images for Field Wiring Instructions**
-│ ├── polar_bears_musical_map.drawio
-│ ├── penguins_musical_layers.pspimage
-│ └── penguins_overview_layout.jpg
-│
-└── Props-Displays -> **Only store images here to build the Display/Prop for LOR**
-│ ├── polar_bears_musical_map.drawio
-│ ├── penguins_musical_layers.pspimage
-│ └── penguins_overview_layout.jpg
+
+Use the Stage, Sub-stage, Scene, shared group, or Display folder already established for the work.
+
+Do not invent a new folder structure from inside LOR.
+
+If a new Stage/Sub-stage/Scene documentation folder is actually needed, create the complete controlled structure using:
+
+[Stage / Sub-stage / Scene Folder Scaffold](../../00_Project_Overview/04-Stage_Substage_Scene_Folder_Scaffold.md)
+
+For Display-folder organization, follow the current Google Drive organization procedure rather than making a new rule in Preview Authoring.
+
+## Required marker files
+
+Folders used by the new FieldWiring or future Procedure system must have the required marker:
+
+```text
+_MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
 ```
-# Display Drawing and Preview Creation
 
-## Overview
+Do not delete or rename these marker files.
 
-To build a display, we need a plottable **vector drawing**.
-
-Scaling a bitmap image (such as *.jpg or *.png) will NOT work for fabrication because bitmap images lose quality when enlarged. A 4 ft × 8 ft panel requires a full-scale vector drawing that can be accurately resized without distortion.
-
-Vector drawings are used for:
-
-- CNC cutting
-- Plotting
-- Wiring overlays
-- Panel layout verification
-- Full-scale printing
-- Documentation
-- Preview background generation
-
-Bitmap images are still important for:
-
-- Documentation
-- Preview images
-- Tracing source artwork
-- Wiring references
-
-Both vector and bitmap workflows are required for building displays.
+See [MSB Source Folder Marker](../../00_Project_Overview/03-MSB_DB_Source_Folder_Marker_Operator_Procedure.md).
 
 ---
 
-# Recommended Software Tools
+# 3. Choose the Correct Background Location
 
-## AutoCAD
+LOR should link to a shared-drive image. Do **not** embed the image into the Preview.
 
-https://www.autodesk.com/products/autocad/
+For new authoring, use an approved marked location.
 
-- Works well with DXF formats
-- Suitable for precise dimensional work
-- Best suited for fabrication and dimensional accuracy
-- We have a limited number of licenses available
+## Normal Preview or Scene background
 
----
+Normally use the appropriate marked:
 
-## Inkscape — Free Vector Graphics Editor
+```text
+PreviewBackground\
+```
 
-https://inkscape.org/
+Examples may include a Stage, Sub-stage, Scene, Display, or shared-group `PreviewBackground` folder.
 
-- Free and open-source vector drawing program
-- Can import bitmap images and trace them into vector graphics
-- Exports scalable vector formats such as *.svg
-- Ideal for signage, outlines, overlays, and panel layouts
-- Works well for organizing display wiring layers
+## When the field wiring drawing is also the LOR background
 
-### IMPORTANT — Full Scale Document Setup
-
-When creating a new display drawing in Inkscape:
-
-- The document size MUST match the actual panel size being built
-- Always start the drawing at full scale
+A published wiring image may also be used directly when that drawing is intentionally the best LOR background.
 
 Examples:
 
-- 4 ft × 8 ft panel
-- 8 ft × 4 ft panel
-- 3 ft × 6 ft coro panel
+```text
+Wiring\BackgroundStage\<published image>
+Wiring\MusicalStage\<published image>
+```
 
-This ensures:
+Use only the current published marked wiring branch.
 
-- Artwork fits correctly on stock frames
-- Layout dimensions remain accurate
-- Wiring overlays align correctly
-- Exported files remain usable for fabrication
+## Do not use SourceDocs
 
----
-
-## GIMP — GNU Image Manipulation Program (Raster Editor)
-
-https://www.gimp.org/
-
-- Free bitmap image editor
-- Useful for cleaning up photos or artwork before vector tracing
-- Helpful for removing backgrounds or increasing contrast
-- Commonly used before importing artwork into Inkscape
-- NOT suitable for final scalable fabrication drawings
-- Can be used to create *.gif files to preview animation
-
-Typical workflow:
-
-1. Clean up artwork in GIMP
-2. Import image into Inkscape
-3. Trace bitmap into vector artwork
-4. Organize drawing into layers
-5. Export production SVG files
-
----
-
-# Layer Requirements
-
-Layers are extremely important for display construction.
-
-Each layer should represent a logical wiring or construction group.
-
-Examples:
-
-- Outline
-- Cut Lines
-- Channel 1
-- Channel 2
-- Roofline
-- Eyes
-- Mouth
-- Floods
-- Mounting Holes
-- Wiring Overlay
-
-Proper layer organization allows:
-
-- Easier troubleshooting
-- Cleaner fabrication files
-- Wiring overlays to be generated
-- Cleaner exported documentation
-- Selective printing and exporting
-
-Poor layer organization makes future maintenance extremely difficult.
-
----
-
-# File Naming Standards
-
-Inkscape uses special SVG features that are NOT fully compatible with many other programs.
-
-Because of this, TWO SVG versions must be preserved.
-
----
-
-## 1. Inkscape MASTER File
-
-This file preserves:
-
-- Layers
-- Guides
-- Inkscape effects
-- Editable objects
-- Internal metadata
-
-### Naming Format
-
-`DisplayName-inkscape.svg`
-
-### Example
-
-`TC-SnowmanPanel-inkscape.svg`
-
-This is the MASTER working file and should always be preserved.
-
----
-
-## 2. Production / Working Export
-
-Once the drawing is finalized for production, export a simplified SVG version for compatibility with other programs.
-
-### Naming Format
-
-`DisplayName-plain.svg`
-
-### Example
-
-`TC-SnowmanPanel-plain.svg`
-
-This version is typically used for:
-
-- CNC software
-- Plotters
-- Sharing with other programs
-- Production workflows
-
----
-
-# JPG / PNG Export Rules
-
-Bitmap images such as *.jpg and *.png are ONLY used for:
-
-- Documentation
-- Wiring previews
-- Web pages
-- Printed instructions
-- Preview backgrounds
-- Quick reference images
-
-Bitmap formats are:
-
-- NOT scalable
-- NOT suitable for fabrication
-- NOT suitable for plotting or CNC work
-
-Because bitmap images are resolution-dependent:
-
-- Export sizes matter
-- Low-resolution exports become blurry when enlarged
-- Large images consume excessive storage space
-
----
-
-# Folder Structure Requirements
-
-Each approved display must have its files stored under the proper stage folder structure.
-
-## Standard Stage Folder Location
+Do not create a new LOR background reference into:
 
 ```text
-G:\Shared drives\Display Folders\StageID-StageName-Prefix\
+SourceDocs\
 ```
 
-Example:
+`SourceDocs` is for working/source material, not normal LOR background or field presentation.
+
+For Master Musical Scenes, follow [Building the Master Musical Preview](E_Master_Musical_Preview_Howto.md).
+
+For field wiring images, follow [Create Wiring Backgrounds](D_Create_Wiring_Backgrounds..md).
+
+---
+
+# 4. Prepare the Display Artwork
+
+Use scalable vector artwork when the drawing will be used for fabrication, plotting, CNC work, or full-size printing.
+
+Bitmap images such as JPG or PNG are useful for Preview backgrounds and documentation.
+
+If using Inkscape, keep both files when appropriate:
 
 ```text
-G:\Shared drives\Display Folders\21-Polar Bear Playground-PB\
+DisplayName-inkscape.svg
+DisplayName-plain.svg
 ```
+
+The `-inkscape.svg` file is the editable master. The `-plain.svg` file is the simpler copy used by other programs.
+
+Do not store general artwork or fabrication files in published field-wiring folders.
 
 ---
 
-# Display Folder Organization
+# 5. Create the Preview Background
 
-Under each stage folder, there should be a dedicated folder for each display.
+Typical image sizes:
 
-This folder should contain:
+- horizontal single panel: about `800 x 600`;
+- vertical single panel: about `600 x 800`;
+- full Stage image: about `3840 x 2160`.
 
-- Inkscape drawings
-- AutoCAD drawings
-- Working SVG files
-- Source artwork
-- Preview images
-- Documentation images
-- Related fabrication files
+JPG is normally used for Preview backgrounds.
 
-Example:
+Save the image in the correct approved location.
+
+In LOR:
+
+1. Open the Preview Editor.
+2. Choose **Background -> Set Image**.
+3. Select the image from the shared drive.
+4. Do **not** embed the image into the Preview.
+
+---
+
+# 6. Draw the Display and Assign Channels
+
+In the LOR Preview Editor:
+
+1. Draw the strings or elements needed to represent the Display.
+2. Assign the correct controller, network, and channels from the approved design.
+3. Check the drawing scale and placement.
+4. Name the channels and Display using [Prop and Display Naming Conventions](A_Naming_Conventions.md).
+5. Add unused controller channels as SPARE channels.
+6. If a Display was moved from old channels, delete the old Display object and create new SPARE channels in its place.
+
+Do not simply hide an old Display channel or rename it to SPARE.
+
+---
+
+# 7. Create a Reusable LOR Prop When Needed
+
+If the Display will be reused in another Preview, export it as a `.leprop` file.
+
+The shared Prop location is:
 
 ```text
-G:\Shared drives\Display Folders\21-Polar Bear Playground-PB\Snowman\
-```
-
----
-
-# Display Groups for Large Projects
-
-For larger multi-part displays, a display group folder may be created to organize related displays together.
-
-This is commonly used when multiple props belong to a larger themed scene.
-
-Example:
-
-```text
-G:\Shared drives\Display Folders\13-Winter Wonderland-WW\Christmas Vacation\
-```
-
-Inside the display group folder, individual display folders may then be created:
-
-```text
-13-Winter Wonderland-WW\
-└── Christmas Vacation\
-    ├── RV\
-    ├── Cousin Eddie\
-    ├── Clark\
-    ├── Garbage Can\
-    └── Uncle Louis\
-```
-
-This helps keep:
-
-- Related artwork together
-- Wiring documentation organized
-- Preview assets grouped logically
-- Fabrication files easier to manage
-- Multi-display scenes easier to maintain
-
----
-
-# IMPORTANT — Avoid Loose Files
-
-Do NOT store unrelated drawing files directly under the stage root folder.
-
-Every display should have its own dedicated folder structure.
-
-This prevents:
-
-- Lost artwork
-- Duplicate files
-- Broken preview references
-- Wiring documentation confusion
-- Difficulty locating fabrication assets later
-
-# Wiring Documentation Folder
-
-⚠️ IMPORTANT:
-
-The `Wiring\` folder is a RESERVED folder structure used for **field installation documentation**.
-
-This folder is NOT intended for storing:
-
-- Raw artwork
-- Working SVG files
-- Fabrication files
-- General preview assets
-- Temporary exports
-
-The Wiring folder exists specifically to support:
-
-- Field setup documentation
-- Controller connection diagrams
-- DrawIO wiring documents
-- FormView-generated wiring PDFs
-- Visual field reference images
-
----
-
-# FormView Integration
-
-The FormView application automatically scans the Wiring folder structure and generates printable field setup documentation.
-
-This documentation is used by setup crews to identify:
-
-- Which controller plugs into which display
-- Wiring paths
-- Display locations
-- Port assignments
-- Visual setup references
-
----
-
-# IMPORTANT — Preview Name Controls Folder Linking
-
-The Preview Name is extremely important because it controls how the FormView application locates the correct Wiring folders.
-
-The Preview Name acts as the pointer between:
-
-- LOR Preview files
-- Wiring documentation folders
-- Background images
-- FormView-generated PDFs
-
-If the Preview Name does NOT match the expected folder structure:
-
-- FormView may fail to locate images
-- Wiring PDFs may generate incorrectly
-- Field setup documentation may be incomplete
-- Wrong displays may appear in generated packets
-
-Because of this, Preview Names must remain standardized and consistent.
-
----
-
-# IMPORTANT — Keep Wiring Folders Clean
-
-The FormView application scans these folders automatically.
-
-⚠️ Any extra images or unrelated files may appear in generated wiring PDFs.
-
-Because of this:
-
-- ONLY place files needed for field setup into these folders
-- Do NOT use the Wiring folders for general artwork storage
-- Do NOT leave old exports or temporary images in these folders
-- Remove obsolete images when displays are updated
-
-If these folders become cluttered, the generated field documentation becomes difficult to use.
-
----
-
-# Typical Wiring Folder Structure
-
-```text
-Wiring\
-Wiring\BackgroundStage\
-Wiring\MusicalStage\
-Wiring\DrawIO\
-```
-
-Additional folders may be added later as the workflow evolves.
-
----
-
-# Future Direction
-
-The current FormView workflow is considered temporary.
-
-Future plans are to migrate the wiring and setup documentation system into the new MSB Database workflow. That system is not yet implemented.
-
-Until then, the existing Wiring folder structure remains critical for field setup operations.
-
-# Prerequisites Before Creating a Preview
-
-Complete the following steps before beginning wiring or preview creation:
-
-1. Start with the approved Display Approval Form
-2. Create the concept drawing of the display
-3. Create the display folder under the correct Stage ID
-4. Create the vector artwork
-5. Create the preview background image (*.jpg)
-6. Save all files into the proper Display folders
-
----
-
-# Open Light O Rama and on the Right Side Click the + to create a New Preview
-
-## Name
-
-```text
-PreviewPropFile [SC-] DisplayName [UID] [StartChannel - EndChannel]
-```    
-
-
-# Image Requirements
-
-## Size Limits
-
-### Maximum
-
-- 4000 × 3000 pixels
-
-### Recommended — Single Panel
-
-- Horizontal: 800 × 600 px
-- Vertical: 600 × 800 px
-
-### Recommended — Full Stage
-
-- 3840 × 2160 px
-
----
-
-# Image Format Requirements
-
-- Save preview images as JPG
-- Optimize with approximately 20% compression
-- PaintShop Pro, GIMP, or similar software may be used
-
----
-
-# Background Image File Naming
-
-Use the display name exactly.
-
-Example:
-
-```text
-SnowmanPanel.jpg
-```
-
----
-
-# Creating a Single-Panel Preview for a New Display
-
-## 1. Open LOR Sequence Editor
-
-All previews are built within Light-O-Rama 
----
-
-## 2. Set the Background Image
-
-In the lower-left panel:
-
-```text
-Background → Set Image
-```
-
-Browse to the background image located under the display stage folder.
-
-Example:
-
-```text
-G:\Shared drives\Display Folders\21-Polar Bear Playground-PB\Wiring\Props-Displays
-```
-
-Use the JPG background image created during the design phase.
-
-⚠️ IMPORTANT:
-
-- Do NOT embed the image into the preview
-- The preview should reference the image externally
-- This keeps preview files smaller and easier to maintain
-
----
-
-## 3. Draw Strings and Assign Channels
-
-- Draw the display strings
-- Assign controllers
-- Assign channels
-- Verify scaling and placement
-- Save the preview file into the correct stage folder
-
-### Naming Guidance
-
-📘 See  
-[Prop and Display Naming Conventions](../01_Preview_Authoring/A_Naming_Conventions.md)  
-for full rules on channel grouping, display IDs, and comment field requirements.
-
----
-
-### Channel Naming Convention
-
-Use the following format:
-
-SC UID-Channel Name
-
-Where:
-
-- **SC** — Stage Code abbreviation of the stage  
-- **UID** — Controller ID assigned to the display  
-- **Channel** — Controller port or channel number  
-- **Name** — Brief description of the channel  
-  - Channel lists sort alphabetically
-
----
-
-5. When channel setup is complete:
-
-   - Select all channels → **Create Group**
-   - Save the group using the **Display Name**
-
-6. Export the group as a `.leprop` file
-
-   - Exported props are saved by default to the author’s local `ImportExport` folder
-   - Copy the `.leprop` file to:
-
-
-G:\Shared drives\MSB Database\Database Previews\PreviewsForProps
-
-
-- Use the **Preview Name** as the file name
-
-7. Save the preview as:
-
-
-Display Prop <Display Name> UID StartChannel-EndChannel
-
-
-8. Export the preview (`.lorprev`) to the same  
-   `PreviewsForProps` folder
-
----
-
-## Example — Display Prop with Channel Grid
-
-[<img src="/Docs/images/ChristmasHippo.jpg" width="600" alt="Display Prop ChristmasHippo TC 7B 01-07 (scaled)">](/Docs/images/ChristmasHippo.jpg)
-
----
-
-## Creating Previews for Stages
-
-The `.leprop` file creates a **PropID** that can be reused inside larger previews, such as:
-
-- `RGB Plus Prop Stage xx` (`MusicalStage`)
-- `Show Background Stage xx` (`BackgroundStage`)
-- `Show Animation xx` *(Not implemented)*
-
-### Master Musical Preview — use the dedicated procedure
-
-The **Master Musical Preview** does not follow the same Stage-identification rule as a normal Background Stage Preview. Its annual/versioned Preview name is shared by every musical Scene, so the parser derives Stage context from each Scene. A Scene's external background-image path can also intentionally identify whether its documentation belongs to the Stage root or to an established nested Scene/Substage folder.
-
-Before creating or changing musical Scenes, follow [Building the Master Musical Preview](E_Master_Musical_Preview_Howto.md). In particular, do not create a Google Drive Scene folder merely because a sequencing Scene exists in LOR, and make sure any Scene background or temporary placeholder is assigned from below the intended documentation root.
-
----
-
-## Background
-
-- When exporting props, they are saved by default to the author’s local **ImportExport** folder
-- Copy the prop file to:
-
-G:\Shared drives\MSB Database\Database Previews\PreviewsForProps
-
-- These props can then be added to a Stage Preview and will be available to everyone
-- Import all required props into the stage preview
-- Verify channel names comply with naming conventions and controller assignments
-- If there are **spare channels**:
-- Include them in the preview
-- Use **SPARE** as the Display Name (Comment field)
-- Color them **orange** as placeholders for future development
-
-## Duplicated Displays
-
-If there are multiple identical displays (such as arrow signs, speed limit signs, or Making Spirits Bright signs), they **MUST** be created together in a single preview so that each display receives a unique **PropID**.
-
-The database will generate errors if more than one display shares the same PropID.
-
-- ❌ Never copy a `.leprop` file from one preview into another preview
-
----
-
-### Example
-
-[<img src="/Docs/images/combined_duplicated_displays.png" width="600" alt="Combined Duplicate Displays">](/Docs/images/combined_duplicated_displays.png)
-
----
-
-### Export Procedure
-
-- Each display group is exported to its own `.leprop` file:
-
-  - `MSB-01.leprop`
-  - `MSB-02.leprop`
-  - `MSB-03.leprop`
-  - `MSB-04.leprop`
-
-- These props can then be safely imported into other previews
-
----
-
-## Editing an Existing Preview
-
-1. Import the preview from the canonical folder:
-
-```
-G:\Shared drives\MSB Database\Database Previews
-```
-
-   This ensures you have the latest version.
-
----
-
-### If the preview does NOT contain a background image
-
-We need to create and add one.
-
-#### Capture the image
-
-- If the show is running, take a photo of the stage.
-- Ensure lighting is sufficient so displays are clearly visible.
-- Capture ALL elements if possible (needed for Field Wiring documentation).
-
-#### Save location depends on stage type
-
-**Musical Stage**
-
-Save to:
-
-```
-G:\Shared drives\Display Folders\Stage Folder\Wiring\MusicalStage\SourceDocs
-```
-
-File name:
-
-
-RGB Plus Stage <Stage#> <Name> Background.jpg
-
-
----
-
-**Background Stage**
-
-Save to:
-
-```
-G:\Shared drives\Display Folders\Stage Folder\Wiring\BackgroundStage\SourceDocs
-```
-
-File name:
-
-
-Show Background Stage <Stage#> <Name> Background.jpg
-
-
----
-
-### Edit the Image
-
-1. Open the image in an editor  
-   - Corel PaintShop Pro is available on the Show PC
-2. Set canvas size to:
-    - 3840 × 2160 pixels
-3. Save as JPG with approximately 20% compression
-
----
-
-### Import Props into the Preview
-
-1. Begin importing the prop files created for the stage.
-2. To add a prop:
-    - **Add → LOR Prop file**
-3. Select props from:
-
-```
 G:\Shared drives\MSB Database\Database Previews\PreviewsForProps
 ```
 
----
+Use reusable Props carefully. Separate physical Displays must have separate LOR identities.
 
-### After Editing
-
-1. Save the preview.
-2. Export the updated `.lorprev` file to your staging folder:
-
-```
-G:\Shared drives\MSB Database\UserPreviewStaging<Author>
-```
+Do not blindly copy one Display object into several places when those objects represent different physical Displays.
 
 ---
 
-## Create Wiring Backgrounds for Stage Previews
+# 8. Choose the Correct Preview Type
 
-This allows Field Wiring documentation to include images.
+## Master Musical Preview
 
-Applies only to:
+Use the **Master Musical Preview** for current musical programming.
 
-- Musical Stage previews
-- Background Stage previews
+Do not create separate `RGB Plus Stage xx` musical Previews as part of the current workflow.
 
----
+For Scene names and Scene backgrounds, follow:
 
-## Field Wiring Images (Basic)
+[Building the Master Musical Preview](E_Master_Musical_Preview_Howto.md)
 
-Fastest method, but limited detail.
-- Only `.jpg` files directly inside the stage folders are used by FormView.
-- ALL images in these folders will be included in Field Wiring documentation.
+## Show Background Stage Preview
 
-⚠️ Remove any files that should not appear.
+These Previews are still used for background/static operation and field wiring.
 
-### File Naming Pattern
+For the wiring image, follow:
 
->Show <Category> <StageType> <Stage#> <DisplayName>-<Tag>.jpg
+[Create Wiring Backgrounds](D_Create_Wiring_Backgrounds..md)
 
-Examples:
+## Show Animation Preview
 
-- Show Background Stage 21 PolarBears-Tagged.jpg
-- Show Background Stage 21 Sliding Penguins-Wired.jpg
-- RGB Plus Prop Stage 15 Wired.jpg
+Use the existing Show Animation Preview where the current show workflow requires it.
 
----
+## Special Previews
 
-## How to Create a Basic Wiring Image
-
-1. Open the complete preview in the Preview Editor.
-2. Capture the entire preview using the Windows Snip Tool (Full Screen).
-3. Save the image to the SourceDocs folder for the stage type.
+Some Previews are intentional exceptions. Do not rename or combine them just to make the Preview names look consistent.
 
 ---
 
-### Save Locations
+# 9. Save and Check Your Work
 
-**Musical Stage**
+Before exporting:
 
-
-G:\Shared drives\Display Folders<StageID-StageName-Prefix>\Wiring\MusicalStage\SourceDocs
-
-
-File example:
-- RGB Plus Prop Stage <Stage#> LOR Preview-Wired.jpg
-
----
-
-**Background Stage**
-
-```
-G:\Shared drives\Display Folders<StageID-StageName-Prefix>\Wiring\BackgroundStage\SourceDocs
-```
-
-File example:
-
-- Show Background Stage <Stage#> LOR Preview-Wired.jpg
+- verify the Display Name and channel names;
+- verify controller and channel assignments;
+- verify SPARE channels;
+- verify the background image still opens from the shared drive;
+- verify new folders, when required, use the approved scaffold and markers;
+- verify the background does not point into `SourceDocs`; and
+- verify you are working in your own copy, not the approved master.
 
 ---
 
-4. If stopping here, copy the image to the main stage folder:
+# 10. Export Your Candidate Preview
 
+When the Preview is ready, export the `.lorprev` file to your own staging folder:
+
+```text
+G:\Shared drives\MSB Database\UserPreviewStaging\<username>
 ```
-G:\Shared drives\Display Folders<StageID-StageName-Prefix>\Wiring<StageType>
-```
 
-5. Re-open the preview and set this image as the background.
-6. Adjust props if needed to align correctly.
-7. Save the preview.
+Allow Google Drive to finish synchronizing the file.
 
-The basic wiring diagram is now complete.
+## Stop Here
+
+`UserPreviewStaging` is the handoff point for your finished candidate.
+
+Do **not**:
+
+- overwrite the approved master Preview;
+- save directly into the approved source folder; or
+- use your personal staging folder as the production Preview source.
+
+The master-update/review process is controlled separately.
 
 ---
 
-## Tagged Wiring Images (Recommended)
+# Before You Finish
 
-Creates a detailed diagram showing Display Names.
+- [ ] I started from the approved design information.
+- [ ] If editing an existing Preview, I used the current approved Preview.
+- [ ] My background image is in an approved marked location.
+- [ ] My background does not point into `SourceDocs`.
+- [ ] My Display and channel names follow the naming rules.
+- [ ] Controller and channel assignments are correct.
+- [ ] Unused channels are shown as SPARE.
+- [ ] Old channels from moved Displays were deleted and replaced with new SPARE channels.
+- [ ] Any new Stage/Sub-stage/Scene folder uses the complete scaffold and required markers.
+- [ ] I exported my work to `UserPreviewStaging\<username>`.
+- [ ] I did not overwrite the approved master.
 
-This cannot be generated inside LOR — use draw.io.
+## Expected Result
 
----
+A complete candidate Preview is saved in your `UserPreviewStaging` folder and is ready for the controlled review/master-update process.
 
-### Create Tagged Diagram in draw.io
+## If Something Is Wrong
 
-1. Open draw.io and create a Blank Diagram.
-2. Open Page Properties:
-   - Orientation: Landscape
-   - Page Size: Custom
-   - Set to match the background image (typically 3840 × 2160)
-3. Insert the wired image as the background.
-4. Add shapes (arrows, boxes, etc.) to label each display.
-5. Double-click shapes and enter the **Display Name**.
-   ⚠️ Do NOT use Channel Names  
-   Channel assignments may change over time.
-6. Formatting guidelines:
-   - Font: Helvetica
-   - Minimum size: 18 pt bold
-   - Recommended: 24 pt bold
-7. Repeat until all displays are labeled.
+If you are unsure about the correct Stage, folder, Scene name, Display Name, background location, or master Preview, stop before exporting and ask for review. Do not guess by creating new folders or new Preview identities.
 
----
+## Related Operator Documents
 
-### Save the draw.io File
+- [Preview Authoring Home](README.md)
+- [Prop and Display Naming Conventions](A_Naming_Conventions.md)
+- [Building the Master Musical Preview](E_Master_Musical_Preview_Howto.md)
+- [Create Wiring Backgrounds](D_Create_Wiring_Backgrounds..md)
+- [Preview Import Workflow](Preview_Import_Workflow.md)
+- [Google Drive Document Organization](../../00_Project_Overview/01-Google_Drive_Document_Organization_Procedure.md)
+- [MSB Source Folder Marker](../../00_Project_Overview/03-MSB_DB_Source_Folder_Marker_Operator_Procedure.md)
 
-**Musical Stage**
+## Related Engineering
 
-```
-G:\Shared drives\Display Folders\Stage Folder\Wiring\MusicalStage\SourceDocs
-```
-
-Example:
-- RGB Plus Prop Stage <Stage#> <Name>-Tagged.drawio
-
----
-
-**Background Stage**
-
-```
-G:\Shared drives\Display Folders\Stage Folder\Wiring\BackgroundStage\SourceDocs
-```
-
-Example:
-
-- Show Background Stage <Stage#> <Name>-Tagged.drawio
-
----
-
-### Export Tagged Image
-
-Export as JPG and save to the stage folder:
-
-**Musical Stage**
-
-```
-G:\Shared drives\Display Folders\Stage Folder\Wiring\MusicalStage
-```
-
-Example:
-
-- RGB Plus Prop Stage <Stage#> <Name>-Tagged.jpg
-
----
-
-**Background Stage**
-
-```
-G:\Shared drives\Display Folders\Stage Folder\Wiring\BackgroundStage
-```
-
-Examples:
-- Show Background Stage <Stage#> PolarBears-Tagged.jpg
-- Show Background Stage <Stage#> Sliding Penguins-Tagged.jpg
-
----
-
-### Final Step
-
-Re-open the preview and assign the tagged image as the background file.
-
-Save the preview.
-
-Field Wiring documentation will now use the tagged diagram.
-
-## ⚠️ IMPORTANT — Large Displays and Field Wiring Images
-
-For large displays, a single preview image may not provide enough detail for wiring documentation.
-
-A preview in LOR can only have **one background image**, but the FormView application supports multiple images for a stage.
-
-FormView will automatically scan the following folders and include **all images found** when generating Field Wiring documentation:
-
-- `MusicalStage`
-- `BackgroundStage`
-
-Example:
-
-```
-G:\Shared drives\Display Folders\21-Polar Bear Playground-PB\Wiring\BackgroundStage
-```
-
-Multiple images may be required to fully document complex stages.
-
-### 🚨 Critical Requirement
-
-**Only keep the images that are REQUIRED for Field Wiring documentation in these folders.**
-
-FormView will print **EVERY image** found.
-
-If unnecessary files are present, the wiring documentation will become cluttered and difficult to use.
-
-Remove any temporary, draft, or unrelated images before finalizing.
-
----
-
-### Example — Tagged Wiring Image
-
-![Show Background Stage 15 Tagged](/Docs/images/Show_Background_Stage_15_Preview_Background_Tagged.jpg)
-
----
-
-## Reminder
-After **any changes** to previews, export the authoritative preview set from the
-approved Master PC and run the controlled V7 production workflow:
-
-1. Open `https://my.sheboyganlights.org/lor2db/` and select **Run parser**.
-2. Review the parser output; correct the previews and rerun as often as needed.
-3. Confirm the exact parser output and select **Ingest to PostgreSQL**.
-4. Review the ingest console and select **Start reconciliation**.
-5. Record required decisions, complete final review, apply, and review the
-   immutable report.
-
-Use `LOR2DB/Reconciliation/00_LOR_Production_Import_and_Reconciliation_Procedure.md`
-for the current stop conditions and exact workflow. The V6 merger/parser/compare
-pipeline is archived and is not a production procedure.
-
-This ensures the system stays consistent for all users.
+- [Preview Merger](../03_Preview_Merger/README.md)
+- [LOR Data Extraction](../02_Data_Extraction/README.md)
+- [FieldWiring Engineering](../../02_Production_Database/01_System_Architecture/09_Wiring_System/README.md)
 
 # Changelog
 
-2026-08-11 - Added Master Musical Preview authoring handoff and documentation-root rule
-2026-05-10 - Updated Recommended Software Tools
-2025-10-05 - Intial Release
+- 2026-08-22 — Rewritten as a plain-language operator procedure using the current marked-folder, Scene scaffold, Master Musical Preview, FieldWiring, and staging rules.
+- 2025-10-05 — Initial release.

--- a/Docs/01_LOR_System/01_Preview_Authoring/D_Create_Wiring_Backgrounds..md
+++ b/Docs/01_LOR_System/01_Preview_Authoring/D_Create_Wiring_Backgrounds..md
@@ -1,217 +1,265 @@
 ---
 title: Create Wiring Backgrounds for Stage Previews
 author: Greg Liebig / Engineering Innovations, LLC
-status: ACTIVE
+status: CURRENT
+revision: 2026-08-22
 ---
 
 # Create Wiring Backgrounds for Stage Previews
 
+| Document Control | Value |
+|---|---|
+| Document Type | Operator Procedure |
+| System | LOR Preview Authoring / Field Wiring |
+| Task | Create and publish field wiring images |
+| Audience | Preview authors and wiring-documentation maintainers |
+| Status | CURRENT |
+| Owner | MSB Production Crew |
+| Last Reviewed | 2026-08-22 |
+
 ## Purpose
 
-This procedure explains how to create and organize the background images and supporting files used by Light-O-Rama Stage Previews and the MSB field-wiring documentation workflow.
+Use this procedure when creating or updating the images used for field wiring instructions.
 
-The wiring background is more than a picture used while authoring a preview. Its stored path and the files placed in the designated Wiring folders are part of the field-documentation pipeline used by FormView.
+These images help the field crew see where Displays and controller connections are located. They do not replace the controller/channel assignments stored in LOR.
 
-At a high level:
+---
 
-```text
-Stage folder
-    -> Wiring folder
-        -> designated Preview background folder
-            -> Preview background image
-            -> supporting field-reference images
-        -> LOR Preview references the background image path
-        -> FormView uses that path/folder relationship
-        -> FormView collects the designated field images
-        -> FormView builds printable HTML field-wiring instructions
-```
+# 1. Use the Correct Wiring Folder
 
-The generated HTML is used by setup crews while plugging displays into controllers and connecting the Stage in the field.
+Use the wiring folder that matches the type of field wiring.
 
-## Standard Stage Folder Location
-
-Each Stage has one unique folder under:
+## Background / Static wiring
 
 ```text
-G:\Shared drives\Display Folders\StageID-StageName-Prefix\
+<Stage / Sub-stage / Scene>\Wiring\BackgroundStage\
 ```
+
+## Musical wiring
+
+```text
+<Stage / Sub-stage / Scene>\Wiring\MusicalStage\
+```
+
+## Working files
+
+Keep editable and temporary work in the matching `SourceDocs` folder:
+
+```text
+Wiring\BackgroundStage\SourceDocs\
+Wiring\MusicalStage\SourceDocs\
+```
+
+Do not use `SourceDocs` as the published field-image location.
+
+---
+
+# 2. Check the Marker Files
+
+Folders used by FieldWiring must have the required marker:
+
+```text
+_MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
+```
+
+For a published wiring path, verify the marker is present in:
+
+- the Stage/Sub-stage/Scene root;
+- `Wiring`; and
+- the `BackgroundStage` or `MusicalStage` folder being used.
+
+Do not rename or delete marker files.
+
+See [MSB Source Folder Marker](../../00_Project_Overview/03-MSB_DB_Source_Folder_Marker_Operator_Procedure.md).
+
+---
+
+# 3. Keep the Published Wiring Folder Clean
+
+Only current field-use images belong directly in `BackgroundStage` or `MusicalStage`.
+
+Do not leave:
+
+- draft images;
+- obsolete images;
+- source files;
+- screenshots that are not part of the current field instructions; or
+- unrelated photographs
+
+in the published folder.
+
+Move working material into `SourceDocs`.
+
+This matters because the field system may show the images stored directly in the selected published wiring folder.
+
+---
+
+# 4. Create a Basic Wiring Image
+
+A basic wiring image can be made from the LOR Preview.
+
+1. Open the complete Stage/Scene Preview in LOR.
+2. Arrange the view so the physical layout is easy to understand.
+3. Capture the complete Preview with Windows Snip Tool or another screen-capture tool.
+4. Save the working capture in the correct `SourceDocs` folder.
+5. Crop, resize, or clean up the image as needed.
+6. Save the finished field-use image directly in the marked `BackgroundStage` or `MusicalStage` folder.
+
+A typical full-Stage image size is about:
+
+```text
+3840 x 2160
+```
+
+The important requirement is that the image remains readable on screen and when printed.
+
+---
+
+# 5. Create a Tagged Wiring Image When More Detail Is Needed
+
+A tagged image is recommended when the plain Preview does not clearly show where physical Displays are located.
+
+A common method is to use draw.io.
+
+1. Open draw.io and create a new diagram.
+2. Set the page size to match the base image when practical.
+3. Insert the base Stage/Scene image.
+4. Add arrows, boxes, or callouts to identify Displays and connection areas.
+5. Label physical Displays using their **Display Names**.
+6. Save the editable `.drawio` file in `SourceDocs`.
+7. Export the finished JPG or PNG directly into the marked published wiring folder.
 
 Example:
 
 ```text
-G:\Shared drives\Display Folders\21-Polar Bear Playground-PB\
+<Stage>\Wiring\BackgroundStage\SourceDocs\Show Background Stage 21 PolarBears-Tagged.drawio
+<Stage>\Wiring\BackgroundStage\Show Background Stage 21 PolarBears-Tagged.jpg
 ```
 
-The existing Stage-oriented folder structure is shared operational infrastructure. Do not create a second unrelated folder structure for wiring documentation.
+Use a readable font size. The goal is a drawing the setup crew can understand quickly.
 
-## Wiring Folder Purpose
+---
 
-The `Wiring\` folder is reserved for field installation documentation and the images needed by the LOR Stage Preview / FormView wiring workflow.
+# 6. More Than One Wiring Image Is Allowed
 
-It is intended to support:
+Large or complicated Stages/Scenes may need more than one wiring image.
 
-- Stage Preview background images;
-- field wiring reference images;
-- controller connection diagrams;
-- Draw.io wiring documents and source material;
-- FormView-generated field wiring instructions; and
-- visual setup references used while connecting the Stage.
-
-Do not use the Wiring folders as general-purpose storage for unrelated artwork, temporary exports, or fabrication files.
-
-## Wiring Folder Layout
-
-A typical Stage wiring structure is:
-
-```text
-G:\Shared drives\Display Folders\21-Polar Bear Playground-PB\
-└── Wiring\
-    ├── BackgroundStage\
-    │   ├── Show Background Stage 21 PolarBears-Tagged.jpg
-    │   ├── Show Background Stage 21 Sliding Penguins-Tagged.jpg
-    │   └── SourceDocs\
-    │       ├── polar_bears_map.drawio
-    │       ├── polar_bears_wiring.pspimage
-    │       └── sliding_penguins_layout.jpg
-    │
-    ├── MusicalStage\
-    │   ├── Show Musical Stage 21 PolarBears-Tagged.jpg
-    │   ├── Show Musical Stage 21 Sliding Penguins-Wired.jpg
-    │   └── SourceDocs\
-    │       ├── polar_bears_musical_map.drawio
-    │       ├── penguins_musical_layers.pspimage
-    │       └── penguins_overview_layout.jpg
-    │
-    └── Props-Displays\
-        ├── polar_bears_musical_map.drawio
-        ├── penguins_musical_layers.pspimage
-        └── penguins_overview_layout.jpg
-```
-
-### `BackgroundStage`
-
-Store the images used for **Show Background Stage** Preview field-wiring instructions here.
-
-The `SourceDocs\` subfolder is the working location for source material used to build those field-wiring background images.
-
-### `MusicalStage`
-
-Store the images used for **Musical Stage** Preview field-wiring instructions here.
-
-The `SourceDocs\` subfolder is the working location for source material used to build those field-wiring background images.
-
-For the **Master Musical Preview**, the Scene's background-image path can also be used to identify the Scene's documentation root. A musical Scene that belongs to the whole Stage should reference an image below the Stage's `Wiring\MusicalStage` branch. A Scene that has an established one-to-one nested documentation folder should reference an image below that folder's `Wiring\MusicalStage` branch. See [Building the Master Musical Preview](E_Master_Musical_Preview_Howto.md) before assigning musical Scene backgrounds.
-
-### `Props-Displays`
-
-Use this area for images needed to build individual Display/Prop previews in LOR. These are distinct from the Stage-level field-wiring instruction images.
-
-## Creating the Wiring Background
-
-The Stage wiring background should provide a useful visual map for field installation. Depending on the Stage, it may be created from Draw.io, PaintShop Pro, Inkscape, GIMP, photographs, layout drawings, or other source material.
-
-The working/source files belong in the appropriate `SourceDocs\` folder. The final image used by the LOR Preview belongs directly in the designated `BackgroundStage\` or `MusicalStage\` folder.
-
-For a Master Musical Preview Scene, a temporary placeholder image may be used while the final field-wiring image is still being developed. In that case, the important requirement is that the placeholder is stored below the correct Stage or nested Scene documentation root before it is assigned in LOR. The placeholder can later be replaced while preserving the intended documentation-root relationship.
-
-The final background should show enough information to make the generated field-wiring instructions useful to the setup crew. The exact drawing content varies by Stage.
-
-## Set the Background Image in LOR
-
-In the LOR Preview editor:
-
-```text
-Background -> Set Image
-```
-
-Browse to the final background image in the correct Stage Wiring folder.
+Store each final field-use image directly in the same marked published folder.
 
 Example:
 
 ```text
-G:\Shared drives\Display Folders\21-Polar Bear Playground-PB\Wiring\BackgroundStage\Show Background Stage 21 PolarBears-Tagged.jpg
+Wiring\BackgroundStage\
+    Show Background Stage 21 PolarBears-Tagged.jpg
+    Show Background Stage 21 Sliding Penguins-Tagged.jpg
 ```
 
-or, for a Musical Stage Preview:
+Only keep images there that belong in the current field packet.
 
-```text
-G:\Shared drives\Display Folders\21-Polar Bear Playground-PB\Wiring\MusicalStage\...
-```
+---
 
-### Do not embed the image
+# 7. When the Wiring Image Is Also the LOR Background
 
-The Preview should reference the background image externally rather than embedding it into the Preview.
+A published wiring image may also be selected as the LOR Preview/Scene background when that is the best image for authoring.
 
-The stored background path is important because the existing wiring-documentation workflow uses that filesystem relationship to locate the Stage wiring material.
+In LOR:
 
-## FormView Relationship
+1. Open the Preview Editor.
+2. Choose **Background -> Set Image**.
+3. Select the current published image directly from the marked `BackgroundStage` or `MusicalStage` folder.
+4. Do **not** embed the image.
+5. Save the Preview.
 
-FormView uses the LOR/parsed Preview background path as the starting point for the wiring-documentation workflow.
+This direct Wiring path is allowed. You do not need to copy the same image into `PreviewBackground` just to use it in LOR.
 
-The current operational behavior is:
+---
 
-1. The Stage Preview references its background image by path.
-2. That path places the Preview within the established Stage `Wiring\` folder structure.
-3. FormView uses the path/folder relationship to locate the designated wiring images associated with that Preview.
-4. Images stored in the applicable field-wiring folder are incorporated into the output.
-5. FormView combines those images with the wiring information derived from the LOR Preview data.
-6. FormView generates a printable HTML document used in the field for plugging displays and controller connections.
+# 8. Master Musical Preview — Important Difference
 
-This folder/path relationship is therefore an operational contract, not merely a file-organizing preference.
+A Master Musical Scene does not have to use a Wiring image as its background.
 
-## Keep the Designated Wiring Folders Clean
+Normally, use a marked `PreviewBackground` image for the Scene.
 
-FormView uses the contents of the designated wiring folders when producing field documentation.
+A directly published `Wiring\MusicalStage` image is also allowed when that wiring drawing is intentionally the best Scene background.
 
-Because of this:
+Do not use `SourceDocs` for a new Scene background.
 
-- only place images needed for the field-wiring instructions in those folders;
-- do not leave unrelated pictures in the active wiring-image folder;
-- do not leave obsolete exports behind after the Stage documentation changes;
-- keep working/source material inside `SourceDocs\` rather than mixed with final field images; and
-- verify the correct final background image is referenced by the LOR Preview.
+See [Building the Master Musical Preview](E_Master_Musical_Preview_Howto.md).
 
-Extra or obsolete images can become part of the generated field documentation and confuse the setup crew.
+---
 
-## Background Image Guidance
+# 9. Check the Wiring Information
 
-For Stage backgrounds, use a JPG image sized appropriately for the Preview and field documentation.
+The picture does not override LOR.
 
-Existing guidance for full Stage images is approximately:
+Before relying on the wiring image, verify the LOR Preview still has the correct:
 
-```text
-3840 x 2160 px
-```
+- controller IDs;
+- channels;
+- networks; and
+- DMX/E1.31 information where applicable.
 
-The image should remain readable when viewed on screen and when incorporated into printed/HTML field instructions.
+If the picture and LOR disagree, stop and correct/review the source information.
 
-## Before Exporting the Preview
+---
 
-Verify:
+# 10. Check the Field Output
 
-1. The Preview references the final image from the correct Stage `Wiring\` folder, or follows the documented Master Musical Preview Scene-root rule when a musical Scene uses a placeholder or nested documentation root.
-2. The background image opens correctly from the shared-drive location.
-3. The designated wiring-image folder contains only current field-use images.
-4. Source/working files are kept in `SourceDocs\` where applicable.
-5. The Stage/Preview naming follows the current Preview Authoring naming rules.
-6. Controller and channel assignments in LOR are correct before relying on the resulting field instructions.
+The browser-based **FieldWiring** system is the current replacement being prepared for field use. **FormView remains available as the fallback/reference until FieldWiring completes deployment and field-device acceptance.**
 
-Then export the Preview using the normal controlled Preview Authoring workflow.
+Before relying on the image set:
 
-## Important System Boundary
+1. use the current field-wiring tool available for the test/field situation;
+2. select the correct Stage/Scene and wiring type;
+3. make sure the expected wiring image(s) appear;
+4. verify there are no old or unrelated images; and
+5. confirm the wiring table matches the area you are working on.
 
-LOR remains authoritative for controller assignments, channel numbers, network/DMX assignments, and show topology.
+If an unwanted image appears, remove or move it from the published wiring folder and check again.
 
-The Wiring folder and its images provide the visual field-documentation layer. FormView combines those visual assets with the LOR-derived wiring data to create a practical installation document; it does not redefine the LOR wiring assignments.
+---
 
-## Related Documents
+# Printed Wiring Instructions Are Temporary
 
+Printed or generated wiring instructions are temporary field working documents.
+
+- Generate a current copy when needed.
+- Use it for the current setup work.
+- Do not laminate or treat it as permanent wiring authority.
+- Discard old copies after the work is complete or after Preview/wiring information changes.
+
+This prevents crews from using stale hookup information.
+
+---
+
+# Before You Finish
+
+- [ ] I used the correct `BackgroundStage` or `MusicalStage` folder.
+- [ ] The Stage/Sub-stage/Scene root is marked.
+- [ ] `Wiring` is marked.
+- [ ] The published `BackgroundStage` / `MusicalStage` folder is marked.
+- [ ] Working files are in `SourceDocs`.
+- [ ] Only current field-use images are in the published wiring folder.
+- [ ] Any LOR background points to an approved marked image and not `SourceDocs`.
+- [ ] LOR controller/channel/network information is correct.
+- [ ] I checked the final image set in the current field-wiring tool.
+
+## Expected Result
+
+The correct current wiring images are available for the same Stage/Sub-stage/Scene as the wiring data, with no draft or unrelated images mixed into the field output.
+
+## Related Operator Documents
+
+- [Preview Authoring Home](README.md)
 - [Building a Preview](B_Building_Preview_Howto.md)
 - [Building the Master Musical Preview](E_Master_Musical_Preview_Howto.md)
-- [Naming Conventions](A_Naming_Conventions.md)
-- [LOR Preview Authoring](README.md)
-- [Wiring System Engineering](../../02_Production_Database/01_System_Architecture/09_Wiring_System/README.md)
+- [MSB Source Folder Marker](../../00_Project_Overview/03-MSB_DB_Source_Folder_Marker_Operator_Procedure.md)
 
-## Engineering Note
+## Related Engineering
 
-This document records the operator-facing folder/path contract. The detailed FormView engineering design — including how it resolves the background path, which folders/files it reads, how it combines images with wiring rows, and how the printable HTML is assembled — must be documented separately from the application source and linked back here.
+- [FieldWiring Engineering](../../02_Production_Database/01_System_Architecture/09_Wiring_System/README.md)
+- [FormView](../04_FormView/README.md)
+
+## Revision History
+
+- 2026-08-22 — Rewritten for operators in plain language and aligned with current FieldWiring, FormView fallback, direct Wiring background paths, and full marker requirements.

--- a/Docs/01_LOR_System/01_Preview_Authoring/E_Master_Musical_Preview_Howto.md
+++ b/Docs/01_LOR_System/01_Preview_Authoring/E_Master_Musical_Preview_Howto.md
@@ -1,339 +1,282 @@
 ---
-title: Building the Master Musical Preview (Operator How-To)
+title: Building the Master Musical Preview
 author: Greg Liebig / Engineering Innovations, LLC
-status: ACTIVE
+status: CURRENT
+revision: 2026-08-22
 ---
 
-# Building the Master Musical Preview (Operator How-To)
+# Building the Master Musical Preview
+
+| Document Control | Value |
+|---|---|
+| Document Type | Operator Procedure |
+| System | LOR Preview Authoring |
+| Task | Build or update the Master Musical Preview |
+| Audience | Musical Preview authors and programmers |
+| Status | CURRENT |
+| Owner | MSB Production Crew |
+| Last Reviewed | 2026-08-22 |
 
 ## Purpose
 
-Use this procedure when creating or maintaining the MSB **Master Musical Preview** in Light-O-Rama (LOR).
+Use this procedure when creating or changing Scenes in the MSB **Master Musical Preview**.
 
-The Master Musical Preview is different from a normal Background Stage Preview:
+The Master Musical Preview contains musical programming for many Stages, so Scene names and background locations must clearly show where the Scene belongs.
 
-- one Master Musical Preview contains musical programming material from many Stages;
-- the Preview name identifies the annual/versioned master preview, not a Stage;
-- each Scene provides the Stage context needed by the parser; and
-- a Scene's background-image path can also identify the Google Drive documentation root that belongs to that Scene.
-
-This relationship is important to the parser, Folder Alignment, FieldWiring, and future field applications.
+You do not need to understand the parser or database to use these rules.
 
 ---
 
-## Master Musical Preview Name
+# 1. Use the Master Musical Preview
 
-The Master Musical Preview uses a common annual/versioned name such as:
+The current musical workflow uses one annual/versioned Master Musical Preview, for example:
 
 ```text
 2026 Master Musical Preview v...
 ```
 
-All Scenes inside that Preview share the same Preview name.
+Do not create separate `RGB Plus Stage xx` musical Previews as part of the current workflow.
 
-**Do not use the Master Musical Preview name to determine Stage placement.**
-
-The Preview name identifies the master musical working set. Stage membership is derived from the Scene information.
+The Master Musical Preview name identifies the overall musical Preview. The **Scene name** identifies the Stage/Sub-stage/Scene context inside it.
 
 ---
 
-## Scene Names Carry Stage Context
+# 2. Name Each Scene Correctly
 
-Each musical Scene must retain enough Stage information in its Scene name for the parser to derive the correct `SceneStageID`.
+Use these naming patterns.
 
-Examples include:
+| What the Scene represents | Naming pattern | Example |
+|---|---|---|
+| Entire Stage | `NN-Name-XY` | `07-Whoville-WV` |
+| Formal Sub-stage | `NNa-Name-XY` | `07a-Who Forest-WF` |
+| Scene within a Stage | `NN-Name` | `13-Christmas Vacation` |
+| Scene within a Sub-stage | `NNa-Name` | `07a-Some Scene` |
+| Display/shared group used only for organizing LOR | Normal Display/group name | `Who Characters` |
 
-```text
-05-Festive Trees-FT
-07-Whoville-WV
-07-Who People
-07a-Who Forest-WF
-```
+Where:
 
-The parser uses the Scene name to determine the Stage because the Master Musical Preview name itself is not Stage-specific.
+- `NN` is the two-digit Stage number;
+- `NNa` is the Stage number plus the Sub-stage letter; and
+- `XY` is the two-letter Stage/Sub-stage code.
 
-A Scene is primarily an LOR sequencing organization. It does **not** automatically mean that a matching Google Drive Scene folder must exist.
+## Important
 
-Some musical Scenes represent the whole Stage. Some represent a meaningful physical/documentation subdivision. Other Scenes may exist only to make musical sequencing easier to understand.
+A Scene in LOR does **not** automatically mean a matching Google Drive Scene folder must be created.
+
+Some Scenes exist only to make programming easier to organize.
+
+Use the existing folder structure unless the Scene really needs its own shared documentation folder.
 
 ---
 
-# Documentation Root — Important
+# 3. Do Not Use `Root` to Identify a Stage in the Master Musical Preview
 
-A musical Scene can use its LOR `BackgroundFile` path to identify the correct Google Drive documentation root.
+The name `Root` is used in some Background Stage Previews.
 
-This is more than a visual-background setting. The stored path provides filesystem evidence that downstream tools can use together with current Stage/Scene identity.
+Do **not** use bare `Root` as the Scene name when the Master Musical Preview needs to identify which Stage the Scene belongs to.
 
-For **new authoring**, the Scene background should be selected from an approved marked database/application source location below the intended documentation root. Do not create new Scene pointers into loose legacy files or `SourceDocs`.
+Use the proper Stage, Sub-stage, Scene, or Display/group name instead.
 
-Approved new-authoring anchors are normally:
+---
 
-```text
-<documentation root>\PreviewBackground\<image>
-```
+# 4. Decide Where the Scene Background Belongs
 
-or, when the published musical wiring drawing is itself the appropriate background:
+For new authoring, use an approved marked folder.
 
-```text
-<documentation root>\Wiring\MusicalStage\<published image>
-```
+There are two normal choices.
 
-The `PreviewBackground` or `Wiring` root must carry the standard MSB database-source marker.
+## Choice A — `PreviewBackground`
 
-Existing legacy Scene pointers may temporarily use older locations while Folder Alignment cleanup continues. That does not make those old locations valid for new authoring.
+Use the marked `PreviewBackground` folder when the Scene uses a normal LOR background image.
 
-## Stage-level musical Scene
+Examples:
 
-When the Scene belongs to the Stage as a whole, use a marked Stage-level source location.
-
-Example using `PreviewBackground`:
+### Whole Stage
 
 ```text
-G:\Shared drives\Display Folders\07-Whoville-WV\
-└── PreviewBackground\
-    ├── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
-    └── WhoPeople.jpg
+G:\Shared drives\Display Folders\07-Whoville-WV\PreviewBackground\WhoPeople.jpg
 ```
 
-Example using a published wiring drawing:
+### Sub-stage
 
 ```text
-G:\Shared drives\Display Folders\07-Whoville-WV\
-└── Wiring\
-    ├── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
-    └── MusicalStage\
-        └── Stage-07-Musical-Tagged.jpg
+G:\Shared drives\Display Folders\07-Whoville-WV\07a-Who Forest-WF\PreviewBackground\WhoForest.jpg
 ```
 
-Both identify Stage 07 as the documentation root.
+### Scene with its own established folder
 
-**Do not use `Wiring\MusicalStage\SourceDocs` as a new Scene background endpoint.** `SourceDocs` is working/source material and is excluded from normal FieldWiring presentation.
+```text
+G:\Shared drives\Display Folders\13-Winter Wonderland-WW\13-Christmas Vacation\PreviewBackground\ChristmasVacation.jpg
+```
 
-## Scene or Sub-stage with its own documentation root
+## Choice B — Published `Wiring\MusicalStage` image
 
-When a musical Scene has a real one-to-one Google Drive folder that owns its own Wiring, Procedures, PreviewBackground, or other shared documentation, use that folder as the documentation root.
+If the published musical wiring drawing is also the best LOR Scene background, you may point directly to that image.
 
 Example:
 
 ```text
-G:\Shared drives\Display Folders\07-Whoville-WV\
-└── 07a-Who Forest-WF\
-    ├── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
-    └── Wiring\
-        ├── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
-        └── MusicalStage\
-            └── WhoForest-Tagged.jpg
+<Stage / Sub-stage / Scene>\Wiring\MusicalStage\<published image>.jpg
 ```
 
-That path identifies this documentation root:
+The Stage/Sub-stage/Scene root, `Wiring`, and `MusicalStage` folders must have their required marker files.
 
-```text
-07-Whoville-WV\07a-Who Forest-WF
-```
+You do **not** need to copy the same published wiring image into `PreviewBackground` just to use it in LOR.
 
 ---
 
-# If a New Scene Documentation Folder Is Needed
+# 5. Never Use `SourceDocs` for a New Scene Background
 
-Do not create an empty or one-off Scene folder and add helper folders later.
+Do not create a new Scene background link into:
 
-If review determines that a Scene genuinely needs its own Google Drive documentation root, create the **complete controlled Stage/Sub-stage/Scene scaffold immediately**.
+```text
+SourceDocs\
+```
 
-Use:
+`SourceDocs` contains working files. It is not a normal field or LOR background location.
+
+Existing old references may still be found during cleanup, but do not create new ones there.
+
+---
+
+# 6. If a New Scene Documentation Folder Is Needed
+
+Do not create an empty Scene folder and add pieces later.
+
+If the Scene really needs its own Google Drive documentation folder, use the complete controlled scaffold:
 
 [Stage / Sub-stage / Scene Folder Scaffold](../../00_Project_Overview/04-Stage_Substage_Scene_Folder_Scaffold.md)
 
-The new Scene root includes:
+Use a separate Scene folder only when the Scene represents a real shared documentation area, such as a group that:
 
-- the structural root marker;
-- marked `PreviewBackground`;
-- marked `Procedures`;
-- marked `Wiring`;
-- the standard procedure and wiring branches; and
-- the standard `Photos` structure, which is not currently a database/application source folder.
+- is installed together;
+- shares wiring;
+- shares Setup/Takedown instructions; or
+- needs its own common background/documentation.
 
-This requirement is especially important for Scenes because new Scene documentation scopes are more likely to be created than entirely new Stages.
-
-A new Scene folder should begin clean. The legacy-tolerance rules that allow loose files to remain in old Stage/Scene roots do not justify putting new loose files into a newly created Scene root.
+If the Scene exists only for sequencing clarity, keep its documentation with the appropriate Stage or Sub-stage.
 
 ---
 
-# Why the Path Matters
+# 7. Check the Required Marker Files
 
-For current controlled authoring, downstream tooling can recognize marked source folders and the standardized path structure.
-
-Example:
+Any folder used by the new FieldWiring system or future Procedure system must have the required marker:
 
 ```text
-07-Whoville-WV\PreviewBackground\WhoPeople.jpg
+_MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
 ```
 
-identifies Stage 07 as the background/documentation context.
+Do not rename or delete marker files.
 
-A direct published wiring path:
+For a new Stage/Sub-stage/Scene folder, the scaffold shows exactly where the markers belong.
 
-```text
-07-Whoville-WV\07a-Who Forest-WF\Wiring\MusicalStage\WhoForest-Tagged.jpg
-```
-
-identifies the nested `07a-Who Forest-WF` documentation root and the Musical wiring context.
-
-The file name is not permanent identity. Current database/LOR relationships plus the controlled folder relationship establish context.
-
-Legacy path text outside the marked structure may still be useful as navigation evidence during cleanup, but applications return to the marked source structure before selecting published field content.
+See [MSB Source Folder Marker](../../00_Project_Overview/03-MSB_DB_Source_Folder_Marker_Operator_Procedure.md).
 
 ---
 
-# Placeholder Background Images Are Allowed
+# 8. A Temporary Background Image Is Allowed
 
-When the final musical wiring image does not yet exist, a temporary background image may be used to establish the correct documentation-root path.
+The final image does not have to be finished before the Scene can be set up.
 
-For new authoring, put the placeholder in the marked `PreviewBackground` folder for the intended Stage/Sub-stage/Scene root.
+You may use a temporary image if:
 
-The placeholder should:
+1. it is saved in the correct marked `PreviewBackground` folder;
+2. it is linked to the Scene in LOR;
+3. it is not embedded in the Preview; and
+4. it is later replaced deliberately without moving the Scene to the wrong documentation location.
 
-1. be stored in the correct marked `PreviewBackground` folder;
-2. be assigned as the Scene background in LOR;
-3. remain an external file reference rather than being embedded into the Preview; and
-4. later be replaced deliberately while preserving the intended documentation root unless the Scene's physical/documentation scope has changed.
-
-Do not use `SourceDocs` for placeholder Scene backgrounds.
+Do not use `SourceDocs` for the temporary image.
 
 ---
 
-# Choosing the Correct Documentation Root
+# 9. Set the Scene Background in LOR
 
-Use the existing physical/documentation organization as the primary guide.
+For each Scene that needs a background:
 
-## If the musical Scene represents the entire Stage
-
-Use the existing Stage root and one of its marked source folders.
-
-Do **not** create a duplicate child folder merely because the LOR Scene name matches the Stage name.
-
-Wrong:
-
-```text
-05-Festive Trees-FT\
-└── 05-Festive Trees-FT\
-    └── Wiring\MusicalStage
-```
-
-Correct Stage-level context:
-
-```text
-05-Festive Trees-FT\PreviewBackground\...
-```
-
-or:
-
-```text
-05-Festive Trees-FT\Wiring\MusicalStage\...
-```
-
-## If there is an established one-to-one Scene/Sub-stage folder
-
-Use that existing structured root and its marked source folders.
-
-## If a new Scene documentation root is genuinely required
-
-Create it using the complete controlled scaffold before assigning new LOR background references to it.
-
-## If the Scene exists only for sequencing clarity
-
-Do not create a new Google Drive folder simply because the Scene exists in LOR.
-
-Use the applicable Stage or Sub-stage documentation root.
-
-If the intended documentation scope is unclear, stop and review it before creating a folder or changing the Scene background.
-
----
-
-# Current Whoville Example
-
-Stage 07 demonstrates why this distinction matters.
-
-The Master Musical Preview can contain Stage-level, Sub-stage, and sequencing Scenes such as:
-
-```text
-07-Whoville-WV
-07-Who People
-07a-Who Forest-WF
-```
-
-They do not all require separate Google Drive documentation folders.
-
-Conceptually:
-
-```text
-07-Whoville-WV
-    -> Stage 07 documentation root
-
-07-Who People
-    -> Stage 07 documentation root when its current controlled background
-       is under Stage 07 PreviewBackground or published MusicalStage Wiring
-
-07a-Who Forest-WF
-    -> nested documentation root when its current controlled background
-       is under 07a-Who Forest-WF PreviewBackground or published Wiring
-```
-
-This allows LOR Scenes to remain useful for musical sequencing without forcing the Google Drive hierarchy to duplicate every Scene.
-
----
-
-# Setting the Scene Background in LOR
-
-For each Scene that needs an explicit documentation-root anchor:
-
-1. Determine whether its documentation belongs to the whole Stage, a formal Sub-stage, or an established Scene documentation folder.
-2. If a new Scene documentation folder is required, create the complete controlled scaffold first.
-3. Choose the current background image from that root's **marked `PreviewBackground`** folder or directly from the published `Wiring\MusicalStage` branch when that drawing is the intended background.
-4. Do not select a new background from `SourceDocs` or from loose legacy material.
-5. In the LOR Preview editor, use:
-
-```text
-Background -> Set Image
-```
-
-6. Select the image from the intended shared-drive location.
-7. Do **not** embed the image into the Preview.
+1. Decide what the Scene represents: Stage, Sub-stage, Scene, Display, or shared group.
+2. Use the correct Scene name.
+3. Decide whether the background belongs in `PreviewBackground` or is intentionally the current published `Wiring\MusicalStage` image.
+4. Verify the selected location has the required marker files.
+5. In the LOR Preview Editor, choose **Background -> Set Image**.
+6. Select the image from the shared drive.
+7. Do **not** embed the image.
 8. Save the Preview.
-9. Repeat for other Scenes where filesystem/documentation scope needs to be explicit.
 
-The image may later change. Preserve the correct documentation-root relationship when replacing it.
-
----
-
-# Before Exporting the Master Musical Preview
-
-Verify:
-
-- [ ] The Preview name follows the current annual/versioned Master Musical Preview convention.
-- [ ] Scene names retain the Stage information needed by the parser.
-- [ ] A new Google Drive Scene folder was created only when the Scene represents a real documentation scope.
-- [ ] Any newly created Stage/Sub-stage/Scene folder uses the complete controlled scaffold.
-- [ ] The structural root marker is present.
-- [ ] `PreviewBackground`, `Procedures`, and `Wiring` carry their required markers.
-- [ ] Stage-level musical Scenes use a current BackgroundFile below the correct marked Stage source folder when a filesystem anchor is needed.
-- [ ] Scenes with their own documentation folder use a current BackgroundFile below that folder's marked source structure.
-- [ ] New Scene background pointers do not enter `SourceDocs` or loose legacy material.
-- [ ] Sequencing-only Scenes have not caused unnecessary Google Drive Scene folders to be created.
-- [ ] Background images remain external references.
-- [ ] The Preview is exported through the normal controlled Preview Authoring / Preview Merger workflow.
-
-After the approved Preview set changes, rerun the current parser when appropriate so Folder Alignment and other LOR-side tools see the current Scene and `BackgroundFile` relationships.
-
-Parser output is a working snapshot of the current approved LOR structure. PostgreSQL ingest remains a separate later production step.
+If the Scene name and folder location do not make sense together, stop and ask for review rather than guessing.
 
 ---
 
-## Related Documents
+# Example — Whoville
 
-- [Building a Preview](B_Building_Preview_Howto.md) — general LOR Preview authoring procedure.
-- [Create Wiring Backgrounds for Stage Previews](D_Create_Wiring_Backgrounds..md) — wiring-image folder and publication procedure.
-- [Naming Conventions](A_Naming_Conventions.md) — current Display and channel naming rules.
-- [Stage / Sub-stage / Scene Folder Scaffold](../../00_Project_Overview/04-Stage_Substage_Scene_Folder_Scaffold.md) — required scaffold when creating a new structured documentation root.
-- [MSB Database Source Folder Marker](../../00_Project_Overview/03-MSB_DB_Source_Folder_Marker_Operator_Procedure.md) — root/source marker rules and local notes.
-- [LOR Preview Authoring](README.md) — Preview Authoring navigation portal.
-- [LOR Data Extraction](../02_Data_Extraction/README.md) — parser and Folder Alignment engineering documentation.
+The Master Musical Preview may contain Scenes such as:
+
+```text
+07-Whoville-WV
+07-Who People
+07a-Who Forest-WF
+```
+
+How to treat them:
+
+- `07-Whoville-WV` represents the whole Stage 07.
+- `07-Who People` is a Scene within Stage 07.
+- `07a-Who Forest-WF` represents the Who Forest Sub-stage.
+
+`07-Who People` does not automatically need its own Google Drive folder. If its documentation belongs to Stage 07, use the Stage 07 controlled folders. Create a separate Scene folder only if it genuinely owns its own shared documentation.
+
+---
+
+# 10. Check the Master Musical Preview Before Exporting
+
+- [ ] The Preview uses the current Master Musical Preview name.
+- [ ] Each Scene name follows the correct naming pattern.
+- [ ] `Root` is not being used to identify a Stage in the Master Musical Preview.
+- [ ] I did not create a Google Drive Scene folder only because a Scene exists in LOR.
+- [ ] Any new Scene folder uses the complete controlled scaffold.
+- [ ] The background is in an approved marked `PreviewBackground` folder or directly in an approved marked published `Wiring\MusicalStage` folder.
+- [ ] The background does not point into `SourceDocs`.
+- [ ] Background images are linked, not embedded.
+
+---
+
+# 11. Export the Candidate
+
+When the Master Musical Preview changes are complete, export the candidate `.lorprev` file to:
+
+```text
+G:\Shared drives\MSB Database\UserPreviewStaging\<username>
+```
+
+Allow Google Drive to finish synchronizing.
+
+Do not overwrite the approved master directly.
+
+---
+
+## Expected Result
+
+The Master Musical Preview has clearly named Scenes, each background points to the correct controlled shared-drive location, and the finished candidate is ready in `UserPreviewStaging` for the controlled review process.
+
+## If Something Is Wrong
+
+If you are unsure whether a Scene should have its own Google Drive folder, where its background belongs, or whether the required marker is present, stop and ask for review. Do not create a new folder or background path simply to make the LOR Scene list match the Drive folder list.
+
+## Related Operator Documents
+
+- [Preview Authoring Home](README.md)
+- [Building a Preview](B_Building_Preview_Howto.md)
+- [Prop and Display Naming Conventions](A_Naming_Conventions.md)
+- [Create Wiring Backgrounds](D_Create_Wiring_Backgrounds..md)
+- [Preview Import Workflow](Preview_Import_Workflow.md)
+- [Stage / Sub-stage / Scene Folder Scaffold](../../00_Project_Overview/04-Stage_Substage_Scene_Folder_Scaffold.md)
+- [MSB Source Folder Marker](../../00_Project_Overview/03-MSB_DB_Source_Folder_Marker_Operator_Procedure.md)
+
+## Related Engineering
+
+- [Google Drive Path Resolution Contract](../../00_Project_Overview/02-Google_Drive_Path_Resolution_Contract.md)
+- [LOR Parser Architecture](../02_Data_Extraction/LOR_Preview_Parser_Architecture.md)
+- [FieldWiring Engineering](../../02_Production_Database/01_System_Architecture/09_Wiring_System/README.md)
+
+## Revision History
+
+- 2026-08-22 — Rewritten for Preview authors in plain language while preserving the current Scene naming, complete scaffold, marker, `PreviewBackground`, direct published Wiring background, and `SourceDocs` exclusion rules.

--- a/Docs/01_LOR_System/01_Preview_Authoring/Preview_Import_Workflow.md
+++ b/Docs/01_LOR_System/01_Preview_Authoring/Preview_Import_Workflow.md
@@ -1,72 +1,125 @@
 # Preview Import Workflow
 
-Use the **latest LOR2DB reconciliation report** to identify the current approved show-preview source before importing previews.
+| Document Control | Value |
+|---|---|
+| Document Type | Operator Procedure |
+| System | LOR Preview Authoring |
+| Task | Get the current approved Preview before editing |
+| Audience | Preview authors and programmers |
+| Status | CURRENT |
+| Owner | MSB Production Crew |
+| Last Reviewed | 2026-08-22 |
 
-The report is available from the [LOR2DB Reporting portal](../../../LOR2DB/Reporting/README.md).
+## Purpose
 
-⚠️ The approved Source folder is the production preview set. **Do not edit, overwrite, or save files in that folder.** Make changes only in your own working copy.
+Use this procedure before changing an existing LOR Preview.
 
----
-
-## Step 1 – Find the Current Approved Preview Source
-
-Open the latest reconciliation report.
-
-Section 3 identifies the **Source folder** used for the current approved production import.
-
-Use that Source folder when importing the current show previews.
-
-The report also lists the approved revision of each preview included in that reconciliation.
+The goal is to make sure you start with the current approved copy instead of an older file from your computer.
 
 ---
 
-## Step 2 – Import a Preview
+# 1. Find the Current Approved Preview Source
 
-When you import a `.lorprev` file, LOR will prompt you depending on whether your system already has that preview:
+Open the latest completed LOR2DB reconciliation report.
 
-- **Case A – Same Version (No Update Needed)**  
-  You’ll see a message like this:  
- ![Import – Same Version](images/import_01.png) 
-  ➡️ If the version matches, no action is needed. Click **Cancel** to avoid creating duplicates.
+The report identifies the source folder used for the current approved Preview set and lists the Preview revisions included in that run.
 
-- **Case B – Newer Version (Update Recommended)**  
-  If the approved preview has a newer revision, you’ll see:  
-  ![Import – Newer Version](images/import_02.png)  
-  ➡️ Click **Yes** to update your existing preview with the latest data.  
-  ➡️ Click **No** only if you need to keep your older version as a separate copy (rare).
+Use the report as the current reference.
+
+Do not assume an older `Database Previews` folder on your computer is current just because it exists.
+
+[LOR2DB Reporting](../../../LOR2DB/03_Reporting/README.md)
 
 ---
 
-## Step 3 – Verify Revision Numbers
+# 2. Import the Preview into LOR
 
-After importing, open the preview. The **revision number** is displayed in the upper right corner:  
-![Preview Revision](images/import_03.png)
+Import the `.lorprev` file you need from the approved source.
 
-- Confirm the revision matches the latest reconciliation report.
-- This ensures you are sequencing with the latest approved design.
+If LOR tells you the Preview already exists:
 
----
+- if your copy is already the current approved version, do not create another duplicate;
+- if the approved copy is newer, update your working copy from the approved source; and
+- if you are not sure which copy is correct, stop and ask before editing.
 
-## Important – Do Not Save to the Approved Source Folder
-
-The Source folder shown in the reconciliation report contains the approved production preview set.
-
-- Import or copy previews from that folder.
-- Do **not** edit files in that folder.
-- Do **not** overwrite files in that folder.
-- Do **not** save new or experimental previews in that folder.
-- Make all changes in your own working location.
-
-The Preview Merger system is under development and is not yet part of the production workflow.
+Do not create a second Preview just to get around an import warning.
 
 ---
 
-## Summary
+# 3. Check the Preview Before Editing
 
-1. Open the latest LOR2DB reconciliation report.
-2. Use Section 3 to find the current approved Source folder.
-3. Import previews from that folder without modifying it.
-4. Verify preview revisions against the reconciliation report.
-5. Make any changes only in your own working copy.
+Open the Preview and check:
 
-Keeping previews aligned avoids mismatches in sequencing and database exports.
+- the Preview name;
+- the revision number; and
+- the background image if the work you are doing depends on it.
+
+For Master Musical Preview work, also review:
+
+[Building the Master Musical Preview](E_Master_Musical_Preview_Howto.md)
+
+before changing Scene names or Scene backgrounds.
+
+---
+
+# 4. Work Only in Your Own Copy
+
+The approved source folder is read-only from the Preview author's point of view.
+
+Do not:
+
+- edit the file directly in the approved source folder;
+- overwrite the approved master;
+- save experiments into the approved source folder; or
+- use your personal staging folder as the production Preview source.
+
+Make your changes in your normal LOR working copy.
+
+---
+
+# 5. Export Your Finished Candidate
+
+When your work is complete, export the candidate `.lorprev` file to:
+
+```text
+G:\Shared drives\MSB Database\UserPreviewStaging\<username>
+```
+
+Allow Google Drive to finish synchronizing.
+
+`UserPreviewStaging` is the handoff location for your finished candidate. It is not the approved master.
+
+---
+
+# Stop Here
+
+Do not replace the approved master yourself.
+
+The review/master-update process is controlled separately.
+
+Your operator task is complete when the correct candidate file is safely in your `UserPreviewStaging` folder.
+
+---
+
+## Expected Result
+
+You started from the current approved Preview, made changes only in your own working copy, and exported the finished candidate to your personal staging folder.
+
+## If Something Is Wrong
+
+If the Preview name, revision, or import message does not match what you expect, stop before editing and ask for review. Do not create a new Preview or overwrite another file to force the import to work.
+
+## Related Operator Documents
+
+- [Preview Authoring Home](README.md)
+- [Building a Preview](B_Building_Preview_Howto.md)
+- [Building the Master Musical Preview](E_Master_Musical_Preview_Howto.md)
+
+## Related Engineering
+
+- [Preview Merger](../03_Preview_Merger/README.md)
+- [LOR2DB Reporting](../../../LOR2DB/03_Reporting/README.md)
+
+## Revision History
+
+- 2026-08-22 — Rewritten as a plain-language operator procedure while preserving the approved-source, personal-copy, and `UserPreviewStaging` boundaries.

--- a/Docs/01_LOR_System/01_Preview_Authoring/README.md
+++ b/Docs/01_LOR_System/01_Preview_Authoring/README.md
@@ -1,38 +1,64 @@
 # LOR Preview Authoring
 
-This area contains the user-facing rules and procedures for creating and maintaining Light-O-Rama previews that can be safely used by the MSB production workflow.
+This area is for people who create, edit, and maintain Light-O-Rama (LOR) Previews for MSB.
+
+You do **not** need to understand the parser, Python, SQLite, PostgreSQL, or database design to use these procedures.
 
 ## Start Here
 
-| I want to... | Go to |
+| I need to... | Use this document |
 |---|---|
-| Understand required display and channel naming | [Naming Conventions](A_Naming_Conventions.md) |
-| Build or update a preview | [Building Preview How-To](B_Building_Preview_Howto.md) |
-| Build or update the Master Musical Preview | [Master Musical Preview How-To](E_Master_Musical_Preview_Howto.md) |
+| Name Displays and channels correctly | [Prop and Display Naming Conventions](A_Naming_Conventions.md) |
+| Build or update a Preview | [Building a Preview](B_Building_Preview_Howto.md) |
+| Build or update the Master Musical Preview | [Building the Master Musical Preview](E_Master_Musical_Preview_Howto.md) |
 | Create a new Scene/Sub-stage documentation folder | [Stage / Sub-stage / Scene Folder Scaffold](../../00_Project_Overview/04-Stage_Substage_Scene_Folder_Scaffold.md) |
-| Create and organize Stage wiring background images | [Create Wiring Backgrounds for Stage Previews](D_Create_Wiring_Backgrounds..md) |
-| Review the February 2026 origin of the LOR-to-database naming contract | [Historical LOR Naming Data Contract](C_LOR_Naming_Data_Contract.md) |
-| Import the current approved preview set | [Preview Import Workflow](Preview_Import_Workflow.md) |
+| Create or update field wiring images | [Create Wiring Backgrounds](D_Create_Wiring_Backgrounds..md) |
+| Get the current approved Preview before editing | [Preview Import Workflow](Preview_Import_Workflow.md) |
 
-The historical naming contract is preserved here because it records the early engineering decisions that connected LOR Comment naming, stage codes, parser output, and Production Database ingestion. It is not the current authoring authority; current naming rules are maintained in [Naming Conventions](A_Naming_Conventions.md).
+## Important Rules
 
-## Important Boundary
+- Work from your own copy of a Preview.
+- Do not overwrite the approved master Preview files.
+- When your work is finished, export your candidate Preview to:
 
-Preview Authoring explains how to create and maintain previews. The controlled process for comparing programmer copies and protecting the approved preview set is documented separately under [Preview Merger](../03_Preview_Merger/README.md).
+```text
+G:\Shared drives\MSB Database\UserPreviewStaging\<username>
+```
 
-Parser engineering and `.lorprev` structure are documented separately under [Data Extraction](../02_Data_Extraction/README.md).
+- `UserPreviewStaging` is a handoff location. It is **not** the approved master.
+- Use the existing Google Drive Stage/Scene/Display organization. Do not invent a new folder structure from inside LOR.
+- New Stage/Sub-stage/Scene documentation folders must use the complete controlled scaffold.
+- Folders used by FieldWiring or the future Procedure system must have the required `_MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt` marker.
+- Do not use `SourceDocs` as a normal LOR background or field-document location.
 
-The [Master Musical Preview How-To](E_Master_Musical_Preview_Howto.md) documents how musical Scene names and Scene background-image paths provide Stage/documentation context without requiring every musical Scene to become a Google Drive folder.
+## How to Read These Documents
 
-When a Scene really does require its own Google Drive documentation scope, create it from the complete [Stage / Sub-stage / Scene Folder Scaffold](../../00_Project_Overview/04-Stage_Substage_Scene_Folder_Scaffold.md) rather than creating a partial one-off folder. New authoring uses the marked `PreviewBackground`, `Procedures`, and `Wiring` source structure; `SourceDocs` is not a normal Scene background or field-presentation endpoint.
+Text shown like `PreviewBackground`, `BackgroundFile`, or `UserPreviewStaging` means an exact folder name, field name, filename, or value that you may need to recognize or use.
 
-Detailed FieldWiring implementation and wiring-system engineering remain separate from these operator procedures.
+## Operator Documentation vs Engineering Documentation
 
-## Related Systems
+The documents in this folder explain how to **use** the Preview system.
+
+The technical documents that explain how the parser, Folder Alignment, FieldWiring, FormView, and databases work are kept separately. Preview authors should not need those engineering details to complete normal work.
+
+## Related Operator Information
 
 - [Google Drive Document Organization](../../00_Project_Overview/01-Google_Drive_Document_Organization_Procedure.md)
-- [MSB Database Source Folder Marker](../../00_Project_Overview/03-MSB_DB_Source_Folder_Marker_Operator_Procedure.md)
+- [MSB Source Folder Marker](../../00_Project_Overview/03-MSB_DB_Source_Folder_Marker_Operator_Procedure.md)
+- [Stage / Sub-stage / Scene Folder Scaffold](../../00_Project_Overview/04-Stage_Substage_Scene_Folder_Scaffold.md)
+
+## Related Engineering
+
+- [LOR Data Extraction / Parser](../02_Data_Extraction/README.md)
 - [Preview Merger](../03_Preview_Merger/README.md)
-- [LOR Data Extraction](../02_Data_Extraction/README.md)
-- [Wiring System Engineering](../../02_Production_Database/01_System_Architecture/09_Wiring_System/README.md)
-- [LOR2DB Ingest](../../../LOR2DB/01_Ingest/README.md)
+- [FormView](../04_FormView/README.md)
+- [FieldWiring Engineering](../../02_Production_Database/01_System_Architecture/09_Wiring_System/README.md)
+- [LOR2DB](../../../LOR2DB/README.md)
+
+## Historical Reference
+
+- [Historical LOR Naming Data Contract](C_LOR_Naming_Data_Contract.md) — engineering history only; not current operator instructions.
+
+## Revision History
+
+- 2026-08-22 — Rewritten as a plain-language operator portal while preserving the current Scene scaffold, marker, Preview staging, and FieldWiring boundaries.

--- a/Docs/01_LOR_System/README.md
+++ b/Docs/01_LOR_System/README.md
@@ -1,23 +1,46 @@
 # LOR System Documentation
 
-This area documents how Light-O-Rama preview information is created, interpreted, and protected before it enters downstream database and field-documentation workflows.
+This area documents both how people **use** Light-O-Rama Preview workflows and how the underlying LOR systems are **engineered and maintained**.
+
+Those are intentionally separate documentation paths.
 
 ## Start Here
 
 | I want to... | Go to |
 |---|---|
-| Create or update LOR previews | [Preview Authoring](01_Preview_Authoring/README.md) |
-| Understand how `.lorprev` data is parsed and structured | [Data Extraction](02_Data_Extraction/README.md) |
-| Understand or use the controlled preview merge process | [Preview Merger](03_Preview_Merger/README.md) |
-| Understand FormView wiring and field-documentation behavior | [FormView](04_FormView/README.md) |
+| Create or update LOR Previews | [Preview Authoring](01_Preview_Authoring/README.md) |
+| Understand or change how `.lorprev` data is parsed and structured | [Data Extraction](02_Data_Extraction/README.md) |
+| Understand or maintain the controlled Preview merge process | [Preview Merger](03_Preview_Merger/README.md) |
+| Understand the legacy/fallback FormView wiring behavior | [FormView](04_FormView/README.md) |
+| Understand or continue the browser-based FieldWiring replacement | [FieldWiring Engineering](../02_Production_Database/01_System_Architecture/09_Wiring_System/README.md) |
+
+## Operator vs Engineering Documentation
+
+**Preview Authoring** is the normal operator path. It is written for Preview authors and programmers who need to create, edit, name, organize, and export LOR Previews without learning parser or database internals.
+
+**Data Extraction, Preview Merger, FormView, and FieldWiring engineering documents** preserve the technical detail needed to build, troubleshoot, validate, and continue development of those systems.
+
+Do not move engineering detail into operator procedures merely because the operator task depends on that engineering. Likewise, do not remove needed implementation context from the engineering documents in an attempt to make them operator manuals.
 
 ## Folder Guide
 
 | Folder | What it contains |
 |---|---|
-| [01_Preview_Authoring](01_Preview_Authoring/README.md) | Naming rules, preview-building instructions, wiring-background preparation, and preview import guidance |
-| [02_Data_Extraction](02_Data_Extraction/README.md) | `.lorprev` structure, parser architecture, SQLite output design, and LOR version compatibility review |
-| [03_Preview_Merger](03_Preview_Merger/README.md) | Preview Merger engineering design and operator workflow |
-| [04_FormView](04_FormView/README.md) | FormView subsystem portal, wiring/document-generation dependencies, and recovered engineering architecture |
+| [01_Preview_Authoring](01_Preview_Authoring/README.md) | Plain-language operator rules for naming, Preview building, Master Musical Scenes, wiring-image preparation, and Preview import/staging |
+| [02_Data_Extraction](02_Data_Extraction/README.md) | `.lorprev` structure, parser architecture, SQLite output design, Folder Alignment, and LOR version compatibility review |
+| [03_Preview_Merger](03_Preview_Merger/README.md) | Preview Merger engineering design, current status, and controlled workflow |
+| [04_FormView](04_FormView/README.md) | FormView fallback/reference subsystem and recovered engineering architecture |
+
+## Engineering Handoff
+
+When LOR engineering work changes how operators perform a task, update both layers before closing the work:
+
+1. update the engineering document that owns the system decision or implementation behavior;
+2. update the affected Preview Authoring/operator procedure in plain language; and
+3. review the responsible README portals so the next work session can resume from repository documentation instead of conversation history.
+
+Before any new repository change, refresh current remote `main` and read the latest affected files. This repository has active parallel sub-projects and older branches can become stale quickly.
+
+The repository is the durable handoff. Chat and email are not the final documentation authority.
 
 For the 5,000-foot project view, return to the [Project Overview](../00_Project_Overview/README.md).

--- a/Docs/02_Production_Database/01_System_Architecture/09_Wiring_System/FieldWiring_Drive_Context_Resolver_Engineering_Design.md
+++ b/Docs/02_Production_Database/01_System_Architecture/09_Wiring_System/FieldWiring_Drive_Context_Resolver_Engineering_Design.md
@@ -4,11 +4,11 @@
 |---|---|
 | Status | DRAFT — resolver design under test |
 | Sub-project | FieldWiring |
-| Current revision | 2026-08-19 |
+| Current revision | 2026-08-22 |
 | Owner | MSB Database Administrator |
 | Runtime data authority | Current V7+ PostgreSQL/LOR snapshot |
 | Legacy comparison authority | FormView / V6 reports are validation evidence only |
-| Code/schema status | Design and read-only test contract; no schema change authorized |
+| Code/schema status | Release-candidate resolver implemented; full child-branch marker enforcement remains open |
 
 ## Purpose
 
@@ -111,21 +111,56 @@ The standard marker is:
 _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
 ```
 
-Every current Stage, formal Sub-stage, and Scene root carries the structural marker.
+The current governing rule is:
 
-Current application-source helpers are marked separately:
+> Every directory used as part of the new FieldWiring or future Procedure application path must contain the marker.
+
+For FieldWiring that includes:
 
 ```text
-PreviewBackground
-Procedures
-Wiring
+<resolved Stage / Sub-stage / Scene root>\
+├── marker
+├── PreviewBackground\
+│   └── marker
+└── Wiring\
+    ├── marker
+    ├── BackgroundStage\
+    │   └── marker
+    └── MusicalStage\
+        └── marker
 ```
 
-`Photos` is not currently an application-source helper.
+The structural root marker validates the resolved Stage/Sub-stage/Scene scope.
 
-The structural marker supports validation of the resolved hierarchy. The helper marker confirms that the helper folder participates in the current application-source contract.
+The `Wiring` marker validates the wiring source root.
+
+The `BackgroundStage` / `MusicalStage` marker validates the actual published wiring branch selected by the operator's wiring context.
+
+A same-scope `PreviewBackground` used for context must also be marked.
+
+`SourceDocs` is not part of the application path and remains a hard exclusion boundary.
 
 Loose files and unmarked legacy folders are ignored for current published-content discovery.
+
+### Current release-candidate enforcement gap
+
+The current implementation in:
+
+```text
+FieldWiring/Application/wiring_images.py
+```
+
+already requires:
+
+- the resolved Stage/Scene root marker;
+- the `Wiring` root marker before publishing wiring images; and
+- the `PreviewBackground` marker before publishing context images.
+
+It does **not yet require the marker inside the selected `BackgroundStage` or `MusicalStage` branch**.
+
+That is an implementation gap against the current marker contract and must be corrected and tested before final FieldWiring deployment acceptance.
+
+Do not change the documentation back to the older narrower rule merely to match the current release-candidate code.
 
 ---
 
@@ -199,9 +234,9 @@ The resolver operates conservatively:
 7. Use allowed exact hierarchy evidence when it resolves.
 8. Walk upward only as needed to identify the nearest valid current structured Stage/Sub-stage/Scene root.
 9. If the stored path is stale, use current identity plus deterministic actual hierarchy rules to find one safe current marked root.
-10. Use structural markers as supporting validation.
+10. Validate the required markers for the selected application path.
 11. Do not rewrite LOR, PostgreSQL, or Drive as a side effect.
-12. If current identity/path/hierarchy evidence does not yield one safe result, report review/unresolved rather than guess.
+12. If current identity/path/hierarchy/marker evidence does not yield one safe result, report review/unresolved rather than guess.
 
 ---
 
@@ -345,7 +380,9 @@ FieldWiring inspects only the applicable branch inside the fixed resolved scope:
 <resolved scope>\Wiring\MusicalStage
 ```
 
-Only files directly in that branch are published wiring-image candidates.
+Both the `Wiring` root and selected published branch must satisfy the marker contract.
+
+Only files directly in that marked branch are published wiring-image candidates.
 
 Expected image extensions include:
 
@@ -388,6 +425,8 @@ Stage 07 cases demonstrated that generic Stage `PreviewBackground` images also m
 
 The shared hierarchy resolver can also support Setup/Takedown/Inspection discovery, but Procedure behavior is separately governed.
 
+The same marker principle applies: every directory the Procedure application uses in its controlled path must be marked before the application consumes it.
+
 FieldWiring should not attempt to present Procedure documents as part of its wiring-image resolution logic.
 
 A broader field interface may later show which procedures are available for the resolved Stage/Scene context, but whether/how those documents open is a Procedure subsystem concern rather than a FieldWiring wiring rule.
@@ -398,14 +437,14 @@ A broader field interface may later show which procedures are available for the 
 
 The Drive/scope resolver gate is accepted when it can demonstrate:
 
-> Given current V7/PostgreSQL identity, current Scene/Preview relationships, current path evidence, structural/source markers, and the actual Google Drive hierarchy, the application can deterministically locate the correct Stage/Sub-stage/Scene scope without V6 runtime data, unsafe folder guessing, or traversal into source-only branches.
+> Given current V7/PostgreSQL identity, current Scene/Preview relationships, current path evidence, the required markers, and the actual Google Drive hierarchy, the application can deterministically locate the correct Stage/Sub-stage/Scene scope without V6 runtime data, unsafe folder guessing, or traversal into source-only branches.
 
 Image completeness is evaluated separately from scope resolution.
 
 FieldWiring presentation acceptance additionally requires that:
 
 - current wiring rows remain the primary result;
-- published images are restricted to the fixed resolved scope;
+- published images are restricted to the fixed resolved scope and marked selected branch;
 - a missing image is clearly reported rather than hidden by parent fallback;
 - same-scope `PreviewBackground` is context only; and
 - no parent/sibling/source image is substituted merely to produce a visual.

--- a/Docs/02_Production_Database/01_System_Architecture/09_Wiring_System/README.md
+++ b/Docs/02_Production_Database/01_System_Architecture/09_Wiring_System/README.md
@@ -179,6 +179,18 @@ The common Drive resolver identifies the structured scope. FieldWiring then insp
 
 Wiring images are supplemental rough-location guidance. Hookup data remains primary and must stay usable when no image exists.
 
+The current controlled marker rule requires the standard marker in **every folder used as part of the FieldWiring application path**. For the current wiring path this includes:
+
+```text
+<resolved Stage / Sub-stage / Scene root>
+Wiring
+Wiring\BackgroundStage   (when selected)
+Wiring\MusicalStage      (when selected)
+PreviewBackground        (when used as same-scope context)
+```
+
+The release-candidate `wiring_images.py` currently enforces the root, `Wiring`, and `PreviewBackground` markers but does not yet require the marker in the selected `BackgroundStage` / `MusicalStage` child branch. This is a known implementation gap against the current Google Drive path contract and must be corrected/tested before production deployment acceptance.
+
 The current laptop environment sees that tree through:
 
 ```text
@@ -217,29 +229,30 @@ Do not infer permanent controller identity from universe, IP address, Unit ID, D
 - E1.31 presentation that does not confuse universe with physical controller identity;
 - future controlled channel/plug-label requests through LabelPrintService;
 - generated browser/PDF field documentation;
-- future disconnected/offline field-document support.
+- future disconnected/offline field-copy support.
 
 ## Resume Development
 
 The parser, PostgreSQL propagation, Run 51 production ingest, FieldWiring DMX read adapter, device-family presentation, and laptop UI acceptance are complete enough for a release candidate.
 
+FieldWiring is now merged to `main`; do not repeat the old pre-merge branch-integration steps from the August 21 checkpoint.
+
 The next engineering sequence is:
 
-1. integrate current `main` into `agent/fieldwiring-engineering-recovery` because the branch is currently behind `main`;
-2. resolve the overlapping Google Drive/Display-folder documentation deliberately;
-3. run the full FieldWiring application test suite and any parser/LOR2DB tests touched by conflict resolution;
-4. smoke-test the verified Run 51 development snapshot one final time;
-5. merge FieldWiring to `main` through the normal PR/merge workflow;
-6. deploy the backend on `msb-prod-db` using live read-only PostgreSQL;
-7. establish the read-only server-visible Display Folders/image source;
-8. publish FieldWiring through the protected `my.sheboyganlights.org` origin using the existing Synology/`msb-prod-db` browser-application pattern;
-9. test tablets/phones;
-10. add **Field Wiring** to the existing Display QR task hub using the already-resolved permanent `display_id`.
+1. refresh current `main` before making further FieldWiring changes;
+2. update `wiring_images.py` and tests so the selected `BackgroundStage` / `MusicalStage` branch marker is enforced in addition to the existing scope/Wiring markers;
+3. run the full FieldWiring application test suite;
+4. deploy the backend on `msb-prod-db` using live read-only PostgreSQL;
+5. establish the read-only server-visible Display Folders/image source;
+6. publish FieldWiring through the protected `my.sheboyganlights.org` origin using the existing Synology/`msb-prod-db` browser-application pattern;
+7. test tablets/phones;
+8. add **Field Wiring** to the existing Display QR task hub using the already-resolved permanent `display_id`.
 
-Use [FieldWiring Server Deployment and Scan Integration Plan](FieldWiring_Server_Deployment_and_Scan_Integration_Plan_2026-08-21.md) for that deployment sequence.
+Use [FieldWiring Server Deployment and Scan Integration Plan](FieldWiring_Server_Deployment_and_Scan_Integration_Plan_2026-08-21.md) for the deployment sequence, but reconcile any older checkpoint wording against this current README before execution.
 
 ## Known Open Work
 
+- enforce the marker on every selected FieldWiring application-path folder, including `BackgroundStage` / `MusicalStage`;
 - production server deployment;
 - server-visible Display Folders mount/synchronization and Windows-path translation;
 - least-privilege production FieldWiring DB role/grants;

--- a/FieldWiring/Application/README.md
+++ b/FieldWiring/Application/README.md
@@ -182,6 +182,22 @@ A Linux production server does not automatically have that path. Before server d
 
 Do not copy ad-hoc images into the application directory or weaken the same-scope/source-marker rules to make deployment easier.
 
+### Marker-enforcement gap identified 2026-08-22
+
+The current controlled-folder rule requires the standard marker in **every folder used as part of the FieldWiring application path**, including:
+
+```text
+<resolved Stage / Sub-stage / Scene root>
+Wiring
+Wiring\BackgroundStage
+Wiring\MusicalStage
+PreviewBackground   (when used for same-scope context)
+```
+
+The current `wiring_images.py` release-candidate implementation already requires the resolved root marker, the `Wiring` root marker, and the `PreviewBackground` marker, but it does **not yet require a marker inside the selected `BackgroundStage` / `MusicalStage` branch**.
+
+That is an implementation gap against the current Google Drive path/marker contract. It must be corrected and covered by tests before final production deployment acceptance.
+
 ## Existing Display QR dependency
 
 The deployed Display QR hub already exists in the Directus scan extension on `msb-prod-db` and resolves permanent `display_id`.
@@ -192,14 +208,13 @@ The intended integration is one new **Field Wiring** action on the existing `/sc
 
 ## Merge/deployment state
 
-Merging FieldWiring to `main` is appropriate after the feature branch is brought current with `main` and the full tests pass again.
+FieldWiring is merged to current `main` as a release candidate. Merge is not the same as production cutover.
 
-At the release-candidate checkpoint the branch was 291 commits ahead of `main` and 8 commits behind it, so update the branch before merging.
-
-Merging code is not the same as production cutover. Keep FormView available until:
+Keep FormView available until:
 
 1. FieldWiring is deployed on the server using live read-only PostgreSQL;
 2. the server can resolve the approved Display Folders/image source;
-3. the protected public route is working;
-4. tablet/phone testing is accepted;
-5. the existing Display scan hub exposes Field Wiring successfully.
+3. the required marker is enforced on every folder in the selected FieldWiring path;
+4. the protected public route is working;
+5. tablet/phone testing is accepted; and
+6. the existing Display scan hub exposes Field Wiring successfully.

--- a/System_Documentation/Project_Rules/README.md
+++ b/System_Documentation/Project_Rules/README.md
@@ -6,6 +6,7 @@ Reusable rules that should apply across multiple repositories belong under [`../
 
 ## Current Project Rules
 
+- [Repository Change Workflow](Repository_Change_Workflow.md) — requires refreshing current remote `main`, reviewing the latest affected files, and resolving stale-branch/concurrent-work issues before changing code, schema, configuration, or controlled documentation.
 - [Stage Setup Documentation Standard](Stage_Setup_Documentation_Standard.md) — governs how Stage/Scene setup instructions relate to the established Google Shared Drive structure, controlled templates, Production Database identity, QR resolution, and the my.sheboyganlights.org presentation layer.
 
 ## Rule Ownership

--- a/System_Documentation/Project_Rules/Repository_Change_Workflow.md
+++ b/System_Documentation/Project_Rules/Repository_Change_Workflow.md
@@ -1,0 +1,65 @@
+# Repository Change Workflow
+
+## Purpose
+
+This project rule defines the minimum repository-synchronization steps that must occur before making changes in the MSB Production Database repository.
+
+The project is worked on across multiple active branches, sub-projects, and conversation threads. A branch that was current when one task started may be stale by the time another task resumes.
+
+## Step Zero — Refresh Before Editing
+
+Before changing code, schema, configuration, or controlled documentation:
+
+1. refresh the repository view from the current remote;
+2. identify the current `main` head;
+3. verify whether the intended working branch is current with `main`;
+4. inspect the latest versions of the files that will be changed; and
+5. if the existing working branch is materially behind current `main`, rebase/merge deliberately or start a fresh branch from current `main` before editing.
+
+Do not assume that repository state remembered from an earlier conversation is still current.
+
+For connector/API-based work where a local `git pull` is not available, creating the work branch directly from current remote `main` and reading the current remote files satisfies the refresh requirement.
+
+## Concurrent Project Work
+
+When another sub-project has changed the same area since the current branch was created:
+
+- review the newer work before applying older planned changes;
+- preserve accepted newer architecture and operator behavior;
+- do not overwrite newer documentation merely because an older branch already contains a draft rewrite;
+- reconcile conflicts against the current repository authority, not conversation memory; and
+- record any newly discovered cross-system conflict in the responsible engineering documentation.
+
+## Documentation Work
+
+Documentation changes are subject to the same synchronization rule as code.
+
+Before rewriting an operator procedure or engineering document:
+
+1. read the current repository version;
+2. read the current engineering authority and related subsystem README when the subject crosses system boundaries;
+3. preserve newer accepted decisions from parallel work;
+4. update the operator document only after the underlying current behavior is understood; and
+5. perform the normal README/documentation closeout after the change.
+
+## Why This Rule Exists
+
+The repository is the durable project record. Parallel development is expected.
+
+Refreshing first prevents:
+
+- overwriting newer work;
+- documenting obsolete behavior;
+- rebuilding decisions already settled in another thread;
+- creating conflicting operator and engineering instructions; and
+- wasting time reconciling changes after they have already been written against a stale base.
+
+## Simple Rule
+
+> **Before changing the repository, refresh current `main` and read the latest affected files. Do not edit from remembered repository state.**
+
+## Related Standards
+
+- [Documentation Standards](../Standards/Documentation_Standards.md)
+- [README Portal Standard](../Standards/README_Portal_Standard.md)
+- [Document Control Standard](../Standards/Document_Control_Standard.md)

--- a/System_Documentation/Project_Rules/Stage_Setup_Documentation_Standard.md
+++ b/System_Documentation/Project_Rules/Stage_Setup_Documentation_Standard.md
@@ -6,7 +6,7 @@ This project rule defines how field-facing Stage and Scene setup instructions ar
 
 Stage Setup Instructions are not the same document class as repository Operator SOPs. They are field-use documents for volunteers physically installing displays and Stage infrastructure in the park. They may consume Production Database information and be discovered through MSB applications, but their normal user experience must remain simple and Stage-oriented.
 
-This rule governs ownership, source/published relationships, document identity, archive behavior, template use, and integration boundaries. It does not redesign the established Google Shared Drive Stage folder structure.
+This rule governs ownership, source/published relationships, document identity, archive behavior, template use, marker requirements, and integration boundaries. It does not redesign the established Google Shared Drive Stage folder structure.
 
 ## Document Class
 
@@ -25,6 +25,44 @@ The exact Stage/Scene folder layout and migration procedure are governed by the 
 Current Setup instructions belong in the established Stage or Scene `Procedures\Setup` location appropriate to what the instruction actually describes.
 
 Legacy documents are being reconciled into the established current/archive structure through the separate document-alignment process. Do not independently move legacy documents based only on this standard.
+
+## Marker Requirement for the Future Procedure System
+
+The standard marker is:
+
+```text
+_MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
+```
+
+The governing rule is:
+
+> **Every folder used as part of the future Procedure application's controlled path must contain the marker.**
+
+For a normal Setup path this includes:
+
+```text
+<Stage / Sub-stage / Scene root>\
+├── marker
+└── Procedures\
+    ├── marker
+    └── Setup\
+        └── marker
+```
+
+The same rule applies to:
+
+```text
+Procedures\Inspection
+Procedures\Takedown
+```
+
+If the Procedure application directly consumes a task-local `images` folder, that `images` folder must also be marked before it becomes part of the application path.
+
+`Archive` and `SourceDocs` are excluded source/history areas and are not normal field-presentation folders. They are not application marker targets unless a later approved design intentionally changes their role.
+
+This is the same marker principle used by FieldWiring. Wiring and Procedures remain separate tasks, but they share the rule that an application may only follow a controlled marked path.
+
+See [MSB Database Source Folder Marker — Operator Procedure](../../Docs/00_Project_Overview/03-MSB_DB_Source_Folder_Marker_Operator_Procedure.md) and [Google Drive Path Resolution Contract](../../Docs/00_Project_Overview/02-Google_Drive_Path_Resolution_Contract.md).
 
 ## Stage, Scene, and Display Scope
 
@@ -81,11 +119,13 @@ Setup-document images must have one predictable home associated with the Setup d
 
 For Setup-specific document assets, use the established Setup-local image location approved for the Stage documentation workflow. Do not create additional competing image folders for the same document family.
 
+If the future Procedure application reads those image files directly, the applicable `images` folder is part of the controlled application path and must contain the marker before application use.
+
 Reusable organization branding such as the MSB logo should come from one approved publicly accessible reusable asset location rather than being copied into every Stage Setup folder.
 
 Images should appear next to the instruction step they clarify whenever practical.
 
-The exact physical folder path for Setup images must remain aligned with the Stage-folder procedure being completed in the document-alignment work; this standard does not independently change that structure.
+The exact physical folder path and presentation behavior for Setup images must remain aligned with the Stage-folder procedure and future Procedure implementation; this standard does not independently invent a second image structure.
 
 ## Database Ownership and Document Resolution
 
@@ -100,6 +140,7 @@ Display QR
     -> permanent Display identity
     -> Production Database relationships
     -> applicable Stage / Scene context
+    -> controlled marked Procedure path
     -> durable Setup document reference(s)
     -> user-facing presentation
 ```
@@ -143,9 +184,11 @@ Archived Setup documents:
 
 Setup and Wiring share the established Stage-oriented documentation model but remain different document systems.
 
-Wiring has its own LOR/FormView-derived contracts and `BackgroundStage` / `MusicalStage` behavior. Setup instructions must not be reorganized as Wiring documents, and Wiring must not be simplified into ordinary Setup procedure folders.
+Wiring has its own LOR/FieldWiring/FormView contracts and `BackgroundStage` / `MusicalStage` behavior. Setup instructions must not be reorganized as Wiring documents, and Wiring must not be simplified into ordinary Setup procedure folders.
 
 The proven reusable architectural idea is that structured system identity can resolve the correct field documentation without requiring the volunteer to understand where that documentation is stored.
+
+Both systems use controlled markers along their application paths, but each task owns its own branch and presentation behavior.
 
 ## Navigation and Discovery
 
@@ -166,6 +209,8 @@ A contributor should be able to determine from the repository:
 The following are agreed project direction, not authorization to invent implementation details:
 
 - keep the established Stage/Scene Google Drive folder structure;
+- require the standard marker in every folder used by the future Procedure application's controlled path;
+- keep `Archive` and `SourceDocs` outside normal field presentation;
 - continue legacy-document alignment through the existing Folder Alignment/document-organization work;
 - use a dedicated Stage Setup Instruction template;
 - maintain a separate contributor/operator procedure for using that template;
@@ -180,7 +225,7 @@ Still unresolved and requiring engineering review:
 - exact Google Doc / published PDF reference storage in PostgreSQL;
 - exact current-vs-published relationship when a Google Doc and PDF both exist;
 - exact scraper/API contract used by `my.sheboyganlights.org`;
-- final Setup image-path rule as the Stage folder-alignment procedure is completed;
+- whether/how task-local `images` are served directly by the future Procedure application;
 - final contributor workflow for generating/publishing PDFs from the controlled template/source.
 
 ## Related Documents
@@ -189,6 +234,8 @@ Still unresolved and requiring engineering review:
 - [Linking and Navigation Standard](../Standards/Linking_and_Navigation_Standard.md)
 - [Templates](../Templates/README.md)
 - [Google Drive Document Organization Procedure](../../Docs/00_Project_Overview/01-Google_Drive_Document_Organization_Procedure.md)
+- [MSB Database Source Folder Marker — Operator Procedure](../../Docs/00_Project_Overview/03-MSB_DB_Source_Folder_Marker_Operator_Procedure.md)
+- [Google Drive Path Resolution Contract](../../Docs/00_Project_Overview/02-Google_Drive_Path_Resolution_Contract.md)
 - [Setup and Deployment Engineering](../../Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/README.md)
 - [Labeling and Scanning](../../Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/README.md)
 - [Wiring System](../../Docs/02_Production_Database/01_System_Architecture/09_Wiring_System/README.md)

--- a/System_Documentation/Project_Rules/Stage_Setup_Documentation_Standard.md
+++ b/System_Documentation/Project_Rules/Stage_Setup_Documentation_Standard.md
@@ -46,7 +46,9 @@ For a normal Setup path this includes:
 └── Procedures\
     ├── marker
     └── Setup\
-        └── marker
+        ├── marker
+        └── images\
+            └── marker
 ```
 
 The same rule applies to:
@@ -54,9 +56,10 @@ The same rule applies to:
 ```text
 Procedures\Inspection
 Procedures\Takedown
+Procedures\Takedown\images
 ```
 
-If the Procedure application directly consumes a task-local `images` folder, that `images` folder must also be marked before it becomes part of the application path.
+`Setup\images` and `Takedown\images` are part of the controlled future Procedure content path and must be marked.
 
 `Archive` and `SourceDocs` are excluded source/history areas and are not normal field-presentation folders. They are not application marker targets unless a later approved design intentionally changes their role.
 
@@ -117,15 +120,17 @@ A separate contributor/operator procedure must explain how to create, revise, ar
 
 Setup-document images must have one predictable home associated with the Setup documentation they support so contributors do not have to guess among unrelated repository or Stage image locations.
 
-For Setup-specific document assets, use the established Setup-local image location approved for the Stage documentation workflow. Do not create additional competing image folders for the same document family.
+For Setup-specific document assets, use the established Setup-local `images` folder. The future Procedure system treats this as part of the controlled task path, so the folder must contain the standard marker.
 
-If the future Procedure application reads those image files directly, the applicable `images` folder is part of the controlled application path and must contain the marker before application use.
+The same rule applies to the Takedown-local `images` folder.
+
+Do not create additional competing image folders for the same document family.
 
 Reusable organization branding such as the MSB logo should come from one approved publicly accessible reusable asset location rather than being copied into every Stage Setup folder.
 
 Images should appear next to the instruction step they clarify whenever practical.
 
-The exact physical folder path and presentation behavior for Setup images must remain aligned with the Stage-folder procedure and future Procedure implementation; this standard does not independently invent a second image structure.
+The exact presentation behavior for task-local images must remain aligned with the future Procedure implementation, but their folder/marker ownership is established now.
 
 ## Database Ownership and Document Resolution
 
@@ -209,7 +214,7 @@ A contributor should be able to determine from the repository:
 The following are agreed project direction, not authorization to invent implementation details:
 
 - keep the established Stage/Scene Google Drive folder structure;
-- require the standard marker in every folder used by the future Procedure application's controlled path;
+- require the standard marker in every folder used by the future Procedure application's controlled path, including Setup/Takedown `images`;
 - keep `Archive` and `SourceDocs` outside normal field presentation;
 - continue legacy-document alignment through the existing Folder Alignment/document-organization work;
 - use a dedicated Stage Setup Instruction template;
@@ -225,7 +230,7 @@ Still unresolved and requiring engineering review:
 - exact Google Doc / published PDF reference storage in PostgreSQL;
 - exact current-vs-published relationship when a Google Doc and PDF both exist;
 - exact scraper/API contract used by `my.sheboyganlights.org`;
-- whether/how task-local `images` are served directly by the future Procedure application;
+- exact runtime serving/rendering behavior for task-local `images`;
 - final contributor workflow for generating/publishing PDFs from the controlled template/source.
 
 ## Related Documents

--- a/System_Documentation/Standards/Documentation_Standards.md
+++ b/System_Documentation/Standards/Documentation_Standards.md
@@ -32,6 +32,86 @@ The following principles apply throughout the project:
 * **Write for the least technical audience that needs the document.**
   Use plain language wherever possible. Introduce technical terminology only when the reader needs it to complete the task.
 
+## Engineering Documentation and Operator Documentation Are Different Products
+
+The repository intentionally maintains separate documentation for two different use cases and audiences.
+
+### Engineering documentation
+
+Engineering documentation exists to **build, change, troubleshoot, validate, and resume development of the system**.
+
+Its audience includes maintainers, developers, database administrators, and future engineering work sessions. Engineering documentation may and should preserve the technical detail needed to avoid rediscovering settled design decisions.
+
+Engineering documentation may include:
+
+- architecture and subsystem boundaries;
+- database objects and data flow;
+- parser and application behavior;
+- filesystem and integration contracts;
+- identity rules;
+- implementation dependencies;
+- validation and failure behavior;
+- relevant historical rationale;
+- known limitations and unresolved work; and
+- authoritative source locations that must be reviewed before changing the subsystem.
+
+Do not simplify an engineering document to the point that a future maintainer must reconstruct the system from source code, chat history, or old troubleshooting sessions.
+
+### Operator documentation
+
+Operator documentation exists to **use the system correctly**.
+
+Its audience includes volunteers, programmers, technicians, managers, and other users performing a defined task. Operator documentation should contain only the technical detail needed to complete the task safely and correctly.
+
+Operator documentation should focus on:
+
+- what the operator is trying to accomplish;
+- what is needed before starting;
+- exact steps in the order performed;
+- names, buttons, folders, fields, and values the operator must recognize;
+- warnings that prevent likely mistakes;
+- what successful completion looks like; and
+- what to do when a common problem occurs.
+
+An operator should not be required to understand Python, SQL, parser internals, UUIDs, database schemas, or application architecture unless that knowledge is genuinely part of the operator's task.
+
+When technical explanation is useful but not required to perform the task, keep it in the responsible engineering document and link to it from a clearly separated **Related Engineering** or **Related Documents** section.
+
+### Do not merge the audiences
+
+Engineering detail must not leak into an operator procedure merely because the engineering explanation exists and is accurate.
+
+Likewise, engineering documentation must not be stripped of essential implementation and decision context merely to make it read like an operator procedure.
+
+The same system may therefore legitimately have:
+
+```text
+Engineering Design
+    = how and why the system works
+
+Operator Procedure / SOP
+    = how a person uses the system
+```
+
+These documents support each other but do not replace one another.
+
+## Repository Documentation Is Durable Project Memory
+
+Conversation, email, and chat are working communication, not the long-term source of project truth.
+
+When a discussion results in an accepted change to architecture, workflow, naming, operation, system boundaries, known limitations, or another controlled decision, that decision must be promoted into the repository document responsible for it.
+
+Do not leave a material decision only in conversation history.
+
+This rule serves two purposes:
+
+1. operators receive current instructions when engineering changes affect how they use the system; and
+2. future engineering work can resume from the repository without spending time reconstructing settled decisions across separate conversations or work threads.
+
+The responsible document may be an engineering design, operator procedure, standard, project rule, subsystem README, or another controlled artifact depending on what changed.
+
+Follow the document-control and README closeout standards when deciding where the durable update belongs.
+
 ## Related Systems and Related Documents
 
 Technical documents, procedures, and subsystem documentation should include navigable **Related Systems** and/or **Related Documents** sections when those relationships help the reader understand where the document fits or where to go next.
@@ -98,4 +178,4 @@ All current documentation should use current, navigable links.
 
 A person arriving at a portal page should normally be able to determine where to go next within about ten seconds.
 
-Technical depth should remain available, but it should be placed deeper in the documentation structure rather than presented to every reader.
+Technical depth should remain available, but it should be placed in the documentation layer intended for the reader rather than presented indiscriminately to every audience.

--- a/System_Documentation/Standards/README_Portal_Standard.md
+++ b/System_Documentation/Standards/README_Portal_Standard.md
@@ -4,9 +4,11 @@
 
 README files are navigation portals. Their job is to help a reader quickly understand where they are and where to go next.
 
-A portal should be short, plain-language, and useful to the least technical audience that needs it.
+A portal should be short, plain-language, and useful to the least technical audience that needs that particular portal.
 
 For an active engineering subsystem, the README also serves as the durable handoff point between development sessions. It must preserve enough current-state context that work can resume from repository documentation instead of reconstructing decisions from conversation history.
+
+These are not conflicting goals because README portals must be written for their actual audience. A volunteer-facing portal and an engineering-subsystem portal have different responsibilities even though both use the same navigation standard.
 
 ## Required Structure
 
@@ -50,27 +52,37 @@ Use only the sections that help the reader navigate.
 
 ## Match the Portal to Its Audience
 
-All portal pages follow the same structural standard, but the language should reflect the intended audience.
+All portal pages follow the same structural standard, but the language and handoff content must reflect the intended audience.
 
-| Audience | Portal Style | Examples |
-|----------|--------------|----------|
-| Volunteers / Operators | Task-oriented | Reconciliation |
-| General Users | User-facing | Repository Root, LOR2DB, Reporting |
-| Engineers / Developers | Engineering | Application |
-| Documentation Maintainers | Standards | System_Documentation |
-
-The structure of the portal remains consistent throughout the repository, but the navigation and terminology should match the people who use it.
+| Audience | Portal Style | Primary Goal |
+|----------|--------------|--------------|
+| Volunteers / Operators | Task-oriented | Find the correct procedure and perform the task |
+| General Users | User-facing | Find information, reports, or the correct system entry point |
+| Engineers / Developers | Engineering | Resume and navigate system development without rediscovering settled work |
+| Documentation Maintainers | Standards | Find and apply documentation rules |
 
 - **Task-oriented portals** help readers complete an operational workflow.
 - **User-facing portals** introduce a system and help readers find information or reports.
-- **Engineering portals** may use technical terminology appropriate for developers and maintainers.
+- **Engineering portals** may use technical terminology appropriate for developers and maintainers and must preserve the current engineering handoff.
 - **Standards portals** describe how the documentation system is organized and maintained.
 
-Choose the portal style based on the primary audience, not the types of documents contained within the folder.
+Choose the portal style based on the primary audience, not merely the types of documents contained within the folder.
+
+### Operator portals must not become engineering handoffs
+
+A volunteer/operator portal should not expose parser internals, database implementation, design rationale, unresolved development detail, or other engineering material merely because that information exists in the same subsystem.
+
+The normal operator path should lead to plain-language procedures. Engineering references belong in a clearly separated related-information section when they are useful.
+
+### Engineering portals must not be reduced to operator summaries
+
+An engineering-subsystem README has a different job. It must remain concise, but it cannot omit current state, system boundaries, authoritative sources, unresolved work, or the correct development restart point when losing that information would force the next engineering session to investigate the same questions again.
+
+Plain language is still preferred where possible, but necessary technical terminology is appropriate for the engineering audience.
 
 ## Engineering Subsystem Handoff
 
-An active engineering or development subsystem README has an additional responsibility: it is the current handoff point for future work.
+An active engineering or development subsystem README has an additional responsibility: it is the current handoff point for future work, including work resumed in a different conversation or development thread.
 
 Use concise sections when applicable to identify:
 
@@ -86,6 +98,20 @@ These sections are not required on simple volunteer-facing portals when they wou
 
 The README is not a development diary. Preserve historical implementation detail in Git history, revision history, incident reports, engineering history, or archive material as appropriate. The README records the current handoff state.
 
+## Conversation-to-Repository Handoff
+
+A material engineering decision is not safely handed off merely because it was resolved in a conversation.
+
+When work changes a subsystem's architecture, workflow, operating behavior, system boundary, authoritative source, known limitation, or next development step:
+
+1. update the detailed document that owns the changed information;
+2. review any affected operator procedure when the change affects how people use the system; and
+3. update the responsible engineering README when the change affects what the next engineering session needs to know.
+
+The repository, not conversation history, is the durable handoff mechanism.
+
+The goal is that a future session can start from the responsible README and linked engineering documents, understand the current state, and continue work without reconstructing settled decisions from previous chats.
+
 ## Mandatory Closeout Rule
 
 Material subsystem work is not complete until the responsible README has been reviewed and, when necessary, updated to reflect the resulting current state.
@@ -97,14 +123,17 @@ Before closing the work:
 1. Update the responsible detailed engineering, procedure, SOP, or reference documents when their owned information changed.
 2. Review the subsystem README after those updates.
 3. Update the README so its current state, authoritative sources, dependencies, known limitations, and next development starting point remain accurate.
-4. Verify its navigation and related-system links.
-5. Commit the README handoff update with the work rather than leaving it for a later cleanup pass.
+4. Review affected operator documentation separately when the engineering change alters an operator task.
+5. Verify navigation and related-system links.
+6. Commit the README handoff update with the work rather than leaving it for a later cleanup pass.
 
 The intended result is that the next work session can begin by reading the repository and continue from the documented state without rehashing or reinvestigating settled decisions.
 
 ## Technical Detail
 
 Technical depth belongs one level deeper in procedures, design documents, runbooks, or subsystem documentation. A portal may briefly identify those destinations but should not reproduce their content.
+
+For engineering portals, this rule means the README summarizes the handoff and links to the detailed engineering authority. It does not mean the README should omit the current engineering state.
 
 ## Maintenance
 

--- a/Utilities/README.md
+++ b/Utilities/README.md
@@ -12,8 +12,11 @@ If a tool primarily serves one subsystem, keep it with that subsystem instead. T
 
 - [MSB PostgreSQL Read-Only MCP](MSB_Postgres_MCP/README.md) — draft cross-system engineering connector for safe read-only access to current Production Database state. It is not deployed and does not authorize database writes or schema changes.
 - [FieldWiring Drive Resolver Test Harness](FieldWiring_Drive_Resolver_Test/README.md) — read-only engineering harness that tests the shared V7+ Stage/Scene Google Drive context-resolution rules against `fieldwiring_snapshot.db` and the mapped `Display Folders` hierarchy before FieldWiring browser implementation.
-- [`populate_msb_db_source_folder_markers.ps1`](populate_msb_db_source_folder_markers.ps1) — preview-first Google Drive utility that adds the approved personalized database-source marker only to existing `PreviewBackground`, `Procedures`, and `Wiring` source helper folders without renaming folders or overwriting existing marker notes. It does not mark Stage/Sub-stage/Scene roots or `Photos`. See the [marker operator procedure](../Docs/00_Project_Overview/03-MSB_DB_Source_Folder_Marker_Operator_Procedure.md).
-- [`remove_misplaced_msb_db_scope_root_markers.ps1`](remove_misplaced_msb_db_scope_root_markers.ps1) — preview-first remediation utility for reports produced by the earlier incorrect marker-population version that targeted Stage/Sub-stage/Scene roots. It considers only `TargetType=ScopeRoot` rows from a supplied CSV; when explicitly applied it backs up each misplaced marker before removing it.
+- [`populate_msb_db_source_folder_markers.ps1`](populate_msb_db_source_folder_markers.ps1) — **INCOMPLETE FOR THE CURRENT MARKER RULE.** This utility was written for the older narrow target set (`PreviewBackground`, `Procedures`, and `Wiring`). The current rule requires markers in every folder used by the FieldWiring/future Procedure application path, including structured roots and the applicable published/task branches. Do not treat a successful run of this utility as proof of full marker compliance until the utility is updated and revalidated. See the [marker operator procedure](../Docs/00_Project_Overview/03-MSB_DB_Source_Folder_Marker_Operator_Procedure.md).
+
+## Retired / Do Not Run
+
+- [`remove_misplaced_msb_db_scope_root_markers.ps1`](remove_misplaced_msb_db_scope_root_markers.ps1) — **DO NOT RUN under the current architecture.** This remediation utility was created during an intermediate design that incorrectly treated Stage/Sub-stage/Scene root markers as misplaced. Current FieldWiring/path-resolution rules require the structural marker on those roots. The utility is retained only as historical/recovery evidence until it is moved to the appropriate archive.
 
 ## Maintenance
 


### PR DESCRIPTION
## Summary

This PR reconciles the Preview Authoring documentation against the current repository after the FieldWiring release-candidate work and separates operator-facing instructions from engineering documentation more clearly.

## What changed

### Preview Authoring operator documentation
- Rewrote the Preview Authoring portal and operator procedures in plain language for Randy/Eric/volunteer use.
- Preserved current Scene/Sub-stage scaffold, marker, Preview staging, Master Musical, and wiring rules.
- Removed parser/database/UUID implementation detail from the normal operator path.
- Added a simple explanation of shaded inline text such as `PreviewBackground` and `BackgroundFile`.
- Kept engineering references available under clearly separated related-engineering links.

### Documentation governance
- Added a repository change workflow requiring current remote `main` to be refreshed and affected files re-read before editing code, schema, configuration, or controlled documentation.
- Clarified that engineering documentation and operator documentation are intentionally different products for different audiences.
- Reinforced README responsibility as the durable engineering handoff between development sessions.

### Google Drive marker rule
- Corrected the marker rule to require `_MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt` in every folder used by FieldWiring or the future Procedure system as part of its controlled application path.
- Current documented path includes Stage/Sub-stage/Scene roots; active `PreviewBackground`; `Wiring`; `BackgroundStage`; `MusicalStage`; `Procedures`; `Inspection`; `Setup`; `Setup\images`; `Takedown`; and `Takedown\images`.
- `SourceDocs` and `Archive` remain excluded from normal field presentation.
- Updated the Stage/Sub-stage/Scene scaffold, Google Drive organization procedure, path-resolution contract, and Stage Setup documentation standard accordingly.

### FieldWiring engineering handoff
- Documented that the current release-candidate `wiring_images.py` does not yet enforce the marker on the selected `BackgroundStage` / `MusicalStage` child branch.
- Kept this as an explicit engineering implementation gap rather than weakening the documentation contract.
- Documented that the existing marker-population utility still reflects the earlier narrower rule and is not full-path authority.
- Marked the old scope-root-marker removal utility as incompatible with the current architecture.

## Scope / non-goals
- No schema changes.
- No Production Database changes.
- No FieldWiring code changes.
- No parser changes.
- No FormView retirement.
- No change to the Display Design Worksheet contract.

## Review focus
Please review especially:
1. whether the operator procedures are now at the right technical level for the team;
2. the full marker-path rule and excluded folders;
3. the Stage/Sub-stage/Scene scaffold;
4. the documented FieldWiring marker-enforcement gap; and
5. the new refresh-before-edit repository workflow rule.

This branch was created from the current `main` after the FieldWiring release-candidate merge and was rechecked immediately before opening this PR.