### PR TITLE
Add Procedure system FieldWiring resolver handoff

### DIFF
--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/00_Procedure_System_Field_Context_Handoff_2026-08-22.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/00_Procedure_System_Field_Context_Handoff_2026-08-22.md
@@ -1,0 +1,363 @@
+# Procedure System Field Context Handoff — 2026-08-22
+
+| Document control | Value |
+|---|---|
+| Status | CURRENT ENGINEERING HANDOFF — resolves Procedure/FieldWiring documentation conflicts |
+| Current revision | 2026-08-22 |
+| Source baseline | `main` after accepted FieldWiring + Display Scan integration |
+| Production field entry | `https://my.sheboyganlights.org/fieldwiring/` and `https://my.sheboyganlights.org/scan/` |
+| Shared document filesystem | read-only Google `Display Folders` hierarchy on `msb-prod-db` |
+| Procedure subsystem | Setup / Takedown / Inspection field-document presentation |
+
+## Purpose
+
+This handoff defines the starting architecture for the Procedure subsystem and resolves conflicting older engineering language about how Setup/Takedown/Inspection documents must be located.
+
+The accepted direction is deliberately simple:
+
+> **Use the same proven structured Stage/Sub-stage/Scene resolution used by FieldWiring. After the structured root is fixed, switch to the Procedure task branch instead of the Wiring branch.**
+
+Do not build a second independent Display-to-Stage/Scene resolver for Procedures.
+
+Do not require a new PostgreSQL row, Google document ID, or manually maintained direct document URL for every published Procedure PDF merely to make the first Procedure browser work.
+
+PostgreSQL remains authoritative for durable Display/Stage/Scene identity and relationships. Google Shared Drive `Display Folders` remains authoritative for editable/published engineering documents. The server-side filesystem is the read-only bridge between those authorities.
+
+---
+
+## Accepted Production Prerequisites — Already Complete
+
+The Procedure project must treat the following as existing production infrastructure, not prerequisites to rediscover or rebuild:
+
+### FieldWiring
+
+FieldWiring is production-operational and already proves:
+
+```text
+permanent Display identity
+    -> current PostgreSQL Stage / Scene / Preview facts
+    -> stored/current LOR path evidence
+    -> Windows-root to Linux-root translation
+    -> bounded marked Stage/Sub-stage/Scene resolution
+    -> read-only Google filesystem traversal
+    -> task-specific field presentation
+```
+
+Relevant production source includes:
+
+```text
+FieldWiring/Application/repository.py
+FieldWiring/Application/wiring_images.py
+FieldWiring/Application/wiring.py
+```
+
+The structured-scope behavior in `wiring_images.py` is the proven starting point. In particular, the current resolver already provides guarded behavior for:
+
+- translating `G:\Shared drives\Display Folders\...` evidence to the server-visible tree;
+- validating the configured `Display Folders` root;
+- resolving a marked Stage root;
+- resolving a marked Scene when one deterministically matches current Scene identity;
+- retaining the known marked Stage root when no distinct Scene folder exists;
+- bounded Scene search rather than unbounded drive crawling;
+- stale path recovery only when one safe current marked hierarchy can be established;
+- stopping before `SourceDocs`;
+- failing visibly rather than guessing when evidence is ambiguous.
+
+### Display Scan
+
+The Display scan integration is accepted production work.
+
+The existing QR/scan route resolves:
+
+```text
+DISP:<display_id>
+    -> ref.display.display_id
+```
+
+FieldWiring is already launched from the Display scan hub using the permanent Display ID.
+
+The Procedure system must reuse that same permanent identity handoff when Procedure actions are later added to the scan hub. No physical QR change is required.
+
+The accepted scan integration is documented in:
+
+```text
+../07_Labeling_and_Scanning/FieldWiring_Scan_Integration_Engineering_Handoff_2026-08-22.md
+```
+
+### Shared Google filesystem
+
+The server-side Google `Display Folders` filesystem is production-operational and intentionally shared infrastructure for FieldWiring and future Procedure applications.
+
+The Procedure project must not create a second Google authorization model, duplicate mount, downloaded document mirror, or Procedure-only Google hierarchy.
+
+The field-presentation service is a read-only consumer of the same human-maintained Shared Drive structure.
+
+---
+
+## Shared Resolver Versus Task Adapter
+
+This distinction is the central conflict-resolution rule.
+
+### Shared structured-scope resolver owns
+
+The common resolver answers only:
+
+> **Which current structured Stage / Sub-stage / Scene root owns this field context?**
+
+Its inputs may include:
+
+- permanent `display_id` when entry began from a Display;
+- current `ref.display` / `ref.stage` relationships;
+- current `ref.lor_scene_display` / `ref.lor_scene` relationships;
+- current Preview/Scene path evidence where useful;
+- the marked Google Drive hierarchy;
+- the configured shared `Display Folders` root.
+
+Its output is a fixed structured context such as:
+
+```text
+scope_type = STAGE | SUBSTAGE | SCENE
+scope_root = <current server-visible marked folder>
+trigger_display_id = <optional permanent Display ID>
+current Stage/Scene identity and provenance
+warnings = <stale path / fallback / ambiguity evidence>
+```
+
+The Procedure project should reuse or extract the existing FieldWiring structured-scope logic rather than implement a second competing algorithm.
+
+If extraction into a common module is required, it must be additive and regression-tested so existing FieldWiring behavior remains unchanged.
+
+### Procedure task adapter owns
+
+Once `scope_root` is fixed, the Procedure adapter answers:
+
+> **Which current Procedure task content is published directly under this already-resolved scope?**
+
+The initial task branches are:
+
+```text
+Setup      -> <scope_root>/Procedures/Setup
+Takedown   -> <scope_root>/Procedures/Takedown
+Inspection -> <scope_root>/Procedures/Inspection
+```
+
+The Procedure adapter must not re-resolve the Display, widen/narrow the scope based on filenames, or crawl to unrelated parent/sibling documentation just because the selected task folder is empty.
+
+This is directly analogous to FieldWiring after structured resolution:
+
+```text
+same structured root
+    |
+    +--> FieldWiring adapter -> Wiring/BackgroundStage or Wiring/MusicalStage
+    |
+    +--> Procedure adapter   -> Procedures/Setup, Procedures/Takedown, Procedures/Inspection
+```
+
+---
+
+## Procedure Marker Contract
+
+Procedure markers remain task-specific and are not identical to FieldWiring's Wiring marker rules.
+
+For the Procedure application path, current governing documentation requires markers on:
+
+```text
+<Stage / Sub-stage / Scene root>
+Procedures
+Procedures/Inspection
+Procedures/Setup
+Procedures/Setup/images
+Procedures/Takedown
+Procedures/Takedown/images
+```
+
+`Archive` and `SourceDocs` are excluded working/history areas and are not normal field-presentation sources.
+
+This is **not** a conflict with reuse of the structured resolver.
+
+The common resolver establishes the structured root. The Procedure adapter then validates the markers required by the Procedure branch it owns.
+
+Do not copy Procedure child-marker requirements back onto FieldWiring's `Wiring/BackgroundStage` or `Wiring/MusicalStage` folders.
+
+---
+
+## Initial Current-Document Discovery Contract
+
+The first Procedure browser does not require a per-document database registry merely to discover current published PDFs.
+
+For the initial implementation, after the structured root and Procedure task branch are validated:
+
+1. enumerate files **directly** in the selected task folder;
+2. present approved current field-document formats supported by the implementation, beginning with PDF;
+3. exclude the marker file itself from user choices;
+4. do not recurse into `Archive`;
+5. do not recurse into `SourceDocs`;
+6. do not treat files inside `images` as independent Procedure documents;
+7. if more than one current PDF exists, present a simple current-document list;
+8. if no current document exists, show a clear missing-document state;
+9. do not search neighboring Stage/Scene folders by filename in order to manufacture a result.
+
+Example:
+
+```text
+resolved scope_root
+    -> Procedures
+        -> Setup
+            -> Current Setup A.pdf
+            -> Current Setup B.pdf
+            -> images/        supporting assets, not separate procedure choices
+            -> Archive/       excluded
+            -> SourceDocs/    excluded
+```
+
+A filename may be used as a user-facing label for a discovered current file. It is not permanent Production Database identity.
+
+---
+
+## Durable Document IDs Are Not an Initial Runtime Prerequisite
+
+Older Setup documents contain language suggesting the Procedure system must first determine where Google Doc IDs or published PDF references are stored in PostgreSQL.
+
+That remains a legitimate **future publication/governance capability**, but it is not required for the first read-only Procedure browser because the accepted server architecture can safely enumerate the controlled current task folder after identity/scope resolution.
+
+Durable per-document metadata may later be justified for needs such as:
+
+- explicit approval/publication workflow;
+- revision history independent of filenames;
+- supersession relationships;
+- Google Doc source -> published PDF lineage;
+- content hashes;
+- audit/history requirements;
+- stable references when documents are deliberately renamed;
+- workflow status beyond what the controlled current/archive folder contract expresses.
+
+Do not create a new schema object merely because older documentation listed this as unresolved.
+
+First prove the read-only Procedure application against the existing identity + hierarchy + marked-filesystem contract. Add schema only when a demonstrated requirement cannot be met safely by that contract.
+
+---
+
+## Source Versus Published Content
+
+The authoring/publication workflow remains separate from runtime discovery.
+
+Current intended Setup flow is still conceptually:
+
+```text
+editable source / legacy source
+    -> review / convert / approve
+    -> current field PDF published directly in Procedures/Setup
+    -> old material retained under Archive or SourceDocs as governed
+```
+
+The Procedure field application consumes the published current result. It does not become the Google Docs editor or document-conversion authority.
+
+The existing question of how a Google Doc source is linked durably to its published PDF may be engineered separately without blocking read-only current-PDF discovery.
+
+---
+
+## Scope Behavior
+
+The Procedure application must preserve context idempotence.
+
+If two Displays resolve to the same structured Scene for Setup, then:
+
+```text
+Display A lookup
+Display B lookup
+Scene browse
+```
+
+must all produce the same base `Procedures/Setup` result for that resolved Scene.
+
+The triggering Display may remain visible for operator orientation, but it must not cause duplicate copies or a different Procedure package merely because a different Display in the same scope was selected.
+
+If the shared structured resolver returns the Stage root rather than a distinct Scene root, the Procedure task is resolved beneath that Stage root. Do not run a second independent Procedure-only Scene guessing algorithm.
+
+---
+
+## Entry Methods
+
+The Procedure browser should ultimately support the same three useful entry paths already established by FieldWiring/Scan:
+
+```text
+Find Display
+Browse Stage / Scene
+Scan permanent Display QR
+```
+
+All three entry methods must converge on the same structured context and then the same Procedure task adapter.
+
+The first Procedure implementation may begin with manual Display/Stage/Scene lookup and add the scan action after standalone Procedure presentation is accepted. The accepted scan platform already provides the permanent `display_id` contract when that integration is ready.
+
+---
+
+## First Engineering Acceptance Target
+
+The first acceptance target should be deliberately narrow:
+
+1. use current `main` as the source baseline;
+2. inspect the current FieldWiring repository/resolver implementation before writing Procedure resolver code;
+3. identify the minimum reusable structured-context interface rather than copying the algorithm into a second code path;
+4. use the existing read-only `Display Folders` filesystem;
+5. resolve one known Stage/Scene context from current PostgreSQL identity;
+6. select `Procedures/Setup` instead of `Wiring/...`;
+7. validate the Procedure markers;
+8. enumerate the current PDF directly in that Setup folder;
+9. serve/open that PDF through a protected `my.sheboyganlights.org` Procedure route;
+10. prove `Archive` and `SourceDocs` cannot be served through normal Procedure endpoints;
+11. prove FieldWiring remains unchanged by any shared-resolver refactor.
+
+Do not begin this acceptance by designing scheduling, forklift state, load planning, Container movement transactions, a Procedure database registry, or a generic document-management system. Those are separate Setup/Deployment concerns.
+
+---
+
+## Conflict Resolution / Precedence
+
+For Procedure resolver engineering, this handoff is the current starting-point authority when older documents appear to conflict.
+
+Interpret older guidance as follows:
+
+### Still valid
+
+- Production Database owns durable Display/Stage/Scene identities and relationships.
+- Google `Display Folders` owns human-maintained field documents.
+- Stage/Sub-stage/Scene structure is authoritative.
+- Procedure task folders and markers are application contracts.
+- `Archive` and `SourceDocs` are excluded from normal field presentation.
+- current published PDF/rendered documents are preferred field output.
+- durable document identity may be added when publication/history requirements justify it.
+
+### Superseded as an initial implementation prerequisite
+
+- Procedure runtime must have a PostgreSQL row for every current PDF before it can find the PDF;
+- every current Procedure PDF must first have a stored Google file/document ID before browser discovery is allowed;
+- Procedures should build their own independent Display-to-Stage/Scene resolver;
+- QR codes should encode Procedure paths or document URLs;
+- a missing current Procedure document should trigger fuzzy filename search elsewhere in the Shared Drive.
+
+---
+
+## Documents the Procedure Thread Must Read First
+
+1. `Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/00_Procedure_System_Field_Context_Handoff_2026-08-22.md`
+2. `Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/Field_Context_Resolution_Contract.md`
+3. `Docs/02_Production_Database/01_System_Architecture/09_Wiring_System/FieldWiring_Drive_Context_Resolver_Engineering_Design.md`
+4. `FieldWiring/Application/wiring_images.py`
+5. `FieldWiring/Application/repository.py`
+6. `Docs/00_Project_Overview/01-Google_Drive_Document_Organization_Procedure.md`
+7. `Docs/00_Project_Overview/03-MSB_DB_Source_Folder_Marker_Operator_Procedure.md`
+8. `System_Documentation/Project_Rules/Stage_Setup_Documentation_Standard.md`
+9. `Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/FieldWiring_Scan_Integration_Engineering_Handoff_2026-08-22.md`
+
+If those documents contain older wording that appears inconsistent, preserve the ownership/marker/publication rules but follow this handoff for the initial resolver/runtime architecture.
+
+---
+
+## Stop Point
+
+The Procedure subsystem may now begin engineering reconnaissance from the accepted FieldWiring/Scan production baseline.
+
+Do not modify FieldWiring, PostgreSQL schema, the Google folder hierarchy, marker placement, or the production scan extension merely to start the Procedure proof of concept.
+
+First reconstruct the reusable structured-context boundary and prove one read-only Setup lookup end-to-end.

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/README.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/README.md
@@ -2,7 +2,7 @@
 
 ## Current State
 
-**Status: DOCUMENTATION ACTIVE / OPERATIONAL ENGINEERING NEXT PRIORITY AFTER SCAN INTEGRATION**
+**Status: DOCUMENTATION ACTIVE / PROCEDURE RESOLVER ENGINEERING READY**
 
 This subsystem covers planning, scheduling, staging, loading, scanning, and moving tested displays and containers from storage to the park for annual setup, plus takedown-related field documentation where it belongs with the same Stage material.
 
@@ -10,7 +10,7 @@ The Stage-oriented folder structure already exists. Setup/Takedown instructions 
 
 The operational database/application workflow for scheduling, pick lists, load order, and forklift scanning is not yet fully engineered. No operator procedure should imply those planned functions are implemented until verified from the current database/application.
 
-FieldWiring is now production-operational, and the existing scan platform is being recovered/documented before its first new additive integration. Once the FieldWiring scan action is accepted, this Setup/Deployment workflow is the next major scanning project.
+**FieldWiring and the Display Scan integration are now accepted production baselines.** Procedure resolver engineering does not need to wait for, rediscover, or redesign either system. Start with [Procedure System Field Context Handoff — 2026-08-22](00_Procedure_System_Field_Context_Handoff_2026-08-22.md), which resolves older documentation conflicts and defines how Setup/Takedown/Inspection reuse the proven FieldWiring structured Stage/Sub-stage/Scene resolver.
 
 MSB has purchased a **Zebra DS3678-HD cordless ultra-rugged 1-D/2-D scanner kit** for the workshop forklift. It uses the Zebra 3600-series USB cradle and supports USB HID keyboard input. Because this is the **HD (High Density)** variant rather than an ER/XR extended-range model, its actual suitability from the forklift seat must be tested with real MSB Container and Storage Location labels before it is accepted as the final forklift-distance standard. See [Scanner Hardware and Tablet Integration](../07_Labeling_and_Scanning/Scanner_Hardware_and_Tablet_Integration.md).
 
@@ -70,42 +70,79 @@ The existing Google Shared Drive Stage/Scene folder structure is the human-facin
 - The existing Google Drive document-organization and Folder Alignment work controls the actual folder structure and migration of legacy material.
 - Setup instructions should be placed and maintained within the existing Stage/Scene structure rather than creating a separate unrelated setup-document tree.
 - [Wiring System](../09_Wiring_System/README.md) owns wiring content in that structure.
-- Setup and Deployment owns setup/takedown instruction behavior and the database/application integration contract for finding applicable Setup documents.
+- Setup and Deployment owns setup/takedown instruction behavior and the application integration contract for finding applicable Procedure documents.
 - [Labeling and Scanning](../07_Labeling_and_Scanning/README.md) owns permanent QR/scanning integration patterns, but QR lookup does not become the content authority.
+- [Procedure System Field Context Handoff](00_Procedure_System_Field_Context_Handoff_2026-08-22.md) owns the current initial resolver/runtime handoff where older documents conflict.
 
 This framework does not by itself define or approve a new database schema.
 
 ## Document Resolution and Field UX
 
-The intended field-access path is:
+The accepted initial field-access path is:
 
 ```text
-Display QR
+Display QR or manual Display/Stage/Scene lookup
     ↓
-Permanent Display identity
+Permanent Display identity when applicable
     ↓
 Production Database relationships
     ↓
-Applicable Stage / Scene
+shared/proven FieldWiring structured Stage / Sub-stage / Scene resolver
     ↓
-Current Setup document reference(s)
+fixed applicable structured root
+    ↓
+Procedure task adapter
+    ↓
+<scope>/Procedures/Setup
+or <scope>/Procedures/Takedown
+or <scope>/Procedures/Inspection
+    ↓
+bounded current-document discovery from the read-only Google filesystem
     ↓
 my.sheboyganlights.org
     ↓
-Current field PDF / rendered instruction
+current field PDF / rendered instruction
 ```
 
-The QR code identifies the asset. It should not need to contain a Google Drive folder path or manually maintained direct Setup-document URL.
+The QR code identifies the asset. It does not contain a Google Drive folder path or manually maintained direct Procedure-document URL.
 
-The Production Database owns the durable identities and relationships used to determine which instructions apply. The database does not need to become the editing system for the Setup content itself.
+The Production Database owns the durable identities and relationships used to determine the structured Stage/Scene context. The database does not become the editing system for Procedure content.
 
-The exact PostgreSQL location for durable Google Doc IDs, published PDF references, or other document identifiers remains an engineering decision that must be based on the current schema rather than guessed.
+For the **initial read-only Procedure browser**, a PostgreSQL row or stored Google document ID for every current published PDF is **not a prerequisite**. Once the current structured root and marked Procedure task folder are validated, the application may enumerate the current published files directly in that controlled folder while excluding `Archive` and `SourceDocs`.
+
+Durable per-document metadata remains a future engineering option when approval workflow, revision history, source-to-publication lineage, supersession, audit, or stable document identity demonstrates a need for it. Do not create schema merely because older documentation listed document-ID storage as unresolved.
 
 `my.sheboyganlights.org` is the intended normal field presentation layer. Field volunteers should not need to understand the GitHub repository, database schema, Google Drive organization, or source-document mechanics to reach the current Setup instruction.
 
+## Resolver Reuse Boundary
+
+Procedures must **reuse or extract the proven FieldWiring structured-scope resolver** rather than create a second independent Display-to-Stage/Scene algorithm.
+
+The shared resolver answers:
+
+> Which current marked Stage / Sub-stage / Scene root owns this context?
+
+The Procedure adapter then answers:
+
+> Which current documents are published in the selected Procedure task branch beneath that already-resolved root?
+
+This means Wiring and Procedures share scope resolution but do not share task-specific content rules:
+
+```text
+resolved structured root
+    |
+    +--> FieldWiring -> Wiring/BackgroundStage or Wiring/MusicalStage
+    |
+    +--> Procedures  -> Procedures/Setup, Procedures/Takedown, Procedures/Inspection
+```
+
+Procedure marker rules remain separate from FieldWiring marker rules. `Archive` and `SourceDocs` remain excluded from normal field presentation.
+
 ## Scan / Forklift Direction
 
-Setup is expected to be a high-volume scan workflow rather than occasional lookup.
+The permanent Display scan platform is already production-operational and resolves `DISP:<display_id>` using permanent Production Database identity. Future Procedure scan actions should consume that existing identity contract; no physical Display QR redesign is required.
+
+Setup is also expected to become a high-volume scan workflow for deployment operations rather than only document lookup.
 
 Durable physical identities remain the starting point:
 
@@ -150,15 +187,21 @@ Detailed testing-season procedures belong with [Testing System](../05_Testing_Sy
 
 ### PostgreSQL remains the operational system of record
 
-Scheduling, operational movement events, load grouping, scan confirmations, deployment status, and the durable relationships required to resolve applicable field documentation should remain in the Production Database when those workflows are engineered.
+Scheduling, operational movement events, load grouping, scan confirmations, deployment status, and durable Stage/Scene/asset relationships remain in the Production Database when those workflows are engineered.
 
 Generic container movement history is not a goal. Movement/history should be recorded only when the Setup/Deployment workflow actually needs a reconstructable event trail.
 
+### Google Shared Drive remains the field-document repository
+
+The shared read-only server filesystem exists so Procedure applications can consume the same human-maintained `Display Folders` hierarchy already used by FieldWiring.
+
+Do not create a second Procedure-only Google hierarchy, duplicate mount, downloaded mirror, or database binary-document store merely to present current procedures.
+
 ### Field document content remains separate from database internals
 
-The database may identify and resolve the correct Setup instruction without requiring field volunteers to operate inside PostgreSQL, Directus, GitHub, or Google Drive.
+The database resolves the current physical context without requiring field volunteers to operate inside PostgreSQL, Directus, GitHub, or Google Drive.
 
-A simple PDF/rendered instruction at the Stage level is preferred when that gives the crew the best user experience.
+A simple PDF/rendered instruction at the Stage/Scene level is preferred when that gives the crew the best user experience.
 
 ### Directus is an initial management interface, not the field-document UX requirement
 
@@ -182,6 +225,9 @@ Legacy and superseded Setup instructions should be archived through the establis
 
 The subsystem is expected to eventually support:
 
+- current Setup/Takedown/Inspection document lookup by Display/Stage/Scene;
+- field-friendly Procedure presentation through `my.sheboyganlights.org`;
+- Procedure actions from the existing Display scan hub after standalone Procedure acceptance;
 - setup season/session context;
 - calendar pull scheduling;
 - pick lists;
@@ -190,8 +236,7 @@ The subsystem is expected to eventually support:
 - Container/Location validation;
 - meaningful pull/stage/load/delivery confirmations;
 - prior-year sequence reference;
-- durable Stage/Scene Setup document resolution;
-- field-friendly Setup-document presentation through `my.sheboyganlights.org`.
+- optional durable per-document publication metadata when a demonstrated workflow requires it.
 
 These are design targets, not implemented schema commitments unless verified in the current database.
 
@@ -199,52 +244,80 @@ These are design targets, not implemented schema commitments unless verified in 
 
 This subsystem depends on existing Production Database identities and relationships, including where applicable:
 
+- permanent Display identity and Stage/Scene relationships;
+- the accepted FieldWiring structured-context behavior;
+- the accepted Display scan platform;
+- the shared read-only Google `Display Folders` filesystem;
 - containers and storage locations;
-- displays and their container assignments;
 - testing readiness/state;
 - people/volunteer identity;
-- labeling and scanning infrastructure;
 - rugged tablet/industrial scanner hardware;
 - Stage/Scene identity and established documentation organization; and
 - site/stage/location information needed for deployment planning.
 
 It must not redefine permanent Display IDs, Container IDs, storage identities, LOR wiring/topology, or other identities already owned by existing subsystems.
 
-Containers of type **KIT** already exist and may hold loose setup materials instead of Displays. Detailed kit-contents inventory is a known future need but is not being engineered as part of the current Scan Integration work.
+Containers of type **KIT** already exist and may hold loose setup materials instead of Displays. Detailed kit-contents inventory is a known future need but is not part of the first Procedure document-resolution proof.
 
 ## Known Limitations / Open Work
 
-Current priority is to close FieldWiring Scan Integration cleanly, then begin Setup/Deployment engineering from the real operational process.
+**FieldWiring and Display Scan are no longer open prerequisites.** The immediate Procedure-document engineering work may proceed from their accepted production baseline.
 
-Open work includes:
+Open Procedure-document work includes:
 
+- inspect/extract the reusable FieldWiring structured-scope boundary without changing its accepted behavior;
+- prove one read-only current Setup PDF lookup end-to-end from current PostgreSQL Stage/Scene context;
+- validate Procedure-specific marker enforcement;
+- enforce `Archive` and `SourceDocs` exclusion at the normal Procedure endpoint;
+- define supported current field-document formats, beginning with PDF;
+- define the simple list behavior when more than one current Procedure applies;
+- define the missing-current-document user experience;
+- define the protected `my.sheboyganlights.org` Procedure route;
+- test PC/phone/tablet and print/offline behavior;
+- add a Procedure action to the existing Display scan hub only after standalone Procedure presentation is accepted;
 - complete the legacy Setup-document alignment/archive procedure already underway;
 - finalize the Stage Setup Instruction template and contributor/operator procedure;
-- finalize the Setup-specific image-location rule within the established Stage folder model;
 - determine the editable-source versus published-PDF relationship where Google Docs remain in use;
-- determine how durable Google document IDs / published document references are represented in the current PostgreSQL schema;
-- define the exact contract consumed by `my.sheboyganlights.org` for Stage/Scene document presentation;
-- determine what entity should be the primary scheduled object: display, container, or both;
-- define how readiness from Testing becomes eligible for Setup/Deployment;
-- define how park destination/stage affects load order;
-- define loads/trips and setup-day changes without destroying useful history;
-- document the real forklift driver workflow and required scan confirmations;
-- receive/test the Zebra DS3678-HD with actual Container and representative Location labels;
-- verify USB HID integration with the actual forklift tablet/workstation;
-- measure usable scan range from the actual forklift position;
-- standardize scanner suffix/terminator behavior for rapid browser scanning;
-- determine whether the HD scanner is sufficient or an ER/XR-class scanner is needed for some distances;
-- determine which management workflows remain in Directus versus a dedicated task-focused interface.
+- engineer durable Google document IDs / published references only if a demonstrated publication/history workflow requires them.
+
+Separate Setup/Deployment operational work still includes scheduling, readiness, pull/load planning, Container/Location movement semantics, forklift workflow, and hardware acceptance. Do not mix those business-process questions into the first Procedure document-resolution proof.
 
 ## Resume Development
 
-### Current prerequisite — finish Scan Integration
+### Current baseline — FieldWiring and Scan are complete
 
-Before beginning Setup application/schema engineering, close the current FieldWiring Scan Integration and leave the Labeling/Scanning and Server Management handoffs current. The existing scan platform is a dependency and should not be rediscovered in the Setup thread.
+Begin from current `main`. Do not rediscover the old live-only scan extension, redesign the physical QR, or rebuild the Google filesystem connection.
+
+Read first:
+
+1. [Procedure System Field Context Handoff — 2026-08-22](00_Procedure_System_Field_Context_Handoff_2026-08-22.md)
+2. [Field Context Resolution Contract](../07_Labeling_and_Scanning/Field_Context_Resolution_Contract.md)
+3. [FieldWiring Drive Context Resolver Engineering Design](../09_Wiring_System/FieldWiring_Drive_Context_Resolver_Engineering_Design.md)
+4. `FieldWiring/Application/wiring_images.py`
+5. `FieldWiring/Application/repository.py`
+6. [Google Drive Document Organization Procedure](../../../00_Project_Overview/01-Google_Drive_Document_Organization_Procedure.md)
+7. [Stage Setup Documentation Standard](../../../../System_Documentation/Project_Rules/Stage_Setup_Documentation_Standard.md)
+8. [FieldWiring Scan Integration Engineering Handoff](../07_Labeling_and_Scanning/FieldWiring_Scan_Integration_Engineering_Handoff_2026-08-22.md)
+
+### First Procedure application proof
+
+The first application proof should remain narrow:
+
+```text
+Display / Stage / Scene lookup
+    -> shared structured-scope resolver
+    -> fixed current scope_root
+    -> Procedures/Setup
+    -> marker validation
+    -> enumerate current PDF(s)
+    -> protected browser presentation
+```
+
+Do not begin by creating Procedure schema, a generic document registry, a second resolver, or forklift/deployment transaction logic.
 
 ### Setup workflow engineering
 
-Then document the real setup-day process from the people who:
+Separately document the real setup-day process from the people who:
 
 - schedule pulls;
 - operate the forklift;
@@ -254,15 +327,15 @@ Then document the real setup-day process from the people who:
 - receive loads at the park;
 - place containers/displays at their destinations.
 
-Define business events and exception handling before designing schema, Directus Flows, scan-session state, or a dedicated field application.
+Define business events and exception handling before designing schema, Directus Flows, scan-session state, or a dedicated deployment application.
 
 ### Hardware acceptance
 
 Begin hardware testing with the [Scanner Hardware and Tablet Integration](../07_Labeling_and_Scanning/Scanner_Hardware_and_Tablet_Integration.md) handoff and the purchased Zebra DS3678-HD. Use actual labels and measured working distances rather than theoretical family-level specifications.
 
-### Setup-document work
+### Setup-document authoring work
 
-For Setup-document work, begin with:
+For Setup-document authoring/alignment work, continue with:
 
 1. the [Stage Setup Documentation Standard](../../../../System_Documentation/Project_Rules/Stage_Setup_Documentation_Standard.md);
 2. the current [Google Drive Document Organization Procedure](../../../00_Project_Overview/01-Google_Drive_Document_Organization_Procedure.md);
@@ -270,23 +343,27 @@ For Setup-document work, begin with:
 4. the controlled [Stage Setup Instruction Template](../../../../System_Documentation/Templates/Stage_Setup_Instruction_Template.md); and
 5. the real Stage/Scene documents currently being reviewed and archived.
 
-Do not redesign the established Stage folder structure while solving document identity, QR resolution, PDF publishing, or intranet UX.
+Do not redesign the established Stage folder structure while solving Procedure resolution, QR integration, PDF publishing, or intranet UX.
 
 ## Related Systems
 
 - [Testing System](../05_Testing_System/README.md) — establishes testing state/readiness before deployment.
 - [Containers and Storage](../04_Containers_and_Storage/README.md) — owns container identity, assignments, storage-location relationships, and KIT container identity.
-- [Wiring System](../09_Wiring_System/README.md) — shares the established Stage-oriented field-documentation model while retaining its own wiring contracts.
-- [Labeling and Scanning](../07_Labeling_and_Scanning/README.md) — owns permanent labels and scan-routing integration patterns.
+- [Wiring System](../09_Wiring_System/README.md) — provides the proven structured field-context implementation while retaining its own wiring content rules.
+- [Labeling and Scanning](../07_Labeling_and_Scanning/README.md) — owns permanent labels and the accepted scan-routing integration pattern.
+- [FieldWiring Scan Integration Engineering Handoff](../07_Labeling_and_Scanning/FieldWiring_Scan_Integration_Engineering_Handoff_2026-08-22.md) — accepted production Display scan baseline.
 - [Scanner Hardware and Tablet Integration](../07_Labeling_and_Scanning/Scanner_Hardware_and_Tablet_Integration.md) — owns the purchased Zebra scanner baseline and hardware/browser-input acceptance contract.
 - [People and Identity](../03_People_and_Identity/README.md) — provides durable person/user identity and audit attribution.
 - [Site Infrastructure / GIS](../11_Site_Infrastructure_GIS/README.md) — may provide destination/location context where applicable.
 
 ## Related Documentation
 
+- [Procedure System Field Context Handoff — 2026-08-22](00_Procedure_System_Field_Context_Handoff_2026-08-22.md)
 - [Stage Setup Documentation Standard](../../../../System_Documentation/Project_Rules/Stage_Setup_Documentation_Standard.md)
 - [Stage Setup Instruction Template](../../../../System_Documentation/Templates/Stage_Setup_Instruction_Template.md)
 - [Google Drive Document Organization Procedure](../../../00_Project_Overview/01-Google_Drive_Document_Organization_Procedure.md)
+- [Field Context Resolution Contract](../07_Labeling_and_Scanning/Field_Context_Resolution_Contract.md)
+- [FieldWiring Drive Context Resolver Engineering Design](../09_Wiring_System/FieldWiring_Drive_Context_Resolver_Engineering_Design.md)
 - [Document Control Standard](../../../../System_Documentation/Standards/Document_Control_Standard.md)
 - [Linking and Navigation Standard](../../../../System_Documentation/Standards/Linking_and_Navigation_Standard.md)
 


### PR DESCRIPTION
## Purpose

Add an authoritative Procedure-system handoff after accepted FieldWiring + Display Scan production integration.

This resolves conflicting older engineering language by establishing that Procedures must reuse/extract the proven FieldWiring structured Stage/Sub-stage/Scene resolver, then switch to the task-specific `Procedures/Setup`, `Procedures/Takedown`, or `Procedures/Inspection` branch.

## Key decisions recorded

- FieldWiring and Display Scan are already accepted production prerequisites.
- Procedures must not build an independent Display-to-Stage/Scene resolver.
- The existing read-only Google `Display Folders` filesystem is shared infrastructure.
- Initial Procedure runtime may enumerate current published PDFs directly in the validated task folder.
- A PostgreSQL row / Google document ID for every current PDF is **not** an initial runtime prerequisite.
- `Archive` and `SourceDocs` remain excluded.
- Procedure marker rules remain task-specific and do not change FieldWiring marker rules.
- Durable per-document metadata remains a future publication/history capability when justified.

Documentation only. No production code, schema, scan runtime, Google folder, or marker changes.