### PR TITLE
Extract shared field-context structured-scope resolver

### DIFF
--- a/Docs/02_Production_Database/01_System_Architecture/09_Wiring_System/FieldWiring_Shared_Structured_Scope_Resolver_Extraction_2026-08-22.md
+++ b/Docs/02_Production_Database/01_System_Architecture/09_Wiring_System/FieldWiring_Shared_Structured_Scope_Resolver_Extraction_2026-08-22.md
@@ -2,9 +2,10 @@
 
 | Document control | Value |
 |---|---|
-| Status | CODE REGRESSION ACCEPTED — production deployment pending |
+| Status | ARCHITECTURE ACCEPTED — production deployment pending |
 | Branch | `agent/shared-field-context-resolver-extraction` |
-| Tested commit | `b7fcd0333f2cb023026643c292b1d615cf5ceb6a` |
+| Code-regression-tested commit | `b7fcd0333f2cb023026643c292b1d615cf5ceb6a` |
+| Live-equivalence-tested branch head | `dcedc36c8d3ad0955fa793e8817c4a88d3535014` |
 | Production baseline during test | `c71d0e50de9917a384ec8cfc836202e7aa2885db` |
 | Primary caller | FieldWiring |
 | Planned second caller | Procedure subsystem |
@@ -112,11 +113,55 @@ Final full regression result at `b7fcd0333f2cb023026643c292b1d615cf5ceb6a`:
 54 passed in 1.01s
 ```
 
-This is the code-level regression acceptance gate. Production deployment and live acceptance remain separate.
+## Live Production-Data Equivalence Gate
 
-## Acceptance Boundary
+After the complete regression suite passed, the branch was launched from the detached worktree as a transient candidate service on:
 
-The extraction is code-level accepted when all of the following remain true:
+```text
+127.0.0.1:8791
+```
+
+The existing production FieldWiring service remained unchanged on:
+
+```text
+192.168.5.9:8790
+```
+
+Both services used the same production read-only PostgreSQL configuration and the same mounted read-only Google `Display Folders` filesystem.
+
+Health matched exactly:
+
+```text
+{"data_mode":"postgres","status":"ok","version":"V0.2.0"}
+```
+
+A live `BridgeBell` lookup selected permanent Display:
+
+```text
+display_id = 312
+```
+
+Production and candidate then returned identical resolver-specific values:
+
+```text
+scope_type = STAGE
+scope_root = /mnt/msb-display-folders/15-Church-Bells-CH
+warnings = [BackgroundFile points directly into the current Stage Wiring branch; the marked Stage root is the FieldWiring documentation scope.]
+wiring image = RGB Plus Prop Stage 15 Church-Tagged.jpg
+relative path = 15-Church-Bells-CH/Wiring/MusicalStage/RGB Plus Prop Stage 15 Church-Tagged.jpg
+```
+
+Result:
+
+```text
+RESOLVER EQUIVALENCE: PASS
+```
+
+The transient candidate service was stopped automatically after the comparison. Production remained on its existing checkout throughout the test.
+
+## Acceptance Decision
+
+The shared structured-scope resolver extraction is **architecture accepted** because all required behavior-preservation gates passed:
 
 1. one task-neutral structured-scope implementation exists;
 2. FieldWiring delegates structured hierarchy resolution to it;
@@ -124,12 +169,25 @@ The extraction is code-level accepted when all of the following remain true:
 4. existing warning behavior remains intact;
 5. `SourceDocs` remains protected;
 6. bounded matching and ambiguity rejection remain intact;
-7. the complete FieldWiring regression suite passes;
-8. Procedure implementation does not begin by copying or redesigning the resolver.
+7. the complete FieldWiring regression suite passes: `54 passed`;
+8. live production-data resolver output matches the current production service;
+9. Procedure implementation is directed to call this same component rather than copy or redesign it.
+
+Production deployment of the extracted module is a separate server-change step and is not represented as complete by this document.
+
+## Production Deployment Caution
+
+At acceptance-test time, the live `/opt/fieldwiring` checkout was still at:
+
+```text
+c71d0e50de9917a384ec8cfc836202e7aa2885db
+```
+
+The resolver branch is based on newer current `main` history. Therefore deployment must not be described as a resolver-only one-commit update. The full repository gap must be reviewed explicitly before moving the live checkout and restarting FieldWiring.
 
 ## Procedure Handoff
 
-After production acceptance, the Procedure subsystem becomes the second caller.
+The Procedure subsystem may now consume the accepted shared resolver as its second caller in engineering/development work.
 
 The intended flow is:
 
@@ -142,6 +200,8 @@ Display / Stage / Scene context
 ```
 
 Procedure marker validation, PDF discovery, `images`, `Archive`, and task-specific `SourceDocs` exclusions remain Procedure-adapter responsibilities.
+
+Procedure production deployment must not fork or substitute another resolver implementation.
 
 ## Related Documents
 

--- a/Docs/02_Production_Database/01_System_Architecture/09_Wiring_System/FieldWiring_Shared_Structured_Scope_Resolver_Extraction_2026-08-22.md
+++ b/Docs/02_Production_Database/01_System_Architecture/09_Wiring_System/FieldWiring_Shared_Structured_Scope_Resolver_Extraction_2026-08-22.md
@@ -1,0 +1,151 @@
+# FieldWiring Shared Structured-Scope Resolver Extraction — 2026-08-22
+
+| Document control | Value |
+|---|---|
+| Status | CODE REGRESSION ACCEPTED — production deployment pending |
+| Branch | `agent/shared-field-context-resolver-extraction` |
+| Tested commit | `b7fcd0333f2cb023026643c292b1d615cf5ceb6a` |
+| Production baseline during test | `c71d0e50de9917a384ec8cfc836202e7aa2885db` |
+| Primary caller | FieldWiring |
+| Planned second caller | Procedure subsystem |
+
+## Purpose
+
+The proven structured Stage/Sub-stage/Scene filesystem resolver was originally embedded in `FieldWiring/Application/wiring_images.py`. That made future field-document applications vulnerable to implementing competing Display/Stage/Scene hierarchy logic.
+
+This change finishes the original architecture boundary by extracting that proven resolver into one task-neutral component while preserving FieldWiring behavior.
+
+## Canonical Shared Component
+
+The canonical implementation is now:
+
+```text
+FieldWiring/Application/field_context_resolver.py
+```
+
+The module is task-neutral even though it remains physically co-located with the current first caller. This location intentionally avoids introducing a new Python package, `PYTHONPATH`, systemd, or deployment-layout change merely for folder organization.
+
+Future callers must consume this same implementation rather than copy its algorithm into a Procedure-, Testing-, or other task-specific module. A broader packaging move, if ever needed, is a separate deployment decision and must not fork the resolver.
+
+## Shared Resolver Owns
+
+`field_context_resolver.py` owns only structured hierarchy resolution:
+
+- Windows `G:\Shared drives\Display Folders\...` evidence translation to the configured server-visible root;
+- marked Stage root validation;
+- stale Stage-path recovery from safe exact path evidence;
+- canonical current Scene-name matching;
+- bounded Scene matching;
+- marker validation for candidate structured roots;
+- ambiguity rejection;
+- `SourceDocs` truncation/protection;
+- conservative Stage fallback when no distinct Scene folder exists;
+- existing warning behavior, with caller-supplied legacy wording where needed.
+
+The resolver answers:
+
+> Which current marked Stage/Sub-stage/Scene root owns this field context?
+
+It does not choose Wiring, Procedure, Setup, Takedown, Inspection, or other task content.
+
+## FieldWiring Still Owns
+
+`FieldWiring/Application/wiring_images.py` remains the FieldWiring adapter and still owns:
+
+- `Musical` -> `Wiring/MusicalStage` selection;
+- non-Musical/background -> `Wiring/BackgroundStage` selection;
+- marked `Wiring` source validation;
+- direct wiring-image enumeration;
+- same-scope marked `PreviewBackground` image enumeration;
+- FieldWiring image payload/URL construction;
+- safe image delivery;
+- hard rejection of `SourceDocs` image requests;
+- FieldWiring-specific warning wording.
+
+No parent Wiring-image fallback was added. No Procedure content rule was added to FieldWiring.
+
+## Important Preserved Behavior
+
+During direct resolver testing, one initially surprising legacy classification was confirmed and intentionally preserved.
+
+For a Scene name such as:
+
+```text
+15-Church-CH
+```
+
+canonical matching also includes:
+
+```text
+15-Church
+```
+
+If path evidence enters `SourceDocs`, traversal is stopped before `SourceDocs`. When the resolver subsequently walks the safe ancestor chain, the marked Stage root `15-Church` may therefore be returned with the existing `SCENE` scope classification.
+
+This is existing production resolver behavior. The returned path remains the marked Stage root and no `SourceDocs` content is traversed or presented. Changing that classification would be a resolver redesign and is outside this extraction.
+
+## Regression Gate
+
+The candidate was tested from a detached server worktree:
+
+```text
+/var/tmp/fieldwiring-resolver-test
+```
+
+The production checkout remained untouched at:
+
+```text
+/opt/fieldwiring
+```
+
+The first full run produced:
+
+```text
+53 passed, 1 failed
+```
+
+The sole failure was a newly added test that incorrectly expected the legacy canonical-name case above to become `STAGE`. A direct diagnostic confirmed the extracted module matched the pre-existing resolver behavior. The test was corrected; the implementation was not redesigned.
+
+Final full regression result at `b7fcd0333f2cb023026643c292b1d615cf5ceb6a`:
+
+```text
+54 passed in 1.01s
+```
+
+This is the code-level regression acceptance gate. Production deployment and live acceptance remain separate.
+
+## Acceptance Boundary
+
+The extraction is code-level accepted when all of the following remain true:
+
+1. one task-neutral structured-scope implementation exists;
+2. FieldWiring delegates structured hierarchy resolution to it;
+3. Wiring branch/image logic remains outside it;
+4. existing warning behavior remains intact;
+5. `SourceDocs` remains protected;
+6. bounded matching and ambiguity rejection remain intact;
+7. the complete FieldWiring regression suite passes;
+8. Procedure implementation does not begin by copying or redesigning the resolver.
+
+## Procedure Handoff
+
+After production acceptance, the Procedure subsystem becomes the second caller.
+
+The intended flow is:
+
+```text
+Display / Stage / Scene context
+        -> field_context_resolver.resolve_structured_scope(...)
+        -> fixed structured scope_root
+        -> Procedure adapter
+        -> Procedures/Setup | Procedures/Takedown | Procedures/Inspection
+```
+
+Procedure marker validation, PDF discovery, `images`, `Archive`, and task-specific `SourceDocs` exclusions remain Procedure-adapter responsibilities.
+
+## Related Documents
+
+- `FieldWiring_Drive_Context_Resolver_Engineering_Design.md`
+- `../12_Setup_and_Deployment/00_Procedure_System_Field_Context_Handoff_2026-08-22.md`
+- `../12_Setup_and_Deployment/01_Shared_Resolver_Extraction_Handoff_2026-08-22.md`
+- `../07_Labeling_and_Scanning/Field_Context_Resolution_Contract.md`

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/01_Shared_Resolver_Extraction_Handoff_2026-08-22.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/01_Shared_Resolver_Extraction_Handoff_2026-08-22.md
@@ -1,0 +1,137 @@
+# Procedure Subsystem — Shared Resolver Extraction Handoff — 2026-08-22
+
+| Document control | Value |
+|---|---|
+| Status | CURRENT ENGINEERING HANDOFF ADDENDUM — production deployment of shared resolver pending |
+| Parent handoff | `00_Procedure_System_Field_Context_Handoff_2026-08-22.md` |
+| Shared resolver branch | `agent/shared-field-context-resolver-extraction` |
+| Code-regression-tested commit | `b7fcd0333f2cb023026643c292b1d615cf5ceb6a` |
+
+## Why this addendum exists
+
+The parent Procedure handoff correctly established that Procedures must reuse FieldWiring's proven Stage/Sub-stage/Scene resolver, but at that time the proven logic was still embedded inside:
+
+```text
+FieldWiring/Application/wiring_images.py
+```
+
+That is no longer the intended code boundary.
+
+This addendum supersedes only those older location statements. It does not change the resolver algorithm or the Procedure task rules already established by the parent handoff.
+
+## Canonical resolver source
+
+The proven structured-scope implementation has now been extracted to:
+
+```text
+FieldWiring/Application/field_context_resolver.py
+```
+
+Canonical callable:
+
+```python
+resolve_structured_scope(...)
+```
+
+The module is task-neutral. It remains physically beside FieldWiring during this extraction so the existing production Python/systemd deployment model does not need to change merely for packaging. The Procedure implementation must consume this same canonical implementation as its second caller; it must not copy the resolver into a Procedure-owned file.
+
+## What Procedures receive from the shared resolver
+
+The shared resolver fixes the current marked structured root from existing Stage/Scene/Preview facts and controlled filesystem evidence.
+
+It preserves the proven behavior for:
+
+- Windows-to-Linux Display Folders path translation;
+- marked Stage/Scene roots;
+- stale path recovery;
+- canonical Scene matching;
+- bounded Scene search;
+- ambiguity rejection;
+- `SourceDocs` protection;
+- conservative fallback behavior;
+- visible warnings rather than unsafe guessing.
+
+The Procedure subsystem must treat the returned `scope_root` as fixed before selecting Procedure content.
+
+## What Procedures own after resolution
+
+After the shared resolver returns the structured context, the Procedure adapter owns only Procedure-specific work:
+
+```text
+<scope_root>/Procedures/Setup
+<scope_root>/Procedures/Takedown
+<scope_root>/Procedures/Inspection
+```
+
+The Procedure adapter owns:
+
+- Procedure/task marker validation;
+- direct current-PDF discovery;
+- supporting `images` behavior;
+- exclusion of `Archive` from normal field presentation;
+- exclusion of `SourceDocs` from normal field presentation;
+- missing-document states;
+- multiple-current-document presentation when allowed;
+- Procedure browser presentation and later scan actions.
+
+It must not re-resolve Stage/Scene from filenames or independently crawl neighboring hierarchy.
+
+## Do not copy FieldWiring's task adapter
+
+The Procedure subsystem reuses the structured resolver, **not** the Wiring-specific adapter.
+
+Do not copy or call FieldWiring rules that select:
+
+```text
+Wiring/BackgroundStage
+Wiring/MusicalStage
+```
+
+Do not apply FieldWiring image-marker rules to Procedure folders.
+
+The intended architecture is:
+
+```text
+                    shared structured resolver
+                              |
+                fixed Stage/Sub-stage/Scene root
+                       /                   \
+                      /                     \
+          FieldWiring adapter           Procedure adapter
+          Wiring/<context>              Procedures/<task>
+```
+
+## Regression evidence
+
+The extracted resolver and FieldWiring adapter were tested together from an isolated server worktree.
+
+Final code-level result:
+
+```text
+54 passed in 1.01s
+```
+
+One new test initially failed because it expected a change to a legacy canonical-name scope classification. Direct testing proved the extracted resolver preserved the production algorithm, so the test was corrected rather than redesigning the resolver.
+
+Production FieldWiring deployment/acceptance of the extracted module is still required before Procedure implementation should treat the new code boundary as production accepted.
+
+## Procedure implementation gate
+
+Do not continue substantive Procedure resolver implementation until the FieldWiring extraction has passed production acceptance.
+
+Once accepted, Procedure engineering should begin from:
+
+1. this addendum;
+2. `00_Procedure_System_Field_Context_Handoff_2026-08-22.md`;
+3. the canonical `field_context_resolver.py` implementation;
+4. the Procedure marker/current-document rules already defined in the parent handoff.
+
+The first Procedure proof should demonstrate a **second caller of the same resolver**, not a second implementation of it.
+
+## Related FieldWiring acceptance record
+
+See:
+
+```text
+../09_Wiring_System/FieldWiring_Shared_Structured_Scope_Resolver_Extraction_2026-08-22.md
+```

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/01_Shared_Resolver_Extraction_Handoff_2026-08-22.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/01_Shared_Resolver_Extraction_Handoff_2026-08-22.md
@@ -2,10 +2,11 @@
 
 | Document control | Value |
 |---|---|
-| Status | CURRENT ENGINEERING HANDOFF ADDENDUM — production deployment of shared resolver pending |
+| Status | CURRENT ENGINEERING HANDOFF ADDENDUM — shared resolver architecture accepted |
 | Parent handoff | `00_Procedure_System_Field_Context_Handoff_2026-08-22.md` |
 | Shared resolver branch | `agent/shared-field-context-resolver-extraction` |
 | Code-regression-tested commit | `b7fcd0333f2cb023026643c292b1d615cf5ceb6a` |
+| Live-equivalence-tested branch head | `dcedc36c8d3ad0955fa793e8817c4a88d3535014` |
 
 ## Why this addendum exists
 
@@ -15,9 +16,9 @@ The parent Procedure handoff correctly established that Procedures must reuse Fi
 FieldWiring/Application/wiring_images.py
 ```
 
-That is no longer the intended code boundary.
+That location statement is now superseded.
 
-This addendum supersedes only those older location statements. It does not change the resolver algorithm or the Procedure task rules already established by the parent handoff.
+This addendum does not change the resolver algorithm or the Procedure task rules already established by the parent handoff.
 
 ## Canonical resolver source
 
@@ -33,7 +34,7 @@ Canonical callable:
 resolve_structured_scope(...)
 ```
 
-The module is task-neutral. It remains physically beside FieldWiring during this extraction so the existing production Python/systemd deployment model does not need to change merely for packaging. The Procedure implementation must consume this same canonical implementation as its second caller; it must not copy the resolver into a Procedure-owned file.
+The module is task-neutral. It remains physically beside FieldWiring so the existing production Python/systemd deployment model does not need to change merely for packaging. The Procedure implementation must consume this same canonical implementation as its second caller; it must not copy the resolver into a Procedure-owned file.
 
 ## What Procedures receive from the shared resolver
 
@@ -101,32 +102,51 @@ The intended architecture is:
           Wiring/<context>              Procedures/<task>
 ```
 
-## Regression evidence
+## Acceptance evidence
 
 The extracted resolver and FieldWiring adapter were tested together from an isolated server worktree.
 
-Final code-level result:
+Complete FieldWiring regression result:
 
 ```text
 54 passed in 1.01s
 ```
 
-One new test initially failed because it expected a change to a legacy canonical-name scope classification. Direct testing proved the extracted resolver preserved the production algorithm, so the test was corrected rather than redesigning the resolver.
+A transient candidate FieldWiring service was then run from the resolver branch on `127.0.0.1:8791` while the unchanged production service remained on `192.168.5.9:8790`.
 
-Production FieldWiring deployment/acceptance of the extracted module is still required before Procedure implementation should treat the new code boundary as production accepted.
+Both used the same production read-only PostgreSQL configuration and mounted Google `Display Folders` tree.
+
+For live Display `312`, production and candidate matched on:
+
+- `scope_type`;
+- `scope_root`;
+- warning text;
+- Wiring image list;
+- relative image path; and
+- image URL.
+
+Result:
+
+```text
+RESOLVER EQUIVALENCE: PASS
+```
+
+The shared resolver extraction is therefore accepted as the common architecture boundary.
 
 ## Procedure implementation gate
 
-Do not continue substantive Procedure resolver implementation until the FieldWiring extraction has passed production acceptance.
+The prior gate preventing substantive Procedure resolver work is now cleared for engineering/development.
 
-Once accepted, Procedure engineering should begin from:
+Procedure engineering should begin from:
 
 1. this addendum;
 2. `00_Procedure_System_Field_Context_Handoff_2026-08-22.md`;
 3. the canonical `field_context_resolver.py` implementation;
 4. the Procedure marker/current-document rules already defined in the parent handoff.
 
-The first Procedure proof should demonstrate a **second caller of the same resolver**, not a second implementation of it.
+The first Procedure proof must demonstrate a **second caller of the same resolver**, not a second implementation of it.
+
+Production deployment of the FieldWiring extraction remains a separate server-management step. Procedure production deployment must not substitute a copied resolver merely because that server update is still pending.
 
 ## Related FieldWiring acceptance record
 

--- a/FieldWiring/Application/README.md
+++ b/FieldWiring/Application/README.md
@@ -1,6 +1,6 @@
 # FieldWiring Application
 
-Status: **production-operational — Display scan integration accepted**
+Status: **production-operational — shared resolver architecture accepted; extraction deployment pending**
 
 This folder contains the browser-based FieldWiring application.
 
@@ -23,8 +23,16 @@ Accepted production state:
 - existing Display Scan hub exposes the independent **Field Wiring** action;
 - FormView remains available as fallback/reference.
 
+Accepted engineering state:
+
+- the proven Stage/Sub-stage/Scene resolver has been extracted from `wiring_images.py` into task-neutral `field_context_resolver.py`;
+- complete FieldWiring regression suite passed: `54 passed in 1.01s`;
+- a live candidate using production PostgreSQL + mounted Google files matched the production resolver output for Display `312`;
+- production deployment of the extraction is still a separate server-management step.
+
 For current engineering/recovery state, start with:
 
+- `Docs/02_Production_Database/01_System_Architecture/09_Wiring_System/FieldWiring_Shared_Structured_Scope_Resolver_Extraction_2026-08-22.md`
 - `Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/FieldWiring_Scan_Integration_Engineering_Handoff_2026-08-22.md`
 - `Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/Deployed_Display_Scan_Runtime_Boundary.md`
 - `Docs/02_Production_Database/01_System_Architecture/09_Wiring_System/README.md`
@@ -73,8 +81,13 @@ wiring_dumbrgb.py
 wiring_e131.py
     reviewed temporary E1.31 physical controller/output mappings
 
+field_context_resolver.py
+    task-neutral marked Stage/Sub-stage/Scene structured-scope resolver
+    shared infrastructure for FieldWiring and future Procedure callers
+
 wiring_images.py
-    guarded same-scope image resolver and image delivery
+    FieldWiring adapter after scope resolution
+    selects Wiring branch, enumerates wiring/context images, and safely serves images
 
 fieldwiring.js
     Display/Stage lookup landing page
@@ -98,6 +111,31 @@ wiring_workspace_focus.js
 wiring_workspace_focus.css
     shared image + Field Hookup desktop/laptop workspace
 ```
+
+## Shared Structured-Scope Boundary
+
+`field_context_resolver.py` owns only the common hierarchy decision:
+
+```text
+current Stage / Scene / Preview facts
+    + controlled path evidence
+    + marked Display Folders hierarchy
+        -> fixed marked Stage/Sub-stage/Scene scope_root
+```
+
+It preserves the production resolver behavior for path translation, marked-root validation, stale-path recovery, bounded Scene matching, ambiguity rejection, `SourceDocs` protection, and visible warning behavior.
+
+After that common result is fixed, `wiring_images.py` owns the FieldWiring-specific branch:
+
+```text
+scope_root
+    -> Wiring/MusicalStage
+       OR Wiring/BackgroundStage
+    -> direct wiring images
+    -> same-scope PreviewBackground context when allowed
+```
+
+Future Procedure work must consume `field_context_resolver.resolve_structured_scope(...)` as a second caller rather than copy the resolver algorithm or reuse FieldWiring's Wiring-specific adapter.
 
 ## Current Presentation Families
 
@@ -177,7 +215,7 @@ SourceDocs                                 excluded / no marker
 
 The marker on `Wiring` guards the selected `BackgroundStage` or `MusicalStage` child branch.
 
-`wiring_images.py` already matches this contract: it checks the resolved structural root, the `Wiring` root, and a controlled `PreviewBackground` when applicable. There is no FieldWiring child-marker enforcement gap.
+`field_context_resolver.py` validates the structured root; `wiring_images.py` then checks the `Wiring` root and controlled `PreviewBackground` when applicable. There is no FieldWiring child-marker enforcement gap.
 
 The future Procedure system has a separate deeper marker contract. Do not add separate markers to production `BackgroundStage` / `MusicalStage` folders merely to imitate Procedure task/image marker rules.
 
@@ -269,6 +307,8 @@ Do not copy secrets or protected runtime configuration into either repository.
 
 FieldWiring Scan Integration is closed as accepted production work.
 
+The shared structured-scope resolver extraction is architecture accepted and awaiting its controlled production checkout/service update.
+
 Separate future work includes:
 
 - Controller Inventory replacement of temporary E1.31 presentation mappings;
@@ -279,6 +319,6 @@ Separate future work includes:
 
 ## Resume Development
 
-Before further FieldWiring application changes, read the current Wiring and Scan handoffs and refresh from current `main`.
+Before further FieldWiring application changes, read the current Wiring/Scan handoffs plus `FieldWiring_Shared_Structured_Scope_Resolver_Extraction_2026-08-22.md` and refresh from current `main`.
 
-The next major Production Database project is Setup/Deployment. Its expected high-volume Container/Location scanning should be designed from the actual setup-day workflow rather than by refactoring FieldWiring-specific code prematurely.
+Procedure engineering may now consume the accepted shared resolver as a second caller. It must not create an independent Display/Stage/Scene resolver or copy `wiring_images.py` task behavior.

--- a/FieldWiring/Application/field_context_resolver.py
+++ b/FieldWiring/Application/field_context_resolver.py
@@ -1,10 +1,9 @@
 """Task-neutral Stage/Sub-stage/Scene filesystem context resolver.
 
-This module contains the structured-scope resolution proven by FieldWiring.  It
+This module contains the structured-scope resolution proven by FieldWiring. It
 resolves the current marked Stage/Scene root from authoritative identity plus
-bounded path/filesystem evidence.  Task-specific consumers (FieldWiring,
-Procedures, and future field applications) own what they do *after* this root
-has been resolved.
+bounded path/filesystem evidence. Task-specific consumers own what they do
+after this root has been resolved.
 
 Do not add Wiring/Procedure content discovery here.
 """
@@ -20,6 +19,11 @@ SKIP_SCOPE_SEARCH = {
     "wiring", "procedures", "photos", "previewbackground", "sourcedocs",
     "archive", "archived", "design archive",
 }
+
+DEFAULT_STAGE_FALLBACK_WARNING = (
+    "No distinct Scene folder matched the current Scene identity; "
+    "known marked Stage root retained as the structured field scope."
+)
 
 
 def _canonical_scene_names(scene_name: str) -> set[str]:
@@ -151,13 +155,13 @@ def resolve_structured_scope(
     windows_drive_root: str = DEFAULT_WINDOWS_DRIVE_ROOT,
     direct_owner_folder_name: str | None = None,
     direct_owner_warning: str | None = None,
+    stage_fallback_warning: str = DEFAULT_STAGE_FALLBACK_WARNING,
 ) -> tuple[Path | None, str, list[str]]:
     """Resolve one current marked Stage/Scene root without discovering task content.
 
     ``direct_owner_folder_name`` preserves a caller's existing exact path-owner
     evidence rule without teaching this shared resolver what that task folder
-    means.  FieldWiring currently supplies ``Wiring``; other callers may omit it.
-    The caller also supplies its legacy warning text so existing user-visible
+    means. The caller may also supply legacy warning strings so user-visible
     warnings remain byte-for-byte stable during extraction.
     """
     warnings: list[str] = []
@@ -203,7 +207,7 @@ def resolve_structured_scope(
         return None, "UNRESOLVED", warnings
 
     # Some callers already use an exact task-root path as explicit
-    # documentation-ownership evidence.  The shared resolver accepts the task
+    # documentation-ownership evidence. The shared resolver accepts the task
     # root name as data; it does not select or inspect task content beneath it.
     direct_owner = _direct_task_owner(pointer, direct_owner_folder_name)
     if direct_owner is not None and _path_is_under(direct_owner, drive_root):
@@ -250,7 +254,5 @@ def resolve_structured_scope(
         )
         return None, "UNRESOLVED", warnings
 
-    warnings.append(
-        "No distinct Scene folder matched the current Scene identity; known marked Stage root retained as the FieldWiring scope."
-    )
+    warnings.append(stage_fallback_warning)
     return stage_root, "STAGE", warnings

--- a/FieldWiring/Application/field_context_resolver.py
+++ b/FieldWiring/Application/field_context_resolver.py
@@ -1,0 +1,256 @@
+"""Task-neutral Stage/Sub-stage/Scene filesystem context resolver.
+
+This module contains the structured-scope resolution proven by FieldWiring.  It
+resolves the current marked Stage/Scene root from authoritative identity plus
+bounded path/filesystem evidence.  Task-specific consumers (FieldWiring,
+Procedures, and future field applications) own what they do *after* this root
+has been resolved.
+
+Do not add Wiring/Procedure content discovery here.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path, PureWindowsPath
+from typing import Any
+
+DEFAULT_WINDOWS_DRIVE_ROOT = r"G:\Shared drives\Display Folders"
+MARKER_NAME = "_MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt"
+SKIP_SCOPE_SEARCH = {
+    "wiring", "procedures", "photos", "previewbackground", "sourcedocs",
+    "archive", "archived", "design archive",
+}
+
+
+def _canonical_scene_names(scene_name: str) -> set[str]:
+    names = {scene_name.strip()}
+    stripped = re.sub(r"-[A-Z]{2,3}$", "", scene_name.strip())
+    if stripped:
+        names.add(stripped)
+    return {name.casefold() for name in names if name}
+
+
+def _windows_relative_parts(path_text: str, root_text: str) -> tuple[str, ...] | None:
+    try:
+        path_parts = PureWindowsPath(path_text).parts
+        root_parts = PureWindowsPath(root_text).parts
+    except Exception:
+        return None
+    if len(path_parts) < len(root_parts):
+        return None
+    if [p.casefold() for p in path_parts[:len(root_parts)]] != [
+        p.casefold() for p in root_parts
+    ]:
+        return None
+    return tuple(path_parts[len(root_parts):])
+
+
+def _localize_evidence_path(
+    path_text: str | None,
+    drive_root: Path,
+    windows_drive_root: str,
+) -> Path | None:
+    if not path_text:
+        return None
+    relative_parts = _windows_relative_parts(path_text, windows_drive_root)
+    if relative_parts is not None:
+        return drive_root.joinpath(*relative_parts)
+    return Path(path_text)
+
+
+def _path_is_under(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def _bounded_scope_matches(
+    stage_root: Path,
+    scene_name: str,
+    max_depth: int = 2,
+) -> list[Path]:
+    targets = _canonical_scene_names(scene_name)
+    matches: list[Path] = []
+
+    def walk(path: Path, depth: int) -> None:
+        if depth > max_depth:
+            return
+        try:
+            children = [p for p in path.iterdir() if p.is_dir()]
+        except OSError:
+            return
+        for child in children:
+            if child.name.casefold() in targets:
+                matches.append(child)
+            if depth < max_depth and child.name.casefold() not in SKIP_SCOPE_SEARCH:
+                walk(child, depth + 1)
+
+    walk(stage_root, 1)
+    unique = {str(item).casefold(): item for item in matches}
+    return sorted(unique.values(), key=lambda p: str(p).casefold())
+
+
+def _truncate_before_sourcedocs(path: Path | None) -> tuple[Path | None, bool]:
+    if path is None:
+        return None, False
+    parts = path.parts
+    for index, part in enumerate(parts):
+        if part.casefold() == "sourcedocs":
+            if index == 0:
+                return None, True
+            return Path(*parts[:index]), True
+    return path, False
+
+
+def _direct_task_owner(pointer: Path | None, task_root_name: str | None) -> Path | None:
+    """Return the structured folder directly above a caller-supplied task root."""
+    if pointer is None or not task_root_name:
+        return None
+    current = pointer.parent if pointer.suffix else pointer
+    target = task_root_name.casefold()
+    for candidate in (current, *current.parents):
+        if candidate.name.casefold() == target:
+            return candidate.parent
+    return None
+
+
+def _recover_stage_root(
+    pointer: Path | None,
+    drive_root: Path,
+    stage_key: str | None,
+) -> Path | None:
+    if pointer is None or not stage_key:
+        return None
+    if not pointer.exists():
+        return None
+    try:
+        relative = pointer.relative_to(drive_root)
+    except ValueError:
+        return None
+    if not relative.parts:
+        return None
+    candidate = drive_root / relative.parts[0]
+    numeric = re.match(r"^(\d{2})", str(stage_key))
+    if not numeric or not candidate.name.casefold().startswith(
+        numeric.group(1).casefold() + "-"
+    ):
+        return None
+    if not candidate.is_dir() or not (candidate / MARKER_NAME).is_file():
+        return None
+    return candidate
+
+
+def resolve_structured_scope(
+    stage: dict[str, Any],
+    scene: dict[str, Any] | None,
+    preview: dict[str, Any],
+    drive_root: Path,
+    *,
+    windows_drive_root: str = DEFAULT_WINDOWS_DRIVE_ROOT,
+    direct_owner_folder_name: str | None = None,
+    direct_owner_warning: str | None = None,
+) -> tuple[Path | None, str, list[str]]:
+    """Resolve one current marked Stage/Scene root without discovering task content.
+
+    ``direct_owner_folder_name`` preserves a caller's existing exact path-owner
+    evidence rule without teaching this shared resolver what that task folder
+    means.  FieldWiring currently supplies ``Wiring``; other callers may omit it.
+    The caller also supplies its legacy warning text so existing user-visible
+    warnings remain byte-for-byte stable during extraction.
+    """
+    warnings: list[str] = []
+    raw_pointer = (scene or {}).get("scene_background_file") or preview.get(
+        "preview_background_file"
+    )
+    localized_pointer = _localize_evidence_path(
+        raw_pointer,
+        drive_root,
+        windows_drive_root,
+    )
+    pointer, blocked = _truncate_before_sourcedocs(localized_pointer)
+    if blocked:
+        warnings.append(
+            "BackgroundFile path enters SourceDocs. Traversal stopped before SourceDocs; source content was not accessed."
+        )
+
+    folder_path = (stage.get("folder_path") or "").strip()
+    stage_root = (
+        _localize_evidence_path(folder_path, drive_root, windows_drive_root)
+        if folder_path
+        else None
+    )
+    valid = bool(
+        stage_root
+        and stage_root.is_dir()
+        and (stage_root / MARKER_NAME).is_file()
+    )
+    if not valid:
+        recovered = _recover_stage_root(pointer, drive_root, stage.get("stage_key"))
+        if recovered is not None:
+            stage_root = recovered
+            valid = True
+            warnings.append(
+                "Persisted Stage folder_path was unavailable or stale; current marked Stage root was recovered from exact LOR path evidence."
+            )
+    if not valid or stage_root is None:
+        warnings.append(
+            "Stage has no usable current folder_path anchor."
+            if not folder_path
+            else f"Stage folder_path is unavailable or unmarked on this server: {folder_path}"
+        )
+        return None, "UNRESOLVED", warnings
+
+    # Some callers already use an exact task-root path as explicit
+    # documentation-ownership evidence.  The shared resolver accepts the task
+    # root name as data; it does not select or inspect task content beneath it.
+    direct_owner = _direct_task_owner(pointer, direct_owner_folder_name)
+    if direct_owner is not None and _path_is_under(direct_owner, drive_root):
+        if direct_owner == stage_root:
+            if direct_owner_warning:
+                warnings.append(direct_owner_warning)
+            return stage_root, "STAGE", warnings
+
+    scene_name = (scene or {}).get("scene_name")
+    if not scene_name or scene_name.strip().casefold() == "root":
+        return stage_root, "STAGE", warnings
+
+    targets = _canonical_scene_names(scene_name)
+    if pointer is not None and _path_is_under(pointer, drive_root):
+        if pointer.exists():
+            current = pointer.parent if pointer.is_file() else pointer
+            while _path_is_under(current, stage_root):
+                if current.name.casefold() in targets:
+                    if (current / MARKER_NAME).is_file():
+                        return current, "SCENE", warnings
+                    warnings.append(
+                        f"Scene source-folder marker is missing: {current / MARKER_NAME}"
+                    )
+                    return None, "UNRESOLVED", warnings
+                if current == stage_root:
+                    break
+                current = current.parent
+
+    matches = _bounded_scope_matches(stage_root, scene_name)
+    marked = [match for match in matches if (match / MARKER_NAME).is_file()]
+    if len(marked) == 1:
+        if raw_pointer:
+            warnings.append(
+                "Stored Scene BackgroundFile did not resolve exactly; one deterministic marked current Scene folder was used."
+            )
+        return marked[0], "SCENE", warnings
+    if len(marked) > 1:
+        warnings.append("More than one marked Scene folder matched the current Scene identity.")
+        return None, "UNRESOLVED", warnings
+    if matches:
+        warnings.append(
+            "Matching Scene folder exists but is not an approved marked source root: "
+            + "; ".join(str(match) for match in matches)
+        )
+        return None, "UNRESOLVED", warnings
+
+    warnings.append(
+        "No distinct Scene folder matched the current Scene identity; known marked Stage root retained as the FieldWiring scope."
+    )
+    return stage_root, "STAGE", warnings

--- a/FieldWiring/Application/test_field_context_resolver.py
+++ b/FieldWiring/Application/test_field_context_resolver.py
@@ -73,7 +73,7 @@ def test_stale_stage_path_recovers_from_exact_path_evidence(tmp_path):
     ]
 
 
-def test_sourcedocs_is_truncated_and_not_used_for_scene_discovery(tmp_path):
+def test_sourcedocs_is_truncated_and_preserves_existing_scope_classification(tmp_path):
     drive_root = tmp_path / "Display Folders"
     stage_root = _mark(drive_root / "15-Church")
     source_docs = stage_root / "Procedures" / "Setup" / "SourceDocs"
@@ -88,11 +88,15 @@ def test_sourcedocs_is_truncated_and_not_used_for_scene_discovery(tmp_path):
         drive_root,
     )
 
-    assert scope_type == "STAGE"
+    # Production FieldWiring already canonicalizes 15-Church-CH to include
+    # 15-Church. After SourceDocs is truncated to Procedures/Setup, upward
+    # matching reaches the marked 15-Church Stage root and classifies that same
+    # path as SCENE. Preserve that classification during extraction; changing
+    # it here would redesign resolver behavior rather than extract it.
+    assert scope_type == "SCENE"
     assert scope_root == stage_root
     assert warnings == [
-        "BackgroundFile path enters SourceDocs. Traversal stopped before SourceDocs; source content was not accessed.",
-        DEFAULT_STAGE_FALLBACK_WARNING,
+        "BackgroundFile path enters SourceDocs. Traversal stopped before SourceDocs; source content was not accessed."
     ]
 
 

--- a/FieldWiring/Application/test_field_context_resolver.py
+++ b/FieldWiring/Application/test_field_context_resolver.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from field_context_resolver import (
+    DEFAULT_STAGE_FALLBACK_WARNING,
+    MARKER_NAME,
+    resolve_structured_scope,
+)
+
+
+WINDOWS_ROOT = r"G:\Shared drives\Display Folders"
+
+
+def _mark(path: Path, text: str = "marker") -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / MARKER_NAME).write_text(text, encoding="utf-8")
+    return path
+
+
+def test_windows_path_translation_resolves_exact_marked_scene(tmp_path):
+    drive_root = tmp_path / "Display Folders"
+    stage_root = _mark(drive_root / "15-Church")
+    scene_root = _mark(stage_root / "15-Church-CH")
+    background = scene_root / "PreviewBackground"
+    background.mkdir()
+    (background / "Church Context.jpg").write_bytes(b"jpeg")
+
+    scope_root, scope_type, warnings = resolve_structured_scope(
+        {
+            "stage_key": "15",
+            "folder_path": WINDOWS_ROOT + r"\15-Church",
+        },
+        {
+            "scene_name": "15-Church-CH",
+            "scene_background_file": (
+                WINDOWS_ROOT
+                + r"\15-Church\15-Church-CH\PreviewBackground\Church Context.jpg"
+            ),
+        },
+        {"preview_background_file": None},
+        drive_root,
+        windows_drive_root=WINDOWS_ROOT,
+    )
+
+    assert scope_type == "SCENE"
+    assert scope_root == scene_root
+    assert warnings == []
+
+
+def test_stale_stage_path_recovers_from_exact_path_evidence(tmp_path):
+    drive_root = tmp_path / "Display Folders"
+    stage_root = _mark(drive_root / "15-Church")
+    background = stage_root / "PreviewBackground"
+    background.mkdir()
+    pointer = background / "Context.jpg"
+    pointer.write_bytes(b"jpeg")
+
+    scope_root, scope_type, warnings = resolve_structured_scope(
+        {
+            "stage_key": "15",
+            "folder_path": str(drive_root / "15-Old-Church"),
+        },
+        {"scene_name": "Root", "scene_background_file": str(pointer)},
+        {"preview_background_file": None},
+        drive_root,
+    )
+
+    assert scope_type == "STAGE"
+    assert scope_root == stage_root
+    assert warnings == [
+        "Persisted Stage folder_path was unavailable or stale; current marked Stage root was recovered from exact LOR path evidence."
+    ]
+
+
+def test_sourcedocs_is_truncated_and_not_used_for_scene_discovery(tmp_path):
+    drive_root = tmp_path / "Display Folders"
+    stage_root = _mark(drive_root / "15-Church")
+    source_docs = stage_root / "Procedures" / "Setup" / "SourceDocs"
+    hidden_scene = _mark(source_docs / "15-Church-CH")
+    pointer = hidden_scene / "legacy.pdf"
+    pointer.write_bytes(b"pdf")
+
+    scope_root, scope_type, warnings = resolve_structured_scope(
+        {"stage_key": "15", "folder_path": str(stage_root)},
+        {"scene_name": "15-Church-CH", "scene_background_file": str(pointer)},
+        {"preview_background_file": None},
+        drive_root,
+    )
+
+    assert scope_type == "STAGE"
+    assert scope_root == stage_root
+    assert warnings == [
+        "BackgroundFile path enters SourceDocs. Traversal stopped before SourceDocs; source content was not accessed.",
+        DEFAULT_STAGE_FALLBACK_WARNING,
+    ]
+
+
+def test_stale_scene_pointer_uses_one_deterministic_marked_scene(tmp_path):
+    drive_root = tmp_path / "Display Folders"
+    stage_root = _mark(drive_root / "15-Church")
+    scene_root = _mark(stage_root / "15-Church-CH")
+
+    scope_root, scope_type, warnings = resolve_structured_scope(
+        {"stage_key": "15", "folder_path": str(stage_root)},
+        {
+            "scene_name": "15-Church-CH",
+            "scene_background_file": str(stage_root / "old" / "missing.jpg"),
+        },
+        {"preview_background_file": None},
+        drive_root,
+    )
+
+    assert scope_type == "SCENE"
+    assert scope_root == scene_root
+    assert warnings == [
+        "Stored Scene BackgroundFile did not resolve exactly; one deterministic marked current Scene folder was used."
+    ]
+
+
+def test_ambiguous_marked_scene_matches_are_rejected(tmp_path):
+    drive_root = tmp_path / "Display Folders"
+    stage_root = _mark(drive_root / "15-Church")
+    _mark(stage_root / "Area-A" / "15-Church-CH")
+    _mark(stage_root / "Area-B" / "15-Church-CH")
+
+    scope_root, scope_type, warnings = resolve_structured_scope(
+        {"stage_key": "15", "folder_path": str(stage_root)},
+        {"scene_name": "15-Church-CH", "scene_background_file": None},
+        {"preview_background_file": None},
+        drive_root,
+    )
+
+    assert scope_type == "UNRESOLVED"
+    assert scope_root is None
+    assert warnings == [
+        "More than one marked Scene folder matched the current Scene identity."
+    ]
+
+
+def test_exact_unmarked_scene_pointer_is_rejected(tmp_path):
+    drive_root = tmp_path / "Display Folders"
+    stage_root = _mark(drive_root / "15-Church")
+    scene_root = stage_root / "15-Church-CH"
+    scene_root.mkdir()
+    pointer = scene_root / "Context.jpg"
+    pointer.write_bytes(b"jpeg")
+
+    scope_root, scope_type, warnings = resolve_structured_scope(
+        {"stage_key": "15", "folder_path": str(stage_root)},
+        {"scene_name": "15-Church-CH", "scene_background_file": str(pointer)},
+        {"preview_background_file": None},
+        drive_root,
+    )
+
+    assert scope_type == "UNRESOLVED"
+    assert scope_root is None
+    assert warnings == [
+        f"Scene source-folder marker is missing: {scene_root / MARKER_NAME}"
+    ]
+
+
+def test_unmarked_bounded_scene_match_is_rejected_without_stage_fallback(tmp_path):
+    drive_root = tmp_path / "Display Folders"
+    stage_root = _mark(drive_root / "15-Church")
+    scene_root = stage_root / "15-Church-CH"
+    scene_root.mkdir()
+
+    scope_root, scope_type, warnings = resolve_structured_scope(
+        {"stage_key": "15", "folder_path": str(stage_root)},
+        {"scene_name": "15-Church-CH", "scene_background_file": None},
+        {"preview_background_file": None},
+        drive_root,
+    )
+
+    assert scope_type == "UNRESOLVED"
+    assert scope_root is None
+    assert warnings == [
+        "Matching Scene folder exists but is not an approved marked source root: "
+        + str(scene_root)
+    ]
+
+
+def test_scene_matching_remains_bounded_to_two_levels(tmp_path):
+    drive_root = tmp_path / "Display Folders"
+    stage_root = _mark(drive_root / "15-Church")
+    _mark(stage_root / "one" / "two" / "15-Church-CH")
+
+    scope_root, scope_type, warnings = resolve_structured_scope(
+        {"stage_key": "15", "folder_path": str(stage_root)},
+        {"scene_name": "15-Church-CH", "scene_background_file": None},
+        {"preview_background_file": None},
+        drive_root,
+    )
+
+    assert scope_type == "STAGE"
+    assert scope_root == stage_root
+    assert warnings == [DEFAULT_STAGE_FALLBACK_WARNING]
+
+
+def test_direct_owner_hint_is_generic_and_preserves_caller_warning(tmp_path):
+    drive_root = tmp_path / "Display Folders"
+    stage_root = _mark(drive_root / "15-Church")
+    task_root = stage_root / "TaskBranch"
+    task_root.mkdir()
+    artifact = task_root / "artifact.dat"
+    artifact.write_bytes(b"x")
+
+    scope_root, scope_type, warnings = resolve_structured_scope(
+        {"stage_key": "15", "folder_path": str(stage_root)},
+        {"scene_name": "15-Church-CH", "scene_background_file": str(artifact)},
+        {"preview_background_file": None},
+        drive_root,
+        direct_owner_folder_name="TaskBranch",
+        direct_owner_warning="caller-specific direct-owner warning",
+    )
+
+    assert scope_type == "STAGE"
+    assert scope_root == stage_root
+    assert warnings == ["caller-specific direct-owner warning"]
+
+
+def test_missing_stage_anchor_fails_visibly_without_guessing(tmp_path):
+    drive_root = tmp_path / "Display Folders"
+    drive_root.mkdir()
+    missing = drive_root / "15-Missing"
+
+    scope_root, scope_type, warnings = resolve_structured_scope(
+        {"stage_key": "15", "folder_path": str(missing)},
+        {"scene_name": "Root", "scene_background_file": None},
+        {"preview_background_file": None},
+        drive_root,
+    )
+
+    assert scope_type == "UNRESOLVED"
+    assert scope_root is None
+    assert warnings == [
+        f"Stage folder_path is unavailable or unmarked on this server: {missing}"
+    ]

--- a/FieldWiring/Application/test_wiring_scope_resolution.py
+++ b/FieldWiring/Application/test_wiring_scope_resolution.py
@@ -36,7 +36,9 @@ def test_no_distinct_scene_folder_retains_stage_scope(tmp_path, monkeypatch):
     assert result["scope_type"] == "STAGE"
     assert result["scope_root"] == str(stage_root)
     assert [image["name"] for image in result["wiring_images"]] == ["church.png"]
-    assert any("stage root retained" in warning.lower() for warning in result["warnings"])
+    assert result["warnings"] == [
+        "No distinct Scene folder matched the current Scene identity; known marked Stage root retained as the FieldWiring scope."
+    ]
 
 
 def test_direct_wiring_pointer_resolves_stage_owner_while_context_selects_branch(tmp_path, monkeypatch):
@@ -57,18 +59,23 @@ def test_direct_wiring_pointer_resolves_stage_owner_while_context_selects_branch
     assert musical_result["scope_type"] == "STAGE"
     assert musical_result["scope_root"] == str(stage_root)
     assert [image["name"] for image in musical_result["wiring_images"]] == ["church.png"]
+    assert musical_result["warnings"] == [
+        "BackgroundFile points directly into the current Stage Wiring branch; the marked Stage root is the FieldWiring documentation scope."
+    ]
 
     background_result = resolve_images(stage, scene, preview, "Background / Static")
     assert background_result["scope_type"] == "STAGE"
     assert background_result["scope_root"] == str(stage_root)
     assert [image["name"] for image in background_result["wiring_images"]] == ["church-background.png"]
+    assert background_result["warnings"] == musical_result["warnings"]
 
 
 def test_unmarked_matching_scene_does_not_fall_back_to_stage(tmp_path, monkeypatch):
     root = tmp_path / "Display Folders"
     root.mkdir()
     stage_root = _stage(root)
-    (stage_root / "15-Church-CH").mkdir()
+    scene_root = stage_root / "15-Church-CH"
+    scene_root.mkdir()
     monkeypatch.setenv("FIELDWIRING_DRIVE_ROOT", str(root))
 
     result = resolve_images(
@@ -81,4 +88,22 @@ def test_unmarked_matching_scene_does_not_fall_back_to_stage(tmp_path, monkeypat
     assert result["scope_type"] == "UNRESOLVED"
     assert result["scope_root"] is None
     assert result["wiring_images"] == []
-    assert any("not an approved marked source root" in warning.lower() for warning in result["warnings"])
+    assert result["warnings"] == [
+        "Matching Scene folder exists but is not an approved marked source root: "
+        + str(scene_root)
+    ]
+
+
+def test_wiring_images_delegates_structured_scope_to_shared_component():
+    source = (Path(__file__).resolve().parent / "wiring_images.py").read_text(encoding="utf-8")
+
+    assert "from field_context_resolver import resolve_structured_scope" in source
+    assert "resolve_structured_scope(" in source
+    assert "branch = \"MusicalStage\"" in source
+    assert "scope_root / \"Wiring\" / branch" in source
+
+    assert "def _resolve_scope_root" not in source
+    assert "def _canonical_scene_names" not in source
+    assert "def _bounded_scope_matches" not in source
+    assert "def _recover_stage_root" not in source
+    assert "def _truncate_before_sourcedocs" not in source

--- a/FieldWiring/Application/wiring_common.py
+++ b/FieldWiring/Application/wiring_common.py
@@ -7,14 +7,15 @@ import re
 from typing import Any
 from zoneinfo import ZoneInfo
 
+from field_context_resolver import (
+    DEFAULT_WINDOWS_DRIVE_ROOT,
+    MARKER_NAME,
+    SKIP_SCOPE_SEARCH,
+)
+
 IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png"}
-MARKER_NAME = "_MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt"
-DEFAULT_DRIVE_ROOT = r"G:\Shared drives\Display Folders"
+DEFAULT_DRIVE_ROOT = DEFAULT_WINDOWS_DRIVE_ROOT
 DEFAULT_TIMEZONE = "America/Chicago"
-SKIP_SCOPE_SEARCH = {
-    "wiring", "procedures", "photos", "previewbackground", "sourcedocs",
-    "archive", "archived", "design archive",
-}
 
 
 class WiringError(RuntimeError):

--- a/FieldWiring/Application/wiring_images.py
+++ b/FieldWiring/Application/wiring_images.py
@@ -2,204 +2,17 @@
 from __future__ import annotations
 
 import os
-import re
 from pathlib import Path, PureWindowsPath
 from typing import Any
 
-from wiring_common import (
-    DEFAULT_DRIVE_ROOT, IMAGE_EXTENSIONS, MARKER_NAME, SKIP_SCOPE_SEARCH, WiringError,
+from field_context_resolver import resolve_structured_scope
+from wiring_common import DEFAULT_DRIVE_ROOT, IMAGE_EXTENSIONS, MARKER_NAME, WiringError
+
+
+FIELDWIRING_DIRECT_OWNER_WARNING = (
+    "BackgroundFile points directly into the current Stage Wiring branch; "
+    "the marked Stage root is the FieldWiring documentation scope."
 )
-
-
-def _canonical_scene_names(scene_name: str) -> set[str]:
-    names = {scene_name.strip()}
-    stripped = re.sub(r"-[A-Z]{2,3}$", "", scene_name.strip())
-    if stripped:
-        names.add(stripped)
-    return {name.casefold() for name in names if name}
-
-
-def _windows_relative_parts(path_text: str, root_text: str) -> tuple[str, ...] | None:
-    try:
-        path_parts = PureWindowsPath(path_text).parts
-        root_parts = PureWindowsPath(root_text).parts
-    except Exception:
-        return None
-    if len(path_parts) < len(root_parts):
-        return None
-    if [p.casefold() for p in path_parts[:len(root_parts)]] != [p.casefold() for p in root_parts]:
-        return None
-    return tuple(path_parts[len(root_parts):])
-
-
-def _localize_evidence_path(path_text: str | None, drive_root: Path) -> Path | None:
-    if not path_text:
-        return None
-    windows_root = os.environ.get("FIELDWIRING_WINDOWS_DRIVE_ROOT", DEFAULT_DRIVE_ROOT).strip() or DEFAULT_DRIVE_ROOT
-    relative_parts = _windows_relative_parts(path_text, windows_root)
-    if relative_parts is not None:
-        return drive_root.joinpath(*relative_parts)
-    return Path(path_text)
-
-
-def _path_is_under(path: Path, root: Path) -> bool:
-    try:
-        path.relative_to(root)
-        return True
-    except ValueError:
-        return False
-
-
-def _bounded_scope_matches(stage_root: Path, scene_name: str, max_depth: int = 2) -> list[Path]:
-    targets = _canonical_scene_names(scene_name)
-    matches: list[Path] = []
-
-    def walk(path: Path, depth: int) -> None:
-        if depth > max_depth:
-            return
-        try:
-            children = [p for p in path.iterdir() if p.is_dir()]
-        except OSError:
-            return
-        for child in children:
-            if child.name.casefold() in targets:
-                matches.append(child)
-            if depth < max_depth and child.name.casefold() not in SKIP_SCOPE_SEARCH:
-                walk(child, depth + 1)
-
-    walk(stage_root, 1)
-    unique = {str(item).casefold(): item for item in matches}
-    return sorted(unique.values(), key=lambda p: str(p).casefold())
-
-
-def _truncate_before_sourcedocs(path: Path | None) -> tuple[Path | None, bool]:
-    if path is None:
-        return None, False
-    parts = path.parts
-    for index, part in enumerate(parts):
-        if part.casefold() == "sourcedocs":
-            if index == 0:
-                return None, True
-            return Path(*parts[:index]), True
-    return path, False
-
-
-def _direct_wiring_owner(pointer: Path | None) -> Path | None:
-    """Return the folder directly above Wiring when BackgroundFile enters Wiring."""
-    if pointer is None:
-        return None
-    current = pointer.parent if pointer.suffix else pointer
-    for candidate in (current, *current.parents):
-        if candidate.name.casefold() == "wiring":
-            return candidate.parent
-    return None
-
-
-def _recover_stage_root(pointer: Path | None, drive_root: Path, stage_key: str | None) -> Path | None:
-    if pointer is None or not stage_key:
-        return None
-    if not pointer.exists():
-        return None
-    try:
-        relative = pointer.relative_to(drive_root)
-    except ValueError:
-        return None
-    if not relative.parts:
-        return None
-    candidate = drive_root / relative.parts[0]
-    numeric = re.match(r"^(\d{2})", str(stage_key))
-    if not numeric or not candidate.name.casefold().startswith(numeric.group(1).casefold() + "-"):
-        return None
-    if not candidate.is_dir() or not (candidate / MARKER_NAME).is_file():
-        return None
-    return candidate
-
-
-def _resolve_scope_root(
-    stage: dict[str, Any],
-    scene: dict[str, Any] | None,
-    preview: dict[str, Any],
-    drive_root: Path,
-) -> tuple[Path | None, str, list[str]]:
-    warnings: list[str] = []
-    raw_pointer = (scene or {}).get("scene_background_file") or preview.get("preview_background_file")
-    localized_pointer = _localize_evidence_path(raw_pointer, drive_root)
-    pointer, blocked = _truncate_before_sourcedocs(localized_pointer)
-    if blocked:
-        warnings.append(
-            "BackgroundFile path enters SourceDocs. Traversal stopped before SourceDocs; source content was not accessed."
-        )
-
-    folder_path = (stage.get("folder_path") or "").strip()
-    stage_root = _localize_evidence_path(folder_path, drive_root) if folder_path else None
-    valid = bool(stage_root and stage_root.is_dir() and (stage_root / MARKER_NAME).is_file())
-    if not valid:
-        recovered = _recover_stage_root(pointer, drive_root, stage.get("stage_key"))
-        if recovered is not None:
-            stage_root = recovered
-            valid = True
-            warnings.append(
-                "Persisted Stage folder_path was unavailable or stale; current marked Stage root was recovered from exact LOR path evidence."
-            )
-    if not valid or stage_root is None:
-        warnings.append(
-            "Stage has no usable current folder_path anchor." if not folder_path
-            else f"Stage folder_path is unavailable or unmarked on this server: {folder_path}"
-        )
-        return None, "UNRESOLVED", warnings
-
-    # A direct BackgroundFile inside Wiring is explicit documentation-ownership
-    # evidence. The folder above Wiring owns the field documentation. This only
-    # resolves the structured owner; resolve_images() still selects
-    # BackgroundStage versus MusicalStage from the already-resolved context.
-    direct_owner = _direct_wiring_owner(pointer)
-    if direct_owner is not None and _path_is_under(direct_owner, drive_root):
-        if direct_owner == stage_root:
-            warnings.append(
-                "BackgroundFile points directly into the current Stage Wiring branch; the marked Stage root is the FieldWiring documentation scope."
-            )
-            return stage_root, "STAGE", warnings
-
-    scene_name = (scene or {}).get("scene_name")
-    if not scene_name or scene_name.strip().casefold() == "root":
-        return stage_root, "STAGE", warnings
-
-    targets = _canonical_scene_names(scene_name)
-    if pointer is not None and _path_is_under(pointer, drive_root):
-        if pointer.exists():
-            current = pointer.parent if pointer.is_file() else pointer
-            while _path_is_under(current, stage_root):
-                if current.name.casefold() in targets:
-                    if (current / MARKER_NAME).is_file():
-                        return current, "SCENE", warnings
-                    warnings.append(f"Scene source-folder marker is missing: {current / MARKER_NAME}")
-                    return None, "UNRESOLVED", warnings
-                if current == stage_root:
-                    break
-                current = current.parent
-
-    matches = _bounded_scope_matches(stage_root, scene_name)
-    marked = [m for m in matches if (m / MARKER_NAME).is_file()]
-    if len(marked) == 1:
-        if raw_pointer:
-            warnings.append(
-                "Stored Scene BackgroundFile did not resolve exactly; one deterministic marked current Scene folder was used."
-            )
-        return marked[0], "SCENE", warnings
-    if len(marked) > 1:
-        warnings.append("More than one marked Scene folder matched the current Scene identity.")
-        return None, "UNRESOLVED", warnings
-    if matches:
-        warnings.append(
-            "Matching Scene folder exists but is not an approved marked source root: "
-            + "; ".join(str(match) for match in matches)
-        )
-        return None, "UNRESOLVED", warnings
-
-    warnings.append(
-        "No distinct Scene folder matched the current Scene identity; known marked Stage root retained as the FieldWiring scope."
-    )
-    return stage_root, "STAGE", warnings
 
 
 def _direct_images(folder: Path) -> list[Path]:
@@ -233,13 +46,39 @@ def resolve_images(
     root_text = os.environ.get("FIELDWIRING_DRIVE_ROOT", DEFAULT_DRIVE_ROOT).strip()
     drive_root = Path(root_text)
     if not drive_root.is_dir():
-        return {"scope_type":"UNAVAILABLE", "scope_root":None, "wiring_images":[], "context_images":[],
-                "warnings":[f"Display Folders root is not available on this server: {root_text}"]}
+        return {
+            "scope_type": "UNAVAILABLE",
+            "scope_root": None,
+            "wiring_images": [],
+            "context_images": [],
+            "warnings": [f"Display Folders root is not available on this server: {root_text}"],
+        }
 
-    scope_root, scope_type, warnings = _resolve_scope_root(stage, scene, preview, drive_root)
+    windows_root = (
+        os.environ.get("FIELDWIRING_WINDOWS_DRIVE_ROOT", DEFAULT_DRIVE_ROOT).strip()
+        or DEFAULT_DRIVE_ROOT
+    )
+    scope_root, scope_type, warnings = resolve_structured_scope(
+        stage,
+        scene,
+        preview,
+        drive_root,
+        windows_drive_root=windows_root,
+        direct_owner_folder_name="Wiring",
+        direct_owner_warning=FIELDWIRING_DIRECT_OWNER_WARNING,
+    )
     if scope_root is None:
-        return {"scope_type":scope_type, "scope_root":None, "wiring_images":[], "context_images":[], "warnings":warnings}
+        return {
+            "scope_type": scope_type,
+            "scope_root": None,
+            "wiring_images": [],
+            "context_images": [],
+            "warnings": warnings,
+        }
 
+    # Everything below this point is intentionally FieldWiring-specific.  The
+    # shared resolver has already fixed the Stage/Scene root; this adapter now
+    # selects only the applicable Wiring branch and supplemental context images.
     branch = "MusicalStage" if selected_context == "Musical" else "BackgroundStage"
     wiring_folder = scope_root / "Wiring" / branch
     wiring_images: list[Path] = []

--- a/FieldWiring/Application/wiring_images.py
+++ b/FieldWiring/Application/wiring_images.py
@@ -13,6 +13,10 @@ FIELDWIRING_DIRECT_OWNER_WARNING = (
     "BackgroundFile points directly into the current Stage Wiring branch; "
     "the marked Stage root is the FieldWiring documentation scope."
 )
+FIELDWIRING_STAGE_FALLBACK_WARNING = (
+    "No distinct Scene folder matched the current Scene identity; "
+    "known marked Stage root retained as the FieldWiring scope."
+)
 
 
 def _direct_images(folder: Path) -> list[Path]:
@@ -66,6 +70,7 @@ def resolve_images(
         windows_drive_root=windows_root,
         direct_owner_folder_name="Wiring",
         direct_owner_warning=FIELDWIRING_DIRECT_OWNER_WARNING,
+        stage_fallback_warning=FIELDWIRING_STAGE_FALLBACK_WARNING,
     )
     if scope_root is None:
         return {
@@ -76,7 +81,7 @@ def resolve_images(
             "warnings": warnings,
         }
 
-    # Everything below this point is intentionally FieldWiring-specific.  The
+    # Everything below this point is intentionally FieldWiring-specific. The
     # shared resolver has already fixed the Stage/Scene root; this adapter now
     # selects only the applicable Wiring branch and supplemental context images.
     branch = "MusicalStage" if selected_context == "Musical" else "BackgroundStage"


### PR DESCRIPTION
## Purpose
Finish the FieldWiring architecture boundary before Procedure implementation by extracting the proven Stage/Sub-stage/Scene resolver from `FieldWiring/Application/wiring_images.py` into the task-neutral `field_context_resolver.py` component.

## Preserved behavior
- marked Stage/Scene resolution
- Windows-to-Linux path translation
- stale Stage-path recovery
- bounded Scene matching
- ambiguity rejection
- `SourceDocs` protection
- existing warning behavior

Wiring branch/image selection remains FieldWiring-specific in `wiring_images.py`.

## Acceptance evidence
- Full FieldWiring regression suite: **54 passed in 1.01s**
- Detached worktree; production checkout untouched during regression
- Transient live candidate on `127.0.0.1:8791` using the production read-only PostgreSQL configuration and mounted Google filesystem
- Live Display `312` resolver comparison against production `192.168.5.9:8790`: **RESOLVER EQUIVALENCE: PASS**
- Production and candidate matched `scope_type`, `scope_root`, warnings, wiring image, relative path, and image URL

## Architecture boundary
`field_context_resolver.py` is now the canonical shared structured-scope implementation. Procedure engineering must consume it as a second caller rather than copy or redesign the algorithm.

## Deployment note
This PR accepts the repository/application architecture. Production server deployment remains a separate controlled server-management step because the live `/opt/fieldwiring` checkout is materially behind current `main`.