### PR TITLE
Close shared resolver production acceptance

### DIFF
--- a/Docs/02_Production_Database/01_System_Architecture/09_Wiring_System/FieldWiring_Shared_Structured_Scope_Resolver_Extraction_2026-08-22.md
+++ b/Docs/02_Production_Database/01_System_Architecture/09_Wiring_System/FieldWiring_Shared_Structured_Scope_Resolver_Extraction_2026-08-22.md
@@ -2,13 +2,15 @@
 
 | Document control | Value |
 |---|---|
-| Status | ARCHITECTURE ACCEPTED — production deployment pending |
-| Branch | `agent/shared-field-context-resolver-extraction` |
+| Status | PRODUCTION ACCEPTED — shared resolver deployed and verified |
+| Original implementation branch | `agent/shared-field-context-resolver-extraction` |
+| Merge PR | `#35` |
+| Production merge commit | `21e9e3b1889289806ccb116b3a546cfcd129fae4` |
 | Code-regression-tested commit | `b7fcd0333f2cb023026643c292b1d615cf5ceb6a` |
 | Live-equivalence-tested branch head | `dcedc36c8d3ad0955fa793e8817c4a88d3535014` |
-| Production baseline during test | `c71d0e50de9917a384ec8cfc836202e7aa2885db` |
+| Previous production baseline | `c71d0e50de9917a384ec8cfc836202e7aa2885db` |
 | Primary caller | FieldWiring |
-| Planned second caller | Procedure subsystem |
+| Approved second caller | Procedure subsystem |
 
 ## Purpose
 
@@ -18,7 +20,7 @@ This change finishes the original architecture boundary by extracting that prove
 
 ## Canonical Shared Component
 
-The canonical implementation is now:
+The canonical implementation is:
 
 ```text
 FieldWiring/Application/field_context_resolver.py
@@ -83,11 +85,11 @@ canonical matching also includes:
 
 If path evidence enters `SourceDocs`, traversal is stopped before `SourceDocs`. When the resolver subsequently walks the safe ancestor chain, the marked Stage root `15-Church` may therefore be returned with the existing `SCENE` scope classification.
 
-This is existing production resolver behavior. The returned path remains the marked Stage root and no `SourceDocs` content is traversed or presented. Changing that classification would be a resolver redesign and is outside this extraction.
+This is existing production resolver behavior. The returned path remains the marked Stage root and no `SourceDocs` content is traversed or presented. Changing that classification would be a resolver redesign and was outside this extraction.
 
 ## Regression Gate
 
-The candidate was tested from a detached server worktree:
+The candidate was first tested from a detached server worktree:
 
 ```text
 /var/tmp/fieldwiring-resolver-test
@@ -107,7 +109,7 @@ The first full run produced:
 
 The sole failure was a newly added test that incorrectly expected the legacy canonical-name case above to become `STAGE`. A direct diagnostic confirmed the extracted module matched the pre-existing resolver behavior. The test was corrected; the implementation was not redesigned.
 
-Final full regression result at `b7fcd0333f2cb023026643c292b1d615cf5ceb6a`:
+Final detached-worktree regression result at `b7fcd0333f2cb023026643c292b1d615cf5ceb6a`:
 
 ```text
 54 passed in 1.01s
@@ -141,7 +143,7 @@ A live `BridgeBell` lookup selected permanent Display:
 display_id = 312
 ```
 
-Production and candidate then returned identical resolver-specific values:
+Production and candidate returned identical resolver-specific values:
 
 ```text
 scope_type = STAGE
@@ -157,11 +159,89 @@ Result:
 RESOLVER EQUIVALENCE: PASS
 ```
 
-The transient candidate service was stopped automatically after the comparison. Production remained on its existing checkout throughout the test.
+The transient candidate service was stopped automatically after the comparison.
+
+## Repository Acceptance
+
+PR `#35` merged the accepted extraction into `main`.
+
+Merged production-source commit:
+
+```text
+21e9e3b1889289806ccb116b3a546cfcd129fae4
+```
+
+The merge preserved the reviewed boundary:
+
+```text
+field_context_resolver.py
+    -> task-neutral structured-scope resolution
+
+wiring_images.py
+    -> FieldWiring-only Wiring branch/image behavior
+```
+
+## Production Deployment and Verification
+
+The production checkout was then advanced from:
+
+```text
+c71d0e50de9917a384ec8cfc836202e7aa2885db
+```
+
+to the merged `main` commit:
+
+```text
+21e9e3b1889289806ccb116b3a546cfcd129fae4
+```
+
+The deployment was guarded by:
+
+- exact old/new commit checks;
+- clean-worktree verification;
+- explicit fetch of merged `main`;
+- `--ff-only` production update;
+- automatic rollback logic on failure;
+- complete FieldWiring regression execution before service acceptance.
+
+The full FieldWiring suite in the production checkout passed:
+
+```text
+54 passed in 1.01s
+```
+
+The production service was restarted and verified:
+
+```text
+systemctl is-active fieldwiring.service
+-> active
+```
+
+Production health after restart:
+
+```text
+{"data_mode":"postgres","status":"ok","version":"V0.2.0"}
+```
+
+A post-deployment live resolver check for permanent Display `312` returned:
+
+```text
+scope_type: STAGE
+scope_root: /mnt/msb-display-folders/15-Church-Bells-CH
+warnings: ['BackgroundFile points directly into the current Stage Wiring branch; the marked Stage root is the FieldWiring documentation scope.']
+wiring_images: ['RGB Plus Prop Stage 15 Church-Tagged.jpg']
+```
+
+Result:
+
+```text
+POST-DEPLOY RESOLVER CHECK: PASS
+FieldWiring shared resolver: DEPLOYED AND VERIFIED
+```
 
 ## Acceptance Decision
 
-The shared structured-scope resolver extraction is **architecture accepted** because all required behavior-preservation gates passed:
+The shared structured-scope resolver extraction is **production accepted** because all required gates passed:
 
 1. one task-neutral structured-scope implementation exists;
 2. FieldWiring delegates structured hierarchy resolution to it;
@@ -169,25 +249,20 @@ The shared structured-scope resolver extraction is **architecture accepted** bec
 4. existing warning behavior remains intact;
 5. `SourceDocs` remains protected;
 6. bounded matching and ambiguity rejection remain intact;
-7. the complete FieldWiring regression suite passes: `54 passed`;
-8. live production-data resolver output matches the current production service;
-9. Procedure implementation is directed to call this same component rather than copy or redesign it.
+7. the complete detached-worktree FieldWiring regression suite passed: `54 passed`;
+8. live candidate output matched the pre-deployment production resolver;
+9. PR `#35` merged the accepted architecture to `main`;
+10. the production checkout is now at the merged commit;
+11. the full production-checkout regression suite passed: `54 passed`;
+12. the production service is active and healthy;
+13. the post-deployment live resolver check passed;
+14. Procedure implementation is directed to call this same component rather than copy or redesign it.
 
-Production deployment of the extracted module is a separate server-change step and is not represented as complete by this document.
-
-## Production Deployment Caution
-
-At acceptance-test time, the live `/opt/fieldwiring` checkout was still at:
-
-```text
-c71d0e50de9917a384ec8cfc836202e7aa2885db
-```
-
-The resolver branch is based on newer current `main` history. Therefore deployment must not be described as a resolver-only one-commit update. The full repository gap must be reviewed explicitly before moving the live checkout and restarting FieldWiring.
+The FieldWiring architecture gate that blocked Procedure implementation is closed.
 
 ## Procedure Handoff
 
-The Procedure subsystem may now consume the accepted shared resolver as its second caller in engineering/development work.
+The Procedure subsystem is now approved to consume the production-accepted shared resolver as its second caller.
 
 The intended flow is:
 

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/01_Shared_Resolver_Extraction_Handoff_2026-08-22.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/01_Shared_Resolver_Extraction_Handoff_2026-08-22.md
@@ -2,9 +2,11 @@
 
 | Document control | Value |
 |---|---|
-| Status | CURRENT ENGINEERING HANDOFF ADDENDUM — shared resolver architecture accepted |
+| Status | CURRENT ENGINEERING HANDOFF ADDENDUM — shared resolver production accepted |
 | Parent handoff | `00_Procedure_System_Field_Context_Handoff_2026-08-22.md` |
-| Shared resolver branch | `agent/shared-field-context-resolver-extraction` |
+| Original resolver branch | `agent/shared-field-context-resolver-extraction` |
+| Merge PR | `#35` |
+| Production resolver commit | `21e9e3b1889289806ccb116b3a546cfcd129fae4` |
 | Code-regression-tested commit | `b7fcd0333f2cb023026643c292b1d615cf5ceb6a` |
 | Live-equivalence-tested branch head | `dcedc36c8d3ad0955fa793e8817c4a88d3535014` |
 
@@ -16,13 +18,13 @@ The parent Procedure handoff correctly established that Procedures must reuse Fi
 FieldWiring/Application/wiring_images.py
 ```
 
-That location statement is now superseded.
+That location statement is superseded.
 
 This addendum does not change the resolver algorithm or the Procedure task rules already established by the parent handoff.
 
 ## Canonical resolver source
 
-The proven structured-scope implementation has now been extracted to:
+The proven structured-scope implementation is:
 
 ```text
 FieldWiring/Application/field_context_resolver.py
@@ -35,6 +37,12 @@ resolve_structured_scope(...)
 ```
 
 The module is task-neutral. It remains physically beside FieldWiring so the existing production Python/systemd deployment model does not need to change merely for packaging. The Procedure implementation must consume this same canonical implementation as its second caller; it must not copy the resolver into a Procedure-owned file.
+
+The shared resolver is now deployed and verified in production FieldWiring at merged commit:
+
+```text
+21e9e3b1889289806ccb116b3a546cfcd129fae4
+```
 
 ## What Procedures receive from the shared resolver
 
@@ -104,9 +112,9 @@ The intended architecture is:
 
 ## Acceptance evidence
 
-The extracted resolver and FieldWiring adapter were tested together from an isolated server worktree.
+The extracted resolver and FieldWiring adapter were first tested together from an isolated server worktree.
 
-Complete FieldWiring regression result:
+Complete detached-worktree FieldWiring regression result:
 
 ```text
 54 passed in 1.01s
@@ -131,22 +139,50 @@ Result:
 RESOLVER EQUIVALENCE: PASS
 ```
 
-The shared resolver extraction is therefore accepted as the common architecture boundary.
+PR `#35` then merged the accepted resolver extraction to `main`.
+
+The production `/opt/fieldwiring` checkout was advanced to:
+
+```text
+21e9e3b1889289806ccb116b3a546cfcd129fae4
+```
+
+The full FieldWiring regression suite was rerun in the production checkout:
+
+```text
+54 passed in 1.01s
+```
+
+The production service restarted successfully and reported:
+
+```text
+active
+{"data_mode":"postgres","status":"ok","version":"V0.2.0"}
+```
+
+The post-deployment resolver check for permanent Display `312` matched the accepted result and ended with:
+
+```text
+POST-DEPLOY RESOLVER CHECK: PASS
+FieldWiring shared resolver: DEPLOYED AND VERIFIED
+```
+
+The shared resolver extraction is therefore **production accepted** as the common architecture boundary.
 
 ## Procedure implementation gate
 
-The prior gate preventing substantive Procedure resolver work is now cleared for engineering/development.
+The FieldWiring resolver gate that previously blocked substantive Procedure implementation is now fully cleared.
 
 Procedure engineering should begin from:
 
 1. this addendum;
 2. `00_Procedure_System_Field_Context_Handoff_2026-08-22.md`;
-3. the canonical `field_context_resolver.py` implementation;
+3. the canonical production-accepted `field_context_resolver.py` implementation;
 4. the Procedure marker/current-document rules already defined in the parent handoff.
 
 The first Procedure proof must demonstrate a **second caller of the same resolver**, not a second implementation of it.
 
-Production deployment of the FieldWiring extraction remains a separate server-management step. Procedure production deployment must not substitute a copied resolver merely because that server update is still pending.
+No further FieldWiring resolver extraction or production-acceptance work is required before Procedure implementation begins.
 
 ## Related FieldWiring acceptance record
 

--- a/FieldWiring/Application/README.md
+++ b/FieldWiring/Application/README.md
@@ -1,6 +1,6 @@
 # FieldWiring Application
 
-Status: **production-operational — shared resolver architecture accepted; extraction deployment pending**
+Status: **production-operational — shared structured-scope resolver deployed and accepted**
 
 This folder contains the browser-based FieldWiring application.
 
@@ -21,14 +21,11 @@ Accepted production state:
 - desktop and phone acceptance passed;
 - Display search repaired and production-tested;
 - existing Display Scan hub exposes the independent **Field Wiring** action;
-- FormView remains available as fallback/reference.
-
-Accepted engineering state:
-
-- the proven Stage/Sub-stage/Scene resolver has been extracted from `wiring_images.py` into task-neutral `field_context_resolver.py`;
-- complete FieldWiring regression suite passed: `54 passed in 1.01s`;
-- a live candidate using production PostgreSQL + mounted Google files matched the production resolver output for Display `312`;
-- production deployment of the extraction is still a separate server-management step.
+- FormView remains available as fallback/reference;
+- the proven Stage/Sub-stage/Scene resolver is extracted into task-neutral `field_context_resolver.py`;
+- resolver extraction merged through PR `#35` and deployed at production commit `21e9e3b1889289806ccb116b3a546cfcd129fae4`;
+- full FieldWiring production-checkout regression suite passed: `54 passed in 1.01s`;
+- post-deployment live resolver verification for Display `312` passed.
 
 For current engineering/recovery state, start with:
 
@@ -83,7 +80,7 @@ wiring_e131.py
 
 field_context_resolver.py
     task-neutral marked Stage/Sub-stage/Scene structured-scope resolver
-    shared infrastructure for FieldWiring and future Procedure callers
+    shared infrastructure for FieldWiring and Procedure callers
 
 wiring_images.py
     FieldWiring adapter after scope resolution
@@ -135,7 +132,41 @@ scope_root
     -> same-scope PreviewBackground context when allowed
 ```
 
-Future Procedure work must consume `field_context_resolver.resolve_structured_scope(...)` as a second caller rather than copy the resolver algorithm or reuse FieldWiring's Wiring-specific adapter.
+Procedure work must consume `field_context_resolver.resolve_structured_scope(...)` as a second caller rather than copy the resolver algorithm or reuse FieldWiring's Wiring-specific adapter.
+
+## Shared Resolver Production Acceptance
+
+The resolver extraction passed three separate gates:
+
+```text
+Detached-worktree regression: 54 passed in 1.01s
+Live candidate vs production:  RESOLVER EQUIVALENCE: PASS
+Production post-deploy test:    54 passed in 1.01s
+```
+
+Production deployment commit:
+
+```text
+21e9e3b1889289806ccb116b3a546cfcd129fae4
+```
+
+Post-deployment service state and health:
+
+```text
+active
+{"data_mode":"postgres","status":"ok","version":"V0.2.0"}
+```
+
+Post-deployment live Display `312` check:
+
+```text
+scope_type = STAGE
+scope_root = /mnt/msb-display-folders/15-Church-Bells-CH
+wiring image = RGB Plus Prop Stage 15 Church-Tagged.jpg
+POST-DEPLOY RESOLVER CHECK: PASS
+```
+
+This closes the FieldWiring architecture gate that previously blocked the Procedure subsystem from becoming the second caller.
 
 ## Current Presentation Families
 
@@ -217,7 +248,7 @@ The marker on `Wiring` guards the selected `BackgroundStage` or `MusicalStage` c
 
 `field_context_resolver.py` validates the structured root; `wiring_images.py` then checks the `Wiring` root and controlled `PreviewBackground` when applicable. There is no FieldWiring child-marker enforcement gap.
 
-The future Procedure system has a separate deeper marker contract. Do not add separate markers to production `BackgroundStage` / `MusicalStage` folders merely to imitate Procedure task/image marker rules.
+The Procedure system has a separate deeper marker contract. Do not add separate markers to production `BackgroundStage` / `MusicalStage` folders merely to imitate Procedure task/image marker rules.
 
 ## Display Deep-Link Contract
 
@@ -307,7 +338,7 @@ Do not copy secrets or protected runtime configuration into either repository.
 
 FieldWiring Scan Integration is closed as accepted production work.
 
-The shared structured-scope resolver extraction is architecture accepted and awaiting its controlled production checkout/service update.
+The shared structured-scope resolver extraction is also closed as accepted production work.
 
 Separate future work includes:
 
@@ -321,4 +352,4 @@ Separate future work includes:
 
 Before further FieldWiring application changes, read the current Wiring/Scan handoffs plus `FieldWiring_Shared_Structured_Scope_Resolver_Extraction_2026-08-22.md` and refresh from current `main`.
 
-Procedure engineering may now consume the accepted shared resolver as a second caller. It must not create an independent Display/Stage/Scene resolver or copy `wiring_images.py` task behavior.
+Procedure engineering may now consume the production-accepted shared resolver as its second caller. It must not create an independent Display/Stage/Scene resolver or copy `wiring_images.py` task behavior.


### PR DESCRIPTION
## Purpose
Close the durable FieldWiring/Procedure documentation after the shared structured-scope resolver was successfully deployed and verified in production.

## Production acceptance evidence
- Production checkout advanced to `21e9e3b1889289806ccb116b3a546cfcd129fae4`
- Full production-checkout FieldWiring regression suite: **54 passed in 1.01s**
- `fieldwiring.service`: **active**
- Health: `{"data_mode":"postgres","status":"ok","version":"V0.2.0"}`
- Post-deployment live Display `312` resolver check: **PASS**

## Scope
Documentation only. No runtime code changes.

This closes the FieldWiring resolver architecture/deployment gate and explicitly clears the Procedure subsystem to use `field_context_resolver.py` as the second caller.