### PR TITLE
Close shared DB field-context production acceptance

### DIFF
--- a/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/Shared_Field_Context_Database_Layer_Acceptance_2026-08-23.md
+++ b/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/Shared_Field_Context_Database_Layer_Acceptance_2026-08-23.md
@@ -2,43 +2,42 @@
 
 | Document control | Value |
 |---|---|
-| Status | ARCHITECTURE ACCEPTED — production deployment pending |
-| Branch | `agent/shared-field-context-database-layer` |
+| Status | **PRODUCTION ACCEPTED** |
+| Architecture branch | `agent/shared-field-context-database-layer` |
+| Merge PR | `#37` |
+| Production deployment commit | `decb4eb7030a35bab3fc2e778fcf271463044044` |
 | Accepted candidate | `c56df80055a80cff6ff497538f1e8f6a892c8bf2` |
-| Production FieldWiring baseline during acceptance | `21e9e3b1889289806ccb116b3a546cfcd129fae4` |
 | Filesystem resolver | `FieldWiring/Application/field_context_resolver.py` |
 | Shared database context | `FieldWiring/Application/field_context_repository.py` |
 | FieldWiring task adapter | `FieldWiring/Application/repository.py` |
-| Procedure status | paused until this layer is production accepted |
+| Procedure gate | **CLEARED — refresh/rebase Procedure branch onto current `main` before resuming** |
 
 ## Purpose
 
-The first shared Field Context extraction correctly centralized filesystem Stage/Sub-stage/Scene resolution in `field_context_resolver.py`, but permanent Display identity and current PostgreSQL Stage/Scene/Preview relationship resolution were still embedded in FieldWiring's `repository.py`.
+The original shared Field Context work centralized filesystem Stage/Sub-stage/Scene resolution in `field_context_resolver.py`, but permanent Display identity and current PostgreSQL Stage/Scene/Preview relationship resolution were still embedded in FieldWiring's `repository.py` and therefore coupled to Wiring-specific eligibility.
 
-That repository intentionally applies FieldWiring eligibility rules such as current LOR prop/device availability. Those task rules are valid for Wiring search and presentation, but they are too narrow to be the common identity/context layer used by Procedures and other field applications.
+That coupling was too narrow for shared field context. A valid inventory Display may need Setup/Takedown documentation even when it has no controller/channel assignment and no FieldWiring package.
 
-This change separates **field identity/context eligibility** from **task eligibility**.
+This work separates **field identity/context eligibility** from **task eligibility**.
 
-## Accepted Architecture
-
-The shared chain is now:
+## Production-Accepted Architecture
 
 ```text
 DISP:<display_id> / manual Display / Stage / Scene selection
         -> task-neutral current PostgreSQL identity/context
-        -> current Display + Stage + all current Scene/Preview candidates
+        -> Display + Stage + all current Scene/Preview candidates
         -> field_context_resolver.resolve_structured_scope(...)
         -> fixed marked Stage/Sub-stage/Scene filesystem scope
         -> task adapter
 ```
 
-Canonical task-neutral PostgreSQL implementation:
+Canonical shared database implementation:
 
 ```text
 FieldWiring/Application/field_context_repository.py
 ```
 
-Canonical filesystem implementation remains unchanged:
+Canonical filesystem implementation remains:
 
 ```text
 FieldWiring/Application/field_context_resolver.py
@@ -46,41 +45,41 @@ FieldWiring/Application/field_context_resolver.py
 
 `resolve_structured_scope(...)` was not redesigned by this work.
 
+No PostgreSQL schema, migration, function, trigger, or production data was changed.
+
 ## Shared Database Context Owns
 
-The shared repository resolves current active Production Database identity and hierarchy without requiring wiring eligibility:
+The shared repository resolves current active Production Database identity and hierarchy without requiring Wiring eligibility:
 
 - permanent `ref.display.display_id`;
-- current active Display name/status boundary;
-- current permanent `ref.display.stage_id -> ref.stage` relationship;
+- current active Display identity;
+- current `ref.display.stage_id -> ref.stage` relationship;
 - Stage key/name/current `folder_path`;
-- all applicable current `ref.lor_scene_display -> ref.lor_scene` Scene memberships;
-- Preview UUID/name and current Preview background/path evidence;
+- current `ref.lor_scene_display -> ref.lor_scene` memberships;
+- Preview UUID/name and current Preview path evidence;
 - Scene UUID/name/background/path evidence;
-- current Scene/Preview candidate set without collapsing valid alternatives into a task-specific choice;
-- controlled Display/Stage search/browse independent of controller/channel availability.
+- the current Scene/Preview candidate set without forcing a task-neutral Preview choice;
+- Display and Stage search/browse independent of controller/channel availability.
 
 The shared layer does **not** decide whether a Display is eligible for FieldWiring, Procedures, Testing, Work Orders, or another task.
 
-No PostgreSQL schema, migration, function, trigger, or production data was changed.
-
 ## FieldWiring Remains Narrow
 
-FieldWiring's `repository.py` is now the Wiring-specific adapter over the shared context layer.
+`FieldWiring/Application/repository.py` is the Wiring-specific adapter over the shared context layer.
 
-The normal FieldWiring Display lookup remains intentionally filtered by the existing wiring/device eligibility rules. Inventory-only Displays do not clutter the Wiring search merely because the shared layer can resolve them.
+The normal FieldWiring Display lookup remains intentionally filtered by the existing Wiring/device eligibility rules. Inventory-only Displays do not clutter the Wiring search merely because the shared layer can resolve them.
 
 The accepted distinction is:
 
 ```text
 Shared Field Context
-    active Display exists and current Stage/Scene context can be resolved
+    current Display exists and current Stage/Scene facts can be resolved
 
 FieldWiring eligibility
     Display also satisfies current Wiring-specific LOR/device requirements
 ```
 
-For direct `display_id` entry, FieldWiring can now distinguish:
+For direct `display_id` entry, FieldWiring now distinguishes:
 
 ```text
 unknown / inactive Display
@@ -90,24 +89,22 @@ valid current Display with no applicable Wiring
     -> No applicable field wiring is available for this Display
 ```
 
-This distinction is required for a future common field-home/task-selection experience.
+## Detached Regression Acceptance
 
-## Regression Gate
+Candidate regression was run from an isolated detached server worktree while production remained unchanged.
 
-The branch was tested from an isolated detached worktree while production remained unchanged.
-
-Final full FieldWiring regression result at candidate `c56df80055a80cff6ff497538f1e8f6a892c8bf2`:
+Final candidate result:
 
 ```text
 64 passed in 2.04s
 ```
 
-The suite includes tests proving:
+The suite proves, among other cases:
 
 - shared search can return active non-wired/inventory Displays;
 - a Display with `device_type='None'` can retain shared Stage/Scene context;
-- an active Display with no LOR prop at all can still resolve its permanent Stage;
-- retired/non-current Displays are excluded from current shared context;
+- an active Display with no LOR prop can still resolve its permanent Stage;
+- retired/non-current Displays are excluded;
 - shared Stage browse does not require wiring;
 - the shared database result can feed the unchanged `resolve_structured_scope(...)` filesystem resolver;
 - normal FieldWiring search still excludes non-wired Displays;
@@ -116,34 +113,27 @@ The suite includes tests proving:
 
 ## Real Production-Data Acceptance — Display 807
 
-A real active inventory Display was selected from production:
+Real active inventory Display:
 
 ```text
 display_id   807
 display_name RA-SteelArch-DS-F-03
 ```
 
-The shared candidate resolved live PostgreSQL facts:
+Shared PostgreSQL context resolved:
 
 ```text
 stage_id     55
 stage_key    25
 stage_name   RGB Plus Stage 25 Racing Arches Traditional
 folder_path  G:\Shared drives\Display Folders\25-Racing Arches-RA
+scene_name   25-Racing Arches-RA
+scene_uuid   1bbc0060-36a6-447c-bbf5-0aa2aa8b6502
+preview_name 2026 Master Musical Preview v6.6.10 2026-08-20
+preview_uuid fcf5c29c-8d51-46c5-9ad0-cc47a97c75bd
 ```
 
-Current Scene/Preview candidate:
-
-```text
-scene_name    25-Racing Arches-RA
-scene_uuid    1bbc0060-36a6-447c-bbf5-0aa2aa8b6502
-preview_name  2026 Master Musical Preview v6.6.10 2026-08-20
-preview_uuid  fcf5c29c-8d51-46c5-9ad0-cc47a97c75bd
-```
-
-Those live facts were then passed to the unchanged filesystem resolver against the mounted read-only Google tree.
-
-Result:
+Those facts were passed to the unchanged filesystem resolver against the mounted read-only Google tree:
 
 ```text
 scope_type = SCENE
@@ -153,7 +143,7 @@ warnings   = []
 DISPLAY 807 SHARED STRUCTURED SCOPE: PASS
 ```
 
-The task-eligibility split was also proven:
+Task-eligibility separation was also proven:
 
 ```text
 shared search for RA-SteelArch-DS-F-03 -> [807]
@@ -161,7 +151,7 @@ FieldWiring filtered search            -> []
 FieldWiring display_context(807)       -> None
 ```
 
-Direct FieldWiring request result:
+Direct FieldWiring result:
 
 ```text
 No applicable field wiring is available for this Display
@@ -171,57 +161,94 @@ This proves that **not wired** no longer means **not a valid Display/context**.
 
 ## Existing FieldWiring Equivalence — Display 312
 
-A normal wired production Display was resolved through the candidate and compared with the unchanged production FieldWiring API.
+Normal wired production Display `312` was resolved through the candidate and compared with the unchanged production FieldWiring API.
 
-Display `312` matched on:
-
-- scope type;
-- scope root;
-- warning text;
-- Wiring image list;
-- context image list;
-- relative image path; and
-- image URL.
-
-Result:
+Resolver/image values matched, including scope type, scope root, warning text, Wiring image list, context image list, relative image path, and image URL.
 
 ```text
 DISPLAY 312 FIELDWIRING EQUIVALENCE: PASS
 ```
 
+## Production Deployment Acceptance
+
+PR `#37` merged the shared database-context layer to `main`.
+
+The production `/opt/fieldwiring` checkout was then advanced to:
+
+```text
+decb4eb7030a35bab3fc2e778fcf271463044044
+```
+
+The complete FieldWiring/shared-context suite was rerun in the production checkout:
+
+```text
+64 passed in 2.05s
+```
+
+The service restarted successfully:
+
+```text
+fieldwiring.service = active
+{"data_mode":"postgres","status":"ok","version":"V0.2.0"}
+```
+
+Post-deployment production checks:
+
+```text
+FieldWiring search for RA-SteelArch-DS-F-03 -> []
+Direct FieldWiring display_id=807           -> HTTP 400 / No applicable field wiring
+DISPLAY 807 FIELDWIRING TASK SEPARATION: PASS
+
+Display 807 shared scope:
+scope_type = SCENE
+scope_root = /mnt/msb-display-folders/25-Racing Arches-RA
+warnings   = []
+DISPLAY 807 SHARED FIELD CONTEXT: PASS
+
+Display 312:
+scope_type = STAGE
+scope_root = /mnt/msb-display-folders/15-Church-Bells-CH
+wiring image = RGB Plus Prop Stage 15 Church-Tagged.jpg
+DISPLAY 312 FIELDWIRING POST-DEPLOY: PASS
+```
+
+Result:
+
+```text
+Shared Field Context database layer: DEPLOYED AND VERIFIED
+```
+
 ## Acceptance Decision
 
-The shared PostgreSQL identity/context layer is architecture accepted because:
+The shared PostgreSQL identity/context layer is **production accepted** because:
 
 1. permanent Display identity resolution no longer depends on Wiring eligibility;
 2. active inventory-only/non-wired Displays can resolve current Stage/Scene/Preview context;
-3. all current Scene/Preview candidates are exposed rather than guessed into one task-neutral choice;
-4. the production-accepted filesystem resolver is unchanged;
+3. current Scene/Preview candidates are exposed without a task-neutral guess;
+4. the production-accepted filesystem resolver remains unchanged;
 5. FieldWiring search/browse remains Wiring-filtered;
 6. direct FieldWiring entry distinguishes valid-but-not-wired from nonexistent;
-7. the complete FieldWiring regression suite passes;
-8. real Display `807` proves the full shared database-to-filesystem chain;
-9. wired Display `312` proves existing FieldWiring behavior remains equivalent.
+7. the complete production suite passes;
+8. real Display `807` proves the database-to-filesystem shared chain;
+9. wired Display `312` proves FieldWiring remains operational after deployment.
 
-Production deployment remains a separate acceptance step.
+## Procedure Gate — Cleared
 
-## Procedure Gate
+The Procedure prerequisite is now cleared.
 
-The Procedure branch remains paused until this database-context layer is merged and production accepted.
+Before resuming `feature/setup-takedown-procedures`, refresh it against current `main`. Procedure must consume this same shared repository rather than copy PostgreSQL relationship SQL into `Procedures`.
 
-After that gate clears, Procedure must consume the same shared repository rather than copy PostgreSQL relationship SQL into `Procedures`.
-
-The intended Procedure chain is:
+The required Procedure chain is:
 
 ```text
 permanent Display / Stage / Scene entry
     -> field_context_repository
-    -> fixed database identity/context facts
+    -> current database identity/context facts
     -> field_context_resolver.resolve_structured_scope(...)
     -> Procedures task adapter
 ```
 
-Procedure task/document discovery remains downstream and must not introduce Wiring eligibility filters into the shared context layer.
+Procedure task/document discovery remains downstream and must not introduce Wiring eligibility filters into shared identity/context resolution.
 
 ## Related Documents
 
@@ -229,3 +256,4 @@ Procedure task/document discovery remains downstream and must not introduce Wiri
 - `../09_Wiring_System/FieldWiring_Shared_Structured_Scope_Resolver_Extraction_2026-08-22.md`
 - `../12_Setup_and_Deployment/00_Procedure_System_Field_Context_Handoff_2026-08-22.md`
 - `../12_Setup_and_Deployment/01_Shared_Resolver_Extraction_Handoff_2026-08-22.md`
+- `../12_Setup_and_Deployment/03_Shared_Field_Context_Database_Layer_Handoff_2026-08-23.md`

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/03_Shared_Field_Context_Database_Layer_Handoff_2026-08-23.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/03_Shared_Field_Context_Database_Layer_Handoff_2026-08-23.md
@@ -2,18 +2,19 @@
 
 | Document control | Value |
 |---|---|
-| Status | CURRENT ENGINEERING HANDOFF — production deployment of shared DB context pending |
-| Shared DB-context branch | `agent/shared-field-context-database-layer` |
-| Accepted candidate | `c56df80055a80cff6ff497538f1e8f6a892c8bf2` |
-| Procedure branch | `feature/setup-takedown-procedures` — remain paused until production acceptance |
+| Status | **CURRENT ENGINEERING HANDOFF — shared database context production accepted; Procedure gate cleared** |
+| Shared DB-context implementation | `FieldWiring/Application/field_context_repository.py` |
+| Merge PR | `#37` |
+| Production deployment commit | `decb4eb7030a35bab3fc2e778fcf271463044044` |
+| Procedure branch | `feature/setup-takedown-procedures` — refresh/rebase onto current `main` before resuming |
 
 ## Why this handoff exists
 
 Procedure browser engineering correctly reused the production-accepted filesystem resolver, but exposed a remaining upstream coupling: permanent Display ID -> current Stage/Scene/Preview relationship resolution was still embedded in FieldWiring's `repository.py` and subject to Wiring-specific eligibility filters.
 
-That is not an acceptable shared boundary for Procedures. A valid inventory Display may need Setup/Takedown documentation even when it has no controller/channel assignment and therefore no FieldWiring package.
+That was not an acceptable shared boundary for Procedures. A valid inventory Display may need Setup/Takedown documentation even when it has no controller/channel assignment and therefore no FieldWiring package.
 
-This handoff records the new shared database-context layer that must be used when Procedure engineering resumes.
+That gap is now closed and production accepted.
 
 ## Canonical shared database context
 
@@ -31,7 +32,7 @@ The production-accepted filesystem resolver remains:
 FieldWiring/Application/field_context_resolver.py
 ```
 
-The combined common chain is:
+The common chain is now:
 
 ```text
 DISP:<display_id> / manual Display / Stage / Scene entry
@@ -61,9 +62,9 @@ Procedures
     owns current Setup/Takedown/Inspection documentation
 ```
 
-Therefore an inventory-only steel arch can be a valid Procedure entry even when FieldWiring correctly reports no applicable wiring.
+Therefore an inventory-only steel arch is a valid Procedure entry even when FieldWiring correctly reports no applicable wiring.
 
-## Real acceptance fixture
+## Real production acceptance fixture
 
 Production Display:
 
@@ -82,7 +83,7 @@ scene_name   25-Racing Arches-RA
 preview      2026 Master Musical Preview v6.6.10 2026-08-20
 ```
 
-The unchanged shared filesystem resolver then returned:
+The unchanged shared filesystem resolver returned:
 
 ```text
 scope_type = SCENE
@@ -100,23 +101,55 @@ FieldWiring direct     -> No applicable field wiring is available for this Displ
 
 This is the required distinction between **valid field context** and **task availability**.
 
-## Regression evidence
+## Acceptance evidence
 
-Complete FieldWiring + shared-context candidate suite:
+Detached candidate regression:
 
 ```text
 64 passed in 2.04s
 ```
 
-Normal wired Display `312` was also compared against the unchanged production FieldWiring API and remained equivalent at the resolver/image boundary.
+Normal wired Display `312` remained equivalent to the unchanged production FieldWiring API before merge.
 
-## Procedure resume rule
+After PR `#37` merged, production `/opt/fieldwiring` was advanced to:
 
-Do not resume substantive Procedure browser/database orchestration until this shared database-context layer is merged and production accepted.
+```text
+decb4eb7030a35bab3fc2e778fcf271463044044
+```
 
-After production acceptance, resume `feature/setup-takedown-procedures` by refreshing/rebasing it onto current `main` and replacing any planned FieldWiring-repository dependency with the canonical shared context repository.
+Production regression and service verification:
 
-Preserve the already accepted Procedure second-caller boundary:
+```text
+64 passed in 2.05s
+fieldwiring.service = active
+{"data_mode":"postgres","status":"ok","version":"V0.2.0"}
+```
+
+Post-deployment checks:
+
+```text
+DISPLAY 807 FIELDWIRING TASK SEPARATION: PASS
+DISPLAY 807 SHARED FIELD CONTEXT: PASS
+DISPLAY 312 FIELDWIRING POST-DEPLOY: PASS
+Shared Field Context database layer: DEPLOYED AND VERIFIED
+```
+
+The shared database-context layer is therefore **production accepted**.
+
+## Procedure resume rule — Gate cleared
+
+The previous pause is now cleared.
+
+Before substantive Procedure browser/database orchestration resumes:
+
+1. refresh/fetch current `main`;
+2. rebase or deliberately merge `feature/setup-takedown-procedures` onto current `main`;
+3. preserve the already accepted Procedure second-caller filesystem adapter work;
+4. use the canonical shared `field_context_repository` for permanent Display/Stage/Scene/Preview facts;
+5. pass those facts into the unchanged `field_context_resolver.resolve_structured_scope(...)`;
+6. keep Procedure task/document discovery downstream.
+
+Preserve this architecture:
 
 ```text
 shared DB context
@@ -132,7 +165,7 @@ Do not:
 - copy FieldWiring SQL into Procedures;
 - redesign `resolve_structured_scope(...)`;
 - create a second Stage/Scene filesystem resolver;
-- create new schema merely to support this first shared read path.
+- create new schema merely to support this shared read path.
 
 ## Related documents
 

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/04_Procedure_Resume_After_Shared_DB_Context_2026-08-23.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/04_Procedure_Resume_After_Shared_DB_Context_2026-08-23.md
@@ -1,0 +1,43 @@
+# Procedure Resume Checkpoint After Shared Database Context — 2026-08-23
+
+Status: **READY TO RESUME ENGINEERING**
+
+The Procedure subsystem pause is cleared.
+
+Production-accepted shared prerequisites now include:
+
+```text
+FieldWiring/Application/field_context_repository.py
+FieldWiring/Application/field_context_resolver.py
+```
+
+Production FieldWiring commit used to accept the shared database-context layer:
+
+```text
+decb4eb7030a35bab3fc2e778fcf271463044044
+```
+
+Acceptance evidence:
+
+```text
+64 passed in production checkout
+fieldwiring.service active
+Display 807 shared context PASS
+Display 807 FieldWiring task separation PASS
+Display 312 FieldWiring post-deploy PASS
+```
+
+When `feature/setup-takedown-procedures` resumes, first refresh it against current `main`. Preserve its accepted `procedure_documents.py` second-caller work, but route permanent Display/Stage/Scene/Preview database facts through `field_context_repository.py` rather than FieldWiring's task-filtered `repository.py` or copied SQL.
+
+Required chain:
+
+```text
+permanent Display / manual Stage/Scene selection
+    -> shared field_context_repository
+    -> shared field_context_resolver.resolve_structured_scope(...)
+    -> fixed scope_root
+    -> Procedure task adapter
+    -> Procedures/Setup | Procedures/Takedown | Procedures/Inspection
+```
+
+FieldWiring-specific wiring eligibility remains downstream and must not be imported into Procedure identity/context resolution.


### PR DESCRIPTION
## Purpose
Record the completed production deployment and clear the Procedure prerequisite after the shared Display/Stage/Scene/Preview database-context layer was merged and verified.

## Production acceptance
- deployed commit `decb4eb7030a35bab3fc2e778fcf271463044044`
- full production regression: **64 passed in 2.05s**
- `fieldwiring.service`: **active**
- health: `{"data_mode":"postgres","status":"ok","version":"V0.2.0"}`
- Display `807` shared field context: **PASS**
- Display `807` FieldWiring task separation: **PASS**
- Display `312` post-deploy FieldWiring regression: **PASS**

## Scope
Documentation only. No runtime code or schema changes.

The Procedure pause is cleared; `feature/setup-takedown-procedures` must refresh/rebase onto current `main` and consume `field_context_repository.py` rather than FieldWiring-filtered repository logic or copied SQL.