### PR TITLE
Refresh Procedure branch from current main

### DIFF
--- a/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/Shared_Field_Context_Database_Layer_Acceptance_2026-08-23.md
+++ b/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/Shared_Field_Context_Database_Layer_Acceptance_2026-08-23.md
@@ -1,0 +1,231 @@
+# Shared Field Context Database Layer Acceptance — 2026-08-23
+
+| Document control | Value |
+|---|---|
+| Status | ARCHITECTURE ACCEPTED — production deployment pending |
+| Branch | `agent/shared-field-context-database-layer` |
+| Accepted candidate | `c56df80055a80cff6ff497538f1e8f6a892c8bf2` |
+| Production FieldWiring baseline during acceptance | `21e9e3b1889289806ccb116b3a546cfcd129fae4` |
+| Filesystem resolver | `FieldWiring/Application/field_context_resolver.py` |
+| Shared database context | `FieldWiring/Application/field_context_repository.py` |
+| FieldWiring task adapter | `FieldWiring/Application/repository.py` |
+| Procedure status | paused until this layer is production accepted |
+
+## Purpose
+
+The first shared Field Context extraction correctly centralized filesystem Stage/Sub-stage/Scene resolution in `field_context_resolver.py`, but permanent Display identity and current PostgreSQL Stage/Scene/Preview relationship resolution were still embedded in FieldWiring's `repository.py`.
+
+That repository intentionally applies FieldWiring eligibility rules such as current LOR prop/device availability. Those task rules are valid for Wiring search and presentation, but they are too narrow to be the common identity/context layer used by Procedures and other field applications.
+
+This change separates **field identity/context eligibility** from **task eligibility**.
+
+## Accepted Architecture
+
+The shared chain is now:
+
+```text
+DISP:<display_id> / manual Display / Stage / Scene selection
+        -> task-neutral current PostgreSQL identity/context
+        -> current Display + Stage + all current Scene/Preview candidates
+        -> field_context_resolver.resolve_structured_scope(...)
+        -> fixed marked Stage/Sub-stage/Scene filesystem scope
+        -> task adapter
+```
+
+Canonical task-neutral PostgreSQL implementation:
+
+```text
+FieldWiring/Application/field_context_repository.py
+```
+
+Canonical filesystem implementation remains unchanged:
+
+```text
+FieldWiring/Application/field_context_resolver.py
+```
+
+`resolve_structured_scope(...)` was not redesigned by this work.
+
+## Shared Database Context Owns
+
+The shared repository resolves current active Production Database identity and hierarchy without requiring wiring eligibility:
+
+- permanent `ref.display.display_id`;
+- current active Display name/status boundary;
+- current permanent `ref.display.stage_id -> ref.stage` relationship;
+- Stage key/name/current `folder_path`;
+- all applicable current `ref.lor_scene_display -> ref.lor_scene` Scene memberships;
+- Preview UUID/name and current Preview background/path evidence;
+- Scene UUID/name/background/path evidence;
+- current Scene/Preview candidate set without collapsing valid alternatives into a task-specific choice;
+- controlled Display/Stage search/browse independent of controller/channel availability.
+
+The shared layer does **not** decide whether a Display is eligible for FieldWiring, Procedures, Testing, Work Orders, or another task.
+
+No PostgreSQL schema, migration, function, trigger, or production data was changed.
+
+## FieldWiring Remains Narrow
+
+FieldWiring's `repository.py` is now the Wiring-specific adapter over the shared context layer.
+
+The normal FieldWiring Display lookup remains intentionally filtered by the existing wiring/device eligibility rules. Inventory-only Displays do not clutter the Wiring search merely because the shared layer can resolve them.
+
+The accepted distinction is:
+
+```text
+Shared Field Context
+    active Display exists and current Stage/Scene context can be resolved
+
+FieldWiring eligibility
+    Display also satisfies current Wiring-specific LOR/device requirements
+```
+
+For direct `display_id` entry, FieldWiring can now distinguish:
+
+```text
+unknown / inactive Display
+    -> Display is not available for current FieldWiring
+
+valid current Display with no applicable Wiring
+    -> No applicable field wiring is available for this Display
+```
+
+This distinction is required for a future common field-home/task-selection experience.
+
+## Regression Gate
+
+The branch was tested from an isolated detached worktree while production remained unchanged.
+
+Final full FieldWiring regression result at candidate `c56df80055a80cff6ff497538f1e8f6a892c8bf2`:
+
+```text
+64 passed in 2.04s
+```
+
+The suite includes tests proving:
+
+- shared search can return active non-wired/inventory Displays;
+- a Display with `device_type='None'` can retain shared Stage/Scene context;
+- an active Display with no LOR prop at all can still resolve its permanent Stage;
+- retired/non-current Displays are excluded from current shared context;
+- shared Stage browse does not require wiring;
+- the shared database result can feed the unchanged `resolve_structured_scope(...)` filesystem resolver;
+- normal FieldWiring search still excludes non-wired Displays;
+- direct FieldWiring entry reports `No applicable field wiring` for a valid shared Display that is not Wiring-eligible;
+- all previously accepted FieldWiring tests remain green.
+
+## Real Production-Data Acceptance — Display 807
+
+A real active inventory Display was selected from production:
+
+```text
+display_id   807
+display_name RA-SteelArch-DS-F-03
+```
+
+The shared candidate resolved live PostgreSQL facts:
+
+```text
+stage_id     55
+stage_key    25
+stage_name   RGB Plus Stage 25 Racing Arches Traditional
+folder_path  G:\Shared drives\Display Folders\25-Racing Arches-RA
+```
+
+Current Scene/Preview candidate:
+
+```text
+scene_name    25-Racing Arches-RA
+scene_uuid    1bbc0060-36a6-447c-bbf5-0aa2aa8b6502
+preview_name  2026 Master Musical Preview v6.6.10 2026-08-20
+preview_uuid  fcf5c29c-8d51-46c5-9ad0-cc47a97c75bd
+```
+
+Those live facts were then passed to the unchanged filesystem resolver against the mounted read-only Google tree.
+
+Result:
+
+```text
+scope_type = SCENE
+scope_root = /mnt/msb-display-folders/25-Racing Arches-RA
+warnings   = []
+
+DISPLAY 807 SHARED STRUCTURED SCOPE: PASS
+```
+
+The task-eligibility split was also proven:
+
+```text
+shared search for RA-SteelArch-DS-F-03 -> [807]
+FieldWiring filtered search            -> []
+FieldWiring display_context(807)       -> None
+```
+
+Direct FieldWiring request result:
+
+```text
+No applicable field wiring is available for this Display
+```
+
+This proves that **not wired** no longer means **not a valid Display/context**.
+
+## Existing FieldWiring Equivalence — Display 312
+
+A normal wired production Display was resolved through the candidate and compared with the unchanged production FieldWiring API.
+
+Display `312` matched on:
+
+- scope type;
+- scope root;
+- warning text;
+- Wiring image list;
+- context image list;
+- relative image path; and
+- image URL.
+
+Result:
+
+```text
+DISPLAY 312 FIELDWIRING EQUIVALENCE: PASS
+```
+
+## Acceptance Decision
+
+The shared PostgreSQL identity/context layer is architecture accepted because:
+
+1. permanent Display identity resolution no longer depends on Wiring eligibility;
+2. active inventory-only/non-wired Displays can resolve current Stage/Scene/Preview context;
+3. all current Scene/Preview candidates are exposed rather than guessed into one task-neutral choice;
+4. the production-accepted filesystem resolver is unchanged;
+5. FieldWiring search/browse remains Wiring-filtered;
+6. direct FieldWiring entry distinguishes valid-but-not-wired from nonexistent;
+7. the complete FieldWiring regression suite passes;
+8. real Display `807` proves the full shared database-to-filesystem chain;
+9. wired Display `312` proves existing FieldWiring behavior remains equivalent.
+
+Production deployment remains a separate acceptance step.
+
+## Procedure Gate
+
+The Procedure branch remains paused until this database-context layer is merged and production accepted.
+
+After that gate clears, Procedure must consume the same shared repository rather than copy PostgreSQL relationship SQL into `Procedures`.
+
+The intended Procedure chain is:
+
+```text
+permanent Display / Stage / Scene entry
+    -> field_context_repository
+    -> fixed database identity/context facts
+    -> field_context_resolver.resolve_structured_scope(...)
+    -> Procedures task adapter
+```
+
+Procedure task/document discovery remains downstream and must not introduce Wiring eligibility filters into the shared context layer.
+
+## Related Documents
+
+- `Field_Context_Resolution_Contract.md`
+- `../09_Wiring_System/FieldWiring_Shared_Structured_Scope_Resolver_Extraction_2026-08-22.md`
+- `../12_Setup_and_Deployment/00_Procedure_System_Field_Context_Handoff_2026-08-22.md`
+- `../12_Setup_and_Deployment/01_Shared_Resolver_Extraction_Handoff_2026-08-22.md`

--- a/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/Shared_Field_Context_Database_Layer_Acceptance_2026-08-23.md
+++ b/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/Shared_Field_Context_Database_Layer_Acceptance_2026-08-23.md
@@ -2,43 +2,42 @@
 
 | Document control | Value |
 |---|---|
-| Status | ARCHITECTURE ACCEPTED — production deployment pending |
-| Branch | `agent/shared-field-context-database-layer` |
+| Status | **PRODUCTION ACCEPTED** |
+| Architecture branch | `agent/shared-field-context-database-layer` |
+| Merge PR | `#37` |
+| Production deployment commit | `decb4eb7030a35bab3fc2e778fcf271463044044` |
 | Accepted candidate | `c56df80055a80cff6ff497538f1e8f6a892c8bf2` |
-| Production FieldWiring baseline during acceptance | `21e9e3b1889289806ccb116b3a546cfcd129fae4` |
 | Filesystem resolver | `FieldWiring/Application/field_context_resolver.py` |
 | Shared database context | `FieldWiring/Application/field_context_repository.py` |
 | FieldWiring task adapter | `FieldWiring/Application/repository.py` |
-| Procedure status | paused until this layer is production accepted |
+| Procedure gate | **CLEARED — refresh/rebase Procedure branch onto current `main` before resuming** |
 
 ## Purpose
 
-The first shared Field Context extraction correctly centralized filesystem Stage/Sub-stage/Scene resolution in `field_context_resolver.py`, but permanent Display identity and current PostgreSQL Stage/Scene/Preview relationship resolution were still embedded in FieldWiring's `repository.py`.
+The original shared Field Context work centralized filesystem Stage/Sub-stage/Scene resolution in `field_context_resolver.py`, but permanent Display identity and current PostgreSQL Stage/Scene/Preview relationship resolution were still embedded in FieldWiring's `repository.py` and therefore coupled to Wiring-specific eligibility.
 
-That repository intentionally applies FieldWiring eligibility rules such as current LOR prop/device availability. Those task rules are valid for Wiring search and presentation, but they are too narrow to be the common identity/context layer used by Procedures and other field applications.
+That coupling was too narrow for shared field context. A valid inventory Display may need Setup/Takedown documentation even when it has no controller/channel assignment and no FieldWiring package.
 
-This change separates **field identity/context eligibility** from **task eligibility**.
+This work separates **field identity/context eligibility** from **task eligibility**.
 
-## Accepted Architecture
-
-The shared chain is now:
+## Production-Accepted Architecture
 
 ```text
 DISP:<display_id> / manual Display / Stage / Scene selection
         -> task-neutral current PostgreSQL identity/context
-        -> current Display + Stage + all current Scene/Preview candidates
+        -> Display + Stage + all current Scene/Preview candidates
         -> field_context_resolver.resolve_structured_scope(...)
         -> fixed marked Stage/Sub-stage/Scene filesystem scope
         -> task adapter
 ```
 
-Canonical task-neutral PostgreSQL implementation:
+Canonical shared database implementation:
 
 ```text
 FieldWiring/Application/field_context_repository.py
 ```
 
-Canonical filesystem implementation remains unchanged:
+Canonical filesystem implementation remains:
 
 ```text
 FieldWiring/Application/field_context_resolver.py
@@ -46,41 +45,41 @@ FieldWiring/Application/field_context_resolver.py
 
 `resolve_structured_scope(...)` was not redesigned by this work.
 
+No PostgreSQL schema, migration, function, trigger, or production data was changed.
+
 ## Shared Database Context Owns
 
-The shared repository resolves current active Production Database identity and hierarchy without requiring wiring eligibility:
+The shared repository resolves current active Production Database identity and hierarchy without requiring Wiring eligibility:
 
 - permanent `ref.display.display_id`;
-- current active Display name/status boundary;
-- current permanent `ref.display.stage_id -> ref.stage` relationship;
+- current active Display identity;
+- current `ref.display.stage_id -> ref.stage` relationship;
 - Stage key/name/current `folder_path`;
-- all applicable current `ref.lor_scene_display -> ref.lor_scene` Scene memberships;
-- Preview UUID/name and current Preview background/path evidence;
+- current `ref.lor_scene_display -> ref.lor_scene` memberships;
+- Preview UUID/name and current Preview path evidence;
 - Scene UUID/name/background/path evidence;
-- current Scene/Preview candidate set without collapsing valid alternatives into a task-specific choice;
-- controlled Display/Stage search/browse independent of controller/channel availability.
+- the current Scene/Preview candidate set without forcing a task-neutral Preview choice;
+- Display and Stage search/browse independent of controller/channel availability.
 
 The shared layer does **not** decide whether a Display is eligible for FieldWiring, Procedures, Testing, Work Orders, or another task.
 
-No PostgreSQL schema, migration, function, trigger, or production data was changed.
-
 ## FieldWiring Remains Narrow
 
-FieldWiring's `repository.py` is now the Wiring-specific adapter over the shared context layer.
+`FieldWiring/Application/repository.py` is the Wiring-specific adapter over the shared context layer.
 
-The normal FieldWiring Display lookup remains intentionally filtered by the existing wiring/device eligibility rules. Inventory-only Displays do not clutter the Wiring search merely because the shared layer can resolve them.
+The normal FieldWiring Display lookup remains intentionally filtered by the existing Wiring/device eligibility rules. Inventory-only Displays do not clutter the Wiring search merely because the shared layer can resolve them.
 
 The accepted distinction is:
 
 ```text
 Shared Field Context
-    active Display exists and current Stage/Scene context can be resolved
+    current Display exists and current Stage/Scene facts can be resolved
 
 FieldWiring eligibility
     Display also satisfies current Wiring-specific LOR/device requirements
 ```
 
-For direct `display_id` entry, FieldWiring can now distinguish:
+For direct `display_id` entry, FieldWiring now distinguishes:
 
 ```text
 unknown / inactive Display
@@ -90,24 +89,22 @@ valid current Display with no applicable Wiring
     -> No applicable field wiring is available for this Display
 ```
 
-This distinction is required for a future common field-home/task-selection experience.
+## Detached Regression Acceptance
 
-## Regression Gate
+Candidate regression was run from an isolated detached server worktree while production remained unchanged.
 
-The branch was tested from an isolated detached worktree while production remained unchanged.
-
-Final full FieldWiring regression result at candidate `c56df80055a80cff6ff497538f1e8f6a892c8bf2`:
+Final candidate result:
 
 ```text
 64 passed in 2.04s
 ```
 
-The suite includes tests proving:
+The suite proves, among other cases:
 
 - shared search can return active non-wired/inventory Displays;
 - a Display with `device_type='None'` can retain shared Stage/Scene context;
-- an active Display with no LOR prop at all can still resolve its permanent Stage;
-- retired/non-current Displays are excluded from current shared context;
+- an active Display with no LOR prop can still resolve its permanent Stage;
+- retired/non-current Displays are excluded;
 - shared Stage browse does not require wiring;
 - the shared database result can feed the unchanged `resolve_structured_scope(...)` filesystem resolver;
 - normal FieldWiring search still excludes non-wired Displays;
@@ -116,34 +113,27 @@ The suite includes tests proving:
 
 ## Real Production-Data Acceptance — Display 807
 
-A real active inventory Display was selected from production:
+Real active inventory Display:
 
 ```text
 display_id   807
 display_name RA-SteelArch-DS-F-03
 ```
 
-The shared candidate resolved live PostgreSQL facts:
+Shared PostgreSQL context resolved:
 
 ```text
 stage_id     55
 stage_key    25
 stage_name   RGB Plus Stage 25 Racing Arches Traditional
 folder_path  G:\Shared drives\Display Folders\25-Racing Arches-RA
+scene_name   25-Racing Arches-RA
+scene_uuid   1bbc0060-36a6-447c-bbf5-0aa2aa8b6502
+preview_name 2026 Master Musical Preview v6.6.10 2026-08-20
+preview_uuid fcf5c29c-8d51-46c5-9ad0-cc47a97c75bd
 ```
 
-Current Scene/Preview candidate:
-
-```text
-scene_name    25-Racing Arches-RA
-scene_uuid    1bbc0060-36a6-447c-bbf5-0aa2aa8b6502
-preview_name  2026 Master Musical Preview v6.6.10 2026-08-20
-preview_uuid  fcf5c29c-8d51-46c5-9ad0-cc47a97c75bd
-```
-
-Those live facts were then passed to the unchanged filesystem resolver against the mounted read-only Google tree.
-
-Result:
+Those facts were passed to the unchanged filesystem resolver against the mounted read-only Google tree:
 
 ```text
 scope_type = SCENE
@@ -153,7 +143,7 @@ warnings   = []
 DISPLAY 807 SHARED STRUCTURED SCOPE: PASS
 ```
 
-The task-eligibility split was also proven:
+Task-eligibility separation was also proven:
 
 ```text
 shared search for RA-SteelArch-DS-F-03 -> [807]
@@ -161,7 +151,7 @@ FieldWiring filtered search            -> []
 FieldWiring display_context(807)       -> None
 ```
 
-Direct FieldWiring request result:
+Direct FieldWiring result:
 
 ```text
 No applicable field wiring is available for this Display
@@ -171,57 +161,94 @@ This proves that **not wired** no longer means **not a valid Display/context**.
 
 ## Existing FieldWiring Equivalence — Display 312
 
-A normal wired production Display was resolved through the candidate and compared with the unchanged production FieldWiring API.
+Normal wired production Display `312` was resolved through the candidate and compared with the unchanged production FieldWiring API.
 
-Display `312` matched on:
-
-- scope type;
-- scope root;
-- warning text;
-- Wiring image list;
-- context image list;
-- relative image path; and
-- image URL.
-
-Result:
+Resolver/image values matched, including scope type, scope root, warning text, Wiring image list, context image list, relative image path, and image URL.
 
 ```text
 DISPLAY 312 FIELDWIRING EQUIVALENCE: PASS
 ```
 
+## Production Deployment Acceptance
+
+PR `#37` merged the shared database-context layer to `main`.
+
+The production `/opt/fieldwiring` checkout was then advanced to:
+
+```text
+decb4eb7030a35bab3fc2e778fcf271463044044
+```
+
+The complete FieldWiring/shared-context suite was rerun in the production checkout:
+
+```text
+64 passed in 2.05s
+```
+
+The service restarted successfully:
+
+```text
+fieldwiring.service = active
+{"data_mode":"postgres","status":"ok","version":"V0.2.0"}
+```
+
+Post-deployment production checks:
+
+```text
+FieldWiring search for RA-SteelArch-DS-F-03 -> []
+Direct FieldWiring display_id=807           -> HTTP 400 / No applicable field wiring
+DISPLAY 807 FIELDWIRING TASK SEPARATION: PASS
+
+Display 807 shared scope:
+scope_type = SCENE
+scope_root = /mnt/msb-display-folders/25-Racing Arches-RA
+warnings   = []
+DISPLAY 807 SHARED FIELD CONTEXT: PASS
+
+Display 312:
+scope_type = STAGE
+scope_root = /mnt/msb-display-folders/15-Church-Bells-CH
+wiring image = RGB Plus Prop Stage 15 Church-Tagged.jpg
+DISPLAY 312 FIELDWIRING POST-DEPLOY: PASS
+```
+
+Result:
+
+```text
+Shared Field Context database layer: DEPLOYED AND VERIFIED
+```
+
 ## Acceptance Decision
 
-The shared PostgreSQL identity/context layer is architecture accepted because:
+The shared PostgreSQL identity/context layer is **production accepted** because:
 
 1. permanent Display identity resolution no longer depends on Wiring eligibility;
 2. active inventory-only/non-wired Displays can resolve current Stage/Scene/Preview context;
-3. all current Scene/Preview candidates are exposed rather than guessed into one task-neutral choice;
-4. the production-accepted filesystem resolver is unchanged;
+3. current Scene/Preview candidates are exposed without a task-neutral guess;
+4. the production-accepted filesystem resolver remains unchanged;
 5. FieldWiring search/browse remains Wiring-filtered;
 6. direct FieldWiring entry distinguishes valid-but-not-wired from nonexistent;
-7. the complete FieldWiring regression suite passes;
-8. real Display `807` proves the full shared database-to-filesystem chain;
-9. wired Display `312` proves existing FieldWiring behavior remains equivalent.
+7. the complete production suite passes;
+8. real Display `807` proves the database-to-filesystem shared chain;
+9. wired Display `312` proves FieldWiring remains operational after deployment.
 
-Production deployment remains a separate acceptance step.
+## Procedure Gate — Cleared
 
-## Procedure Gate
+The Procedure prerequisite is now cleared.
 
-The Procedure branch remains paused until this database-context layer is merged and production accepted.
+Before resuming `feature/setup-takedown-procedures`, refresh it against current `main`. Procedure must consume this same shared repository rather than copy PostgreSQL relationship SQL into `Procedures`.
 
-After that gate clears, Procedure must consume the same shared repository rather than copy PostgreSQL relationship SQL into `Procedures`.
-
-The intended Procedure chain is:
+The required Procedure chain is:
 
 ```text
 permanent Display / Stage / Scene entry
     -> field_context_repository
-    -> fixed database identity/context facts
+    -> current database identity/context facts
     -> field_context_resolver.resolve_structured_scope(...)
     -> Procedures task adapter
 ```
 
-Procedure task/document discovery remains downstream and must not introduce Wiring eligibility filters into the shared context layer.
+Procedure task/document discovery remains downstream and must not introduce Wiring eligibility filters into shared identity/context resolution.
 
 ## Related Documents
 
@@ -229,3 +256,4 @@ Procedure task/document discovery remains downstream and must not introduce Wiri
 - `../09_Wiring_System/FieldWiring_Shared_Structured_Scope_Resolver_Extraction_2026-08-22.md`
 - `../12_Setup_and_Deployment/00_Procedure_System_Field_Context_Handoff_2026-08-22.md`
 - `../12_Setup_and_Deployment/01_Shared_Resolver_Extraction_Handoff_2026-08-22.md`
+- `../12_Setup_and_Deployment/03_Shared_Field_Context_Database_Layer_Handoff_2026-08-23.md`

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/03_Shared_Field_Context_Database_Layer_Handoff_2026-08-23.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/03_Shared_Field_Context_Database_Layer_Handoff_2026-08-23.md
@@ -1,0 +1,141 @@
+# Procedure Subsystem — Shared Field Context Database Layer Handoff — 2026-08-23
+
+| Document control | Value |
+|---|---|
+| Status | CURRENT ENGINEERING HANDOFF — production deployment of shared DB context pending |
+| Shared DB-context branch | `agent/shared-field-context-database-layer` |
+| Accepted candidate | `c56df80055a80cff6ff497538f1e8f6a892c8bf2` |
+| Procedure branch | `feature/setup-takedown-procedures` — remain paused until production acceptance |
+
+## Why this handoff exists
+
+Procedure browser engineering correctly reused the production-accepted filesystem resolver, but exposed a remaining upstream coupling: permanent Display ID -> current Stage/Scene/Preview relationship resolution was still embedded in FieldWiring's `repository.py` and subject to Wiring-specific eligibility filters.
+
+That is not an acceptable shared boundary for Procedures. A valid inventory Display may need Setup/Takedown documentation even when it has no controller/channel assignment and therefore no FieldWiring package.
+
+This handoff records the new shared database-context layer that must be used when Procedure engineering resumes.
+
+## Canonical shared database context
+
+The task-neutral implementation is:
+
+```text
+FieldWiring/Application/field_context_repository.py
+```
+
+It owns current active Display identity plus current Stage/Scene/Preview relationship facts.
+
+The production-accepted filesystem resolver remains:
+
+```text
+FieldWiring/Application/field_context_resolver.py
+```
+
+The combined common chain is:
+
+```text
+DISP:<display_id> / manual Display / Stage / Scene entry
+        -> field_context_repository
+        -> Display + Stage + Scene/Preview candidate facts
+        -> field_context_resolver.resolve_structured_scope(...)
+        -> fixed marked structured scope_root
+        -> Procedure adapter
+```
+
+Procedure must not copy these PostgreSQL queries into a Procedure-owned repository.
+
+## Shared versus task-specific eligibility
+
+The governing rule is:
+
+```text
+Shared Field Context
+    resolves every current active Display and its available hierarchy facts
+    without requiring Wiring eligibility
+
+FieldWiring
+    keeps current Wiring-specific search/browse/device eligibility downstream
+
+Procedures
+    may use wired or non-wired Displays when the resolved structured scope
+    owns current Setup/Takedown/Inspection documentation
+```
+
+Therefore an inventory-only steel arch can be a valid Procedure entry even when FieldWiring correctly reports no applicable wiring.
+
+## Real acceptance fixture
+
+Production Display:
+
+```text
+807  RA-SteelArch-DS-F-03
+```
+
+Shared database result:
+
+```text
+stage_id     55
+stage_key    25
+stage_name   RGB Plus Stage 25 Racing Arches Traditional
+folder_path  G:\Shared drives\Display Folders\25-Racing Arches-RA
+scene_name   25-Racing Arches-RA
+preview      2026 Master Musical Preview v6.6.10 2026-08-20
+```
+
+The unchanged shared filesystem resolver then returned:
+
+```text
+scope_type = SCENE
+scope_root = /mnt/msb-display-folders/25-Racing Arches-RA
+warnings   = []
+```
+
+At the same time:
+
+```text
+shared Display search -> includes 807
+FieldWiring search     -> excludes 807
+FieldWiring direct     -> No applicable field wiring is available for this Display
+```
+
+This is the required distinction between **valid field context** and **task availability**.
+
+## Regression evidence
+
+Complete FieldWiring + shared-context candidate suite:
+
+```text
+64 passed in 2.04s
+```
+
+Normal wired Display `312` was also compared against the unchanged production FieldWiring API and remained equivalent at the resolver/image boundary.
+
+## Procedure resume rule
+
+Do not resume substantive Procedure browser/database orchestration until this shared database-context layer is merged and production accepted.
+
+After production acceptance, resume `feature/setup-takedown-procedures` by refreshing/rebasing it onto current `main` and replacing any planned FieldWiring-repository dependency with the canonical shared context repository.
+
+Preserve the already accepted Procedure second-caller boundary:
+
+```text
+shared DB context
+    -> shared filesystem scope
+    -> Procedure task adapter
+    -> Procedures/Setup | Takedown | Inspection
+```
+
+Do not:
+
+- widen FieldWiring search to every inventory Display;
+- apply `device_type`/controller/channel eligibility to Procedure identity lookup;
+- copy FieldWiring SQL into Procedures;
+- redesign `resolve_structured_scope(...)`;
+- create a second Stage/Scene filesystem resolver;
+- create new schema merely to support this first shared read path.
+
+## Related documents
+
+- `../07_Labeling_and_Scanning/Shared_Field_Context_Database_Layer_Acceptance_2026-08-23.md`
+- `00_Procedure_System_Field_Context_Handoff_2026-08-22.md`
+- `01_Shared_Resolver_Extraction_Handoff_2026-08-22.md`

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/03_Shared_Field_Context_Database_Layer_Handoff_2026-08-23.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/03_Shared_Field_Context_Database_Layer_Handoff_2026-08-23.md
@@ -2,18 +2,19 @@
 
 | Document control | Value |
 |---|---|
-| Status | CURRENT ENGINEERING HANDOFF — production deployment of shared DB context pending |
-| Shared DB-context branch | `agent/shared-field-context-database-layer` |
-| Accepted candidate | `c56df80055a80cff6ff497538f1e8f6a892c8bf2` |
-| Procedure branch | `feature/setup-takedown-procedures` — remain paused until production acceptance |
+| Status | **CURRENT ENGINEERING HANDOFF — shared database context production accepted; Procedure gate cleared** |
+| Shared DB-context implementation | `FieldWiring/Application/field_context_repository.py` |
+| Merge PR | `#37` |
+| Production deployment commit | `decb4eb7030a35bab3fc2e778fcf271463044044` |
+| Procedure branch | `feature/setup-takedown-procedures` — refresh/rebase onto current `main` before resuming |
 
 ## Why this handoff exists
 
 Procedure browser engineering correctly reused the production-accepted filesystem resolver, but exposed a remaining upstream coupling: permanent Display ID -> current Stage/Scene/Preview relationship resolution was still embedded in FieldWiring's `repository.py` and subject to Wiring-specific eligibility filters.
 
-That is not an acceptable shared boundary for Procedures. A valid inventory Display may need Setup/Takedown documentation even when it has no controller/channel assignment and therefore no FieldWiring package.
+That was not an acceptable shared boundary for Procedures. A valid inventory Display may need Setup/Takedown documentation even when it has no controller/channel assignment and therefore no FieldWiring package.
 
-This handoff records the new shared database-context layer that must be used when Procedure engineering resumes.
+That gap is now closed and production accepted.
 
 ## Canonical shared database context
 
@@ -31,7 +32,7 @@ The production-accepted filesystem resolver remains:
 FieldWiring/Application/field_context_resolver.py
 ```
 
-The combined common chain is:
+The common chain is now:
 
 ```text
 DISP:<display_id> / manual Display / Stage / Scene entry
@@ -61,9 +62,9 @@ Procedures
     owns current Setup/Takedown/Inspection documentation
 ```
 
-Therefore an inventory-only steel arch can be a valid Procedure entry even when FieldWiring correctly reports no applicable wiring.
+Therefore an inventory-only steel arch is a valid Procedure entry even when FieldWiring correctly reports no applicable wiring.
 
-## Real acceptance fixture
+## Real production acceptance fixture
 
 Production Display:
 
@@ -82,7 +83,7 @@ scene_name   25-Racing Arches-RA
 preview      2026 Master Musical Preview v6.6.10 2026-08-20
 ```
 
-The unchanged shared filesystem resolver then returned:
+The unchanged shared filesystem resolver returned:
 
 ```text
 scope_type = SCENE
@@ -100,23 +101,55 @@ FieldWiring direct     -> No applicable field wiring is available for this Displ
 
 This is the required distinction between **valid field context** and **task availability**.
 
-## Regression evidence
+## Acceptance evidence
 
-Complete FieldWiring + shared-context candidate suite:
+Detached candidate regression:
 
 ```text
 64 passed in 2.04s
 ```
 
-Normal wired Display `312` was also compared against the unchanged production FieldWiring API and remained equivalent at the resolver/image boundary.
+Normal wired Display `312` remained equivalent to the unchanged production FieldWiring API before merge.
 
-## Procedure resume rule
+After PR `#37` merged, production `/opt/fieldwiring` was advanced to:
 
-Do not resume substantive Procedure browser/database orchestration until this shared database-context layer is merged and production accepted.
+```text
+decb4eb7030a35bab3fc2e778fcf271463044044
+```
 
-After production acceptance, resume `feature/setup-takedown-procedures` by refreshing/rebasing it onto current `main` and replacing any planned FieldWiring-repository dependency with the canonical shared context repository.
+Production regression and service verification:
 
-Preserve the already accepted Procedure second-caller boundary:
+```text
+64 passed in 2.05s
+fieldwiring.service = active
+{"data_mode":"postgres","status":"ok","version":"V0.2.0"}
+```
+
+Post-deployment checks:
+
+```text
+DISPLAY 807 FIELDWIRING TASK SEPARATION: PASS
+DISPLAY 807 SHARED FIELD CONTEXT: PASS
+DISPLAY 312 FIELDWIRING POST-DEPLOY: PASS
+Shared Field Context database layer: DEPLOYED AND VERIFIED
+```
+
+The shared database-context layer is therefore **production accepted**.
+
+## Procedure resume rule — Gate cleared
+
+The previous pause is now cleared.
+
+Before substantive Procedure browser/database orchestration resumes:
+
+1. refresh/fetch current `main`;
+2. rebase or deliberately merge `feature/setup-takedown-procedures` onto current `main`;
+3. preserve the already accepted Procedure second-caller filesystem adapter work;
+4. use the canonical shared `field_context_repository` for permanent Display/Stage/Scene/Preview facts;
+5. pass those facts into the unchanged `field_context_resolver.resolve_structured_scope(...)`;
+6. keep Procedure task/document discovery downstream.
+
+Preserve this architecture:
 
 ```text
 shared DB context
@@ -132,7 +165,7 @@ Do not:
 - copy FieldWiring SQL into Procedures;
 - redesign `resolve_structured_scope(...)`;
 - create a second Stage/Scene filesystem resolver;
-- create new schema merely to support this first shared read path.
+- create new schema merely to support this shared read path.
 
 ## Related documents
 

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/04_Procedure_Resume_After_Shared_DB_Context_2026-08-23.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/04_Procedure_Resume_After_Shared_DB_Context_2026-08-23.md
@@ -1,0 +1,43 @@
+# Procedure Resume Checkpoint After Shared Database Context — 2026-08-23
+
+Status: **READY TO RESUME ENGINEERING**
+
+The Procedure subsystem pause is cleared.
+
+Production-accepted shared prerequisites now include:
+
+```text
+FieldWiring/Application/field_context_repository.py
+FieldWiring/Application/field_context_resolver.py
+```
+
+Production FieldWiring commit used to accept the shared database-context layer:
+
+```text
+decb4eb7030a35bab3fc2e778fcf271463044044
+```
+
+Acceptance evidence:
+
+```text
+64 passed in production checkout
+fieldwiring.service active
+Display 807 shared context PASS
+Display 807 FieldWiring task separation PASS
+Display 312 FieldWiring post-deploy PASS
+```
+
+When `feature/setup-takedown-procedures` resumes, first refresh it against current `main`. Preserve its accepted `procedure_documents.py` second-caller work, but route permanent Display/Stage/Scene/Preview database facts through `field_context_repository.py` rather than FieldWiring's task-filtered `repository.py` or copied SQL.
+
+Required chain:
+
+```text
+permanent Display / manual Stage/Scene selection
+    -> shared field_context_repository
+    -> shared field_context_resolver.resolve_structured_scope(...)
+    -> fixed scope_root
+    -> Procedure task adapter
+    -> Procedures/Setup | Procedures/Takedown | Procedures/Inspection
+```
+
+FieldWiring-specific wiring eligibility remains downstream and must not be imported into Procedure identity/context resolution.

--- a/FieldWiring/Application/field_context_repository.py
+++ b/FieldWiring/Application/field_context_repository.py
@@ -1,0 +1,570 @@
+"""Task-neutral read-only Production Database field-context repository.
+
+This module owns permanent Display -> Stage / Scene / Preview relationship
+resolution for field applications. It deliberately does not decide whether a
+Display is eligible for FieldWiring, Procedures, Testing, or any other task.
+
+The filesystem Stage/Sub-stage/Scene resolver remains in
+``field_context_resolver.py``. This repository supplies the authoritative
+current database facts that a caller passes to that resolver.
+"""
+from __future__ import annotations
+
+import re
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator
+
+try:
+    import psycopg2
+    from psycopg2.extras import RealDictCursor
+except ImportError:  # development snapshot mode does not require psycopg2
+    psycopg2 = None
+    RealDictCursor = None
+
+
+class ConfigError(RuntimeError):
+    pass
+
+
+def classify_context(preview_name: str | None) -> str:
+    name = (preview_name or "").lower()
+    if "master musical" in name:
+        return "Musical"
+    if "show background" in name or name.startswith("show stage"):
+        return "Background / Static"
+    if "show animation" in name:
+        return "Animation"
+    return "Other"
+
+
+def normalized_display_query(value: str) -> tuple[str, str]:
+    value = value.strip()
+    match = re.fullmatch(r"DISP:(\d+)", value, re.IGNORECASE)
+    if match:
+        return "id", match.group(1)
+    if value.isdigit():
+        return "id", value
+    return "text", value
+
+
+def _scope_kind(scene_name: str | None) -> str:
+    return (
+        "Scene"
+        if scene_name and scene_name.strip().casefold() != "root"
+        else "Stage / Preview"
+    )
+
+
+def _stage_payload(row: Any) -> dict[str, Any]:
+    return {
+        "stage_id": row["stage_id"],
+        "stage_key": row["stage_key"],
+        "stage_name": row["stage_name"],
+        "folder_path": row["folder_path"],
+    }
+
+
+def _context_payload(
+    *,
+    preview_uuid: str | None,
+    preview_name: str | None,
+    preview_background_file: str | None,
+    preview_revision: Any = None,
+    source_filename: str | None = None,
+    scene_uuid: str | None,
+    scene_name: str | None,
+    scene_stage_key: Any = None,
+    scene_background_file: str | None = None,
+) -> dict[str, Any]:
+    preview = {
+        "preview_uuid": preview_uuid,
+        "preview_name": preview_name,
+        "preview_background_file": preview_background_file,
+        "preview_revision": preview_revision,
+        "source_filename": source_filename,
+    }
+    scene = None
+    if scene_uuid or scene_name:
+        scene = {
+            "scene_uuid": scene_uuid,
+            "scene_name": scene_name,
+            "scene_stage_key": scene_stage_key,
+            "scene_background_file": scene_background_file,
+        }
+    return {
+        "preview": preview,
+        "scene": scene,
+        "scope_kind": _scope_kind(scene_name),
+        "context_type": classify_context(preview_name),
+    }
+
+
+class FieldContextRepository:
+    """Task-neutral current Display/Stage/Scene/Preview relationship contract."""
+
+    def search_displays(self, query: str, limit: int = 40) -> list[dict[str, Any]]:
+        raise NotImplementedError
+
+    def display_context(self, display_id: int) -> dict[str, Any] | None:
+        raise NotImplementedError
+
+    def stages(self) -> list[dict[str, Any]]:
+        raise NotImplementedError
+
+
+class SQLiteFieldContextRepository(FieldContextRepository):
+    """Read-only shared field context over a FieldWiring SQLite fixture."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+        if not self.path.is_file():
+            raise ConfigError(f"FIELDWIRING_DEV_SNAPSHOT does not exist: {self.path}")
+
+    @contextmanager
+    def connect(self) -> Iterator[sqlite3.Connection]:
+        uri = f"file:{self.path.as_posix()}?mode=ro"
+        conn = sqlite3.connect(uri, uri=True)
+        conn.row_factory = sqlite3.Row
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    @staticmethod
+    def _has_table(conn: sqlite3.Connection, table_name: str) -> bool:
+        row = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type IN ('table','view') AND name = ? LIMIT 1",
+            (table_name,),
+        ).fetchone()
+        return row is not None
+
+    @staticmethod
+    def _has_column(conn: sqlite3.Connection, table_name: str, column_name: str) -> bool:
+        try:
+            rows = conn.execute(f"PRAGMA table_info({table_name})").fetchall()
+        except sqlite3.DatabaseError:
+            return False
+        return any(row["name"] == column_name for row in rows)
+
+    def _display_base_with_connection(
+        self,
+        conn: sqlite3.Connection,
+        display_id: int,
+    ) -> sqlite3.Row | None:
+        folder_sql = (
+            "s.folder_path"
+            if self._has_column(conn, "ref__stage", "folder_path")
+            else "NULL AS folder_path"
+        )
+        return conn.execute(
+            f"""
+            SELECT d.display_id, d.display_name, d.stage_id,
+                   s.stage_key, s.stage_name, {folder_sql}
+            FROM ref__display d
+            LEFT JOIN ref__stage s ON s.stage_id = d.stage_id
+            WHERE d.display_id = ? AND d.display_status_id = 1
+            """,
+            (display_id,),
+        ).fetchone()
+
+    def _context_details(
+        self,
+        conn: sqlite3.Connection,
+        preview_uuid: str | None,
+        scene_uuid: str | None,
+        fallback_preview_name: str | None,
+        fallback_scene_name: str | None,
+        fallback_scene_stage_key: Any,
+    ) -> dict[str, Any]:
+        preview_name = fallback_preview_name
+        preview_background_file = None
+        preview_revision = None
+        source_filename = None
+        if preview_uuid and self._has_table(conn, "lor_snap__v_current_previews"):
+            row = conn.execute(
+                """
+                SELECT name, background_file, revision, source_filename
+                FROM lor_snap__v_current_previews
+                WHERE id = ? LIMIT 1
+                """,
+                (preview_uuid,),
+            ).fetchone()
+            if row:
+                preview_name = row["name"] or preview_name
+                preview_background_file = row["background_file"]
+                preview_revision = row["revision"]
+                source_filename = row["source_filename"]
+
+        scene_name = fallback_scene_name
+        scene_stage_key = fallback_scene_stage_key
+        scene_background_file = None
+        if (
+            preview_uuid
+            and scene_uuid
+            and self._has_table(conn, "lor_snap__v_current_scenes")
+        ):
+            row = conn.execute(
+                """
+                SELECT name, stage_id, background_file
+                FROM lor_snap__v_current_scenes
+                WHERE preview_id = ? AND scene_id = ? LIMIT 1
+                """,
+                (preview_uuid, scene_uuid),
+            ).fetchone()
+            if row:
+                scene_name = row["name"] or scene_name
+                scene_stage_key = row["stage_id"] or scene_stage_key
+                scene_background_file = row["background_file"]
+
+        return _context_payload(
+            preview_uuid=preview_uuid,
+            preview_name=preview_name,
+            preview_background_file=preview_background_file,
+            preview_revision=preview_revision,
+            source_filename=source_filename,
+            scene_uuid=scene_uuid,
+            scene_name=scene_name,
+            scene_stage_key=scene_stage_key,
+            scene_background_file=scene_background_file,
+        )
+
+    def _contexts_with_connection(
+        self,
+        conn: sqlite3.Connection,
+        display_name: str,
+    ) -> list[dict[str, Any]]:
+        if not self._has_table(conn, "lor_snap__v_display_lor_occurrence"):
+            return []
+        rows = conn.execute(
+            """
+            SELECT preview_id, preview_name, preview_stage_id,
+                   scene_id, scene_name, scene_stage_id, location_type
+            FROM lor_snap__v_display_lor_occurrence
+            WHERE display_name = ? AND location_type = 'SCENE'
+            ORDER BY
+                CASE WHEN lower(coalesce(scene_name, '')) = 'root' THEN 1 ELSE 0 END,
+                preview_name,
+                scene_name
+            """,
+            (display_name,),
+        ).fetchall()
+        contexts: list[dict[str, Any]] = []
+        seen: set[tuple[Any, Any]] = set()
+        for row in rows:
+            key = (row["preview_id"], row["scene_id"])
+            if key in seen:
+                continue
+            seen.add(key)
+            contexts.append(
+                self._context_details(
+                    conn,
+                    row["preview_id"],
+                    row["scene_id"],
+                    row["preview_name"],
+                    row["scene_name"],
+                    row["scene_stage_id"] or row["preview_stage_id"],
+                )
+            )
+        return contexts
+
+    def display_context_with_connection(
+        self,
+        conn: sqlite3.Connection,
+        display_id: int,
+    ) -> dict[str, Any] | None:
+        row = self._display_base_with_connection(conn, display_id)
+        if row is None:
+            return None
+        return {
+            "display_id": row["display_id"],
+            "display_name": row["display_name"],
+            "stage": _stage_payload(row),
+            "contexts": self._contexts_with_connection(conn, row["display_name"]),
+        }
+
+    def display_context(self, display_id: int) -> dict[str, Any] | None:
+        with self.connect() as conn:
+            return self.display_context_with_connection(conn, display_id)
+
+    def search_displays(self, query: str, limit: int = 40) -> list[dict[str, Any]]:
+        kind, value = normalized_display_query(query)
+        if not value:
+            return []
+        with self.connect() as conn:
+            folder_sql = (
+                "s.folder_path"
+                if self._has_column(conn, "ref__stage", "folder_path")
+                else "NULL AS folder_path"
+            )
+            if kind == "id":
+                rows = conn.execute(
+                    f"""
+                    SELECT d.display_id, d.display_name, d.stage_id,
+                           s.stage_key, s.stage_name, {folder_sql}
+                    FROM ref__display d
+                    LEFT JOIN ref__stage s ON s.stage_id = d.stage_id
+                    WHERE d.display_status_id = 1 AND d.display_id = ?
+                    """,
+                    (int(value),),
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    f"""
+                    SELECT d.display_id, d.display_name, d.stage_id,
+                           s.stage_key, s.stage_name, {folder_sql}
+                    FROM ref__display d
+                    LEFT JOIN ref__stage s ON s.stage_id = d.stage_id
+                    WHERE d.display_status_id = 1
+                      AND lower(d.display_name) LIKE lower(?)
+                    ORDER BY CASE WHEN lower(d.display_name) = lower(?) THEN 0 ELSE 1 END,
+                             d.display_name
+                    LIMIT ?
+                    """,
+                    (f"%{value}%", value, limit),
+                ).fetchall()
+        return [
+            {
+                "display_id": row["display_id"],
+                "display_name": row["display_name"],
+                "stage": _stage_payload(row),
+            }
+            for row in rows
+        ]
+
+    def stages(self) -> list[dict[str, Any]]:
+        with self.connect() as conn:
+            folder_sql = (
+                "folder_path"
+                if self._has_column(conn, "ref__stage", "folder_path")
+                else "NULL AS folder_path"
+            )
+            stage_rows = conn.execute(
+                f"""
+                SELECT stage_id, stage_key, stage_name, {folder_sql}, park_order, sub_order
+                FROM ref__stage
+                ORDER BY park_order, sub_order, stage_key
+                """
+            ).fetchall()
+            scene_rows = []
+            if self._has_table(conn, "lor_snap__v_display_lor_occurrence"):
+                scene_rows = conn.execute(
+                    """
+                    SELECT DISTINCT preview_id, preview_name, preview_stage_id,
+                           scene_id, scene_name, scene_stage_id
+                    FROM lor_snap__v_display_lor_occurrence
+                    WHERE location_type = 'SCENE'
+                    ORDER BY preview_name, scene_name
+                    """
+                ).fetchall()
+
+            by_stage: dict[str, list[dict[str, Any]]] = {}
+            seen: set[tuple[str, Any, Any]] = set()
+            for row in scene_rows:
+                stage_key = row["scene_stage_id"] or row["preview_stage_id"]
+                if not stage_key:
+                    continue
+                key = (str(stage_key), row["preview_id"], row["scene_id"])
+                if key in seen:
+                    continue
+                seen.add(key)
+                by_stage.setdefault(str(stage_key), []).append(
+                    self._context_details(
+                        conn,
+                        row["preview_id"],
+                        row["scene_id"],
+                        row["preview_name"],
+                        row["scene_name"],
+                        stage_key,
+                    )
+                )
+
+        result: list[dict[str, Any]] = []
+        for row in stage_rows:
+            contexts = by_stage.get(str(row["stage_key"]), [])
+            result.append({"stage": _stage_payload(row), "contexts": contexts})
+        return result
+
+
+class PostgresFieldContextRepository(FieldContextRepository):
+    """Production shared field-context adapter. Sessions are read-only."""
+
+    def __init__(self, dsn: str) -> None:
+        if psycopg2 is None:
+            raise ConfigError("psycopg2 is required for PostgreSQL mode")
+        self.dsn = dsn
+
+    @contextmanager
+    def connect(self) -> Iterator[Any]:
+        conn = psycopg2.connect(self.dsn)
+        conn.set_session(readonly=True, autocommit=True)
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    @staticmethod
+    def _row_dicts(cur: Any) -> list[dict[str, Any]]:
+        return [dict(row) for row in cur.fetchall()]
+
+    def display_context_with_cursor(self, cur: Any, display_id: int) -> dict[str, Any] | None:
+        cur.execute(
+            """
+            SELECT d.display_id, d.display_name, d.stage_id,
+                   st.stage_key, st.stage_name, st.folder_path
+            FROM ref.display d
+            LEFT JOIN ref.stage st ON st.stage_id = d.stage_id
+            WHERE d.display_id = %s AND d.display_status_id = 1
+            """,
+            (display_id,),
+        )
+        row = cur.fetchone()
+        if row is None:
+            return None
+        base = dict(row)
+
+        cur.execute(
+            """
+            SELECT
+                ls.preview_uuid,
+                cp.name AS preview_name,
+                cp.background_file AS preview_background_file,
+                cp.revision AS preview_revision,
+                cp.source_filename,
+                ls.scene_uuid,
+                ls.scene_name,
+                ls.stage_id AS scene_stage_id,
+                ls.background_file AS scene_background_file
+            FROM ref.lor_scene_display lsd
+            JOIN ref.lor_scene ls ON ls.lor_scene_id = lsd.lor_scene_id
+            LEFT JOIN lor_snap.v_current_previews cp ON cp.id = ls.preview_uuid
+            WHERE lsd.display_id = %s
+            ORDER BY
+                CASE WHEN lower(coalesce(ls.scene_name, '')) = 'root' THEN 1 ELSE 0 END,
+                cp.name,
+                ls.scene_name
+            """,
+            (display_id,),
+        )
+        contexts = [
+            _context_payload(
+                preview_uuid=item.get("preview_uuid"),
+                preview_name=item.get("preview_name"),
+                preview_background_file=item.get("preview_background_file"),
+                preview_revision=item.get("preview_revision"),
+                source_filename=item.get("source_filename"),
+                scene_uuid=item.get("scene_uuid"),
+                scene_name=item.get("scene_name"),
+                scene_stage_key=item.get("scene_stage_id"),
+                scene_background_file=item.get("scene_background_file"),
+            )
+            for item in self._row_dicts(cur)
+        ]
+        return {
+            "display_id": base["display_id"],
+            "display_name": base["display_name"],
+            "stage": _stage_payload(base),
+            "contexts": contexts,
+        }
+
+    def display_context(self, display_id: int) -> dict[str, Any] | None:
+        with self.connect() as conn, conn.cursor(cursor_factory=RealDictCursor) as cur:
+            return self.display_context_with_cursor(cur, display_id)
+
+    def search_displays(self, query: str, limit: int = 40) -> list[dict[str, Any]]:
+        kind, value = normalized_display_query(query)
+        if not value:
+            return []
+        with self.connect() as conn, conn.cursor(cursor_factory=RealDictCursor) as cur:
+            if kind == "id":
+                cur.execute(
+                    """
+                    SELECT d.display_id, d.display_name, d.stage_id,
+                           st.stage_key, st.stage_name, st.folder_path
+                    FROM ref.display d
+                    LEFT JOIN ref.stage st ON st.stage_id = d.stage_id
+                    WHERE d.display_status_id = 1 AND d.display_id = %s
+                    """,
+                    (int(value),),
+                )
+            else:
+                cur.execute(
+                    """
+                    SELECT d.display_id, d.display_name, d.stage_id,
+                           st.stage_key, st.stage_name, st.folder_path
+                    FROM ref.display d
+                    LEFT JOIN ref.stage st ON st.stage_id = d.stage_id
+                    WHERE d.display_status_id = 1
+                      AND d.display_name ILIKE %s
+                    ORDER BY
+                        CASE WHEN lower(d.display_name) = lower(%s) THEN 0 ELSE 1 END,
+                        d.display_name
+                    LIMIT %s
+                    """,
+                    (f"%{value}%", value, limit),
+                )
+            rows = self._row_dicts(cur)
+        return [
+            {
+                "display_id": row["display_id"],
+                "display_name": row["display_name"],
+                "stage": _stage_payload(row),
+            }
+            for row in rows
+        ]
+
+    def stages(self) -> list[dict[str, Any]]:
+        with self.connect() as conn, conn.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute(
+                """
+                SELECT stage_id, stage_key, stage_name, folder_path,
+                       park_order, sub_order
+                FROM ref.stage
+                ORDER BY park_order, sub_order, stage_key
+                """
+            )
+            stage_rows = self._row_dicts(cur)
+
+            cur.execute(
+                """
+                SELECT
+                    ls.stage_id,
+                    ls.preview_uuid,
+                    cp.name AS preview_name,
+                    cp.background_file AS preview_background_file,
+                    cp.revision AS preview_revision,
+                    cp.source_filename,
+                    ls.scene_uuid,
+                    ls.scene_name,
+                    ls.background_file AS scene_background_file
+                FROM ref.lor_scene ls
+                LEFT JOIN lor_snap.v_current_previews cp ON cp.id = ls.preview_uuid
+                ORDER BY ls.stage_id, cp.name, ls.scene_name
+                """
+            )
+            context_rows = self._row_dicts(cur)
+
+        by_stage: dict[int, list[dict[str, Any]]] = {}
+        for item in context_rows:
+            by_stage.setdefault(int(item["stage_id"]), []).append(
+                _context_payload(
+                    preview_uuid=item.get("preview_uuid"),
+                    preview_name=item.get("preview_name"),
+                    preview_background_file=item.get("preview_background_file"),
+                    preview_revision=item.get("preview_revision"),
+                    source_filename=item.get("source_filename"),
+                    scene_uuid=item.get("scene_uuid"),
+                    scene_name=item.get("scene_name"),
+                    scene_stage_key=item.get("stage_id"),
+                    scene_background_file=item.get("scene_background_file"),
+                )
+            )
+
+        return [
+            {
+                "stage": _stage_payload(row),
+                "contexts": by_stage.get(int(row["stage_id"]), []),
+            }
+            for row in stage_rows
+        ]

--- a/FieldWiring/Application/repository.py
+++ b/FieldWiring/Application/repository.py
@@ -181,7 +181,7 @@ class SQLiteSnapshotRepository(Repository):
             )
 
     def stages(self) -> list[dict[str, Any]]:
-        # FieldWiring browse intentionally remains wiring-filtered.
+        # Preserve the accepted SQLite development-snapshot behavior exactly.
         with self.connect() as conn:
             stage_rows = conn.execute(
                 """
@@ -194,16 +194,8 @@ class SQLiteSnapshotRepository(Repository):
                 """
                 SELECT DISTINCT preview_id, preview_name, preview_stage_id,
                        scene_id, scene_name, scene_stage_id
-                FROM lor_snap__v_display_lor_occurrence o
+                FROM lor_snap__v_display_lor_occurrence
                 WHERE location_type = 'SCENE'
-                  AND EXISTS (
-                      SELECT 1
-                      FROM ref__display d
-                      JOIN lor_snap__v_current_props p ON p.raw_prop_id = d.lor_prop_id
-                      WHERE d.display_name = o.display_name
-                        AND d.display_status_id = 1
-                        AND lower(coalesce(p.device_type, '')) <> 'none'
-                  )
                 ORDER BY preview_name, scene_name
                 """
             ).fetchall()
@@ -273,7 +265,7 @@ class PostgresRepository(Repository):
         return self._field_context.stages()
 
     @staticmethod
-    def _fieldwiring_device_type(cur: Any, display_id: int) -> str | None:
+    def _fieldwiring_device_type(cur: Any, display_id: int) -> tuple[bool, str | None]:
         cur.execute(
             """
             SELECT p.device_type
@@ -287,7 +279,7 @@ class PostgresRepository(Repository):
             (display_id,),
         )
         row = cur.fetchone()
-        return row["device_type"] if row else None
+        return (row is not None, row["device_type"] if row else None)
 
     def search_displays(self, query: str, limit: int = 40) -> list[dict[str, Any]]:
         kind, value = normalized_display_query(query)
@@ -352,13 +344,13 @@ class PostgresRepository(Repository):
             shared = self._field_context.display_context_with_cursor(cur, display_id)
             if shared is None:
                 return None
-            device_type = self._fieldwiring_device_type(cur, display_id)
-            if device_type is None:
+            eligible, device_type = self._fieldwiring_device_type(cur, display_id)
+            if not eligible:
                 return None
             return _flatten_fieldwiring_context(shared, device_type)
 
     def stages(self) -> list[dict[str, Any]]:
-        # FieldWiring browse intentionally remains wiring-filtered.
+        # Preserve the production FieldWiring browse eligibility filter exactly.
         with self.connect() as conn, conn.cursor(cursor_factory=RealDictCursor) as cur:
             cur.execute(
                 """

--- a/FieldWiring/Application/repository.py
+++ b/FieldWiring/Application/repository.py
@@ -1,47 +1,72 @@
-"""Read-only FieldWiring lookup repository adapters."""
-
+"""Read-only FieldWiring repository adapter over shared field context."""
 from __future__ import annotations
 
-import re
 import sqlite3
-from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Any
 
-try:
-    import psycopg2
-    from psycopg2.extras import RealDictCursor
-except ImportError:  # development snapshot mode does not require psycopg2
-    psycopg2 = None
-    RealDictCursor = None
-
-
-class ConfigError(RuntimeError):
-    pass
+from field_context_repository import (
+    ConfigError,
+    PostgresFieldContextRepository,
+    RealDictCursor,
+    SQLiteFieldContextRepository,
+    classify_context,
+    normalized_display_query,
+)
 
 
-def classify_context(preview_name: str | None) -> str:
-    name = (preview_name or "").lower()
-    if "master musical" in name:
-        return "Musical"
-    if "show background" in name or name.startswith("show stage"):
-        return "Background / Static"
-    if "show animation" in name:
-        return "Animation"
-    return "Other"
-
-
-def normalized_display_query(value: str) -> tuple[str, str]:
-    value = value.strip()
-    match = re.fullmatch(r"DISP:(\d+)", value, re.IGNORECASE)
-    if match:
-        return "id", match.group(1)
-    if value.isdigit():
-        return "id", value
-    return "text", value
+def _flatten_fieldwiring_context(
+    shared: dict[str, Any],
+    device_type: str | None,
+) -> dict[str, Any]:
+    """Adapt shared identity/context facts to FieldWiring's legacy flat shape."""
+    stage = shared.get("stage") or {}
+    contexts = shared.get("contexts") or []
+    selected = contexts[0] if contexts else None
+    preview = (selected or {}).get("preview") or {}
+    scene = (selected or {}).get("scene") or {}
+    scene_name = scene.get("scene_name")
+    return {
+        "display_id": shared.get("display_id"),
+        "display_name": shared.get("display_name"),
+        "stage_id": stage.get("stage_id"),
+        "stage_key": stage.get("stage_key"),
+        "stage_name": stage.get("stage_name"),
+        "device_type": device_type,
+        "preview_uuid": preview.get("preview_uuid"),
+        "preview_name": preview.get("preview_name"),
+        "scene_uuid": scene.get("scene_uuid"),
+        "scene_name": scene_name,
+        "scope_kind": (
+            (selected or {}).get("scope_kind")
+            if selected
+            else "Stage / Preview"
+        ),
+        "context_type": (
+            (selected or {}).get("context_type")
+            if selected
+            else classify_context(None)
+        ),
+    }
 
 
 class Repository:
+    """FieldWiring-facing repository contract.
+
+    ``shared_*`` methods expose task-neutral identity/context facts. The legacy
+    methods remain FieldWiring-filtered so the existing Wiring search/browse UI
+    does not widen to inventory-only Displays.
+    """
+
+    def shared_search_displays(self, query: str, limit: int = 40) -> list[dict[str, Any]]:
+        raise NotImplementedError
+
+    def shared_display_context(self, display_id: int) -> dict[str, Any] | None:
+        raise NotImplementedError
+
+    def shared_stages(self) -> list[dict[str, Any]]:
+        raise NotImplementedError
+
     def search_displays(self, query: str, limit: int = 40) -> list[dict[str, Any]]:
         raise NotImplementedError
 
@@ -53,22 +78,23 @@ class Repository:
 
 
 class SQLiteSnapshotRepository(Repository):
-    """Read-only development adapter for exported FieldWiring snapshot fixtures."""
+    """FieldWiring adapter over the shared read-only SQLite field context."""
 
     def __init__(self, path: str) -> None:
         self.path = Path(path)
-        if not self.path.is_file():
-            raise ConfigError(f"FIELDWIRING_DEV_SNAPSHOT does not exist: {self.path}")
+        self._field_context = SQLiteFieldContextRepository(self.path)
 
-    @contextmanager
-    def connect(self) -> Iterator[sqlite3.Connection]:
-        uri = f"file:{self.path.as_posix()}?mode=ro"
-        conn = sqlite3.connect(uri, uri=True)
-        conn.row_factory = sqlite3.Row
-        try:
-            yield conn
-        finally:
-            conn.close()
+    def connect(self):
+        return self._field_context.connect()
+
+    def shared_search_displays(self, query: str, limit: int = 40) -> list[dict[str, Any]]:
+        return self._field_context.search_displays(query, limit)
+
+    def shared_display_context(self, display_id: int) -> dict[str, Any] | None:
+        return self._field_context.display_context(display_id)
+
+    def shared_stages(self) -> list[dict[str, Any]]:
+        return self._field_context.stages()
 
     def _device_type(self, conn: sqlite3.Connection, lor_prop_id: str | None) -> str | None:
         if not lor_prop_id:
@@ -83,70 +109,6 @@ class SQLiteSnapshotRepository(Repository):
             (lor_prop_id,),
         ).fetchone()
         return row[0] if row else None
-
-    def _display_base(self, conn: sqlite3.Connection, display_id: int) -> sqlite3.Row | None:
-        return conn.execute(
-            """
-            SELECT d.display_id, d.display_name, d.stage_id, d.lor_prop_id,
-                   s.stage_key, s.stage_name
-            FROM ref__display d
-            LEFT JOIN ref__stage s ON s.stage_id = d.stage_id
-            WHERE d.display_id = ? AND d.display_status_id = 1
-            """,
-            (display_id,),
-        ).fetchone()
-
-    def _occurrence_context(self, conn: sqlite3.Connection, display_name: str) -> dict[str, Any]:
-        rows = conn.execute(
-            """
-            SELECT preview_id, preview_name, preview_stage_id,
-                   scene_id, scene_name, scene_stage_id, location_type
-            FROM lor_snap__v_display_lor_occurrence
-            WHERE display_name = ?
-            ORDER BY preview_name, scene_name
-            """,
-            (display_name,),
-        ).fetchall()
-        if not rows:
-            return {
-                "preview_uuid": None,
-                "preview_name": None,
-                "scene_uuid": None,
-                "scene_name": None,
-                "scope_kind": "Unresolved",
-                "context_type": "Unknown",
-            }
-        preview_uuid = next((r["preview_id"] for r in rows if r["preview_id"]), None)
-        preview_name = next((r["preview_name"] for r in rows if r["preview_name"]), None)
-        non_root = next(
-            (
-                r
-                for r in rows
-                if r["location_type"] == "SCENE"
-                and r["scene_name"]
-                and r["scene_name"].strip().lower() != "root"
-            ),
-            None,
-        )
-        root = next(
-            (
-                r
-                for r in rows
-                if r["location_type"] == "SCENE"
-                and r["scene_name"]
-                and r["scene_name"].strip().lower() == "root"
-            ),
-            None,
-        )
-        selected = non_root or root
-        return {
-            "preview_uuid": preview_uuid,
-            "preview_name": preview_name,
-            "scene_uuid": selected["scene_id"] if selected else None,
-            "scene_name": selected["scene_name"] if selected else None,
-            "scope_kind": "Scene" if non_root else "Stage / Preview",
-            "context_type": classify_context(preview_name),
-        }
 
     def search_displays(self, query: str, limit: int = 40) -> list[dict[str, Any]]:
         kind, value = normalized_display_query(query)
@@ -185,41 +147,41 @@ class SQLiteSnapshotRepository(Repository):
                 device_type = self._device_type(conn, row["lor_prop_id"])
                 if (device_type or "").strip().lower() == "none":
                     continue
-                context = self._occurrence_context(conn, row["display_name"])
-                result.append(
-                    {
-                        "display_id": row["display_id"],
-                        "display_name": row["display_name"],
-                        "stage_id": row["stage_id"],
-                        "stage_key": row["stage_key"],
-                        "stage_name": row["stage_name"],
-                        "device_type": device_type,
-                        **context,
-                    }
+                shared = self._field_context.display_context_with_connection(
+                    conn,
+                    int(row["display_id"]),
                 )
+                if shared is None:
+                    continue
+                result.append(_flatten_fieldwiring_context(shared, device_type))
                 if len(result) >= limit:
                     break
             return result
 
     def display_context(self, display_id: int) -> dict[str, Any] | None:
         with self.connect() as conn:
-            row = self._display_base(conn, display_id)
+            row = conn.execute(
+                """
+                SELECT lor_prop_id
+                FROM ref__display
+                WHERE display_id = ? AND display_status_id = 1
+                """,
+                (display_id,),
+            ).fetchone()
             if row is None:
                 return None
             device_type = self._device_type(conn, row["lor_prop_id"])
             if (device_type or "").strip().lower() == "none":
                 return None
-            return {
-                "display_id": row["display_id"],
-                "display_name": row["display_name"],
-                "stage_id": row["stage_id"],
-                "stage_key": row["stage_key"],
-                "stage_name": row["stage_name"],
-                "device_type": device_type,
-                **self._occurrence_context(conn, row["display_name"]),
-            }
+            shared = self._field_context.display_context_with_connection(conn, display_id)
+            return (
+                _flatten_fieldwiring_context(shared, device_type)
+                if shared is not None
+                else None
+            )
 
     def stages(self) -> list[dict[str, Any]]:
+        # FieldWiring browse intentionally remains wiring-filtered.
         with self.connect() as conn:
             stage_rows = conn.execute(
                 """
@@ -232,8 +194,16 @@ class SQLiteSnapshotRepository(Repository):
                 """
                 SELECT DISTINCT preview_id, preview_name, preview_stage_id,
                        scene_id, scene_name, scene_stage_id
-                FROM lor_snap__v_display_lor_occurrence
+                FROM lor_snap__v_display_lor_occurrence o
                 WHERE location_type = 'SCENE'
+                  AND EXISTS (
+                      SELECT 1
+                      FROM ref__display d
+                      JOIN lor_snap__v_current_props p ON p.raw_prop_id = d.lor_prop_id
+                      WHERE d.display_name = o.display_name
+                        AND d.display_status_id = 1
+                        AND lower(coalesce(p.device_type, '')) <> 'none'
+                  )
                 ORDER BY preview_name, scene_name
                 """
             ).fetchall()
@@ -280,25 +250,44 @@ class SQLiteSnapshotRepository(Repository):
 
 
 class PostgresRepository(Repository):
-    """Production read adapter. Every PostgreSQL session is read-only."""
+    """Production FieldWiring adapter over shared read-only PostgreSQL context."""
 
     def __init__(self, dsn: str) -> None:
-        if psycopg2 is None:
-            raise ConfigError("psycopg2 is required for PostgreSQL mode")
+        self._field_context = PostgresFieldContextRepository(dsn)
         self.dsn = dsn
 
-    @contextmanager
-    def connect(self) -> Iterator[Any]:
-        conn = psycopg2.connect(self.dsn)
-        conn.set_session(readonly=True, autocommit=True)
-        try:
-            yield conn
-        finally:
-            conn.close()
+    def connect(self):
+        return self._field_context.connect()
 
     @staticmethod
     def _row_dicts(cur: Any) -> list[dict[str, Any]]:
         return [dict(row) for row in cur.fetchall()]
+
+    def shared_search_displays(self, query: str, limit: int = 40) -> list[dict[str, Any]]:
+        return self._field_context.search_displays(query, limit)
+
+    def shared_display_context(self, display_id: int) -> dict[str, Any] | None:
+        return self._field_context.display_context(display_id)
+
+    def shared_stages(self) -> list[dict[str, Any]]:
+        return self._field_context.stages()
+
+    @staticmethod
+    def _fieldwiring_device_type(cur: Any, display_id: int) -> str | None:
+        cur.execute(
+            """
+            SELECT p.device_type
+            FROM ref.display d
+            JOIN lor_snap.v_current_props p ON p.raw_prop_id = d.lor_prop_id
+            WHERE d.display_id = %s
+              AND d.display_status_id = 1
+              AND upper(coalesce(p.device_type, '')) <> 'NONE'
+            LIMIT 1
+            """,
+            (display_id,),
+        )
+        row = cur.fetchone()
+        return row["device_type"] if row else None
 
     def search_displays(self, query: str, limit: int = 40) -> list[dict[str, Any]]:
         kind, value = normalized_display_query(query)
@@ -345,67 +334,31 @@ class PostgresRepository(Repository):
                     (f"%{value}%", value, limit),
                 )
             base = self._row_dicts(cur)
+            result: list[dict[str, Any]] = []
             for item in base:
-                context = self._display_context_with_cursor(cur, int(item["display_id"]))
-                if context:
-                    item.update(
-                        {
-                            "preview_uuid": context.get("preview_uuid"),
-                            "preview_name": context.get("preview_name"),
-                            "scene_uuid": context.get("scene_uuid"),
-                            "scene_name": context.get("scene_name"),
-                            "scope_kind": context.get("scope_kind"),
-                            "context_type": context.get("context_type"),
-                        }
-                    )
-            return base
-
-    def _display_context_with_cursor(self, cur: Any, display_id: int) -> dict[str, Any] | None:
-        cur.execute(
-            """
-            SELECT
-                d.display_id, d.display_name, d.stage_id,
-                st.stage_key, st.stage_name,
-                p.device_type,
-                ls.preview_uuid,
-                cp.name AS preview_name,
-                ls.scene_uuid,
-                ls.scene_name
-            FROM ref.display d
-            LEFT JOIN ref.stage st ON st.stage_id = d.stage_id
-            JOIN lor_snap.v_current_props p ON p.raw_prop_id = d.lor_prop_id
-            LEFT JOIN ref.lor_scene_display lsd ON lsd.display_id = d.display_id
-            LEFT JOIN ref.lor_scene ls ON ls.lor_scene_id = lsd.lor_scene_id
-            LEFT JOIN lor_snap.v_current_previews cp ON cp.id = ls.preview_uuid
-            WHERE d.display_id = %s
-              AND d.display_status_id = 1
-              AND upper(coalesce(p.device_type, '')) <> 'NONE'
-            ORDER BY
-                CASE WHEN lower(coalesce(ls.scene_name, '')) = 'root' THEN 1 ELSE 0 END,
-                cp.name,
-                ls.scene_name
-            LIMIT 1
-            """,
-            (display_id,),
-        )
-        row = cur.fetchone()
-        if row is None:
-            return None
-        item = dict(row)
-        scene_name = item.get("scene_name")
-        item["scope_kind"] = (
-            "Scene"
-            if scene_name and scene_name.strip().lower() != "root"
-            else "Stage / Preview"
-        )
-        item["context_type"] = classify_context(item.get("preview_name"))
-        return item
+                shared = self._field_context.display_context_with_cursor(
+                    cur,
+                    int(item["display_id"]),
+                )
+                if shared is None:
+                    continue
+                result.append(
+                    _flatten_fieldwiring_context(shared, item.get("device_type"))
+                )
+            return result
 
     def display_context(self, display_id: int) -> dict[str, Any] | None:
         with self.connect() as conn, conn.cursor(cursor_factory=RealDictCursor) as cur:
-            return self._display_context_with_cursor(cur, display_id)
+            shared = self._field_context.display_context_with_cursor(cur, display_id)
+            if shared is None:
+                return None
+            device_type = self._fieldwiring_device_type(cur, display_id)
+            if device_type is None:
+                return None
+            return _flatten_fieldwiring_context(shared, device_type)
 
     def stages(self) -> list[dict[str, Any]]:
+        # FieldWiring browse intentionally remains wiring-filtered.
         with self.connect() as conn, conn.cursor(cursor_factory=RealDictCursor) as cur:
             cur.execute(
                 """

--- a/FieldWiring/Application/test_field_context_repository.py
+++ b/FieldWiring/Application/test_field_context_repository.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from field_context_repository import SQLiteFieldContextRepository
+
+
+def make_fixture(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE ref__display (
+            display_id INTEGER PRIMARY KEY,
+            display_name TEXT,
+            stage_id INTEGER,
+            lor_prop_id TEXT,
+            display_status_id INTEGER
+        );
+        CREATE TABLE ref__stage (
+            stage_id INTEGER PRIMARY KEY,
+            stage_key TEXT,
+            stage_name TEXT,
+            folder_path TEXT,
+            park_order INTEGER,
+            sub_order INTEGER
+        );
+        CREATE TABLE lor_snap__v_current_props (
+            raw_prop_id TEXT,
+            device_type TEXT
+        );
+        CREATE TABLE lor_snap__v_display_lor_occurrence (
+            display_name TEXT,
+            preview_id TEXT,
+            preview_name TEXT,
+            preview_stage_id TEXT,
+            scene_id TEXT,
+            scene_name TEXT,
+            scene_stage_id TEXT,
+            location_type TEXT
+        );
+        CREATE TABLE lor_snap__v_current_previews (
+            id TEXT,
+            name TEXT,
+            background_file TEXT,
+            revision TEXT,
+            source_filename TEXT
+        );
+        CREATE TABLE lor_snap__v_current_scenes (
+            preview_id TEXT,
+            scene_id TEXT,
+            name TEXT,
+            stage_id TEXT,
+            background_file TEXT
+        );
+
+        INSERT INTO ref__stage VALUES (15, '15', 'Church', '/drive/15-Church', 15, 0);
+        INSERT INTO ref__stage VALUES (20, '20', 'Steel Arches', '/drive/20-Steel-Arches', 20, 0);
+
+        INSERT INTO ref__display VALUES (309, 'CH-RGBCandyCane-01', 15, 'lor-309', 1);
+        INSERT INTO ref__display VALUES (323, 'CH-SteelArch-01', 15, 'lor-323', 1);
+        INSERT INTO ref__display VALUES (400, 'SA-SteelArch-InventoryOnly', 20, NULL, 1);
+        INSERT INTO ref__display VALUES (401, 'SA-Retired-Arch', 20, NULL, 3);
+
+        INSERT INTO lor_snap__v_current_props VALUES ('lor-309', 'LOR');
+        INSERT INTO lor_snap__v_current_props VALUES ('lor-323', 'None');
+
+        INSERT INTO lor_snap__v_current_previews VALUES (
+            'preview-musical','2026 Master Musical Preview','G:/Shared drives/Display Folders/15-Church/bg.jpg','7','master.lorprev'
+        );
+        INSERT INTO lor_snap__v_current_scenes VALUES (
+            'preview-musical','scene-church','15-Church-CH','15','G:/Shared drives/Display Folders/15-Church/scene.jpg'
+        );
+
+        INSERT INTO lor_snap__v_display_lor_occurrence VALUES (
+            'CH-RGBCandyCane-01','preview-musical','2026 Master Musical Preview','15',
+            'scene-church','15-Church-CH','15','SCENE'
+        );
+        INSERT INTO lor_snap__v_display_lor_occurrence VALUES (
+            'CH-SteelArch-01','preview-musical','2026 Master Musical Preview','15',
+            'scene-church','15-Church-CH','15','SCENE'
+        );
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def repo(tmp_path: Path) -> SQLiteFieldContextRepository:
+    path = tmp_path / "field-context.db"
+    make_fixture(path)
+    return SQLiteFieldContextRepository(path)
+
+
+def test_shared_search_includes_wired_and_inventory_only_pattern_matches(tmp_path):
+    rows = repo(tmp_path).search_displays("CH-")
+    assert [row["display_id"] for row in rows] == [309, 323]
+
+
+def test_inventory_only_display_with_lor_scene_still_resolves_context(tmp_path):
+    context = repo(tmp_path).display_context(323)
+    assert context is not None
+    assert context["display_name"] == "CH-SteelArch-01"
+    assert context["stage"]["stage_key"] == "15"
+    assert context["stage"]["folder_path"] == "/drive/15-Church"
+    assert len(context["contexts"]) == 1
+    candidate = context["contexts"][0]
+    assert candidate["scene"]["scene_name"] == "15-Church-CH"
+    assert candidate["preview"]["preview_uuid"] == "preview-musical"
+    assert candidate["context_type"] == "Musical"
+
+
+def test_inventory_only_display_without_lor_prop_still_resolves_stage(tmp_path):
+    context = repo(tmp_path).display_context(400)
+    assert context is not None
+    assert context["display_name"] == "SA-SteelArch-InventoryOnly"
+    assert context["stage"]["stage_key"] == "20"
+    assert context["stage"]["folder_path"] == "/drive/20-Steel-Arches"
+    assert context["contexts"] == []
+
+
+def test_retired_display_is_not_shared_current_context(tmp_path):
+    assert repo(tmp_path).display_context(401) is None
+
+
+def test_shared_stage_browse_does_not_require_wiring(tmp_path):
+    stages = repo(tmp_path).stages()
+    steel = next(item for item in stages if item["stage"]["stage_key"] == "20")
+    assert steel["stage"]["stage_name"] == "Steel Arches"
+    assert steel["contexts"] == []

--- a/FieldWiring/Application/test_field_context_repository.py
+++ b/FieldWiring/Application/test_field_context_repository.py
@@ -93,9 +93,9 @@ def repo(tmp_path: Path) -> SQLiteFieldContextRepository:
     return SQLiteFieldContextRepository(path)
 
 
-def test_shared_search_includes_wired_and_nonwired_pattern_matches(tmp_path):
+def test_shared_search_preserves_normal_wired_pattern_match(tmp_path):
     rows = repo(tmp_path).search_displays("CH-RGB")
-    assert [row["display_id"] for row in rows] == [309, 323]
+    assert [row["display_id"] for row in rows] == [309]
 
 
 def test_shared_search_includes_inventory_only_matching_name(tmp_path):

--- a/FieldWiring/Application/test_field_context_repository.py
+++ b/FieldWiring/Application/test_field_context_repository.py
@@ -93,9 +93,14 @@ def repo(tmp_path: Path) -> SQLiteFieldContextRepository:
     return SQLiteFieldContextRepository(path)
 
 
-def test_shared_search_includes_wired_and_inventory_only_pattern_matches(tmp_path):
-    rows = repo(tmp_path).search_displays("CH-")
+def test_shared_search_includes_wired_and_nonwired_pattern_matches(tmp_path):
+    rows = repo(tmp_path).search_displays("CH-RGB")
     assert [row["display_id"] for row in rows] == [309, 323]
+
+
+def test_shared_search_includes_inventory_only_matching_name(tmp_path):
+    rows = repo(tmp_path).search_displays("SteelArch")
+    assert [row["display_id"] for row in rows] == [323, 400]
 
 
 def test_inventory_only_display_with_lor_scene_still_resolves_context(tmp_path):

--- a/FieldWiring/Application/test_field_context_repository.py
+++ b/FieldWiring/Application/test_field_context_repository.py
@@ -4,6 +4,7 @@ import sqlite3
 from pathlib import Path
 
 from field_context_repository import SQLiteFieldContextRepository
+from field_context_resolver import MARKER_NAME, resolve_structured_scope
 
 
 def make_fixture(path: Path) -> None:
@@ -117,6 +118,33 @@ def test_inventory_only_display_without_lor_prop_still_resolves_stage(tmp_path):
     assert context["stage"]["stage_key"] == "20"
     assert context["stage"]["folder_path"] == "/drive/20-Steel-Arches"
     assert context["contexts"] == []
+
+
+def test_inventory_only_display_reaches_shared_structured_scope(tmp_path):
+    shared_repo = repo(tmp_path)
+    drive_root = tmp_path / "Display Folders"
+    stage_root = drive_root / "20-Steel-Arches"
+    stage_root.mkdir(parents=True)
+    (stage_root / MARKER_NAME).write_text("stage", encoding="utf-8")
+
+    with sqlite3.connect(shared_repo.path) as conn:
+        conn.execute(
+            "UPDATE ref__stage SET folder_path = ? WHERE stage_id = 20",
+            (str(stage_root),),
+        )
+        conn.commit()
+
+    context = shared_repo.display_context(400)
+    assert context is not None
+    scope_root, scope_type, warnings = resolve_structured_scope(
+        context["stage"],
+        None,
+        {},
+        drive_root,
+    )
+    assert scope_root == stage_root
+    assert scope_type == "STAGE"
+    assert warnings == []
 
 
 def test_retired_display_is_not_shared_current_context(tmp_path):

--- a/FieldWiring/Application/test_repository.py
+++ b/FieldWiring/Application/test_repository.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from repository import SQLiteSnapshotRepository, classify_context, normalized_display_query
+from wiring import WiringError, build_wiring_package
 
 
 def make_fixture(path: Path) -> None:
@@ -84,6 +85,12 @@ def test_search_excludes_device_type_none(repo):
     assert "CH-RGBTree-Base" not in names
 
 
+def test_shared_search_includes_inventory_only_display(repo):
+    rows = repo.shared_search_displays("CH-RGB")
+    names = [row["display_name"] for row in rows]
+    assert names == ["CH-RGBCandyCane-01", "CH-RGBTree-Base"]
+
+
 def test_canonical_display_id_lookup(repo):
     rows = repo.search_displays("DISP:309")
     assert [row["display_id"] for row in rows] == [309]
@@ -96,6 +103,20 @@ def test_display_context_is_field_friendly(repo):
     assert context["scene_name"] == "15-Church-CH"
     assert context["context_type"] == "Musical"
     assert context["scope_kind"] == "Scene"
+
+
+def test_inventory_only_display_resolves_shared_context_but_not_fieldwiring(repo):
+    shared = repo.shared_display_context(323)
+    assert shared is not None
+    assert shared["display_name"] == "CH-RGBTree-Base"
+    assert shared["stage"]["stage_key"] == "15"
+    assert shared["contexts"][0]["scene"]["scene_name"] == "15-Church-CH"
+    assert repo.display_context(323) is None
+
+
+def test_inventory_only_direct_fieldwiring_entry_is_not_reported_as_unknown(repo):
+    with pytest.raises(WiringError, match="No applicable field wiring"):
+        build_wiring_package(repo, display_id=323)
 
 
 def test_stage_browse_contains_scene(repo):

--- a/FieldWiring/Application/wiring.py
+++ b/FieldWiring/Application/wiring.py
@@ -28,8 +28,17 @@ def build_wiring_package(
 ) -> dict[str, Any]:
     trigger_context: dict[str, Any] | None = None
     if display_id is not None:
+        # New shared-context-aware repositories first prove that the permanent
+        # Display itself is current/valid. FieldWiring eligibility is a separate
+        # downstream decision. Older test doubles without the shared method keep
+        # the established single-call behavior.
+        shared_lookup = getattr(repo, "shared_display_context", None)
+        shared_context = shared_lookup(display_id) if callable(shared_lookup) else None
+
         trigger_context = repo.display_context(display_id)
         if trigger_context is None:
+            if shared_context is not None:
+                raise WiringError("No applicable field wiring is available for this Display")
             raise WiringError("Display is not available for current FieldWiring")
 
         resolved_stage_id = trigger_context.get("stage_id")


### PR DESCRIPTION
Merge the production-accepted shared Field Context database layer from current `main` into `feature/setup-takedown-procedures` before Procedure browser/database orchestration resumes. Preserve the existing accepted Procedure second-caller implementation and documentation. This PR intentionally targets the Procedure feature branch; it does not modify `main`.