### PR TITLE
Repair shared field-context hierarchy browse contract

### DIFF
--- a/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/Shared_Field_Context_Hierarchy_Browse_Repair_Acceptance_2026-08-23.md
+++ b/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/Shared_Field_Context_Hierarchy_Browse_Repair_Acceptance_2026-08-23.md
@@ -1,0 +1,329 @@
+# Shared Field Context Hierarchy / Browse Repair Acceptance — 2026-08-23
+
+| Document control | Value |
+|---|---|
+| Status | ARCHITECTURE ACCEPTED — production deployment pending |
+| Branch | `agent/shared-field-context-hierarchy-browse-repair` |
+| Base `main` | `340669b96b7da255d20700c9d9eddad92bb9c058` |
+| Accepted candidate | `b1d897cf2b4d157ebf8a713c8dcc939726012df0` |
+| Shared DB evidence source | `FieldWiring/Application/field_context_repository.py` |
+| Existing structured-scope resolver | `FieldWiring/Application/field_context_resolver.py` |
+| Canonical field-facing hierarchy entry point | `FieldWiring/Application/field_context_hierarchy.py` |
+| Lower-level hierarchy builder | `FieldWiring/Application/field_context_browse.py` |
+| Procedure status | paused until this repair is merged and production accepted |
+
+## Governing authority
+
+This repair is governed by the released Google Drive architecture, not by raw PostgreSQL or LOR naming:
+
+- `Docs/00_Project_Overview/00-Google_Drive.md` Revision 1.3.1;
+- `Docs/00_Project_Overview/01-Google_Drive_Document_Organization_Procedure.md`.
+
+The required field hierarchy remains:
+
+```text
+Display Folders
+  -> NN-Name-XY top-level Stage
+      -> optional NNa-Name-XY Sub-stage
+          -> optional defined NNa-Scene
+      -> optional defined NN-Scene
+```
+
+This work does not redesign that hierarchy.
+
+## Defect found
+
+The production-accepted shared database context layer correctly separated permanent Display identity from FieldWiring eligibility, but its `stages()` output was still raw database/LOR evidence:
+
+```text
+all ref.stage rows
+    +
+all ref.lor_scene rows
+    -> grouped by database stage
+```
+
+That raw evidence was incorrectly usable as though it were the field browse hierarchy.
+
+The resulting defects included:
+
+- `ref.stage.stage_name` appearing as a field-facing Stage label even when it was Preview/LOR-oriented;
+- Sub-stages such as `05a` and `07a` appearing as peer/top-level Stage rows rather than nested physical scopes;
+- every LOR Scene association being exposed as a possible child context;
+- `Root` and Master Musical Stage-binding scenes creating duplicate choices even when they resolved to the Stage root;
+- nonphysical `90–94` database stages being eligible to appear in browse;
+- Stage `39/40` alignment conflicts being at risk of silent guessing.
+
+## Audit evidence
+
+The Procedure acceptance investigation produced `procedure_stage_scope_audit.csv` against the accepted SQLite snapshot plus the live `G:\Shared drives\Display Folders` tree.
+
+The supplied audit contains 128 rows with these classifications:
+
+```text
+EXPLICIT_STAGE_ROOT                37
+RAW_CONTEXT_RETURNS_STAGE_ROOT     36
+UNRESOLVED_REVIEW_REQUIRED         29
+DISTINCT_MARKED_CHILD_SCOPE        26
+```
+
+The audit demonstrates the central distinction required by this repair:
+
+```text
+raw LOR Scene association
+    !=
+automatic field/documentation Scene
+```
+
+Representative audit evidence:
+
+- Stage `15`: `15-Church-CH` and `Root` resolve to `15-Church-Bells-CH` Stage root;
+- Stage `13`: four prefixed marked child scopes resolve distinctly, while `13-Grover Train`, `Die Hard`, and `Static Contactor` return the Stage root;
+- Stage `21`: `21-SnowballBears` resolves to a distinct marked child Scene, while `21-Sliding Penguins` and `Root` return the Stage root;
+- Stage `05a`: actual marked Sub-stage is `05-Festive Trees-FT/05a-Mega Star-MS` even though the Stage row lacks a usable persisted `folder_path`;
+- Stage `07a`: actual marked Sub-stage is `07-Whoville-WV/07a-Who Forest-WF` while the persisted path is stale/misaligned;
+- Stage `39`: persisted Stage path points at `40-Parade Float-PF` and cannot be trusted for automatic browse binding;
+- Stage `40`: current Stage row has no usable persisted folder anchor;
+- Stages `90–94`: do not resolve to normal physical field roots.
+
+## Accepted architecture
+
+Database rows remain evidence. The field-facing hierarchy is created only after current filesystem roots have been resolved and validated.
+
+Canonical caller chain:
+
+```text
+field_context_repository.stages()
+    -> raw DB / LOR evidence only
+    -> field_context_hierarchy.resolve_field_hierarchy(repository, drive_root)
+        -> field_context_browse lower-level resolution/grouping
+        -> field_context_resolver.resolve_structured_scope(...)
+        -> current marked filesystem roots
+        -> deduplicate by resolved root
+        -> Stage -> Sub-stage -> defined Scene browse tree
+        + review_required alignment findings
+```
+
+Applications must not present `repository.stages()` directly as the field hierarchy.
+
+## Field-facing labels
+
+The resolved current Google Drive scope basename is the field-facing label.
+
+Examples:
+
+```text
+15-Church-Bells-CH
+07-Whoville-WV
+07a-Who Forest-WF
+13-Winter Wonderland-WW
+21-Polar Bear Playground-PB
+25-Racing Arches-RA
+```
+
+`ref.stage.stage_name` remains database/LOR evidence and is returned only as supporting metadata. It is not field label authority.
+
+## Stage rules
+
+A normal top-level Stage browse node requires:
+
+1. one actual marked top-level `NN-*` folder directly beneath `Display Folders`;
+2. one corresponding current raw Stage row;
+3. persisted top-level Stage path evidence that resolves back to that same current marked root.
+
+If the top-level Stage path evidence is missing, stale, conflicting, or points at another Stage, the node is suppressed from normal browse and surfaced under `review_required`.
+
+This rule is data-driven. No special-case code for Stage `39` or `40` is used.
+
+## Sub-stage rules
+
+A formal Sub-stage is an actual marked `NNa-*` child beneath its owning `NN-*` Stage.
+
+A marked physical child relationship provides the additional ownership boundary required for nested browse. Therefore a stale or missing Sub-stage `folder_path` is surfaced for review but does not erase an otherwise unambiguous real nested scope.
+
+This preserves current real cases such as:
+
+```text
+05-Festive Trees-FT
+  -> 05a-Mega Star-MS
+
+07-Whoville-WV
+  -> 07a-Who Forest-WF
+```
+
+## Scene rules
+
+A LOR Scene becomes a browse Scene only when the existing structured-scope resolver resolves it to one distinct marked child scope whose folder name has the owning Stage/Sub-stage prefix.
+
+If the LOR Scene resolves to the owning Stage/Sub-stage root, it remains context/binding evidence on that root and does not create a duplicate child browse choice.
+
+Therefore:
+
+- `Root` never creates a duplicate browse Scene;
+- `15-Church-CH` is Stage-root evidence, not a child Scene;
+- `25-Racing Arches-RA` is Stage-root evidence, not a child Scene;
+- `21-Sliding Penguins` is Stage-root evidence;
+- `21-SnowballBears` is a distinct Scene;
+- the four Stage 13 prefixed marked child scopes are distinct Scenes;
+- unprefixed/raw LOR groups are not promoted merely because LOR calls them Scenes.
+
+## Review output
+
+Unresolved or conflicting evidence is preserved as structured `review_required` output rather than silently guessed.
+
+Representative live review findings include:
+
+```text
+05a PERSISTED_SUBSTAGE_PATH_REVIEW_REQUIRED
+07a PERSISTED_SUBSTAGE_PATH_REVIEW_REQUIRED
+39  PERSISTED_STAGE_PATH_REVIEW_REQUIRED
+39  TOP_LEVEL_STAGE_BINDING_REVIEW_REQUIRED
+40  PERSISTED_STAGE_PATH_REVIEW_REQUIRED
+40  TOP_LEVEL_STAGE_BINDING_REVIEW_REQUIRED
+90–94 DATABASE_STAGE_NOT_IN_FIELD_HIERARCHY
+```
+
+The browse layer is therefore conservative while still exposing known real physical hierarchy.
+
+## Synthetic regression gate
+
+Final detached-worktree regression at candidate `b1d897cf2b4d157ebf8a713c8dcc939726012df0`:
+
+```text
+74 passed in 2.09s
+```
+
+The new tests cover:
+
+- Stage-root deduplication;
+- Stage/Sub-stage nesting;
+- defined Scene creation from distinct marked child roots;
+- rejection of raw/unprefixed LOR Scene groups as automatic field Scenes;
+- top-level Stage path conflict suppression;
+- top-level Stage missing-path suppression;
+- preservation of valid nested Sub-stage browse despite reviewable persisted-path drift.
+
+All previously accepted FieldWiring/shared-context tests remain green.
+
+## Live production-data acceptance
+
+The candidate was executed read-only against production PostgreSQL and `/mnt/msb-display-folders`.
+
+Final result:
+
+```text
+normal Stage count: 27
+review-required count: 36
+normal Stage keys:
+00 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 18 19 20 21 22 23 24 25 26 30
+
+SHARED FIELD HIERARCHY LIVE ACCEPTANCE: PASS
+```
+
+Representative live acceptance:
+
+### Stage 15 Church
+
+```text
+label:      15-Church-Bells-CH
+scope_root: /mnt/msb-display-folders/15-Church-Bells-CH
+scenes:     []
+root context count: 2
+```
+
+Master Musical/Root rows collapse to the Stage root.
+
+### Stage 07 / 07a
+
+```text
+Stage:      07-Whoville-WV
+Scenes:     07-Who People
+            07-Who Spiral Tree
+Sub-stage:  07a-Who Forest-WF
+```
+
+`07a` is nested rather than top-level.
+
+### Stage 13
+
+Only the four current defined marked child Scene scopes are exposed:
+
+```text
+13-Christmas Story
+13-Christmas Vacation
+13-Christmas With the Kranks
+13-Nightmare Before Christmas
+```
+
+Raw LOR groups that return the Stage root do not appear as child Scenes.
+
+### Stage 21
+
+```text
+Scene: 21-SnowballBears
+```
+
+`21-Sliding Penguins` collapses to Stage root.
+
+### Stage 25
+
+`25-Racing Arches-RA` remains one Stage browse node; its same-name Master Musical Scene does not duplicate it.
+
+### Stage 39 / 40
+
+Both are excluded from normal browse and surfaced for review because current persisted path evidence is not safe enough to bind automatically.
+
+### Stages 90–94
+
+None appear in normal physical browse.
+
+## Identity and FieldWiring preservation
+
+Permanent Display identity behavior is unchanged.
+
+Real inventory-only Display `807` remains valid shared context:
+
+```text
+807  RA-SteelArch-DS-F-03
+Stage 25
+shared search includes 807
+FieldWiring search excludes 807
+direct FieldWiring -> No applicable field wiring is available for this Display
+```
+
+Normal wired Display `312` candidate output remained exactly equivalent to the unchanged production FieldWiring API:
+
+```text
+scope_type: STAGE
+scope_root: /mnt/msb-display-folders/15-Church-Bells-CH
+wiring_images: RGB Plus Prop Stage 15 Church-Tagged.jpg
+```
+
+## Runtime characteristic
+
+Building the hierarchy touches the live read-only Google/rclone tree and is materially slower than returning raw PostgreSQL rows. This is expected because filesystem structure is part of the authoritative field-browse contract.
+
+Consumers may later cache or refresh the resolved browse result at an appropriate boundary, but performance work must not replace resolved filesystem authority with raw database rows or weaken review/ambiguity handling.
+
+No caching design is introduced by this repair.
+
+## Scope preserved
+
+This repair does not:
+
+- modify Procedures;
+- widen FieldWiring search;
+- change permanent `display_id` resolution;
+- remove inventory-only Display support;
+- change FieldWiring eligibility filters;
+- modify `field_context_resolver.resolve_structured_scope(...)`;
+- create PostgreSQL schema, migrations, functions, or data changes;
+- rename or move Google Drive folders;
+- infer new hierarchy rules outside the released Google Drive documents.
+
+## Acceptance decision
+
+The repaired shared field hierarchy is architecture accepted because it now represents the actual released Google Drive field hierarchy rather than raw LOR/database association rows, preserves all established identity and FieldWiring behavior, and surfaces unsafe alignment conditions instead of guessing.
+
+Production deployment remains a separate gate.
+
+After merge and production acceptance, the Procedure branch may resume by merging current `main` into `feature/setup-takedown-procedures` and replacing raw Stage browse consumption with the canonical resolved hierarchy entry point.

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/08_Shared_Field_Context_Hierarchy_Browse_Repair_Handoff_2026-08-23.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/08_Shared_Field_Context_Hierarchy_Browse_Repair_Handoff_2026-08-23.md
@@ -1,0 +1,138 @@
+# Procedure Handoff — Shared Field Context Hierarchy / Browse Repair — 2026-08-23
+
+| Document control | Value |
+|---|---|
+| Status | CURRENT ENGINEERING HANDOFF — production deployment pending |
+| Repair branch | `agent/shared-field-context-hierarchy-browse-repair` |
+| Accepted candidate | `b1d897cf2b4d157ebf8a713c8dcc939726012df0` |
+| Procedure branch | `feature/setup-takedown-procedures` — remain paused until production acceptance |
+
+## Why Procedure is paused again
+
+Procedure browser acceptance exposed a defect in the shared browse contract, not in Procedure task/document discovery.
+
+The shared database repository's raw `stages()` result contains `ref.stage` and LOR Scene evidence. That evidence must not be rendered directly as the field Stage/Sub-stage/Scene hierarchy.
+
+The released Google Drive architecture remains authoritative:
+
+```text
+Display Folders
+  -> NN-Name-XY Stage
+      -> optional NNa-Name-XY Sub-stage
+          -> optional defined NNa-Scene
+      -> optional defined NN-Scene
+```
+
+A raw LOR Scene is not automatically a field/documentation Scene.
+
+## Canonical shared browse entry point
+
+After this repair is production accepted, Procedure Stage browsing must consume:
+
+```text
+FieldWiring/Application/field_context_hierarchy.py
+    resolve_field_hierarchy(repository, drive_root)
+```
+
+The lower-level shared hierarchy builder is:
+
+```text
+FieldWiring/Application/field_context_browse.py
+```
+
+The existing structured-scope resolver remains unchanged:
+
+```text
+FieldWiring/Application/field_context_resolver.py
+    resolve_structured_scope(...)
+```
+
+The shared database repository remains the source of current DB/LOR evidence:
+
+```text
+FieldWiring/Application/field_context_repository.py
+```
+
+## Required chain after resume
+
+```text
+permanent Display identity / field browse request
+    -> field_context_repository
+    -> raw current DB/LOR evidence
+    -> field_context_hierarchy.resolve_field_hierarchy(...)
+    -> actual marked Stage -> Sub-stage -> defined Scene browse tree
+    -> selected resolved field scope
+    -> Procedure task adapter
+    -> Setup / Takedown / Inspection discovery
+```
+
+Do not present `repository.stages()` directly.
+
+## Governing behavior
+
+The repaired hierarchy:
+
+- labels Stage/Sub-stage/Scene nodes from the actual resolved folder basename;
+- nests `05a` and `07a` beneath their owning top-level Stages;
+- creates a child Scene only when the existing structured-scope resolver resolves a raw LOR Scene to one distinct marked prefixed child scope;
+- collapses `Root` and Stage-binding Master Musical scenes to the Stage root rather than creating duplicate choices;
+- deduplicates by the resolved marked filesystem root;
+- excludes `90–94` from normal physical browse;
+- suppresses top-level `39/40` from normal browse while their current DB/filesystem alignment remains unsafe;
+- surfaces stale/missing/conflicting path evidence under `review_required` rather than guessing.
+
+## Acceptance evidence
+
+Synthetic regression:
+
+```text
+74 passed in 2.09s
+```
+
+Live read-only production-data acceptance:
+
+```text
+normal Stage count: 27
+review-required count: 36
+SHARED FIELD HIERARCHY LIVE ACCEPTANCE: PASS
+```
+
+Representative cases accepted:
+
+- Stage 15 Church: Stage root only; raw `15-Church-CH` and `Root` do not create child Scenes;
+- Stage 07: `07a-Who Forest-WF` nested under `07-Whoville-WV`;
+- Stage 13: exactly four defined marked child Scene scopes;
+- Stage 21: `21-SnowballBears` child Scene, `21-Sliding Penguins` Stage-root evidence;
+- Stage 25: same-name Racing Arches LOR Scene collapses to the Stage root;
+- Stage 39/40: review-only rather than guessed;
+- Stage 90–94: absent from normal physical browse;
+- inventory Display 807: shared identity/context preserved while FieldWiring remains unavailable;
+- normal wired Display 312: candidate output exactly equivalent to unchanged production FieldWiring.
+
+## Procedure resume rule
+
+Do not modify Procedure code as part of this shared repair.
+
+After the repair is merged and production accepted:
+
+1. merge current `origin/main` into `feature/setup-takedown-procedures`;
+2. preserve the existing accepted Procedure browser/orchestration/document work;
+3. replace raw shared Stage browse consumption with `field_context_hierarchy.resolve_field_hierarchy(...)`;
+4. retain permanent Display lookup through `field_context_repository.py`;
+5. keep Procedure task/document discovery downstream of resolved field scope.
+
+Do not:
+
+- copy PostgreSQL relationship SQL into Procedures;
+- treat every raw LOR Scene as a browse Scene;
+- use `ref.stage.stage_name` as the field-facing Stage label;
+- invent a second Stage/Sub-stage/Scene resolver;
+- alter FieldWiring eligibility or search;
+- add schema for the browse repair;
+- silently guess Stage 39/40 alignment.
+
+## Related acceptance record
+
+See:
+
+`../07_Labeling_and_Scanning/Shared_Field_Context_Hierarchy_Browse_Repair_Acceptance_2026-08-23.md`

--- a/FieldWiring/Application/field_context_browse.py
+++ b/FieldWiring/Application/field_context_browse.py
@@ -1,0 +1,533 @@
+"""Resolved Stage/Sub-stage/Scene browse over shared field-context evidence.
+
+Raw ``ref.stage`` rows and raw LOR Scene rows are evidence, not field browse
+nodes.  The released Google Drive hierarchy is represented only after current
+filesystem roots have been resolved and validated.
+
+This module does not discover Wiring or Procedure content.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+from field_context_resolver import MARKER_NAME, resolve_structured_scope
+
+_STAGE_KEY_RE = re.compile(r"^\d{2}$")
+_SUBSTAGE_KEY_RE = re.compile(r"^(\d{2})[A-Za-z]$")
+_TOP_STAGE_FOLDER_RE = re.compile(r"^(\d{2})-(?=.)")
+_SUBSTAGE_FOLDER_RE = re.compile(r"^(\d{2}[A-Za-z])-(?=.)")
+
+
+class FieldHierarchyError(RuntimeError):
+    pass
+
+
+def _marked(path: Path) -> bool:
+    return path.is_dir() and (path / MARKER_NAME).is_file()
+
+
+def _path_key(path: Path) -> str:
+    return str(path).replace("\\", "/").casefold().rstrip("/")
+
+
+def _children(path: Path) -> list[Path]:
+    try:
+        return sorted(
+            [item for item in path.iterdir() if item.is_dir()],
+            key=lambda item: item.name.casefold(),
+        )
+    except OSError:
+        return []
+
+
+def _context_key(context: dict[str, Any]) -> tuple[str, str]:
+    preview = context.get("preview") or {}
+    scene = context.get("scene") or {}
+    return (
+        str(preview.get("preview_uuid") or ""),
+        str(scene.get("scene_uuid") or ""),
+    )
+
+
+def _dedupe_contexts(contexts: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+    for context in contexts:
+        key = _context_key(context)
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(context)
+    return result
+
+
+def _review_key(item: dict[str, Any]) -> tuple[Any, ...]:
+    return (
+        item.get("code"),
+        item.get("stage_id"),
+        item.get("stage_key"),
+        item.get("scope_root"),
+        item.get("scene_uuid"),
+        item.get("scene_name"),
+    )
+
+
+def _add_review(
+    reviews: list[dict[str, Any]],
+    seen: set[tuple[Any, ...]],
+    item: dict[str, Any],
+) -> None:
+    key = _review_key(item)
+    if key in seen:
+        return
+    seen.add(key)
+    reviews.append(item)
+
+
+def _node(scope_type: str, root: Path, stage: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "scope_type": scope_type,
+        "label": root.name,
+        "scope_root": str(root),
+        "stage_id": stage.get("stage_id"),
+        "stage_key": stage.get("stage_key"),
+        "database_stage_name": stage.get("stage_name"),
+        "database_folder_path": stage.get("folder_path"),
+        "contexts": [],
+        "scenes": [],
+    }
+
+
+def _scan_top_roots(
+    drive_root: Path,
+) -> tuple[dict[str, list[Path]], dict[str, list[Path]]]:
+    marked: dict[str, list[Path]] = {}
+    unmarked: dict[str, list[Path]] = {}
+    for child in _children(drive_root):
+        match = _TOP_STAGE_FOLDER_RE.match(child.name)
+        if not match:
+            continue
+        target = marked if _marked(child) else unmarked
+        target.setdefault(match.group(1), []).append(child)
+    return marked, unmarked
+
+
+def _scan_substage_roots(
+    stage_root: Path,
+    stage_key: str,
+) -> tuple[dict[str, list[Path]], dict[str, list[Path]]]:
+    marked: dict[str, list[Path]] = {}
+    unmarked: dict[str, list[Path]] = {}
+    for child in _children(stage_root):
+        match = _SUBSTAGE_FOLDER_RE.match(child.name)
+        if not match:
+            continue
+        key = match.group(1)
+        if key[:2].casefold() != stage_key.casefold():
+            continue
+        target = marked if _marked(child) else unmarked
+        target.setdefault(key.casefold(), []).append(child)
+    return marked, unmarked
+
+
+def _persisted_path_warnings(
+    stage: dict[str, Any],
+    actual_root: Path,
+    drive_root: Path,
+) -> list[str]:
+    resolved, _, warnings = resolve_structured_scope(stage, None, {}, drive_root)
+    if resolved is not None and _path_key(resolved) == _path_key(actual_root):
+        return []
+    return warnings or [
+        "Persisted Stage folder_path does not resolve to the current marked field root."
+    ]
+
+
+def _context_review(
+    code: str,
+    stage: dict[str, Any],
+    context: dict[str, Any],
+    warnings: list[str],
+    scope_root: Path | None = None,
+) -> dict[str, Any]:
+    preview = context.get("preview") or {}
+    scene = context.get("scene") or {}
+    return {
+        "code": code,
+        "stage_id": stage.get("stage_id"),
+        "stage_key": stage.get("stage_key"),
+        "scene_uuid": scene.get("scene_uuid"),
+        "scene_name": scene.get("scene_name"),
+        "preview_uuid": preview.get("preview_uuid"),
+        "preview_name": preview.get("preview_name"),
+        "scope_root": str(scope_root) if scope_root is not None else None,
+        "warnings": list(warnings),
+    }
+
+
+def _attach_contexts(
+    node: dict[str, Any],
+    stage: dict[str, Any],
+    contexts: list[dict[str, Any]],
+    owning_root: Path,
+    owning_key: str,
+    drive_root: Path,
+    reviews: list[dict[str, Any]],
+    review_seen: set[tuple[Any, ...]],
+) -> None:
+    scene_nodes: dict[str, dict[str, Any]] = {}
+    resolver_stage = {
+        "stage_id": stage.get("stage_id"),
+        "stage_key": stage.get("stage_key"),
+        "folder_path": str(owning_root),
+    }
+
+    for context in contexts:
+        preview = context.get("preview") or {}
+        scene = context.get("scene")
+        scope_root, scope_type, warnings = resolve_structured_scope(
+            resolver_stage,
+            scene,
+            preview,
+            drive_root,
+        )
+        if scope_root is None or scope_type == "UNRESOLVED":
+            _add_review(
+                reviews,
+                review_seen,
+                _context_review(
+                    "LOR_CONTEXT_UNRESOLVED",
+                    stage,
+                    context,
+                    warnings,
+                ),
+            )
+            continue
+
+        if _path_key(scope_root) == _path_key(owning_root):
+            node["contexts"].append(context)
+            continue
+
+        try:
+            relative = scope_root.relative_to(owning_root)
+        except ValueError:
+            _add_review(
+                reviews,
+                review_seen,
+                _context_review(
+                    "LOR_CONTEXT_OUTSIDE_OWNING_SCOPE",
+                    stage,
+                    context,
+                    warnings,
+                    scope_root,
+                ),
+            )
+            continue
+
+        if len(relative.parts) != 1:
+            _add_review(
+                reviews,
+                review_seen,
+                _context_review(
+                    "LOR_CONTEXT_NESTING_REVIEW_REQUIRED",
+                    stage,
+                    context,
+                    warnings,
+                    scope_root,
+                ),
+            )
+            continue
+
+        if not scope_root.name.casefold().startswith(owning_key.casefold() + "-"):
+            _add_review(
+                reviews,
+                review_seen,
+                _context_review(
+                    "LOR_CONTEXT_NOT_DEFINED_FIELD_SCENE",
+                    stage,
+                    context,
+                    warnings,
+                    scope_root,
+                ),
+            )
+            continue
+
+        if not _marked(scope_root):
+            _add_review(
+                reviews,
+                review_seen,
+                _context_review(
+                    "FIELD_SCENE_MARKER_MISSING",
+                    stage,
+                    context,
+                    warnings,
+                    scope_root,
+                ),
+            )
+            continue
+
+        key = _path_key(scope_root)
+        child = scene_nodes.get(key)
+        if child is None:
+            child = {
+                "scope_type": "SCENE",
+                "label": scope_root.name,
+                "scope_root": str(scope_root),
+                "stage_id": stage.get("stage_id"),
+                "stage_key": stage.get("stage_key"),
+                "contexts": [],
+            }
+            scene_nodes[key] = child
+        child["contexts"].append(context)
+
+    node["contexts"] = _dedupe_contexts(node["contexts"])
+    for child in scene_nodes.values():
+        child["contexts"] = _dedupe_contexts(child["contexts"])
+    node["scenes"] = sorted(
+        scene_nodes.values(),
+        key=lambda item: (item["label"].casefold(), item["scope_root"].casefold()),
+    )
+
+
+def build_field_hierarchy(
+    raw_stage_items: list[dict[str, Any]],
+    drive_root: str | Path,
+) -> dict[str, Any]:
+    """Return actual field hierarchy plus unresolved alignment evidence."""
+    root = Path(drive_root)
+    if not root.is_dir():
+        raise FieldHierarchyError(f"Display Folders root is not available: {root}")
+
+    marked_top, unmarked_top = _scan_top_roots(root)
+    reviews: list[dict[str, Any]] = []
+    review_seen: set[tuple[Any, ...]] = set()
+    by_key: dict[str, list[dict[str, Any]]] = {}
+    for item in raw_stage_items:
+        stage = item.get("stage") or {}
+        key = str(stage.get("stage_key") or "").strip()
+        if key:
+            by_key.setdefault(key.casefold(), []).append(item)
+
+    stages: list[dict[str, Any]] = []
+    consumed: set[int] = set()
+
+    for stage_key in sorted(marked_top):
+        roots = marked_top[stage_key]
+        matches = by_key.get(stage_key.casefold(), [])
+        if len(roots) != 1 or len(matches) != 1:
+            _add_review(
+                reviews,
+                review_seen,
+                {
+                    "code": "STAGE_BINDING_REVIEW_REQUIRED",
+                    "stage_key": stage_key,
+                    "scope_root": str(roots[0]) if roots else None,
+                    "warnings": [
+                        "No unique current ref.stage row and marked top-level Stage root pair could be established."
+                    ],
+                },
+            )
+            continue
+
+        item = matches[0]
+        stage = item.get("stage") or {}
+        stage_root = roots[0]
+        stage_id = stage.get("stage_id")
+        if stage_id is not None:
+            consumed.add(int(stage_id))
+        node = _node("STAGE", stage_root, stage)
+        node["sub_stages"] = []
+
+        path_warnings = _persisted_path_warnings(stage, stage_root, root)
+        if path_warnings:
+            _add_review(
+                reviews,
+                review_seen,
+                {
+                    "code": "PERSISTED_STAGE_PATH_REVIEW_REQUIRED",
+                    "stage_id": stage_id,
+                    "stage_key": stage_key,
+                    "scope_root": str(stage_root),
+                    "database_folder_path": stage.get("folder_path"),
+                    "warnings": path_warnings,
+                },
+            )
+
+        marked_sub, unmarked_sub = _scan_substage_roots(stage_root, stage_key)
+        sub_items: dict[str, list[dict[str, Any]]] = {}
+        for key, candidates in by_key.items():
+            match = _SUBSTAGE_KEY_RE.fullmatch(key)
+            if match and match.group(1).casefold() == stage_key.casefold():
+                sub_items[key] = candidates
+
+        for sub_key, sub_roots in sorted(marked_sub.items()):
+            sub_matches = sub_items.get(sub_key.casefold(), [])
+            if len(sub_roots) != 1 or len(sub_matches) != 1:
+                _add_review(
+                    reviews,
+                    review_seen,
+                    {
+                        "code": "SUBSTAGE_BINDING_REVIEW_REQUIRED",
+                        "stage_key": sub_key,
+                        "scope_root": str(sub_roots[0]) if sub_roots else None,
+                        "warnings": [
+                            "No unique current ref.stage row and marked Sub-stage root pair could be established."
+                        ],
+                    },
+                )
+                continue
+
+            sub_item = sub_matches[0]
+            sub_stage = sub_item.get("stage") or {}
+            sub_root = sub_roots[0]
+            sub_id = sub_stage.get("stage_id")
+            if sub_id is not None:
+                consumed.add(int(sub_id))
+            sub_node = _node("SUBSTAGE", sub_root, sub_stage)
+
+            path_warnings = _persisted_path_warnings(sub_stage, sub_root, root)
+            if path_warnings:
+                _add_review(
+                    reviews,
+                    review_seen,
+                    {
+                        "code": "PERSISTED_SUBSTAGE_PATH_REVIEW_REQUIRED",
+                        "stage_id": sub_id,
+                        "stage_key": sub_stage.get("stage_key"),
+                        "scope_root": str(sub_root),
+                        "database_folder_path": sub_stage.get("folder_path"),
+                        "warnings": path_warnings,
+                    },
+                )
+
+            _attach_contexts(
+                sub_node,
+                sub_stage,
+                list(sub_item.get("contexts") or []),
+                sub_root,
+                str(sub_stage.get("stage_key") or sub_key),
+                root,
+                reviews,
+                review_seen,
+            )
+            node["sub_stages"].append(sub_node)
+
+        for sub_key, sub_roots in sorted(unmarked_sub.items()):
+            if sub_key.casefold() not in sub_items or sub_key.casefold() in marked_sub:
+                continue
+            for sub_root in sub_roots:
+                _add_review(
+                    reviews,
+                    review_seen,
+                    {
+                        "code": "SUBSTAGE_ROOT_UNMARKED",
+                        "stage_key": sub_key,
+                        "scope_root": str(sub_root),
+                        "warnings": [
+                            "Sub-stage-shaped folder exists but is not a current marked field scope."
+                        ],
+                    },
+                )
+
+        for sub_key, sub_matches in sorted(sub_items.items()):
+            if sub_key.casefold() in marked_sub:
+                continue
+            for sub_item in sub_matches:
+                sub_stage = sub_item.get("stage") or {}
+                _add_review(
+                    reviews,
+                    review_seen,
+                    {
+                        "code": "SUBSTAGE_ROOT_NOT_RESOLVED",
+                        "stage_id": sub_stage.get("stage_id"),
+                        "stage_key": sub_stage.get("stage_key"),
+                        "database_folder_path": sub_stage.get("folder_path"),
+                        "warnings": [
+                            "Current Sub-stage database row has no unique marked child field root."
+                        ],
+                    },
+                )
+
+        _attach_contexts(
+            node,
+            stage,
+            list(item.get("contexts") or []),
+            stage_root,
+            stage_key,
+            root,
+            reviews,
+            review_seen,
+        )
+        node["sub_stages"] = sorted(
+            node["sub_stages"],
+            key=lambda item: (str(item["stage_key"]).casefold(), item["label"].casefold()),
+        )
+        stages.append(node)
+
+    for stage_key, roots in sorted(unmarked_top.items()):
+        if stage_key.casefold() not in by_key:
+            continue
+        for stage_root in roots:
+            _add_review(
+                reviews,
+                review_seen,
+                {
+                    "code": "STAGE_ROOT_UNMARKED",
+                    "stage_key": stage_key,
+                    "scope_root": str(stage_root),
+                    "warnings": [
+                        "Stage-shaped top-level folder exists but is not a current marked field scope."
+                    ],
+                },
+            )
+
+    for items in by_key.values():
+        for item in items:
+            stage = item.get("stage") or {}
+            stage_id = stage.get("stage_id")
+            if stage_id is not None and int(stage_id) in consumed:
+                continue
+            key = str(stage.get("stage_key") or "")
+            if not (_STAGE_KEY_RE.fullmatch(key) or _SUBSTAGE_KEY_RE.fullmatch(key)):
+                continue
+            _add_review(
+                reviews,
+                review_seen,
+                {
+                    "code": "DATABASE_STAGE_NOT_IN_FIELD_HIERARCHY",
+                    "stage_id": stage_id,
+                    "stage_key": key,
+                    "database_stage_name": stage.get("stage_name"),
+                    "database_folder_path": stage.get("folder_path"),
+                    "warnings": [
+                        "Current database Stage/Sub-stage row did not map to one actual marked field hierarchy root."
+                    ],
+                },
+            )
+
+    return {
+        "stages": sorted(
+            stages,
+            key=lambda item: (str(item["stage_key"]).casefold(), item["label"].casefold()),
+        ),
+        "review_required": sorted(
+            reviews,
+            key=lambda item: (
+                str(item.get("stage_key") or "").casefold(),
+                str(item.get("code") or "").casefold(),
+                str(item.get("scope_root") or "").casefold(),
+                str(item.get("scene_name") or "").casefold(),
+            ),
+        ),
+    }
+
+
+def resolve_field_hierarchy(repository: Any, drive_root: str | Path) -> dict[str, Any]:
+    """Canonical shared browse entry point.
+
+    ``repository.stages()`` is treated only as raw DB/LOR evidence. Applications
+    must consume this resolved result rather than present those rows directly.
+    """
+    return build_field_hierarchy(repository.stages(), drive_root)

--- a/FieldWiring/Application/field_context_hierarchy.py
+++ b/FieldWiring/Application/field_context_hierarchy.py
@@ -1,0 +1,107 @@
+"""Validated field-facing Stage/Sub-stage/Scene browse contract.
+
+This module is the conservative public wrapper over ``field_context_browse``.
+The lower-level builder resolves actual marked filesystem roots and deduplicates
+raw LOR Scene evidence by resolved scope.  This wrapper adds the final top-level
+Stage binding gate required by the released Google Drive hierarchy contract:
+
+a top-level Stage is normal browse only when the persisted ``ref.stage`` path
+resolves back to that same marked top-level field root.  Missing, stale, or
+conflicting Stage-path evidence is review-only rather than silently guessed.
+
+Sub-stage rows are intentionally handled differently.  A marked NNa child root
+beneath its owning NN Stage is already physically bounded by the authoritative
+Google Drive hierarchy, so stale/missing Sub-stage ``folder_path`` remains a
+review finding but does not erase that real nested scope.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from field_context_browse import build_field_hierarchy as _build_field_hierarchy
+
+_TOP_LEVEL_PATH_REVIEW = "PERSISTED_STAGE_PATH_REVIEW_REQUIRED"
+_TOP_LEVEL_BINDING_REVIEW = "TOP_LEVEL_STAGE_BINDING_REVIEW_REQUIRED"
+
+
+def _review_sort_key(item: dict[str, Any]) -> tuple[str, str, str, str]:
+    return (
+        str(item.get("stage_key") or "").casefold(),
+        str(item.get("code") or "").casefold(),
+        str(item.get("scope_root") or "").casefold(),
+        str(item.get("scene_name") or "").casefold(),
+    )
+
+
+def build_field_hierarchy(
+    raw_stage_items: list[dict[str, Any]],
+    drive_root: str | Path,
+) -> dict[str, Any]:
+    """Return resolved field hierarchy with ambiguous top-level Stages removed.
+
+    ``field_context_browse`` remains responsible for filesystem resolution,
+    hierarchy shape, Scene deduplication, and review evidence.  This wrapper
+    converts any top-level Stage with unresolved persisted-path alignment into
+    review-only output.
+    """
+    result = _build_field_hierarchy(raw_stage_items, drive_root)
+    stages = list(result.get("stages") or [])
+    reviews = list(result.get("review_required") or [])
+
+    blocked: dict[str, list[dict[str, Any]]] = {}
+    for review in reviews:
+        if review.get("code") != _TOP_LEVEL_PATH_REVIEW:
+            continue
+        key = str(review.get("stage_key") or "").strip()
+        if key:
+            blocked.setdefault(key.casefold(), []).append(review)
+
+    normal: list[dict[str, Any]] = []
+    existing_review_keys = {
+        (
+            item.get("code"),
+            item.get("stage_id"),
+            str(item.get("stage_key") or "").casefold(),
+            str(item.get("scope_root") or "").casefold(),
+        )
+        for item in reviews
+    }
+
+    for stage in stages:
+        key = str(stage.get("stage_key") or "").strip()
+        findings = blocked.get(key.casefold())
+        if not findings:
+            normal.append(stage)
+            continue
+
+        review = {
+            "code": _TOP_LEVEL_BINDING_REVIEW,
+            "stage_id": stage.get("stage_id"),
+            "stage_key": key,
+            "scope_root": stage.get("scope_root"),
+            "database_stage_name": stage.get("database_stage_name"),
+            "database_folder_path": stage.get("database_folder_path"),
+            "warnings": [
+                "Marked top-level field Stage exists, but persisted ref.stage path evidence does not resolve to that same root; normal browse suppressed pending alignment review."
+            ],
+        }
+        dedupe_key = (
+            review["code"],
+            review.get("stage_id"),
+            key.casefold(),
+            str(review.get("scope_root") or "").casefold(),
+        )
+        if dedupe_key not in existing_review_keys:
+            reviews.append(review)
+            existing_review_keys.add(dedupe_key)
+
+    return {
+        "stages": normal,
+        "review_required": sorted(reviews, key=_review_sort_key),
+    }
+
+
+def resolve_field_hierarchy(repository: Any, drive_root: str | Path) -> dict[str, Any]:
+    """Canonical shared field-facing hierarchy entry point."""
+    return build_field_hierarchy(repository.stages(), drive_root)

--- a/FieldWiring/Application/test_field_context_browse.py
+++ b/FieldWiring/Application/test_field_context_browse.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from field_context_browse import resolve_field_hierarchy
+from field_context_resolver import MARKER_NAME
+
+
+class FakeRepository:
+    def __init__(self, items):
+        self.items = items
+
+    def stages(self):
+        return self.items
+
+
+def mark(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / MARKER_NAME).write_text("scope", encoding="utf-8")
+    return path
+
+
+def evidence_file(root: Path, *parts: str) -> str:
+    path = root.joinpath(*parts)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"x")
+    return str(path)
+
+
+def context(scene_name: str, scene_uuid: str, pointer: str, preview_uuid: str = "p1"):
+    return {
+        "preview": {
+            "preview_uuid": preview_uuid,
+            "preview_name": "2026 Master Musical Preview",
+            "preview_background_file": None,
+            "preview_revision": "1",
+            "source_filename": "master.lorprev",
+        },
+        "scene": {
+            "scene_uuid": scene_uuid,
+            "scene_name": scene_name,
+            "scene_stage_key": None,
+            "scene_background_file": pointer,
+        },
+        "scope_kind": "Scene",
+        "context_type": "Musical",
+    }
+
+
+def stage_item(stage_id: int, stage_key: str, stage_name: str, folder_path: str | None, contexts=None):
+    return {
+        "stage": {
+            "stage_id": stage_id,
+            "stage_key": stage_key,
+            "stage_name": stage_name,
+            "folder_path": folder_path,
+        },
+        "contexts": list(contexts or []),
+    }
+
+
+def by_key(hierarchy, key: str):
+    return next(item for item in hierarchy["stages"] if item["stage_key"] == key)
+
+
+def test_stage_15_root_contexts_collapse_to_one_field_stage(tmp_path):
+    drive = tmp_path / "Display Folders"
+    church = mark(drive / "15-Church-Bells-CH")
+    pointer = evidence_file(church, "Wiring", "MusicalStage", "church.jpg")
+
+    items = [
+        stage_item(
+            45,
+            "15",
+            "Show Background Stage 15 Church",
+            str(church),
+            [
+                context("15-Church-CH", "scene-musical", pointer),
+                context("Root", "scene-root", pointer, "p2"),
+            ],
+        )
+    ]
+
+    result = resolve_field_hierarchy(FakeRepository(items), drive)
+    assert len(result["stages"]) == 1
+    stage = result["stages"][0]
+    assert stage["label"] == "15-Church-Bells-CH"
+    assert stage["database_stage_name"] == "Show Background Stage 15 Church"
+    assert stage["scenes"] == []
+    assert {c["scene"]["scene_name"] for c in stage["contexts"]} == {
+        "15-Church-CH",
+        "Root",
+    }
+
+
+def test_stage_07_contains_07a_substage_and_defined_scene(tmp_path):
+    drive = tmp_path / "Display Folders"
+    stage = mark(drive / "07-Whoville-WV")
+    who_people = mark(stage / "07-Who People")
+    substage = mark(stage / "07a-Who Forest-WF")
+    stale_substage = stage / "07a-Who Forest"
+    stale_substage.mkdir()
+
+    stage_pointer = evidence_file(who_people, "PreviewBackground", "people.jpg")
+    sub_pointer = evidence_file(substage, "Wiring", "MusicalStage", "forest.jpg")
+
+    items = [
+        stage_item(
+            37,
+            "07",
+            "Show Background Stage 07 WhoHouse Mt Crumpet",
+            str(stage),
+            [context("07-Who People", "scene-people", stage_pointer)],
+        ),
+        stage_item(
+            59,
+            "07a",
+            "RGB Plus Stage 07a Who Forest",
+            str(stale_substage),
+            [context("07a-Who Forest-WF", "scene-forest", sub_pointer)],
+        ),
+    ]
+
+    result = resolve_field_hierarchy(FakeRepository(items), drive)
+    assert [item["stage_key"] for item in result["stages"]] == ["07"]
+    whoville = result["stages"][0]
+    assert [item["label"] for item in whoville["scenes"]] == ["07-Who People"]
+    assert [item["stage_key"] for item in whoville["sub_stages"]] == ["07a"]
+    forest = whoville["sub_stages"][0]
+    assert forest["label"] == "07a-Who Forest-WF"
+    assert forest["scenes"] == []
+    assert any(
+        item["code"] == "PERSISTED_SUBSTAGE_PATH_REVIEW_REQUIRED"
+        and item["stage_key"] == "07a"
+        for item in result["review_required"]
+    )
+
+
+def test_stage_13_and_21_emit_only_distinct_defined_scene_roots(tmp_path):
+    drive = tmp_path / "Display Folders"
+    winter = mark(drive / "13-Winter Wonderland-WW")
+    christmas_story = mark(winter / "13-Christmas Story")
+    bears = mark(drive / "21-Polar Bear Playground-PB")
+    snowballs = mark(bears / "21-SnowballBears")
+
+    story_pointer = evidence_file(christmas_story, "PreviewBackground", "story.jpg")
+    winter_root_pointer = evidence_file(winter, "Wiring", "BackgroundStage", "stage.jpg")
+    snowball_pointer = evidence_file(snowballs, "PreviewBackground", "snowballs.jpg")
+    bears_root_pointer = evidence_file(bears, "Wiring", "BackgroundStage", "stage.jpg")
+
+    items = [
+        stage_item(
+            43,
+            "13",
+            "Show Background Stage 13 Winter Wonderland",
+            str(winter),
+            [
+                context("13-Christmas Story", "story", story_pointer),
+                context("13-Grover Train", "grover", winter_root_pointer, "p2"),
+            ],
+        ),
+        stage_item(
+            51,
+            "21",
+            "Show Background Stage 21 Polar Bears",
+            str(bears),
+            [
+                context("21-SnowballBears", "snowballs", snowball_pointer),
+                context("21-Sliding Penguins", "sliding", bears_root_pointer, "p2"),
+                context("Root", "root", bears_root_pointer, "p3"),
+            ],
+        ),
+    ]
+
+    result = resolve_field_hierarchy(FakeRepository(items), drive)
+    assert [item["label"] for item in by_key(result, "13")["scenes"]] == [
+        "13-Christmas Story"
+    ]
+    assert [item["label"] for item in by_key(result, "21")["scenes"]] == [
+        "21-SnowballBears"
+    ]
+
+
+def test_raw_lor_scene_does_not_promote_unprefixed_group_folder(tmp_path):
+    drive = tmp_path / "Display Folders"
+    entrance = mark(drive / "01-Front Entrance-FE")
+    goal = mark(entrance / "Goal Sign")
+    pointer = evidence_file(goal, "PreviewBackground", "goal.jpg")
+
+    items = [
+        stage_item(
+            31,
+            "01",
+            "Show Background Stage 01 FE Open-Close Sign",
+            str(entrance),
+            [context("Goal Sign", "goal", pointer)],
+        )
+    ]
+
+    result = resolve_field_hierarchy(FakeRepository(items), drive)
+    entrance_node = result["stages"][0]
+    assert entrance_node["scenes"] == []
+    assert any(
+        item["code"] == "LOR_CONTEXT_NOT_DEFINED_FIELD_SCENE"
+        and item["scene_name"] == "Goal Sign"
+        for item in result["review_required"]
+    )
+
+
+def test_stage_39_40_alignment_is_review_not_browse_guess(tmp_path):
+    drive = tmp_path / "Display Folders"
+    drive.mkdir()
+    parade = drive / "40-Parade Float-PF"
+    parade.mkdir()
+
+    items = [
+        stage_item(58, "39", "RGB Plus Stage 39 Parade Float", str(parade)),
+        stage_item(368, "40", "CommandCenter-CC", None),
+    ]
+
+    result = resolve_field_hierarchy(FakeRepository(items), drive)
+    assert result["stages"] == []
+    review_keys = {item.get("stage_key") for item in result["review_required"]}
+    assert {"39", "40"}.issubset(review_keys)
+    assert any(
+        item["code"] == "STAGE_ROOT_UNMARKED" and item["stage_key"] == "40"
+        for item in result["review_required"]
+    )
+
+
+def test_database_only_90_series_rows_are_not_normal_field_stages(tmp_path):
+    drive = tmp_path / "Display Folders"
+    mark(drive / "15-Church-Bells-CH")
+
+    items = [
+        stage_item(45, "15", "Show Background Stage 15 Church", str(drive / "15-Church-Bells-CH")),
+        stage_item(91, "90", "Show Animation EL 90 Elf On Shelf-1", None),
+        stage_item(92, "91", "Show Animation EL 91 Elf On Shelf-2", None),
+    ]
+
+    result = resolve_field_hierarchy(FakeRepository(items), drive)
+    assert [item["stage_key"] for item in result["stages"]] == ["15"]
+    review_keys = {item.get("stage_key") for item in result["review_required"]}
+    assert {"90", "91"}.issubset(review_keys)

--- a/FieldWiring/Application/test_field_context_hierarchy.py
+++ b/FieldWiring/Application/test_field_context_hierarchy.py
@@ -1,0 +1,92 @@
+from pathlib import Path
+
+from field_context_hierarchy import build_field_hierarchy
+from field_context_resolver import MARKER_NAME
+
+
+def mark(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / MARKER_NAME).write_text("marker", encoding="utf-8")
+    return path
+
+
+def raw_stage(stage_id: int, key: str, name: str, folder_path: str | None):
+    return {
+        "stage": {
+            "stage_id": stage_id,
+            "stage_key": key,
+            "stage_name": name,
+            "folder_path": folder_path,
+        },
+        "contexts": [],
+    }
+
+
+def test_valid_top_level_stage_remains_normal(tmp_path):
+    drive = tmp_path / "Display Folders"
+    root = mark(drive / "15-Church-Bells-CH")
+
+    result = build_field_hierarchy(
+        [raw_stage(15, "15", "LOR Church Name", str(root))],
+        drive,
+    )
+
+    assert [item["stage_key"] for item in result["stages"]] == ["15"]
+    assert result["stages"][0]["label"] == "15-Church-Bells-CH"
+    assert not any(
+        item["code"] == "TOP_LEVEL_STAGE_BINDING_REVIEW_REQUIRED"
+        for item in result["review_required"]
+    )
+
+
+def test_conflicting_top_level_stage_path_is_review_only(tmp_path):
+    drive = tmp_path / "Display Folders"
+    mark(drive / "39-Parade Float-PF")
+    other = mark(drive / "40-Parade Float-PF")
+
+    result = build_field_hierarchy(
+        [raw_stage(39, "39", "RGB Plus Stage 39 Parade Float", str(other))],
+        drive,
+    )
+
+    assert result["stages"] == []
+    codes = [item["code"] for item in result["review_required"]]
+    assert "PERSISTED_STAGE_PATH_REVIEW_REQUIRED" in codes
+    assert "TOP_LEVEL_STAGE_BINDING_REVIEW_REQUIRED" in codes
+
+
+def test_missing_top_level_stage_path_is_review_only(tmp_path):
+    drive = tmp_path / "Display Folders"
+    mark(drive / "40-CommandCenter")
+
+    result = build_field_hierarchy(
+        [raw_stage(40, "40", "CommandCenter-CC", None)],
+        drive,
+    )
+
+    assert result["stages"] == []
+    codes = [item["code"] for item in result["review_required"]]
+    assert "PERSISTED_STAGE_PATH_REVIEW_REQUIRED" in codes
+    assert "TOP_LEVEL_STAGE_BINDING_REVIEW_REQUIRED" in codes
+
+
+def test_nested_substage_with_missing_persisted_path_remains_browseable(tmp_path):
+    drive = tmp_path / "Display Folders"
+    stage_root = mark(drive / "07-Whoville-WV")
+    mark(stage_root / "07a-Who Forest-WF")
+
+    result = build_field_hierarchy(
+        [
+            raw_stage(7, "07", "Whoville", str(stage_root)),
+            raw_stage(70, "07a", "Who Forest", None),
+        ],
+        drive,
+    )
+
+    assert [item["stage_key"] for item in result["stages"]] == ["07"]
+    assert [item["stage_key"] for item in result["stages"][0]["sub_stages"]] == ["07a"]
+    assert any(
+        item["code"] == "PERSISTED_SUBSTAGE_PATH_REVIEW_REQUIRED"
+        and str(item.get("stage_key")) == "07a"
+        for item in result["review_required"]
+    )

--- a/FieldWiring/Engineering/field_hierarchy_live_acceptance.py
+++ b/FieldWiring/Engineering/field_hierarchy_live_acceptance.py
@@ -1,0 +1,216 @@
+"""Read-only live acceptance probe for shared Field Context hierarchy browse.
+
+Engineering-only utility. It reads production PostgreSQL and the mounted
+Display Folders tree, reports representative hierarchy cases, and compares a
+normal FieldWiring package with the unchanged production API. It performs no
+writes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.request
+from pathlib import Path
+
+APPLICATION = Path(__file__).resolve().parents[1] / "Application"
+sys.path.insert(0, str(APPLICATION))
+
+from field_context_browse import resolve_field_hierarchy
+from field_context_repository import PostgresFieldContextRepository
+from repository import PostgresRepository
+from wiring import WiringError, build_wiring_package
+
+
+def main() -> int:
+    failures: list[str] = []
+
+    def check(condition: bool, message: str) -> None:
+        if condition:
+            print("PASS:", message)
+        else:
+            print("FAIL:", message)
+            failures.append(message)
+
+    dsn = os.environ["FIELDWIRING_DATABASE_DSN"]
+    drive_root = Path(os.environ["FIELDWIRING_DRIVE_ROOT"])
+    shared = PostgresFieldContextRepository(dsn)
+    fw = PostgresRepository(dsn)
+
+    hierarchy = resolve_field_hierarchy(shared, drive_root)
+    stages = hierarchy["stages"]
+    reviews = hierarchy["review_required"]
+
+    def normal_stage(key: str):
+        return [item for item in stages if str(item.get("stage_key")) == key]
+
+    def one_stage(key: str):
+        matches = normal_stage(key)
+        if len(matches) != 1:
+            failures.append(f"Expected exactly one normal Stage {key}; found {len(matches)}")
+            print(f"FAIL: Stage {key} normal node count = {len(matches)}")
+            return None
+        return matches[0]
+
+    def scene_labels(node):
+        return [item["label"] for item in (node or {}).get("scenes", [])]
+
+    def substage_labels(node):
+        return [item["label"] for item in (node or {}).get("sub_stages", [])]
+
+    print("--- hierarchy summary ---")
+    print("normal Stage count:", len(stages))
+    print("review-required count:", len(reviews))
+    print("normal Stage keys:", [item.get("stage_key") for item in stages])
+
+    print("\n--- Stage 15 Church ---")
+    s15 = one_stage("15")
+    if s15:
+        print("label:", s15["label"])
+        print("scope_root:", s15["scope_root"])
+        print("scenes:", scene_labels(s15))
+        print("root context count:", len(s15.get("contexts") or []))
+        check(s15["label"] == "15-Church-Bells-CH", "Stage 15 uses actual folder label")
+        check(scene_labels(s15) == [], "Stage 15 Master Musical/Root rows do not create child Scenes")
+        check(len(s15.get("contexts") or []) >= 1, "Stage 15 retains root-binding context evidence")
+
+    print("\n--- Stage 07 / Sub-stage 07a ---")
+    s07 = one_stage("07")
+    if s07:
+        print("Stage label:", s07["label"])
+        print("Stage scenes:", scene_labels(s07))
+        print("Sub-stages:", substage_labels(s07))
+        check(s07["label"] == "07-Whoville-WV", "Stage 07 uses actual top-level folder")
+        check("07a-Who Forest-WF" in substage_labels(s07), "07a is nested beneath Stage 07")
+        check("07-Who People" in scene_labels(s07), "07-Who People is a defined Stage 07 Scene")
+        check("07-Who Spiral Tree" in scene_labels(s07), "07-Who Spiral Tree is a defined Stage 07 Scene")
+        for item in s07.get("sub_stages", []):
+            if item.get("label") == "07a-Who Forest-WF":
+                print("07a scope_root:", item.get("scope_root"))
+                print("07a scenes:", scene_labels(item))
+
+    print("\n--- Stage 13 defined Scenes ---")
+    s13 = one_stage("13")
+    if s13:
+        labels = scene_labels(s13)
+        print("label:", s13["label"])
+        print("scenes:", labels)
+        expected = {
+            "13-Christmas Story",
+            "13-Christmas Vacation",
+            "13-Christmas With the Kranks",
+            "13-Nightmare Before Christmas",
+        }
+        check(set(labels) == expected, "Stage 13 exposes only the four defined marked child Scene scopes")
+        check(not ({"13-Grover Train", "Die Hard", "Static Contactor", "Root"} & set(labels)), "Stage 13 raw LOR groups resolving to Stage root are not child Scenes")
+
+    print("\n--- Stage 21 defined Scene ---")
+    s21 = one_stage("21")
+    if s21:
+        labels = scene_labels(s21)
+        print("label:", s21["label"])
+        print("scenes:", labels)
+        check(labels == ["21-SnowballBears"], "Stage 21 exposes only 21-SnowballBears as a child Scene")
+        check("21-Sliding Penguins" not in labels, "21-Sliding Penguins collapses to Stage 21 root")
+
+    print("\n--- Stage 25 root deduplication ---")
+    s25 = one_stage("25")
+    if s25:
+        print("label:", s25["label"])
+        print("scenes:", scene_labels(s25))
+        print("root context count:", len(s25.get("contexts") or []))
+        check(s25["label"] == "25-Racing Arches-RA", "Stage 25 uses actual folder label")
+        check(scene_labels(s25) == [], "25-Racing Arches-RA LOR Scene does not duplicate the Stage root")
+
+    print("\n--- Stage 39 / 40 alignment review ---")
+    for key in ("39", "40"):
+        normal = normal_stage(key)
+        findings = [item for item in reviews if str(item.get("stage_key")) == key]
+        print("Stage", key, "normal browse nodes:", len(normal))
+        for item in normal:
+            print(" normal:", item.get("label"), "|", item.get("scope_root"), "| DB:", item.get("database_stage_name"), item.get("database_folder_path"))
+        print("Stage", key, "review findings:")
+        for finding in findings:
+            print(" ", finding.get("code"), "|", finding.get("scope_root"), "|", finding.get("database_folder_path"), "|", finding.get("warnings"))
+        check(not normal, f"Stage {key} alignment conflict is not silently promoted into normal browse")
+        check(bool(findings), f"Stage {key} alignment issue is surfaced for review")
+
+    print("\n--- Stage 90-94 normal browse exclusion ---")
+    for key in ("90", "91", "92", "93", "94"):
+        normal = normal_stage(key)
+        print(key, "normal nodes:", len(normal))
+        check(not normal, f"Stage {key} is not a normal physical browse Stage")
+
+    print("\n--- inventory Display 807 ---")
+    c807 = shared.display_context(807)
+    print("shared context:", c807)
+    check(c807 is not None, "Display 807 resolves shared context")
+    if c807:
+        check(c807.get("display_name") == "RA-SteelArch-DS-F-03", "Display 807 identity preserved")
+        check(str((c807.get("stage") or {}).get("stage_key")) == "25", "Display 807 remains bound to Stage 25")
+    shared_ids = [item["display_id"] for item in shared.search_displays("RA-SteelArch-DS-F-03")]
+    fw_ids = [item["display_id"] for item in fw.search_displays("RA-SteelArch-DS-F-03")]
+    print("shared search:", shared_ids)
+    print("FieldWiring search:", fw_ids)
+    check(807 in shared_ids, "Shared search includes inventory Display 807")
+    check(807 not in fw_ids, "FieldWiring search remains wiring-filtered")
+    try:
+        build_wiring_package(fw, display_id=807)
+    except WiringError as exc:
+        print("FieldWiring direct result:", str(exc))
+        check(str(exc) == "No applicable field wiring is available for this Display", "Direct Display 807 FieldWiring request keeps explicit no-wiring result")
+    else:
+        check(False, "Display 807 must not unexpectedly produce a FieldWiring package")
+
+    print("\n--- wired Display 312 candidate vs production ---")
+    try:
+        candidate = build_wiring_package(fw, display_id=312)
+        with urllib.request.urlopen(
+            "http://192.168.5.9:8790/api/wiring?display_id=312",
+            timeout=10,
+        ) as response:
+            production = json.load(response)["wiring"]
+
+        def comparable(package):
+            return {
+                "context": package["context"],
+                "images": package["images"],
+                "controller_groups": package["controller_groups"],
+                "rows": package["rows"],
+            }
+
+        check(comparable(candidate) == comparable(production), "Display 312 candidate remains equivalent to production FieldWiring")
+        print("scope_type:", candidate["images"]["scope_type"])
+        print("scope_root:", candidate["images"]["scope_root"])
+        print("wiring_images:", [item["name"] for item in candidate["images"]["wiring_images"]])
+    except Exception as exc:
+        print("FAIL: Display 312 equivalence raised:", repr(exc))
+        failures.append("Display 312 FieldWiring equivalence could not complete")
+
+    print("\n--- representative review findings ---")
+    for finding in reviews:
+        if str(finding.get("stage_key")) in {"05a", "07a", "39", "40", "90", "91", "92", "93", "94"}:
+            print(
+                finding.get("stage_key"),
+                finding.get("code"),
+                "|",
+                finding.get("scope_root"),
+                "|",
+                finding.get("database_folder_path"),
+                "|",
+                finding.get("warnings"),
+            )
+
+    print("\n--- acceptance summary ---")
+    if failures:
+        print("LIVE ACCEPTANCE: REVIEW REQUIRED")
+        for failure in failures:
+            print(" -", failure)
+        return 1
+
+    print("SHARED FIELD HIERARCHY LIVE ACCEPTANCE: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/FieldWiring/Engineering/field_hierarchy_live_acceptance_v2.py
+++ b/FieldWiring/Engineering/field_hierarchy_live_acceptance_v2.py
@@ -1,0 +1,19 @@
+"""Run the durable live hierarchy acceptance probe against the final Stage gate."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+APPLICATION = Path(__file__).resolve().parents[1] / "Application"
+sys.path.insert(0, str(APPLICATION))
+
+import field_hierarchy_live_acceptance as probe
+from field_context_hierarchy import resolve_field_hierarchy
+
+# Reuse the accepted diagnostic body while substituting the final canonical
+# hierarchy entry point. This keeps the representative live assertions
+# identical to the first diagnostic run.
+probe.resolve_field_hierarchy = resolve_field_hierarchy
+
+if __name__ == "__main__":
+    raise SystemExit(probe.main())


### PR DESCRIPTION
## Purpose
Repair the shared field-context browse contract so applications consume the released Google Drive Stage -> Sub-stage -> defined Scene hierarchy rather than raw `ref.stage` / LOR Scene association rows.

## Governing authority
- `Docs/00_Project_Overview/00-Google_Drive.md` Revision 1.3.1
- `Docs/00_Project_Overview/01-Google_Drive_Document_Organization_Procedure.md`

## Architecture
Canonical field-facing entry point:

`FieldWiring/Application/field_context_hierarchy.py`

It consumes raw DB/LOR evidence from `field_context_repository.py`, uses the existing `field_context_resolver.resolve_structured_scope(...)`, deduplicates by resolved marked filesystem root, nests formal NNa Sub-stages under NN Stages, creates child Scenes only for distinct marked prefixed child roots, and returns unsafe alignment evidence under `review_required` rather than guessing.

Raw `repository.stages()` remains evidence and must not be rendered directly as field browse.

## Preserved boundaries
- permanent `display_id` resolution unchanged
- inventory-only Display support preserved
- FieldWiring eligibility/search remains downstream and unchanged
- existing structured-scope resolver unchanged
- no Procedure code changes
- no PostgreSQL schema/data changes
- no Google Drive moves/renames

## Regression
Final detached-worktree suite:

`74 passed in 2.09s`

## Live production-data acceptance
Read-only candidate against production PostgreSQL + `/mnt/msb-display-folders`:

- Stage 15 Church: Stage-root dedup PASS
- Stage 07 / 07a nesting PASS
- Stage 13 defined Scenes PASS
- Stage 21 defined Scene PASS
- Stage 25 Stage-root dedup PASS
- Stage 39/40 suppressed from normal browse and surfaced for review PASS
- Stage 90–94 excluded from normal physical browse PASS
- inventory Display 807 shared context / FieldWiring separation PASS
- wired Display 312 candidate exactly equivalent to unchanged production FieldWiring PASS

Final result:

`SHARED FIELD HIERARCHY LIVE ACCEPTANCE: PASS`

## Procedure gate
Procedure remains paused until this repair is merged and production accepted. After that, merge current `main` into `feature/setup-takedown-procedures` and replace raw Stage browse consumption with `field_context_hierarchy.resolve_field_hierarchy(...)`.