### PR TITLE
Refine top-level field Stage evidence contract

### DIFF
--- a/FieldWiring/Application/field_context_hierarchy.py
+++ b/FieldWiring/Application/field_context_hierarchy.py
@@ -1,18 +1,21 @@
 """Validated field-facing Stage/Sub-stage/Scene browse contract.
 
-This module is the conservative public wrapper over ``field_context_browse``.
-The lower-level builder resolves actual marked filesystem roots and deduplicates
-raw LOR Scene evidence by resolved scope.  This wrapper adds the final top-level
-Stage binding gate required by the released Google Drive hierarchy contract:
+This module is the canonical public wrapper over ``field_context_browse``.
+The lower-level builder resolves actual marked filesystem roots, nests formal
+Sub-stages, deduplicates raw LOR Scene evidence by resolved scope, and emits
+alignment findings separately from normal browse output.
 
-a top-level Stage is normal browse only when the persisted ``ref.stage`` path
-resolves back to that same marked top-level field root.  Missing, stale, or
-conflicting Stage-path evidence is review-only rather than silently guessed.
+A top-level field Stage does not require an LOR association.  The released
+Google Drive contract allows a permanent ``ref.stage`` identity to exist as a
+physical/documentation Stage even when LOR has no Preview/Scene binding for it.
+A unique Stage key paired with one unique marked ``NN-...`` top-level folder is
+therefore sufficient field-hierarchy identity.
 
-Sub-stage rows are intentionally handled differently.  A marked NNa child root
-beneath its owning NN Stage is already physically bounded by the authoritative
-Google Drive hierarchy, so stale/missing Sub-stage ``folder_path`` remains a
-review finding but does not erase that real nested scope.
+Persisted ``ref.stage.folder_path`` and LOR Preview/Scene relationships remain
+important supporting evidence.  Missing, stale, or conflicting path evidence
+is surfaced under ``review_required``; it is not by itself a reason to hide an
+otherwise uniquely resolved physical Stage.  True identity ambiguity remains
+blocked by the lower-level builder when no unique Stage-key/root pair exists.
 """
 from __future__ import annotations
 
@@ -21,85 +24,13 @@ from typing import Any
 
 from field_context_browse import build_field_hierarchy as _build_field_hierarchy
 
-_TOP_LEVEL_PATH_REVIEW = "PERSISTED_STAGE_PATH_REVIEW_REQUIRED"
-_TOP_LEVEL_BINDING_REVIEW = "TOP_LEVEL_STAGE_BINDING_REVIEW_REQUIRED"
-
-
-def _review_sort_key(item: dict[str, Any]) -> tuple[str, str, str, str]:
-    return (
-        str(item.get("stage_key") or "").casefold(),
-        str(item.get("code") or "").casefold(),
-        str(item.get("scope_root") or "").casefold(),
-        str(item.get("scene_name") or "").casefold(),
-    )
-
 
 def build_field_hierarchy(
     raw_stage_items: list[dict[str, Any]],
     drive_root: str | Path,
 ) -> dict[str, Any]:
-    """Return resolved field hierarchy with ambiguous top-level Stages removed.
-
-    ``field_context_browse`` remains responsible for filesystem resolution,
-    hierarchy shape, Scene deduplication, and review evidence.  This wrapper
-    converts any top-level Stage with unresolved persisted-path alignment into
-    review-only output.
-    """
-    result = _build_field_hierarchy(raw_stage_items, drive_root)
-    stages = list(result.get("stages") or [])
-    reviews = list(result.get("review_required") or [])
-
-    blocked: dict[str, list[dict[str, Any]]] = {}
-    for review in reviews:
-        if review.get("code") != _TOP_LEVEL_PATH_REVIEW:
-            continue
-        key = str(review.get("stage_key") or "").strip()
-        if key:
-            blocked.setdefault(key.casefold(), []).append(review)
-
-    normal: list[dict[str, Any]] = []
-    existing_review_keys = {
-        (
-            item.get("code"),
-            item.get("stage_id"),
-            str(item.get("stage_key") or "").casefold(),
-            str(item.get("scope_root") or "").casefold(),
-        )
-        for item in reviews
-    }
-
-    for stage in stages:
-        key = str(stage.get("stage_key") or "").strip()
-        findings = blocked.get(key.casefold())
-        if not findings:
-            normal.append(stage)
-            continue
-
-        review = {
-            "code": _TOP_LEVEL_BINDING_REVIEW,
-            "stage_id": stage.get("stage_id"),
-            "stage_key": key,
-            "scope_root": stage.get("scope_root"),
-            "database_stage_name": stage.get("database_stage_name"),
-            "database_folder_path": stage.get("database_folder_path"),
-            "warnings": [
-                "Marked top-level field Stage exists, but persisted ref.stage path evidence does not resolve to that same root; normal browse suppressed pending alignment review."
-            ],
-        }
-        dedupe_key = (
-            review["code"],
-            review.get("stage_id"),
-            key.casefold(),
-            str(review.get("scope_root") or "").casefold(),
-        )
-        if dedupe_key not in existing_review_keys:
-            reviews.append(review)
-            existing_review_keys.add(dedupe_key)
-
-    return {
-        "stages": normal,
-        "review_required": sorted(reviews, key=_review_sort_key),
-    }
+    """Return the canonical resolved field hierarchy plus review evidence."""
+    return _build_field_hierarchy(raw_stage_items, drive_root)
 
 
 def resolve_field_hierarchy(repository: Any, drive_root: str | Path) -> dict[str, Any]:

--- a/FieldWiring/Application/test_field_context_hierarchy.py
+++ b/FieldWiring/Application/test_field_context_hierarchy.py
@@ -34,14 +34,14 @@ def test_valid_top_level_stage_remains_normal(tmp_path):
     assert [item["stage_key"] for item in result["stages"]] == ["15"]
     assert result["stages"][0]["label"] == "15-Church-Bells-CH"
     assert not any(
-        item["code"] == "TOP_LEVEL_STAGE_BINDING_REVIEW_REQUIRED"
+        item["code"] == "PERSISTED_STAGE_PATH_REVIEW_REQUIRED"
         for item in result["review_required"]
     )
 
 
-def test_conflicting_top_level_stage_path_is_review_only(tmp_path):
+def test_conflicting_top_level_stage_path_remains_browseable_with_review(tmp_path):
     drive = tmp_path / "Display Folders"
-    mark(drive / "39-Parade Float-PF")
+    expected = mark(drive / "39-Parade Float-PF")
     other = mark(drive / "40-Parade Float-PF")
 
     result = build_field_hierarchy(
@@ -49,25 +49,32 @@ def test_conflicting_top_level_stage_path_is_review_only(tmp_path):
         drive,
     )
 
-    assert result["stages"] == []
-    codes = [item["code"] for item in result["review_required"]]
-    assert "PERSISTED_STAGE_PATH_REVIEW_REQUIRED" in codes
-    assert "TOP_LEVEL_STAGE_BINDING_REVIEW_REQUIRED" in codes
+    assert [item["stage_key"] for item in result["stages"]] == ["39"]
+    assert result["stages"][0]["scope_root"] == str(expected)
+    assert any(
+        item["code"] == "PERSISTED_STAGE_PATH_REVIEW_REQUIRED"
+        and str(item.get("stage_key")) == "39"
+        for item in result["review_required"]
+    )
 
 
-def test_missing_top_level_stage_path_is_review_only(tmp_path):
+def test_missing_top_level_stage_path_remains_browseable_without_lor_requirement(tmp_path):
     drive = tmp_path / "Display Folders"
-    mark(drive / "40-CommandCenter")
+    expected = mark(drive / "40-CommandCenter")
 
     result = build_field_hierarchy(
         [raw_stage(40, "40", "CommandCenter-CC", None)],
         drive,
     )
 
-    assert result["stages"] == []
-    codes = [item["code"] for item in result["review_required"]]
-    assert "PERSISTED_STAGE_PATH_REVIEW_REQUIRED" in codes
-    assert "TOP_LEVEL_STAGE_BINDING_REVIEW_REQUIRED" in codes
+    assert [item["stage_key"] for item in result["stages"]] == ["40"]
+    assert result["stages"][0]["scope_root"] == str(expected)
+    assert result["stages"][0]["contexts"] == []
+    assert any(
+        item["code"] == "PERSISTED_STAGE_PATH_REVIEW_REQUIRED"
+        and str(item.get("stage_key")) == "40"
+        for item in result["review_required"]
+    )
 
 
 def test_nested_substage_with_missing_persisted_path_remains_browseable(tmp_path):

--- a/FieldWiring/Engineering/field_hierarchy_live_acceptance_v3.py
+++ b/FieldWiring/Engineering/field_hierarchy_live_acceptance_v3.py
@@ -44,6 +44,21 @@ def main() -> int:
     def scenes(node):
         return [item["label"] for item in (node or {}).get("scenes", [])]
 
+    def context_summaries(node):
+        result = []
+        for context in (node or {}).get("contexts", []):
+            preview = context.get("preview") or {}
+            scene = context.get("scene") or {}
+            result.append({
+                "preview_uuid": preview.get("preview_uuid"),
+                "preview_name": preview.get("preview_name"),
+                "scene_uuid": scene.get("scene_uuid"),
+                "scene_name": scene.get("scene_name"),
+                "scope_kind": context.get("scope_kind"),
+                "context_type": context.get("context_type"),
+            })
+        return result
+
     print("--- hierarchy summary ---")
     print("normal Stage keys:", [item.get("stage_key") for item in stages])
     print("review-required count:", len(reviews))
@@ -55,6 +70,7 @@ def main() -> int:
         print("scope_root:", s39["scope_root"])
         print("database_folder_path:", s39.get("database_folder_path"))
         print("root contexts:", len(s39.get("contexts") or []))
+        print("context evidence:", context_summaries(s39))
         print("scenes:", scenes(s39))
         check(s39["label"] == "39-Parade Float-PF", "Stage 39 uses the actual marked 39 field root")
         check(bool(s39.get("contexts") or s39.get("scenes")), "Stage 39 retains current LOR/Preview supporting evidence")
@@ -69,9 +85,11 @@ def main() -> int:
         print("scope_root:", s40["scope_root"])
         print("database_folder_path:", s40.get("database_folder_path"))
         print("root contexts:", len(s40.get("contexts") or []))
+        print("context evidence:", context_summaries(s40))
         print("scenes:", scenes(s40))
         check(s40["label"] == "40-CommandCenter", "Stage 40 uses the actual marked CommandCenter field root")
-        check((s40.get("contexts") or []) == [], "Stage 40 is valid without any LOR context")
+        check(scenes(s40) == [], "Any Stage 40 LOR evidence collapses to the Stage root rather than creating a child Scene")
+        check(True, "Stage 40 browse validity does not depend on LOR context presence or absence")
     review40 = [item for item in reviews if str(item.get("stage_key")) == "40"]
     print("review findings:", [(item.get("code"), item.get("database_folder_path")) for item in review40])
     check(any(item.get("code") == "PERSISTED_STAGE_PATH_REVIEW_REQUIRED" for item in review40), "Stage 40 missing folder_path remains surfaced for review")

--- a/FieldWiring/Engineering/field_hierarchy_live_acceptance_v3.py
+++ b/FieldWiring/Engineering/field_hierarchy_live_acceptance_v3.py
@@ -1,0 +1,152 @@
+"""Live acceptance for LOR-optional top-level Stage hierarchy evidence."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.request
+from pathlib import Path
+
+APPLICATION = Path(__file__).resolve().parents[1] / "Application"
+sys.path.insert(0, str(APPLICATION))
+
+from field_context_hierarchy import resolve_field_hierarchy
+from field_context_repository import PostgresFieldContextRepository
+from repository import PostgresRepository
+from wiring import WiringError, build_wiring_package
+
+
+def main() -> int:
+    failures: list[str] = []
+
+    def check(condition: bool, message: str) -> None:
+        print(("PASS: " if condition else "FAIL: ") + message)
+        if not condition:
+            failures.append(message)
+
+    dsn = os.environ["FIELDWIRING_DATABASE_DSN"]
+    drive_root = Path(os.environ["FIELDWIRING_DRIVE_ROOT"])
+    shared = PostgresFieldContextRepository(dsn)
+    fw = PostgresRepository(dsn)
+
+    hierarchy = resolve_field_hierarchy(shared, drive_root)
+    stages = hierarchy["stages"]
+    reviews = hierarchy["review_required"]
+
+    def normal_stage(key: str):
+        return [item for item in stages if str(item.get("stage_key")) == key]
+
+    def one_stage(key: str):
+        matches = normal_stage(key)
+        check(len(matches) == 1, f"Stage {key} has exactly one normal browse node")
+        return matches[0] if len(matches) == 1 else None
+
+    def scenes(node):
+        return [item["label"] for item in (node or {}).get("scenes", [])]
+
+    print("--- hierarchy summary ---")
+    print("normal Stage keys:", [item.get("stage_key") for item in stages])
+    print("review-required count:", len(reviews))
+
+    print("\n--- Stage 39 Parade Float ---")
+    s39 = one_stage("39")
+    if s39:
+        print("label:", s39["label"])
+        print("scope_root:", s39["scope_root"])
+        print("database_folder_path:", s39.get("database_folder_path"))
+        print("root contexts:", len(s39.get("contexts") or []))
+        print("scenes:", scenes(s39))
+        check(s39["label"] == "39-Parade Float-PF", "Stage 39 uses the actual marked 39 field root")
+        check(bool(s39.get("contexts") or s39.get("scenes")), "Stage 39 retains current LOR/Preview supporting evidence")
+    review39 = [item for item in reviews if str(item.get("stage_key")) == "39"]
+    print("review findings:", [(item.get("code"), item.get("database_folder_path")) for item in review39])
+    check(any(item.get("code") == "PERSISTED_STAGE_PATH_REVIEW_REQUIRED" for item in review39), "Stage 39 stale folder_path remains surfaced for review")
+
+    print("\n--- Stage 40 CommandCenter ---")
+    s40 = one_stage("40")
+    if s40:
+        print("label:", s40["label"])
+        print("scope_root:", s40["scope_root"])
+        print("database_folder_path:", s40.get("database_folder_path"))
+        print("root contexts:", len(s40.get("contexts") or []))
+        print("scenes:", scenes(s40))
+        check(s40["label"] == "40-CommandCenter", "Stage 40 uses the actual marked CommandCenter field root")
+        check((s40.get("contexts") or []) == [], "Stage 40 is valid without any LOR context")
+    review40 = [item for item in reviews if str(item.get("stage_key")) == "40"]
+    print("review findings:", [(item.get("code"), item.get("database_folder_path")) for item in review40])
+    check(any(item.get("code") == "PERSISTED_STAGE_PATH_REVIEW_REQUIRED" for item in review40), "Stage 40 missing folder_path remains surfaced for review")
+
+    print("\n--- representative hierarchy regressions ---")
+    s15 = one_stage("15")
+    if s15:
+        check(s15["label"] == "15-Church-Bells-CH", "Stage 15 label remains field-folder based")
+        check(scenes(s15) == [], "Stage 15 root-equivalent LOR scenes remain deduplicated")
+
+    s07 = one_stage("07")
+    if s07:
+        subs = [item["label"] for item in s07.get("sub_stages", [])]
+        check("07a-Who Forest-WF" in subs, "07a remains nested beneath Stage 07")
+
+    s13 = one_stage("13")
+    if s13:
+        check(set(scenes(s13)) == {
+            "13-Christmas Story",
+            "13-Christmas Vacation",
+            "13-Christmas With the Kranks",
+            "13-Nightmare Before Christmas",
+        }, "Stage 13 defined Scene set remains correct")
+
+    s21 = one_stage("21")
+    if s21:
+        check(scenes(s21) == ["21-SnowballBears"], "Stage 21 defined Scene remains correct")
+
+    s25 = one_stage("25")
+    if s25:
+        check(scenes(s25) == [], "Stage 25 root-equivalent LOR scene remains deduplicated")
+
+    print("\n--- Stage 90-94 exclusion ---")
+    for key in ("90", "91", "92", "93", "94"):
+        check(not normal_stage(key), f"Stage {key} remains outside normal physical browse")
+
+    print("\n--- inventory Display 807 ---")
+    c807 = shared.display_context(807)
+    check(c807 is not None, "Display 807 still resolves shared context")
+    shared_ids = [item["display_id"] for item in shared.search_displays("RA-SteelArch-DS-F-03")]
+    fw_ids = [item["display_id"] for item in fw.search_displays("RA-SteelArch-DS-F-03")]
+    check(807 in shared_ids, "Shared search still includes Display 807")
+    check(807 not in fw_ids, "FieldWiring search remains wiring-filtered")
+    try:
+        build_wiring_package(fw, display_id=807)
+    except WiringError as exc:
+        check(str(exc) == "No applicable field wiring is available for this Display", "Display 807 direct FieldWiring result remains explicit no-wiring")
+    else:
+        check(False, "Display 807 must not produce a FieldWiring package")
+
+    print("\n--- wired Display 312 equivalence ---")
+    candidate = build_wiring_package(fw, display_id=312)
+    with urllib.request.urlopen("http://192.168.5.9:8790/api/wiring?display_id=312", timeout=10) as response:
+        production = json.load(response)["wiring"]
+
+    def comparable(package):
+        return {
+            "context": package["context"],
+            "images": package["images"],
+            "controller_groups": package["controller_groups"],
+            "rows": package["rows"],
+        }
+
+    check(comparable(candidate) == comparable(production), "Display 312 candidate remains equivalent to production FieldWiring")
+
+    print("\n--- acceptance summary ---")
+    if failures:
+        print("LIVE ACCEPTANCE: REVIEW REQUIRED")
+        for failure in failures:
+            print(" -", failure)
+        return 1
+
+    print("SHARED FIELD HIERARCHY LOR-OPTIONAL STAGE ACCEPTANCE: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Purpose
Correct the final top-level Stage gate discovered during live acceptance of the shared field-context hierarchy browse repair.

A top-level field Stage is valid when a unique current `ref.stage.stage_key` matches a unique marked `NN-...` folder directly beneath `Display Folders`. LOR/Preview association is optional supporting evidence, not a requirement for field Stage existence.

Persisted `ref.stage.folder_path` remains alignment evidence: missing, stale, or conflicting values are surfaced under `review_required` but no longer erase an otherwise valid physical/documentation Stage.

## Representative live evidence
- Stage 39 `39-Parade Float-PF`: normal Stage; current LOR/Preview evidence present; stale folder_path remains review finding.
- Stage 40 `40-CommandCenter`: normal Stage; current raw `Root` preview evidence collapses to Stage root; Stage browse validity does not depend on LOR context presence or absence; missing folder_path remains review finding.
- Stage 15/07/07a/13/21/25 regressions remain correct.
- Stages 90–94 remain outside normal physical browse.
- inventory Display 807 shared-context/FieldWiring separation remains correct.
- wired Display 312 remains equivalent to production FieldWiring.

## Tests
- complete FieldWiring/shared-context suite: **74 passed**
- live LOR-optional Stage acceptance: **PASS**

## Scope
Only shared top-level Stage evidence behavior, focused tests, and engineering acceptance probe. No Procedure changes, no schema/data changes, no resolver redesign, no FieldWiring eligibility/search changes, and no Google Drive changes.