### PR TITLE
Recover shared field-context path contract

### DIFF
--- a/Docs/00_Project_Overview/06-Operator_UI_Message_Contract.md
+++ b/Docs/00_Project_Overview/06-Operator_UI_Message_Contract.md
@@ -1,0 +1,186 @@
+# Operator UI Message Contract
+
+| Document control | Value |
+|---|---|
+| Status | **GOVERNING OPERATOR UI CONTRACT** |
+| Applies to | FieldWiring, Procedures, Scan, Testing, Work Orders, LOR2DB operator pages, and future operator-facing applications |
+| Audience | MSB volunteers and operators |
+| Engineering audience | Application and database maintainers |
+
+## Purpose
+
+All MSB operator-facing applications must present errors, warnings, missing-content findings, and review conditions in one consistent human-readable style.
+
+An operator must be able to report a problem accurately without knowing:
+
+- PostgreSQL schema or table names;
+- internal diagnostic codes;
+- Python/JavaScript function names;
+- Linux server mount paths;
+- GitHub repository paths; or
+- implementation-specific resolver terminology.
+
+Internal engineering diagnostics remain valuable and may be retained in logs, tests, API engineering metadata, or a clearly separated engineering-details view. They must not be used as the primary operator message.
+
+## Required Operator Message Content
+
+When enough context is available, a visible operator message must identify:
+
+1. **What function/content failed** — for example Wiring, Setup procedure, Takedown procedure, Inspection procedure, Testing, Work Order, or Scan action.
+2. **What item/context is affected** — Display, Stage, Sub-stage, Scene, Container, Work Order, or other operator-recognizable identity.
+3. **Where the operator should expect the item or content to exist** when a human-maintained location applies.
+4. **What the operator can report or do next** without interpreting an engineering code.
+
+For Google Drive-backed field documents, the message must show the exact expected task folder whenever it can be constructed from already-resolved context.
+
+Examples:
+
+```text
+Wiring not found for 21-Sliding Penguins in folder
+G:\Shared drives\Display Folders\21-Polar Bear Playground-PB\21-Sliding Penguins\Wiring\MusicalStage.
+```
+
+```text
+Setup procedure not found for 13-Christmas Story in folder
+G:\Shared drives\Display Folders\13-Winter Wonderland-WW\13-Christmas Story\Procedures\Setup.
+```
+
+```text
+Takedown procedure not found for Stage 15 in folder
+G:\Shared drives\Display Folders\15-Church-Bells-CH\Procedures\Takedown.
+```
+
+The operator can now report both the missing item and the exact place that should be checked.
+
+## Engineering Code Separation
+
+Internal codes such as:
+
+```text
+LOR_CONTEXT_NOT_DEFINED_FIELD_SCENE
+FIELD_SCENE_MARKER_MISSING
+DATABASE_STAGE_NOT_IN_FIELD_HIERARCHY
+```
+
+are engineering identifiers.
+
+They may be retained separately, for example:
+
+```json
+{
+  "code": "LOR_CONTEXT_NOT_DEFINED_FIELD_SCENE",
+  "operator_warning": "Wiring not found for 21-Sliding Penguins in folder G:\\Shared drives\\Display Folders\\21-Polar Bear Playground-PB\\Wiring\\MusicalStage."
+}
+```
+
+The browser/operator presentation must use `operator_warning`, not `code`, as the visible primary message.
+
+An unmapped/new engineering code must fall back to a useful generic operator message. The raw internal code must not leak into normal operator presentation merely because a mapping is missing.
+
+## Human-Facing Path Rule
+
+When a Google Drive location is reported to an operator, use the canonical human-facing path:
+
+```text
+G:\Shared drives\Display Folders\...
+```
+
+Do not show the production server mount path as the normal operator location:
+
+```text
+/mnt/msb-display-folders/...
+```
+
+Server paths may remain in engineering logs when needed. Operator presentation translates the already-known server-relative path text to the canonical Shared Drive path without performing another filesystem lookup.
+
+## Task-Specific Folder Rule
+
+The shared context resolver identifies the owning Stage/Sub-stage/Scene scope.
+
+The task adapter already knows its own relative content branch and must supply that branch to the operator-message formatter.
+
+Examples:
+
+```text
+FieldWiring / Musical
+    -> Wiring\MusicalStage
+
+FieldWiring / Background
+    -> Wiring\BackgroundStage
+
+Setup
+    -> Procedures\Setup
+
+Takedown
+    -> Procedures\Takedown
+
+Inspection
+    -> Procedures\Inspection
+```
+
+The shared message formatter must not choose the task branch itself.
+
+This preserves the application boundary:
+
+```text
+shared context
+    -> resolved physical scope
+    -> task adapter chooses content branch
+    -> operator formatter reports the already-known expected location
+```
+
+## Performance Requirement
+
+Operator-message formatting must not materially increase application latency.
+
+The formatter must use information already available from the completed request. It must not perform:
+
+- additional PostgreSQL queries;
+- SQLite queries;
+- Google Drive enumeration;
+- filesystem `exists`/directory scans;
+- marker validation;
+- HTTP/network requests; or
+- a second context-resolution pass.
+
+Formatting is a pure presentation operation over already-resolved values.
+
+If constructing a useful operator message would require new I/O, that I/O belongs in the normal application/resolution workflow and must be justified independently. The message layer itself must remain formatting-only.
+
+## Consistency Across Applications
+
+This contract applies to every operator-facing MSB UI, even when the underlying subsystem is unrelated to Google Drive.
+
+The exact fields vary by subsystem, but the presentation principle does not:
+
+```text
+technical condition
+    -> internal diagnostic code/details
+    -> operator translation
+    -> plain-language affected item + expected location/action + next useful information
+```
+
+Examples outside field documents may use a record/action rather than a folder:
+
+```text
+Work Order 184 could not be opened for DISP:251. Report Work Order 184 and Display DISP:251.
+```
+
+```text
+Testing is not available for DISP:251 because no current test session was found. Start or select a current test session first.
+```
+
+The operator should never need to translate a developer error code before reporting a problem.
+
+## Acceptance Rule For New Operator UIs
+
+A new or changed operator-facing UI is not accepted until its error/warning states demonstrate that:
+
+- internal codes are not the primary visible message;
+- the affected operator-recognizable item is named;
+- the expected location/action is shown when known;
+- Google Drive paths use the canonical operator path when applicable;
+- an unmapped diagnostic still produces useful plain language; and
+- message generation introduces no additional I/O or context-resolution work.
+
+This requirement is part of UI acceptance, not optional cleanup after deployment.

--- a/Docs/00_Project_Overview/README.md
+++ b/Docs/00_Project_Overview/README.md
@@ -13,6 +13,7 @@ Detailed engineering and operator instructions belong in the subsystem documenta
 - [MSB Database Source Folder Marker](03-MSB_DB_Source_Folder_Marker_Operator_Procedure.md) — operator procedure for the `_MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt` marker used at controlled structural roots and database/application source folders.
 - [Stage / Sub-stage / Scene Folder Scaffold](04-Stage_Substage_Scene_Folder_Scaffold.md) — controlled folder scaffold to use whenever a new Scene, Sub-stage, or Stage documentation root is created.
 - [Google Workspace Application Read Identity](05-Google_Workspace_Application_Read_Identity.md) — shared Google Workspace read-identity purpose, permission boundary, human-authoring requirement, and split between Production Database and server-management documentation.
+- [Operator UI Message Contract](06-Operator_UI_Message_Contract.md) — governing cross-application rule for plain-language operator errors/warnings, exact expected locations/actions, engineering-code separation, and zero-I/O message formatting.
 
 The current subsystem documentation remains authoritative for detailed operating and engineering rules.
 

--- a/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/Shared_Field_Context_Path_Contract_Recovery_2026-08-23.md
+++ b/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/Shared_Field_Context_Path_Contract_Recovery_2026-08-23.md
@@ -1,0 +1,179 @@
+# Shared Field Context Path-Contract Recovery — 2026-08-23
+
+| Document control | Value |
+|---|---|
+| Status | **ENGINEERING RECOVERY — runtime contract correction** |
+| Branch | `agent/shared-field-context-path-contract-recovery` |
+| Governing filesystem contract | `Docs/00_Project_Overview/02-Google_Drive_Path_Resolution_Contract.md` |
+| Shared context contract | `Field_Context_Resolution_Contract.md` |
+| FieldWiring resolver design | `../09_Wiring_System/FieldWiring_Drive_Context_Resolver_Engineering_Design.md` |
+| Procedure status | Frozen at the reverted green baseline until shared recovery is accepted |
+
+## Why this recovery exists
+
+The earlier shared-hierarchy implementation correctly recognized that raw `ref.stage` and raw LOR Scene rows could not simply be rendered as the field hierarchy. However, it solved that problem by enumerating the mounted `Display Folders` tree and rebuilding the Stage/Sub-stage/Scene hierarchy at application request time.
+
+That runtime behavior is **superseded by this recovery** because it conflicts with the pre-existing governing path-resolution documents and produced unacceptable field-browser latency.
+
+The governing documents already established the intended runtime behavior:
+
+```text
+current Production Database identity / relationships
+        +
+current LOR BackgroundFile/path evidence
+        |
+        v
+walk the supplied path upward only as needed
+        |
+        v
+nearest valid Stage / Sub-stage / Scene scope
+        |
+        v
+task adapter selects its own fixed relative branch
+```
+
+The resolver must not rediscover the entire park hierarchy from Google Drive during a normal phone/tablet/desktop request.
+
+## Authority boundary
+
+The following rules are now explicit engineering gates.
+
+1. `Docs/00_Project_Overview/02-Google_Drive_Path_Resolution_Contract.md` owns filesystem/path interpretation.
+2. `Field_Context_Resolution_Contract.md` owns the shared identity/context boundary.
+3. `FieldWiring_Drive_Context_Resolver_Engineering_Design.md` owns FieldWiring-specific resolver behavior.
+4. A lower-level acceptance document or implementation must not introduce a competing runtime traversal model without an explicit architecture review.
+
+## Shared runtime responsibilities
+
+### Shared database/context repository
+
+`FieldWiring/Application/field_context_repository.py`
+
+Owns current read-only Production Database facts:
+
+- permanent Display identity;
+- current Stage/Sub-stage relationship;
+- current Scene membership;
+- current Preview identity/context;
+- current stored BackgroundFile/path evidence.
+
+### Shared lookup hierarchy
+
+`FieldWiring/Application/field_context_hierarchy.py`
+
+Owns the fast common lookup/browse presentation model.
+
+It is built only from already-reconciled database/LOR facts and stored path **strings**. It performs no Google Drive enumeration.
+
+Its purpose is to give FieldWiring, Procedures, and future field applications the same Stage/Sub-stage/Scene navigation model.
+
+### Shared structured-scope resolver
+
+`FieldWiring/Application/field_context_resolver.py`
+
+Owns resolution of one selected context to one structured filesystem root.
+
+It must:
+
+1. start from the supplied current Stage/Scene/Preview facts;
+2. use Scene `BackgroundFile` first when present, otherwise allowed Preview path evidence;
+3. treat the pointer as navigation evidence, not task content identity;
+4. stop before `SourceDocs`;
+5. walk upward through that supplied path;
+6. ignore helper folders and unprefixed Display/group folders while walking upward;
+7. return the nearest valid marked Scene, Sub-stage, or Stage root;
+8. fall back upward to the owning Stage when a more-specific Scene scope is not present;
+9. use only bounded stale-pointer recovery inside the already-known Stage when exact evidence no longer resolves;
+10. never enumerate `Display Folders` to discover candidate Stages.
+
+### Task adapters
+
+After the shared root is fixed, the task adapter alone chooses content:
+
+```text
+FieldWiring
+    -> <scope>\Wiring\BackgroundStage
+    -> <scope>\Wiring\MusicalStage
+
+Procedures
+    -> <scope>\Procedures\Setup
+    -> <scope>\Procedures\Takedown
+    -> <scope>\Procedures\Inspection
+```
+
+Changing task does not change the resolved physical scope.
+
+## Background ownership is not documentation ownership
+
+The governing worked examples remain authoritative.
+
+A BackgroundFile may point to:
+
+- a Stage `PreviewBackground`;
+- a Scene `PreviewBackground`;
+- a Display-specific `PreviewBackground` beneath a Scene;
+- a Display-specific `PreviewBackground` directly beneath a Stage;
+- `Wiring\BackgroundStage`;
+- `Wiring\MusicalStage`;
+- or another allowed current/legacy location within the owning Stage.
+
+The resolver climbs through that existing path until it reaches the applicable structured documentation owner.
+
+Example:
+
+```text
+21-Polar Bear Playground-PB
+  -> 21-Sliding Penguins
+      -> PB-SlidingPenguins-07
+          -> PreviewBackground\Penguin-07.jpg
+```
+
+The background owner is the Display folder, but the shared documentation owner is `21-Sliding Penguins`.
+
+If the same Display is directly beneath the Stage with no defined Scene, the resolver climbs to `21-Polar Bear Playground-PB`.
+
+## Runtime browse vs engineering validation
+
+`FieldWiring/Application/field_context_browse.py` may remain useful as a **read-only engineering/alignment validator** that compares database/path evidence with the actual mounted Drive tree.
+
+It is not the normal runtime source for `/api/stages` or equivalent shared field lookup.
+
+This distinction supersedes the runtime-crawler portions of:
+
+`Shared_Field_Context_Hierarchy_Browse_Repair_Acceptance_2026-08-23.md`
+
+The historical acceptance record remains valuable evidence of the issue that was found, but its statement that normal browse should rebuild the hierarchy by walking the mounted Drive is no longer the runtime contract.
+
+## Regression gate
+
+The documented worked path examples are being converted into executable tests.
+
+Required regression cases include:
+
+- Stage-level `PreviewBackground` -> Stage;
+- Scene-level `PreviewBackground` -> Scene;
+- Display-level `PreviewBackground` beneath a Scene -> climb to Scene;
+- Display-level `PreviewBackground` directly beneath a Stage -> climb to Stage;
+- direct Stage Wiring path -> Stage;
+- direct Scene Wiring path -> Scene;
+- formal Sub-stage path -> Sub-stage;
+- `Root` -> owning Stage, never a literal child;
+- Master Musical Stage-binding Scene -> Stage, not a fake child Scene;
+- nested legacy Scene proven by exact path -> Scene;
+- `SourceDocs` -> hard traversal boundary;
+- stale pointer -> bounded recovery inside the known Stage only;
+- unprefixed Display/group folder -> never promoted to Scene merely from its folder name;
+- runtime lookup hierarchy -> must succeed even when the supplied `drive_root` object would fail if accessed.
+
+## No schema change authorized by this recovery
+
+This recovery does not currently authorize:
+
+- parser changes;
+- new PostgreSQL schema objects;
+- rewriting LOR paths;
+- moving/renaming Google Drive folders;
+- Procedure application changes;
+- production deployment.
+
+The immediate objective is to restore the already-documented shared context boundaries and prove them with regression tests before application integration resumes.

--- a/FieldWiring/Application/backend.py
+++ b/FieldWiring/Application/backend.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from flask import Flask, Response, jsonify, request, send_file, send_from_directory
 
+from field_context_hierarchy import build_field_hierarchy
 from repository import ConfigError, PostgresRepository, Repository, SQLiteSnapshotRepository
 from wiring import WiringError, build_wiring_package, safe_image_path
 
@@ -174,7 +175,11 @@ def api_display_context(display_id: int) -> Response:
 
 @app.get("/api/stages")
 def api_stages() -> Response:
-    return jsonify(stages=repository().stages())
+    hierarchy = build_field_hierarchy(repository().shared_stages())
+    return jsonify(
+        stages=hierarchy["stages"],
+        review_required=hierarchy["review_required"],
+    )
 
 
 @app.get("/api/wiring")

--- a/FieldWiring/Application/backend.py
+++ b/FieldWiring/Application/backend.py
@@ -37,6 +37,60 @@ def optional_int(name: str) -> int | None:
     return int(raw)
 
 
+def operator_config_error(_: ConfigError) -> str:
+    """Formatting-only operator message; retain configuration detail separately."""
+    return (
+        "Field Wiring is temporarily unavailable because its current data source "
+        "could not be opened. Report that the Field Wiring service is unavailable."
+    )
+
+
+def operator_wiring_error(exc: WiringError) -> str:
+    """Translate internal FieldWiring failures without changing engineering errors."""
+    text = str(exc)
+    folded = text.casefold()
+
+    if folded.startswith("invalid "):
+        return "This Field Wiring link is invalid. Return to lookup and select the Display or Stage again."
+
+    if "does not belong to the requested" in folded or "requires a resolved stage and preview" in folded:
+        return (
+            "This Field Wiring link no longer matches the current Display, Stage, or Scene. "
+            "Return to lookup and select it again."
+        )
+
+    if "not present in the current" in folded or "not present in the production database" in folded:
+        return (
+            "This Field Wiring link no longer matches the current approved data. "
+            "Return to lookup and select the Display or Stage again."
+        )
+
+    if "no applicable field wiring" in folded or "display is not available for current fieldwiring" in folded:
+        return "No current Field Wiring is available for this Display."
+
+    if "no current field wiring rows" in folded:
+        return "No current Field Wiring data is available for this Stage or Scene."
+
+    if (
+        "dmx source" in folded
+        or "dmx source-detail" in folded
+        or "atomic dmx" in folded
+        or "v7.0.11" in folded
+    ):
+        return (
+            "Current Field Wiring data for this selection is incomplete. "
+            "Report the selected Display, Stage, or Scene so engineering can verify the current wiring data."
+        )
+
+    if "image path" in folded or "wiring image is not available" in folded or "sourcedocs content" in folded:
+        return "The requested wiring image is not available. Return to the current Field Wiring page and try another image."
+
+    return (
+        "Field Wiring could not be opened for this selection. Return to lookup and try again, "
+        "or report the selected Display, Stage, or Scene."
+    )
+
+
 @app.get("/")
 def index() -> Response:
     return send_from_directory(BASE_DIR, "index.html")
@@ -143,12 +197,18 @@ def api_wiring_image() -> Response:
 
 @app.errorhandler(ConfigError)
 def config_error(exc: ConfigError) -> tuple[Response, int]:
-    return jsonify(error=str(exc)), 503
+    return jsonify(
+        error=operator_config_error(exc),
+        engineering_error=str(exc),
+    ), 503
 
 
 @app.errorhandler(WiringError)
 def wiring_error(exc: WiringError) -> tuple[Response, int]:
-    return jsonify(error=str(exc)), 400
+    return jsonify(
+        error=operator_wiring_error(exc),
+        engineering_error=str(exc),
+    ), 400
 
 
 if __name__ == "__main__":

--- a/FieldWiring/Application/field_context_browse.py
+++ b/FieldWiring/Application/field_context_browse.py
@@ -1,9 +1,11 @@
 """Resolved Stage/Sub-stage/Scene browse over shared field-context evidence.
 
 Raw ``ref.stage`` rows and raw LOR Scene rows are evidence, not field browse
-nodes.  The released Google Drive hierarchy is represented only after current
+nodes. The released Google Drive hierarchy is represented only after current
 filesystem roots have been resolved and validated.
 
+This module is an engineering/alignment validator. Normal application runtime
+browse must use ``field_context_hierarchy.py`` and must not scan the Drive tree.
 This module does not discover Wiring or Procedure content.
 """
 from __future__ import annotations
@@ -167,6 +169,14 @@ def _context_review(
     }
 
 
+def _unprefixed_group_context(context: dict[str, Any], owning_key: str) -> bool:
+    scene = context.get("scene") or {}
+    name = str(scene.get("scene_name") or "").strip()
+    if not name or name.casefold() == "root":
+        return False
+    return not name.casefold().startswith(owning_key.casefold() + "-")
+
+
 def _attach_contexts(
     node: dict[str, Any],
     stage: dict[str, Any],
@@ -207,6 +217,22 @@ def _attach_contexts(
             continue
 
         if _path_key(scope_root) == _path_key(owning_root):
+            # The runtime resolver correctly climbs through unprefixed
+            # Display/group folders to the owning structured scope. The
+            # engineering validator still records that the raw LOR Scene was
+            # not itself a defined field Scene so alignment work can see it.
+            if _unprefixed_group_context(context, owning_key):
+                _add_review(
+                    reviews,
+                    review_seen,
+                    _context_review(
+                        "LOR_CONTEXT_NOT_DEFINED_FIELD_SCENE",
+                        stage,
+                        context,
+                        warnings,
+                        scope_root,
+                    ),
+                )
             node["contexts"].append(context)
             continue
 
@@ -525,9 +551,10 @@ def build_field_hierarchy(
 
 
 def resolve_field_hierarchy(repository: Any, drive_root: str | Path) -> dict[str, Any]:
-    """Canonical shared browse entry point.
+    """Engineering/alignment validator entry point.
 
-    ``repository.stages()`` is treated only as raw DB/LOR evidence. Applications
-    must consume this resolved result rather than present those rows directly.
+    ``repository.stages()`` is raw DB/LOR evidence. This function may inspect
+    the Drive tree for alignment validation, but it is not the normal web-app
+    browse source. Normal runtime browse is ``field_context_hierarchy``.
     """
     return build_field_hierarchy(repository.stages(), drive_root)

--- a/FieldWiring/Application/field_context_hierarchy.py
+++ b/FieldWiring/Application/field_context_hierarchy.py
@@ -1,38 +1,363 @@
-"""Validated field-facing Stage/Sub-stage/Scene browse contract.
+"""Fast shared Stage/Sub-stage/Scene lookup hierarchy from current DB/LOR facts.
 
-This module is the canonical public wrapper over ``field_context_browse``.
-The lower-level builder resolves actual marked filesystem roots, nests formal
-Sub-stages, deduplicates raw LOR Scene evidence by resolved scope, and emits
-alignment findings separately from normal browse output.
+This module is the shared browse/presentation model for field applications.
+It performs **no Google Drive enumeration**.  The hierarchy is built from the
+already-reconciled Production Database Stage/Scene relationships plus stored
+LOR path strings.  Filesystem access belongs to ``field_context_resolver`` only
+after an operator has selected one context and a task needs its documents.
 
-A top-level field Stage does not require an LOR association.  The released
-Google Drive contract allows a permanent ``ref.stage`` identity to exist as a
-physical/documentation Stage even when LOR has no Preview/Scene binding for it.
-A unique Stage key paired with one unique marked ``NN-...`` top-level folder is
-therefore sufficient field-hierarchy identity.
-
-Persisted ``ref.stage.folder_path`` and LOR Preview/Scene relationships remain
-important supporting evidence.  Missing, stale, or conflicting path evidence
-is surfaced under ``review_required``; it is not by itself a reason to hide an
-otherwise uniquely resolved physical Stage.  True identity ambiguity remains
-blocked by the lower-level builder when no unique Stage-key/root pair exists.
+``field_context_browse.py`` remains an engineering/alignment validator that may
+inspect the Drive tree.  It is not the normal runtime browse source.
 """
 from __future__ import annotations
 
-from pathlib import Path
+import re
+from pathlib import PurePosixPath, PureWindowsPath
 from typing import Any
 
-from field_context_browse import build_field_hierarchy as _build_field_hierarchy
+_STAGE_KEY_RE = re.compile(r"^\d{2}$")
+_SUBSTAGE_KEY_RE = re.compile(r"^(\d{2})[A-Za-z]$")
+
+
+def _path_parts(path_text: str | None) -> tuple[str, ...]:
+    if not path_text:
+        return ()
+    try:
+        if "\\" in path_text or re.match(r"^[A-Za-z]:", path_text):
+            return tuple(PureWindowsPath(path_text).parts)
+        return tuple(PurePosixPath(path_text).parts)
+    except Exception:
+        return ()
+
+
+def _path_with_parts(path_text: str, count: int) -> str | None:
+    parts = _path_parts(path_text)
+    if not parts or count <= 0 or count > len(parts):
+        return None
+    try:
+        if "\\" in path_text or re.match(r"^[A-Za-z]:", path_text):
+            return str(PureWindowsPath(*parts[:count]))
+        return str(PurePosixPath(*parts[:count]))
+    except Exception:
+        return None
+
+
+def _context_pointer(context: dict[str, Any]) -> str | None:
+    scene = context.get("scene") or {}
+    preview = context.get("preview") or {}
+    return scene.get("scene_background_file") or preview.get("preview_background_file")
+
+
+def _root_part_from_pointer(
+    pointer: str | None,
+    key: str,
+) -> tuple[str | None, str | None]:
+    """Return one path segment/root path matching ``key-`` from stored evidence."""
+    parts = _path_parts(pointer)
+    target = key.casefold() + "-"
+    for index, part in enumerate(parts):
+        if part.casefold().startswith(target):
+            full = _path_with_parts(str(pointer), index + 1) if pointer else None
+            return part, full
+    return None, None
+
+
+def _valid_persisted_label(stage: dict[str, Any]) -> tuple[str | None, str | None]:
+    path = str(stage.get("folder_path") or "").strip()
+    key = str(stage.get("stage_key") or "").strip()
+    if not path or not key:
+        return None, None
+    parts = _path_parts(path)
+    if not parts:
+        return None, None
+    label = parts[-1]
+    if label.casefold().startswith(key.casefold() + "-"):
+        return label, path
+    return None, None
+
+
+def _unique_pointer_root(
+    contexts: list[dict[str, Any]],
+    key: str,
+) -> tuple[str | None, str | None]:
+    found: dict[str, tuple[str, str | None]] = {}
+    for context in contexts:
+        pointer = _context_pointer(context)
+        label, full = _root_part_from_pointer(pointer, key)
+        if label:
+            found[label.casefold()] = (label, full)
+    if len(found) != 1:
+        return None, None
+    return next(iter(found.values()))
+
+
+def _node_label_and_path(
+    stage: dict[str, Any],
+    contexts: list[dict[str, Any]],
+) -> tuple[str, str | None, str]:
+    key = str(stage.get("stage_key") or "").strip()
+    persisted_label, persisted_path = _valid_persisted_label(stage)
+    if persisted_label:
+        return persisted_label, persisted_path, "PERSISTED_STAGE_PATH"
+
+    pointer_label, pointer_path = _unique_pointer_root(contexts, key)
+    if pointer_label:
+        return pointer_label, pointer_path, "LOR_PATH_EVIDENCE"
+
+    name = str(stage.get("stage_name") or "").strip()
+    return (name or key or "Unresolved"), None, "DATABASE_STAGE_NAME_FALLBACK"
+
+
+def _context_summary(context: dict[str, Any]) -> dict[str, Any]:
+    preview = context.get("preview") or {}
+    scene = context.get("scene") or {}
+    return {
+        "preview_uuid": preview.get("preview_uuid"),
+        "preview_name": preview.get("preview_name"),
+        "preview_background_file": preview.get("preview_background_file"),
+        "scene_uuid": scene.get("scene_uuid"),
+        "scene_name": scene.get("scene_name"),
+        "scene_stage_key": scene.get("scene_stage_key"),
+        "scene_background_file": scene.get("scene_background_file"),
+        "scope_kind": context.get("scope_kind"),
+        "context_type": context.get("context_type"),
+    }
+
+
+def _scene_child_from_pointer(
+    context: dict[str, Any],
+    owner_key: str,
+    owner_label: str,
+) -> tuple[str | None, str | None]:
+    pointer = _context_pointer(context)
+    parts = _path_parts(pointer)
+    if not parts:
+        return None, None
+
+    owner_index: int | None = None
+    for index, part in enumerate(parts):
+        if part.casefold() == owner_label.casefold():
+            owner_index = index
+            break
+
+    if owner_index is None:
+        # Fall back to the first owner-key segment.  This still uses only the
+        # stored path string and does not inspect the filesystem.
+        for index, part in enumerate(parts):
+            if part.casefold().startswith(owner_key.casefold() + "-"):
+                owner_index = index
+                break
+
+    if owner_index is None:
+        return None, None
+
+    target = owner_key.casefold() + "-"
+    for index in range(owner_index + 1, len(parts)):
+        part = parts[index]
+        if part.casefold().startswith(target):
+            return part, _path_with_parts(str(pointer), index + 1) if pointer else None
+    return None, None
+
+
+def _scene_name_candidate(scene_name: str | None, owner_key: str, owner_label: str) -> str | None:
+    name = str(scene_name or "").strip()
+    if not name or name.casefold() == "root":
+        return None
+    if name.casefold() == owner_label.casefold():
+        return None
+    if not name.casefold().startswith(owner_key.casefold() + "-"):
+        return None
+
+    # Without path evidence, an NN-Name-XY value is conservatively treated as
+    # Stage-root binding evidence rather than invented as a child.  Exact path
+    # evidence may still prove a legacy nested child with such a name.
+    if _STAGE_KEY_RE.fullmatch(owner_key) and re.fullmatch(
+        rf"{re.escape(owner_key)}-.+-[A-Za-z]{{2,3}}", name
+    ):
+        return None
+    if _SUBSTAGE_KEY_RE.fullmatch(owner_key) and re.fullmatch(
+        rf"{re.escape(owner_key)}-.+-[A-Za-z]{{2,3}}", name
+    ):
+        return None
+    return name
+
+
+def _attach_contexts(node: dict[str, Any], contexts: list[dict[str, Any]]) -> None:
+    owner_key = str(node.get("stage_key") or "")
+    owner_label = str(node.get("label") or "")
+    scene_nodes: dict[str, dict[str, Any]] = {}
+
+    for context in contexts:
+        child_label, child_path = _scene_child_from_pointer(context, owner_key, owner_label)
+        if child_label is None:
+            scene = context.get("scene") or {}
+            child_label = _scene_name_candidate(
+                scene.get("scene_name"),
+                owner_key,
+                owner_label,
+            )
+
+        if child_label is None:
+            node["contexts"].append(_context_summary(context))
+            continue
+
+        key = child_label.casefold()
+        child = scene_nodes.get(key)
+        if child is None:
+            child = {
+                "scope_type": "SCENE",
+                "label": child_label,
+                "stage_id": node.get("stage_id"),
+                "stage_key": owner_key,
+                "scope_path_evidence": child_path,
+                "contexts": [],
+            }
+            scene_nodes[key] = child
+        elif child.get("scope_path_evidence") is None and child_path is not None:
+            child["scope_path_evidence"] = child_path
+        child["contexts"].append(_context_summary(context))
+
+    node["scenes"] = sorted(scene_nodes.values(), key=lambda item: item["label"].casefold())
+
+
+def _is_animation_only_without_field_path(
+    stage: dict[str, Any],
+    contexts: list[dict[str, Any]],
+) -> bool:
+    persisted_label, _ = _valid_persisted_label(stage)
+    if persisted_label:
+        return False
+    if not contexts:
+        return False
+    return all(str(item.get("context_type") or "") == "Animation" for item in contexts)
 
 
 def build_field_hierarchy(
     raw_stage_items: list[dict[str, Any]],
-    drive_root: str | Path,
+    drive_root: Any = None,
 ) -> dict[str, Any]:
-    """Return the canonical resolved field hierarchy plus review evidence."""
-    return _build_field_hierarchy(raw_stage_items, drive_root)
+    """Return the shared lookup hierarchy without filesystem I/O.
+
+    ``drive_root`` is retained only for compatibility with the earlier API.  It
+    is intentionally unused; callers must not rely on browse-time Drive scans.
+    """
+    del drive_root
+    reviews: list[dict[str, Any]] = []
+    top_nodes: dict[str, dict[str, Any]] = {}
+    sub_items: list[tuple[dict[str, Any], list[dict[str, Any]]]] = []
+
+    for item in raw_stage_items:
+        stage = item.get("stage") or {}
+        contexts = list(item.get("contexts") or [])
+        key = str(stage.get("stage_key") or "").strip()
+        if _SUBSTAGE_KEY_RE.fullmatch(key):
+            sub_items.append((stage, contexts))
+            continue
+        if not _STAGE_KEY_RE.fullmatch(key):
+            continue
+        if _is_animation_only_without_field_path(stage, contexts):
+            reviews.append(
+                {
+                    "code": "DATABASE_STAGE_NOT_IN_FIELD_HIERARCHY",
+                    "stage_id": stage.get("stage_id"),
+                    "stage_key": key,
+                    "warnings": [
+                        "Animation-only Stage row has no persisted physical Stage path and is excluded from normal field browse."
+                    ],
+                }
+            )
+            continue
+
+        label, path_evidence, label_basis = _node_label_and_path(stage, contexts)
+        node = {
+            "scope_type": "STAGE",
+            "label": label,
+            "stage_id": stage.get("stage_id"),
+            "stage_key": key,
+            "database_stage_name": stage.get("stage_name"),
+            "database_folder_path": stage.get("folder_path"),
+            "scope_path_evidence": path_evidence,
+            "label_basis": label_basis,
+            "contexts": [],
+            "scenes": [],
+            "sub_stages": [],
+        }
+        if label_basis == "DATABASE_STAGE_NAME_FALLBACK":
+            reviews.append(
+                {
+                    "code": "STAGE_PATH_EVIDENCE_REVIEW_REQUIRED",
+                    "stage_id": stage.get("stage_id"),
+                    "stage_key": key,
+                    "warnings": [
+                        "No usable persisted or LOR path string identified the field-facing Stage folder label."
+                    ],
+                }
+            )
+        _attach_contexts(node, contexts)
+        top_nodes[key.casefold()] = node
+
+    for stage, contexts in sub_items:
+        key = str(stage.get("stage_key") or "").strip()
+        match = _SUBSTAGE_KEY_RE.fullmatch(key)
+        if not match:
+            continue
+        parent = top_nodes.get(match.group(1).casefold())
+        if parent is None:
+            reviews.append(
+                {
+                    "code": "SUBSTAGE_PARENT_REVIEW_REQUIRED",
+                    "stage_id": stage.get("stage_id"),
+                    "stage_key": key,
+                    "warnings": ["No current top-level Stage row owns this Sub-stage key."],
+                }
+            )
+            continue
+
+        label, path_evidence, label_basis = _node_label_and_path(stage, contexts)
+        node = {
+            "scope_type": "SUBSTAGE",
+            "label": label,
+            "stage_id": stage.get("stage_id"),
+            "stage_key": key,
+            "database_stage_name": stage.get("stage_name"),
+            "database_folder_path": stage.get("folder_path"),
+            "scope_path_evidence": path_evidence,
+            "label_basis": label_basis,
+            "contexts": [],
+            "scenes": [],
+        }
+        if label_basis == "DATABASE_STAGE_NAME_FALLBACK":
+            reviews.append(
+                {
+                    "code": "SUBSTAGE_PATH_EVIDENCE_REVIEW_REQUIRED",
+                    "stage_id": stage.get("stage_id"),
+                    "stage_key": key,
+                    "warnings": [
+                        "No usable persisted or LOR path string identified the field-facing Sub-stage folder label."
+                    ],
+                }
+            )
+        _attach_contexts(node, contexts)
+        parent["sub_stages"].append(node)
+
+    stages = sorted(top_nodes.values(), key=lambda item: item["stage_key"].casefold())
+    for stage in stages:
+        stage["sub_stages"] = sorted(
+            stage["sub_stages"], key=lambda item: item["stage_key"].casefold()
+        )
+
+    return {
+        "stages": stages,
+        "review_required": sorted(
+            reviews,
+            key=lambda item: (
+                str(item.get("stage_key") or "").casefold(),
+                str(item.get("code") or "").casefold(),
+            ),
+        ),
+    }
 
 
-def resolve_field_hierarchy(repository: Any, drive_root: str | Path) -> dict[str, Any]:
-    """Canonical shared field-facing hierarchy entry point."""
+def resolve_field_hierarchy(repository: Any, drive_root: Any = None) -> dict[str, Any]:
+    """Canonical shared field lookup hierarchy entry point."""
     return build_field_hierarchy(repository.stages(), drive_root)

--- a/FieldWiring/Application/field_context_hierarchy.py
+++ b/FieldWiring/Application/field_context_hierarchy.py
@@ -151,8 +151,12 @@ def _scene_child_from_pointer(
     if owner_index is None:
         return None, None
 
+    # BackgroundFile evidence names a file, so its final path segment is never
+    # a Stage/Sub-stage/Scene folder.  Excluding the filename prevents a file
+    # such as ``03-welcome area.jpg`` from being promoted into the browse
+    # hierarchy merely because its basename begins with the owning Stage key.
     target = owner_key.casefold() + "-"
-    for index in range(owner_index + 1, len(parts)):
+    for index in range(owner_index + 1, max(owner_index + 1, len(parts) - 1)):
         part = parts[index]
         if part.casefold().startswith(target):
             return part, _path_with_parts(str(pointer), index + 1) if pointer else None

--- a/FieldWiring/Application/field_context_hierarchy.py
+++ b/FieldWiring/Application/field_context_hierarchy.py
@@ -167,7 +167,25 @@ def _scene_name_candidate(scene_name: str | None, owner_key: str, owner_label: s
     name = str(scene_name or "").strip()
     if not name or name.casefold() == "root":
         return None
-    if name.casefold() == owner_label.casefold():
+
+    # If no exact child folder was proven by path evidence, treat the
+    # owning Stage/Sub-stage label and that label without its terminal short
+    # code as the same owner identity.  Example:
+    #
+    #   03-Welcome Area-WA  <->  03-Welcome Area
+    #
+    # Exact nested path evidence is evaluated before this fallback, so a real
+    # child folder with the same textual base can still resolve as a Scene.
+    canonical_owner_names = {owner_label.casefold()}
+    owner_without_short_code = re.sub(
+        r"-[A-Za-z]{2,3}$",
+        "",
+        owner_label,
+    ).strip()
+    if owner_without_short_code:
+        canonical_owner_names.add(owner_without_short_code.casefold())
+
+    if name.casefold() in canonical_owner_names:
         return None
     if not name.casefold().startswith(owner_key.casefold() + "-"):
         return None

--- a/FieldWiring/Application/field_context_operator_messages.py
+++ b/FieldWiring/Application/field_context_operator_messages.py
@@ -1,12 +1,25 @@
 """Translate shared field-context diagnostics into operator-facing task messages.
 
 Engineering codes remain stable for logs/tests. Field applications must not
-render those codes directly. Instead, the task adapter supplies its human task
-name (for example ``Wiring`` or ``Setup procedure``) and this module returns a
-plain-language message using the current Scene/scope folder evidence.
+render those codes directly. The task adapter supplies both its human task name
+and, when applicable, the exact task-relative folder beneath the resolved
+Stage/Sub-stage/Scene scope.
+
+Examples::
+
+    Wiring / Musical      -> Wiring\\MusicalStage
+    Wiring / Background   -> Wiring\\BackgroundStage
+    Setup procedure       -> Procedures\\Setup
+    Takedown procedure    -> Procedures\\Takedown
+    Inspection procedure  -> Procedures\\Inspection
+
+The shared mapper does not choose the task branch. That remains owned by the
+calling task adapter.
 """
 from __future__ import annotations
 
+import re
+from pathlib import PurePosixPath, PureWindowsPath
 from typing import Any
 
 
@@ -15,16 +28,16 @@ OPERATOR_WARNING_MAP = {
         "{task} not found for {subject} in folder {folder}."
     ),
     "LOR_CONTEXT_UNRESOLVED": (
-        "{task} location could not be resolved for {subject} in folder {folder}."
+        "{task} location could not be resolved for {subject}. Expected folder: {folder}."
     ),
     "FIELD_SCENE_MARKER_MISSING": (
         "{task} folder for {subject} is not approved for field use: {folder}."
     ),
     "LOR_CONTEXT_OUTSIDE_OWNING_SCOPE": (
-        "{task} location for {subject} points outside the expected Stage folder: {folder}."
+        "{task} location for {subject} points outside the expected Stage area. Expected folder: {folder}."
     ),
     "LOR_CONTEXT_NESTING_REVIEW_REQUIRED": (
-        "{task} location for {subject} needs review in folder {folder}."
+        "{task} location for {subject} needs review. Expected folder: {folder}."
     ),
 }
 
@@ -37,7 +50,7 @@ def _subject(diagnostic: dict[str, Any]) -> str:
     )
 
 
-def _folder(diagnostic: dict[str, Any]) -> str:
+def _scope_folder(diagnostic: dict[str, Any]) -> str:
     return str(
         diagnostic.get("scope_root")
         or diagnostic.get("database_folder_path")
@@ -45,21 +58,66 @@ def _folder(diagnostic: dict[str, Any]) -> str:
     )
 
 
-def operator_warning(diagnostic: dict[str, Any], *, task: str) -> str:
+def _expected_folder(
+    diagnostic: dict[str, Any],
+    task_relative_folder: str | None,
+) -> str:
+    base = _scope_folder(diagnostic)
+    relative = str(task_relative_folder or "").strip().strip("\\/")
+    if not relative:
+        return base
+
+    # Preserve the path style already exposed to the operator. Windows/Drive
+    # paths remain Windows paths; server-side POSIX paths remain POSIX paths.
+    if "\\" in base or re.match(r"^[A-Za-z]:", base):
+        relative_parts = [
+            part
+            for part in PureWindowsPath(relative).parts
+            if part not in {"\\", "/"}
+        ]
+        return str(PureWindowsPath(base, *relative_parts))
+
+    if base.startswith("/"):
+        relative_parts = [
+            part
+            for part in PurePosixPath(relative.replace("\\", "/")).parts
+            if part != "/"
+        ]
+        return str(PurePosixPath(base, *relative_parts))
+
+    return base.rstrip("\\/") + "\\" + relative.replace("/", "\\")
+
+
+def operator_warning(
+    diagnostic: dict[str, Any],
+    *,
+    task: str,
+    task_relative_folder: str | None = None,
+) -> str:
     """Return one operator-safe message without exposing the engineering code."""
     code = str(diagnostic.get("code") or "")
     template = OPERATOR_WARNING_MAP.get(code)
+    folder = _expected_folder(diagnostic, task_relative_folder)
     if template is None:
-        return f"{task} is not available for {_subject(diagnostic)}."
+        return f"{task} is not available for {_subject(diagnostic)}. Expected folder: {folder}."
     return template.format(
         task=task,
         subject=_subject(diagnostic),
-        folder=_folder(diagnostic),
+        folder=folder,
     )
 
 
-def with_operator_warning(diagnostic: dict[str, Any], *, task: str) -> dict[str, Any]:
+def with_operator_warning(
+    diagnostic: dict[str, Any],
+    *,
+    task: str,
+    task_relative_folder: str | None = None,
+) -> dict[str, Any]:
     """Keep engineering metadata while adding the UI-safe translated message."""
     result = dict(diagnostic)
-    result["operator_warning"] = operator_warning(diagnostic, task=task)
+    result["operator_warning"] = operator_warning(
+        diagnostic,
+        task=task,
+        task_relative_folder=task_relative_folder,
+    )
     return result

--- a/FieldWiring/Application/field_context_operator_messages.py
+++ b/FieldWiring/Application/field_context_operator_messages.py
@@ -1,5 +1,10 @@
 """Translate shared field-context diagnostics into operator-facing task messages.
 
+This module is formatting-only runtime code. It must perform no database
+queries, filesystem access, Drive enumeration, marker checks, or network calls.
+It receives facts the caller already resolved and turns them into useful
+operator-facing text.
+
 Engineering codes remain stable for logs/tests. Field applications must not
 render those codes directly. The task adapter supplies both its human task name
 and, when applicable, the exact task-relative folder beneath the resolved
@@ -14,7 +19,8 @@ Examples::
     Inspection procedure  -> Procedures\\Inspection
 
 The shared mapper does not choose the task branch. That remains owned by the
-calling task adapter.
+calling task adapter. Server-side mount paths are translated textually to the
+canonical operator-visible Shared Drive path; no filesystem lookup is used.
 """
 from __future__ import annotations
 
@@ -22,6 +28,9 @@ import re
 from pathlib import PurePosixPath, PureWindowsPath
 from typing import Any
 
+
+OPERATOR_DRIVE_ROOT = r"G:\Shared drives\Display Folders"
+SERVER_DRIVE_ROOT = "/mnt/msb-display-folders"
 
 OPERATOR_WARNING_MAP = {
     "LOR_CONTEXT_NOT_DEFINED_FIELD_SCENE": (
@@ -50,25 +59,33 @@ def _subject(diagnostic: dict[str, Any]) -> str:
     )
 
 
-def _scope_folder(diagnostic: dict[str, Any]) -> str:
-    return str(
+def _operator_scope_folder(diagnostic: dict[str, Any]) -> str:
+    raw = str(
         diagnostic.get("scope_root")
         or diagnostic.get("database_folder_path")
         or "the current Stage folder"
     )
+
+    normalized = raw.replace("\\", "/").rstrip("/")
+    server_root = SERVER_DRIVE_ROOT.rstrip("/")
+    if normalized.casefold() == server_root.casefold():
+        return OPERATOR_DRIVE_ROOT
+    if normalized.casefold().startswith(server_root.casefold() + "/"):
+        suffix = normalized[len(server_root):].lstrip("/")
+        return str(PureWindowsPath(OPERATOR_DRIVE_ROOT, *PurePosixPath(suffix).parts))
+
+    return raw
 
 
 def _expected_folder(
     diagnostic: dict[str, Any],
     task_relative_folder: str | None,
 ) -> str:
-    base = _scope_folder(diagnostic)
+    base = _operator_scope_folder(diagnostic)
     relative = str(task_relative_folder or "").strip().strip("\\/")
     if not relative:
         return base
 
-    # Preserve the path style already exposed to the operator. Windows/Drive
-    # paths remain Windows paths; server-side POSIX paths remain POSIX paths.
     if "\\" in base or re.match(r"^[A-Za-z]:", base):
         relative_parts = [
             part

--- a/FieldWiring/Application/field_context_operator_messages.py
+++ b/FieldWiring/Application/field_context_operator_messages.py
@@ -1,0 +1,65 @@
+"""Translate shared field-context diagnostics into operator-facing task messages.
+
+Engineering codes remain stable for logs/tests. Field applications must not
+render those codes directly. Instead, the task adapter supplies its human task
+name (for example ``Wiring`` or ``Setup procedure``) and this module returns a
+plain-language message using the current Scene/scope folder evidence.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+OPERATOR_WARNING_MAP = {
+    "LOR_CONTEXT_NOT_DEFINED_FIELD_SCENE": (
+        "{task} not found for {subject} in folder {folder}."
+    ),
+    "LOR_CONTEXT_UNRESOLVED": (
+        "{task} location could not be resolved for {subject} in folder {folder}."
+    ),
+    "FIELD_SCENE_MARKER_MISSING": (
+        "{task} folder for {subject} is not approved for field use: {folder}."
+    ),
+    "LOR_CONTEXT_OUTSIDE_OWNING_SCOPE": (
+        "{task} location for {subject} points outside the expected Stage folder: {folder}."
+    ),
+    "LOR_CONTEXT_NESTING_REVIEW_REQUIRED": (
+        "{task} location for {subject} needs review in folder {folder}."
+    ),
+}
+
+
+def _subject(diagnostic: dict[str, Any]) -> str:
+    return str(
+        diagnostic.get("scene_name")
+        or diagnostic.get("stage_key")
+        or "this selection"
+    )
+
+
+def _folder(diagnostic: dict[str, Any]) -> str:
+    return str(
+        diagnostic.get("scope_root")
+        or diagnostic.get("database_folder_path")
+        or "the current Stage folder"
+    )
+
+
+def operator_warning(diagnostic: dict[str, Any], *, task: str) -> str:
+    """Return one operator-safe message without exposing the engineering code."""
+    code = str(diagnostic.get("code") or "")
+    template = OPERATOR_WARNING_MAP.get(code)
+    if template is None:
+        return f"{task} is not available for {_subject(diagnostic)}."
+    return template.format(
+        task=task,
+        subject=_subject(diagnostic),
+        folder=_folder(diagnostic),
+    )
+
+
+def with_operator_warning(diagnostic: dict[str, Any], *, task: str) -> dict[str, Any]:
+    """Keep engineering metadata while adding the UI-safe translated message."""
+    result = dict(diagnostic)
+    result["operator_warning"] = operator_warning(diagnostic, task=task)
+    return result

--- a/FieldWiring/Application/field_context_operator_messages.py
+++ b/FieldWiring/Application/field_context_operator_messages.py
@@ -5,10 +5,10 @@ queries, filesystem access, Drive enumeration, marker checks, or network calls.
 It receives facts the caller already resolved and turns them into useful
 operator-facing text.
 
-Engineering codes remain stable for logs/tests. Field applications must not
-render those codes directly. The task adapter supplies both its human task name
-and, when applicable, the exact task-relative folder beneath the resolved
-Stage/Sub-stage/Scene scope.
+Engineering codes remain stable for logs/tests. Operator-facing applications
+must not render those codes directly. A task adapter supplies its human task
+name and, when applicable, the exact task-relative location already selected by
+that application.
 
 Examples::
 
@@ -18,9 +18,9 @@ Examples::
     Takedown procedure    -> Procedures\\Takedown
     Inspection procedure  -> Procedures\\Inspection
 
-The shared mapper does not choose the task branch. That remains owned by the
-calling task adapter. Server-side mount paths are translated textually to the
-canonical operator-visible Shared Drive path; no filesystem lookup is used.
+The shared mapper does not choose the task branch. Server-side mount paths are
+translated textually to the canonical operator-visible Shared Drive path; no
+filesystem lookup is used.
 """
 from __future__ import annotations
 
@@ -48,15 +48,29 @@ OPERATOR_WARNING_MAP = {
     "LOR_CONTEXT_NESTING_REVIEW_REQUIRED": (
         "{task} location for {subject} needs review. Expected folder: {folder}."
     ),
+    # Generic cross-application task conditions. These are intentionally not
+    # FieldWiring-specific so Procedure and future operator UIs can use the
+    # same presentation contract without copying strings.
+    "TASK_CONTENT_NOT_FOUND": (
+        "{task} not found for {subject} in folder {folder}."
+    ),
+    "TASK_FOLDER_UNAPPROVED": (
+        "{task} folder for {subject} is not approved for field use: {folder}."
+    ),
+    "TASK_SCOPE_UNRESOLVED": (
+        "{task} location could not be resolved for {subject}. Expected folder: {folder}."
+    ),
 }
 
 
 def _subject(diagnostic: dict[str, Any]) -> str:
-    return str(
-        diagnostic.get("scene_name")
-        or diagnostic.get("stage_key")
-        or "this selection"
-    )
+    scene_name = str(diagnostic.get("scene_name") or "").strip()
+    stage_key = str(diagnostic.get("stage_key") or "").strip()
+    if scene_name and scene_name.casefold() != "root":
+        return scene_name
+    if stage_key:
+        return f"Stage {stage_key}"
+    return "this selection"
 
 
 def _operator_scope_folder(diagnostic: dict[str, Any]) -> str:
@@ -77,10 +91,11 @@ def _operator_scope_folder(diagnostic: dict[str, Any]) -> str:
     return raw
 
 
-def _expected_folder(
+def expected_operator_folder(
     diagnostic: dict[str, Any],
-    task_relative_folder: str | None,
+    task_relative_folder: str | None = None,
 ) -> str:
+    """Return a human-facing expected folder using already-resolved path text."""
     base = _operator_scope_folder(diagnostic)
     relative = str(task_relative_folder or "").strip().strip("\\/")
     if not relative:
@@ -114,7 +129,7 @@ def operator_warning(
     """Return one operator-safe message without exposing the engineering code."""
     code = str(diagnostic.get("code") or "")
     template = OPERATOR_WARNING_MAP.get(code)
-    folder = _expected_folder(diagnostic, task_relative_folder)
+    folder = expected_operator_folder(diagnostic, task_relative_folder)
     if template is None:
         return f"{task} is not available for {_subject(diagnostic)}. Expected folder: {folder}."
     return template.format(

--- a/FieldWiring/Application/field_context_resolver.py
+++ b/FieldWiring/Application/field_context_resolver.py
@@ -35,7 +35,6 @@ DEFAULT_STAGE_FALLBACK_WARNING = (
     "known marked Stage root retained as the structured field scope."
 )
 
-_STAGE_KEY_RE = re.compile(r"^(\d{2})$")
 _SUBSTAGE_KEY_RE = re.compile(r"^(\d{2})[A-Za-z]$")
 _SUBSTAGE_CHILD_RE = re.compile(r"^(\d{2}[A-Za-z])-(?=.)")
 
@@ -56,11 +55,11 @@ def _windows_relative_parts(path_text: str, root_text: str) -> tuple[str, ...] |
         return None
     if len(path_parts) < len(root_parts):
         return None
-    if [p.casefold() for p in path_parts[:len(root_parts)]] != [
-        p.casefold() for p in root_parts
+    if [part.casefold() for part in path_parts[: len(root_parts)]] != [
+        part.casefold() for part in root_parts
     ]:
         return None
-    return tuple(path_parts[len(root_parts):])
+    return tuple(path_parts[len(root_parts) :])
 
 
 def _localize_evidence_path(
@@ -104,11 +103,11 @@ def _structured_scope_type(
     stage_root: Path,
     stage_key: str | None,
 ) -> str | None:
-    """Classify one ancestor using hierarchy position plus documented naming.
+    """Classify one existing ancestor from hierarchy position and naming.
 
-    Position matters. A nested ``NN-...-XY`` folder can be legacy Scene
-    evidence even though the preferred current Scene naming omits the suffix;
-    it must not be mistaken for another top-level Stage merely from its name.
+    A nested ``NN-Name-XY`` folder may legitimately be a legacy/current Scene
+    even though preferred new Scene names omit the short-code suffix. Position
+    under the already-known owning Stage therefore matters more than suffix.
     """
     if _same_path(candidate, stage_root):
         return _anchor_scope_type(stage_root, stage_key)
@@ -138,10 +137,8 @@ def _walk_up_from_pointer(
 ) -> tuple[Path | None, str | None, Path | None]:
     """Walk upward from exact path evidence to the nearest structured scope.
 
-    Returns ``(resolved_root, scope_type, unmarked_structured)``. A structured
-    child that exists but is unmarked is an explicit review condition; it is
-    not treated the same as an absent Scene and is not silently skipped to the
-    parent Stage.
+    A structured child that exists but is unmarked is a review condition. It
+    is not silently skipped in favor of its parent Stage.
     """
     current = pointer.parent if pointer.is_file() else pointer
 
@@ -163,7 +160,7 @@ def _bounded_scope_matches(
     scene_name: str,
     max_depth: int = 2,
 ) -> list[Path]:
-    """Conservative stale-pointer recovery inside one known Stage only."""
+    """Conservative stale/no-pointer recovery inside one known Stage only."""
     targets = _canonical_scene_names(scene_name)
     matches: list[Path] = []
 
@@ -171,7 +168,7 @@ def _bounded_scope_matches(
         if depth > max_depth:
             return
         try:
-            children = [p for p in path.iterdir() if p.is_dir()]
+            children = [child for child in path.iterdir() if child.is_dir()]
         except OSError:
             return
         for child in children:
@@ -182,7 +179,7 @@ def _bounded_scope_matches(
 
     walk(stage_root, 1)
     unique = {str(item).casefold(): item for item in matches}
-    return sorted(unique.values(), key=lambda p: str(p).casefold())
+    return sorted(unique.values(), key=lambda item: str(item).casefold())
 
 
 def _truncate_before_sourcedocs(path: Path | None) -> tuple[Path | None, bool]:
@@ -198,7 +195,6 @@ def _truncate_before_sourcedocs(path: Path | None) -> tuple[Path | None, bool]:
 
 
 def _direct_task_owner(pointer: Path | None, task_root_name: str | None) -> Path | None:
-    """Return the structured folder directly above a caller-supplied task root."""
     if pointer is None or not task_root_name:
         return None
     current = pointer.parent if pointer.suffix else pointer
@@ -214,10 +210,8 @@ def _recover_stage_root(
     drive_root: Path,
     stage_key: str | None,
 ) -> Path | None:
-    """Recover only the owning top-level Stage from the supplied pointer path."""
-    if pointer is None or not stage_key:
-        return None
-    if not pointer.exists():
+    """Recover the owning top-level Stage from supplied path evidence only."""
+    if pointer is None or not stage_key or not pointer.exists():
         return None
     try:
         relative = pointer.relative_to(drive_root)
@@ -225,6 +219,7 @@ def _recover_stage_root(
         return None
     if not relative.parts:
         return None
+
     candidate = drive_root / relative.parts[0]
     numeric = re.match(r"^(\d{2})", str(stage_key))
     if not numeric or not candidate.name.casefold().startswith(
@@ -234,13 +229,6 @@ def _recover_stage_root(
     if not candidate.is_dir() or not (candidate / MARKER_NAME).is_file():
         return None
     return candidate
-
-
-def _scene_name_looks_like_stage_binding(scene_name: str, stage_key: str | None) -> bool:
-    key = str(stage_key or "").strip()
-    if not _STAGE_KEY_RE.fullmatch(key):
-        return False
-    return bool(re.fullmatch(rf"{re.escape(key)}-.+-[A-Za-z]{{2,3}}", scene_name.strip()))
 
 
 def resolve_structured_scope(
@@ -256,9 +244,14 @@ def resolve_structured_scope(
 ) -> tuple[Path | None, str, list[str]]:
     """Resolve one current marked Stage/Sub-stage/Scene root.
 
-    The resolver never scans the Display Folders root. Exact path evidence is
-    followed upward first. Only when that exact path is stale may a bounded
-    name recovery occur inside the already-known owning Stage.
+    Resolution order follows the engineering contract:
+
+    1. use exact current path evidence and walk upward;
+    2. if exact evidence is stale/absent, try one bounded Scene/Sub-stage match
+       inside the already-known Stage;
+    3. only when no more-specific structured scope exists, retain the Stage.
+
+    No Display-Folders root enumeration occurs here.
     """
     warnings: list[str] = []
     raw_pointer = (scene or {}).get("scene_background_file") or preview.get(
@@ -281,20 +274,22 @@ def resolve_structured_scope(
         if folder_path
         else None
     )
-    valid = bool(
+    valid_stage = bool(
         stage_root
         and stage_root.is_dir()
         and (stage_root / MARKER_NAME).is_file()
     )
-    if not valid:
+
+    if not valid_stage:
         recovered = _recover_stage_root(pointer, drive_root, stage.get("stage_key"))
         if recovered is not None:
             stage_root = recovered
-            valid = True
+            valid_stage = True
             warnings.append(
                 "Persisted Stage folder_path was unavailable or stale; current marked Stage root was recovered from exact LOR path evidence."
             )
-    if not valid or stage_root is None:
+
+    if not valid_stage or stage_root is None:
         warnings.append(
             "Stage has no usable current folder_path anchor."
             if not folder_path
@@ -306,6 +301,9 @@ def resolve_structured_scope(
     if not scene_name or scene_name.strip().casefold() == "root":
         return stage_root, _anchor_scope_type(stage_root, stage.get("stage_key")), warnings
 
+    # Exact LOR path evidence is authoritative navigation evidence. Ignore
+    # helper and Display/group folders while walking upward until the nearest
+    # structured marked Scene/Sub-stage/Stage root is reached.
     if pointer is not None and _path_is_under(pointer, drive_root) and pointer.exists():
         if not _path_is_under(pointer, stage_root):
             warnings.append(
@@ -332,27 +330,37 @@ def resolve_structured_scope(
                 )
                 return None, "UNRESOLVED", warnings
 
-    if _scene_name_looks_like_stage_binding(scene_name, stage.get("stage_key")):
-        warnings.append(stage_fallback_warning)
-        return stage_root, _anchor_scope_type(stage_root, stage.get("stage_key")), warnings
-
+    # If exact path evidence did not identify a more-specific owner, try the
+    # documented Scene/Sub-stage name within the already-known Stage. This is
+    # bounded recovery, not hierarchy discovery. A real marked Scene wins; an
+    # existing unmarked matching Scene is a review condition; only an absent
+    # Scene falls back to Stage.
     matches = _bounded_scope_matches(stage_root, scene_name)
     marked = [match for match in matches if (match / MARKER_NAME).is_file()]
+
     if len(marked) == 1:
-        scope_type = _structured_scope_type(marked[0], stage_root, stage.get("stage_key"))
+        scope_type = _structured_scope_type(
+            marked[0],
+            stage_root,
+            stage.get("stage_key"),
+        )
         if scope_type is None:
             warnings.append(
                 "Matching folder exists but is not a structured Stage/Sub-stage/Scene scope under the current path contract."
             )
             return None, "UNRESOLVED", warnings
-        if raw_pointer:
+        if raw_pointer and (pointer is None or not pointer.exists()):
             warnings.append(
                 "Stored BackgroundFile did not resolve exactly; one deterministic marked current structured scope was used inside the known Stage."
             )
         return marked[0], scope_type, warnings
+
     if len(marked) > 1:
-        warnings.append("More than one marked structured folder matched the current Scene identity.")
+        warnings.append(
+            "More than one marked structured folder matched the current Scene identity."
+        )
         return None, "UNRESOLVED", warnings
+
     if matches:
         warnings.append(
             "Matching structured folder exists but is not an approved marked source root: "

--- a/FieldWiring/Application/field_context_resolver.py
+++ b/FieldWiring/Application/field_context_resolver.py
@@ -106,7 +106,7 @@ def _structured_scope_type(
 ) -> str | None:
     """Classify one ancestor using hierarchy position plus documented naming.
 
-    Position matters.  A nested ``NN-...-XY`` folder can be legacy Scene
+    Position matters. A nested ``NN-...-XY`` folder can be legacy Scene
     evidence even though the preferred current Scene naming omits the suffix;
     it must not be mistaken for another top-level Stage merely from its name.
     """
@@ -121,25 +121,12 @@ def _structured_scope_type(
 
     sub_match = _SUBSTAGE_CHILD_RE.match(candidate.name)
     if sub_match and sub_match.group(1)[:2].casefold() == base.casefold():
-        # A direct NNa child of the owning Stage is the formal Sub-stage root.
         if _same_path(candidate.parent, stage_root):
             return "SUBSTAGE"
-        # A deeper NNa-prefixed child is a Scene owned by that Sub-stage.
         return "SCENE"
 
-    # A child beginning with the current Stage/Sub-stage key is a structured
-    # Scene at this hierarchy depth.  Unprefixed Display/group folders are
-    # intentionally ignored so resolution can continue upward.
     if key and candidate.name.casefold().startswith(key.casefold() + "-"):
         return "SCENE"
-
-    # When a Sub-stage row is anchored temporarily at its parent Stage because
-    # its persisted folder_path is absent/stale, its direct NNa root is still
-    # recognizable by the full Sub-stage key.
-    if _SUBSTAGE_KEY_RE.fullmatch(key) and candidate.name.casefold().startswith(
-        key.casefold() + "-"
-    ):
-        return "SUBSTAGE" if _same_path(candidate.parent, stage_root) else "SCENE"
 
     return None
 
@@ -149,26 +136,26 @@ def _walk_up_from_pointer(
     stage_root: Path,
     stage_key: str | None,
 ) -> tuple[Path | None, str | None, Path | None]:
-    """Walk upward from exact path evidence to the nearest marked scope.
+    """Walk upward from exact path evidence to the nearest structured scope.
 
-    Returns ``(resolved_root, scope_type, first_unmarked_structured)``.
-    No sibling, Stage-root, or Display-Folders enumeration occurs here.
+    Returns ``(resolved_root, scope_type, unmarked_structured)``. A structured
+    child that exists but is unmarked is an explicit review condition; it is
+    not treated the same as an absent Scene and is not silently skipped to the
+    parent Stage.
     """
     current = pointer.parent if pointer.is_file() else pointer
-    first_unmarked: Path | None = None
 
     while _path_is_under(current, stage_root):
         scope_type = _structured_scope_type(current, stage_root, stage_key)
         if scope_type is not None:
             if (current / MARKER_NAME).is_file():
-                return current, scope_type, first_unmarked
-            if first_unmarked is None:
-                first_unmarked = current
+                return current, scope_type, None
+            return None, None, current
         if _same_path(current, stage_root):
             break
         current = current.parent
 
-    return None, None, first_unmarked
+    return None, None, None
 
 
 def _bounded_scope_matches(
@@ -269,8 +256,8 @@ def resolve_structured_scope(
 ) -> tuple[Path | None, str, list[str]]:
     """Resolve one current marked Stage/Sub-stage/Scene root.
 
-    The resolver never scans the Display Folders root.  Exact path evidence is
-    followed upward first.  Only when that exact path is stale may a bounded
+    The resolver never scans the Display Folders root. Exact path evidence is
+    followed upward first. Only when that exact path is stale may a bounded
     name recovery occur inside the already-known owning Stage.
     """
     warnings: list[str] = []
@@ -319,9 +306,6 @@ def resolve_structured_scope(
     if not scene_name or scene_name.strip().casefold() == "root":
         return stage_root, _anchor_scope_type(stage_root, stage.get("stage_key")), warnings
 
-    # Exact LOR path evidence owns the first attempt.  Walk upward through the
-    # path already supplied by LOR; ignore Display/group/helper folders until a
-    # valid structured Scene/Sub-stage/Stage root is reached.
     if pointer is not None and _path_is_under(pointer, drive_root) and pointer.exists():
         if not _path_is_under(pointer, stage_root):
             warnings.append(
@@ -348,16 +332,10 @@ def resolve_structured_scope(
                 )
                 return None, "UNRESOLVED", warnings
 
-    # A Stage-binding Master Musical Scene (NN-Name-XY) is Stage evidence when
-    # its path did not identify a distinct child.  Do not invent a child Scene
-    # merely because the LOR Scene name carries a Stage-style suffix.
     if _scene_name_looks_like_stage_binding(scene_name, stage.get("stage_key")):
         warnings.append(stage_fallback_warning)
         return stage_root, _anchor_scope_type(stage_root, stage.get("stage_key")), warnings
 
-    # Stale-pointer recovery is allowed only inside the already-known Stage and
-    # remains bounded.  This preserves the documented deterministic recovery
-    # without turning runtime resolution into a Drive crawler.
     matches = _bounded_scope_matches(stage_root, scene_name)
     marked = [match for match in matches if (match / MARKER_NAME).is_file()]
     if len(marked) == 1:

--- a/FieldWiring/Application/field_context_resolver.py
+++ b/FieldWiring/Application/field_context_resolver.py
@@ -363,7 +363,7 @@ def resolve_structured_scope(
 
     if matches:
         warnings.append(
-            "Matching structured folder exists but is not an approved marked source root: "
+            "Matching Scene folder exists but is not an approved marked source root: "
             + "; ".join(str(match) for match in matches)
         )
         return None, "UNRESOLVED", warnings

--- a/FieldWiring/Application/field_context_resolver.py
+++ b/FieldWiring/Application/field_context_resolver.py
@@ -1,9 +1,19 @@
 """Task-neutral Stage/Sub-stage/Scene filesystem context resolver.
 
-This module contains the structured-scope resolution proven by FieldWiring. It
-resolves the current marked Stage/Scene root from authoritative identity plus
-bounded path/filesystem evidence. Task-specific consumers own what they do
-after this root has been resolved.
+The governing runtime contract is path-first and bounded:
+
+* start from current Production Database/LOR identity and BackgroundFile evidence;
+* use that pointer only as navigation evidence;
+* walk upward only as needed to the nearest valid marked structured scope;
+* never enumerate the Display Folders root to rediscover the park hierarchy;
+* after the structured scope is fixed, task-specific callers choose their own
+  relative branches such as Wiring or Procedures.
+
+The authoritative behavior is documented in:
+
+* Docs/00_Project_Overview/02-Google_Drive_Path_Resolution_Contract.md
+* Docs/02_Production_Database/01_System_Architecture/09_Wiring_System/
+  FieldWiring_Drive_Context_Resolver_Engineering_Design.md
 
 Do not add Wiring/Procedure content discovery here.
 """
@@ -21,9 +31,13 @@ SKIP_SCOPE_SEARCH = {
 }
 
 DEFAULT_STAGE_FALLBACK_WARNING = (
-    "No distinct Scene folder matched the current Scene identity; "
+    "No distinct Scene/Sub-stage scope resolved from current path evidence; "
     "known marked Stage root retained as the structured field scope."
 )
+
+_STAGE_KEY_RE = re.compile(r"^(\d{2})$")
+_SUBSTAGE_KEY_RE = re.compile(r"^(\d{2})[A-Za-z]$")
+_SUBSTAGE_CHILD_RE = re.compile(r"^(\d{2}[A-Za-z])-(?=.)")
 
 
 def _canonical_scene_names(scene_name: str) -> set[str]:
@@ -70,11 +84,99 @@ def _path_is_under(path: Path, root: Path) -> bool:
         return False
 
 
+def _same_path(left: Path, right: Path) -> bool:
+    return str(left).replace("\\", "/").casefold().rstrip("/") == str(right).replace(
+        "\\", "/"
+    ).casefold().rstrip("/")
+
+
+def _anchor_scope_type(stage_root: Path, stage_key: str | None) -> str:
+    key = str(stage_key or "").strip()
+    if _SUBSTAGE_KEY_RE.fullmatch(key) and stage_root.name.casefold().startswith(
+        key.casefold() + "-"
+    ):
+        return "SUBSTAGE"
+    return "STAGE"
+
+
+def _structured_scope_type(
+    candidate: Path,
+    stage_root: Path,
+    stage_key: str | None,
+) -> str | None:
+    """Classify one ancestor using hierarchy position plus documented naming.
+
+    Position matters.  A nested ``NN-...-XY`` folder can be legacy Scene
+    evidence even though the preferred current Scene naming omits the suffix;
+    it must not be mistaken for another top-level Stage merely from its name.
+    """
+    if _same_path(candidate, stage_root):
+        return _anchor_scope_type(stage_root, stage_key)
+
+    key = str(stage_key or "").strip()
+    base_match = re.match(r"^(\d{2})", key)
+    if not base_match:
+        return None
+    base = base_match.group(1)
+
+    sub_match = _SUBSTAGE_CHILD_RE.match(candidate.name)
+    if sub_match and sub_match.group(1)[:2].casefold() == base.casefold():
+        # A direct NNa child of the owning Stage is the formal Sub-stage root.
+        if _same_path(candidate.parent, stage_root):
+            return "SUBSTAGE"
+        # A deeper NNa-prefixed child is a Scene owned by that Sub-stage.
+        return "SCENE"
+
+    # A child beginning with the current Stage/Sub-stage key is a structured
+    # Scene at this hierarchy depth.  Unprefixed Display/group folders are
+    # intentionally ignored so resolution can continue upward.
+    if key and candidate.name.casefold().startswith(key.casefold() + "-"):
+        return "SCENE"
+
+    # When a Sub-stage row is anchored temporarily at its parent Stage because
+    # its persisted folder_path is absent/stale, its direct NNa root is still
+    # recognizable by the full Sub-stage key.
+    if _SUBSTAGE_KEY_RE.fullmatch(key) and candidate.name.casefold().startswith(
+        key.casefold() + "-"
+    ):
+        return "SUBSTAGE" if _same_path(candidate.parent, stage_root) else "SCENE"
+
+    return None
+
+
+def _walk_up_from_pointer(
+    pointer: Path,
+    stage_root: Path,
+    stage_key: str | None,
+) -> tuple[Path | None, str | None, Path | None]:
+    """Walk upward from exact path evidence to the nearest marked scope.
+
+    Returns ``(resolved_root, scope_type, first_unmarked_structured)``.
+    No sibling, Stage-root, or Display-Folders enumeration occurs here.
+    """
+    current = pointer.parent if pointer.is_file() else pointer
+    first_unmarked: Path | None = None
+
+    while _path_is_under(current, stage_root):
+        scope_type = _structured_scope_type(current, stage_root, stage_key)
+        if scope_type is not None:
+            if (current / MARKER_NAME).is_file():
+                return current, scope_type, first_unmarked
+            if first_unmarked is None:
+                first_unmarked = current
+        if _same_path(current, stage_root):
+            break
+        current = current.parent
+
+    return None, None, first_unmarked
+
+
 def _bounded_scope_matches(
     stage_root: Path,
     scene_name: str,
     max_depth: int = 2,
 ) -> list[Path]:
+    """Conservative stale-pointer recovery inside one known Stage only."""
     targets = _canonical_scene_names(scene_name)
     matches: list[Path] = []
 
@@ -125,6 +227,7 @@ def _recover_stage_root(
     drive_root: Path,
     stage_key: str | None,
 ) -> Path | None:
+    """Recover only the owning top-level Stage from the supplied pointer path."""
     if pointer is None or not stage_key:
         return None
     if not pointer.exists():
@@ -146,6 +249,13 @@ def _recover_stage_root(
     return candidate
 
 
+def _scene_name_looks_like_stage_binding(scene_name: str, stage_key: str | None) -> bool:
+    key = str(stage_key or "").strip()
+    if not _STAGE_KEY_RE.fullmatch(key):
+        return False
+    return bool(re.fullmatch(rf"{re.escape(key)}-.+-[A-Za-z]{{2,3}}", scene_name.strip()))
+
+
 def resolve_structured_scope(
     stage: dict[str, Any],
     scene: dict[str, Any] | None,
@@ -157,12 +267,11 @@ def resolve_structured_scope(
     direct_owner_warning: str | None = None,
     stage_fallback_warning: str = DEFAULT_STAGE_FALLBACK_WARNING,
 ) -> tuple[Path | None, str, list[str]]:
-    """Resolve one current marked Stage/Scene root without discovering task content.
+    """Resolve one current marked Stage/Sub-stage/Scene root.
 
-    ``direct_owner_folder_name`` preserves a caller's existing exact path-owner
-    evidence rule without teaching this shared resolver what that task folder
-    means. The caller may also supply legacy warning strings so user-visible
-    warnings remain byte-for-byte stable during extraction.
+    The resolver never scans the Display Folders root.  Exact path evidence is
+    followed upward first.  Only when that exact path is stale may a bounded
+    name recovery occur inside the already-known owning Stage.
     """
     warnings: list[str] = []
     raw_pointer = (scene or {}).get("scene_background_file") or preview.get(
@@ -206,53 +315,72 @@ def resolve_structured_scope(
         )
         return None, "UNRESOLVED", warnings
 
-    # Some callers already use an exact task-root path as explicit
-    # documentation-ownership evidence. The shared resolver accepts the task
-    # root name as data; it does not select or inspect task content beneath it.
-    direct_owner = _direct_task_owner(pointer, direct_owner_folder_name)
-    if direct_owner is not None and _path_is_under(direct_owner, drive_root):
-        if direct_owner == stage_root:
-            if direct_owner_warning:
-                warnings.append(direct_owner_warning)
-            return stage_root, "STAGE", warnings
-
     scene_name = (scene or {}).get("scene_name")
     if not scene_name or scene_name.strip().casefold() == "root":
-        return stage_root, "STAGE", warnings
+        return stage_root, _anchor_scope_type(stage_root, stage.get("stage_key")), warnings
 
-    targets = _canonical_scene_names(scene_name)
-    if pointer is not None and _path_is_under(pointer, drive_root):
-        if pointer.exists():
-            current = pointer.parent if pointer.is_file() else pointer
-            while _path_is_under(current, stage_root):
-                if current.name.casefold() in targets:
-                    if (current / MARKER_NAME).is_file():
-                        return current, "SCENE", warnings
-                    warnings.append(
-                        f"Scene source-folder marker is missing: {current / MARKER_NAME}"
-                    )
-                    return None, "UNRESOLVED", warnings
-                if current == stage_root:
-                    break
-                current = current.parent
+    # Exact LOR path evidence owns the first attempt.  Walk upward through the
+    # path already supplied by LOR; ignore Display/group/helper folders until a
+    # valid structured Scene/Sub-stage/Stage root is reached.
+    if pointer is not None and _path_is_under(pointer, drive_root) and pointer.exists():
+        if not _path_is_under(pointer, stage_root):
+            warnings.append(
+                "BackgroundFile resolves beneath Display Folders but outside the current Stage anchor; exact path evidence was not used for scope selection."
+            )
+        else:
+            resolved, scope_type, unmarked = _walk_up_from_pointer(
+                pointer,
+                stage_root,
+                stage.get("stage_key"),
+            )
+            if resolved is not None and scope_type is not None:
+                direct_owner = _direct_task_owner(pointer, direct_owner_folder_name)
+                if (
+                    direct_owner_warning
+                    and direct_owner is not None
+                    and _same_path(direct_owner, resolved)
+                ):
+                    warnings.append(direct_owner_warning)
+                return resolved, scope_type, warnings
+            if unmarked is not None:
+                warnings.append(
+                    f"Structured source-folder marker is missing: {unmarked / MARKER_NAME}"
+                )
+                return None, "UNRESOLVED", warnings
 
+    # A Stage-binding Master Musical Scene (NN-Name-XY) is Stage evidence when
+    # its path did not identify a distinct child.  Do not invent a child Scene
+    # merely because the LOR Scene name carries a Stage-style suffix.
+    if _scene_name_looks_like_stage_binding(scene_name, stage.get("stage_key")):
+        warnings.append(stage_fallback_warning)
+        return stage_root, _anchor_scope_type(stage_root, stage.get("stage_key")), warnings
+
+    # Stale-pointer recovery is allowed only inside the already-known Stage and
+    # remains bounded.  This preserves the documented deterministic recovery
+    # without turning runtime resolution into a Drive crawler.
     matches = _bounded_scope_matches(stage_root, scene_name)
     marked = [match for match in matches if (match / MARKER_NAME).is_file()]
     if len(marked) == 1:
+        scope_type = _structured_scope_type(marked[0], stage_root, stage.get("stage_key"))
+        if scope_type is None:
+            warnings.append(
+                "Matching folder exists but is not a structured Stage/Sub-stage/Scene scope under the current path contract."
+            )
+            return None, "UNRESOLVED", warnings
         if raw_pointer:
             warnings.append(
-                "Stored Scene BackgroundFile did not resolve exactly; one deterministic marked current Scene folder was used."
+                "Stored BackgroundFile did not resolve exactly; one deterministic marked current structured scope was used inside the known Stage."
             )
-        return marked[0], "SCENE", warnings
+        return marked[0], scope_type, warnings
     if len(marked) > 1:
-        warnings.append("More than one marked Scene folder matched the current Scene identity.")
+        warnings.append("More than one marked structured folder matched the current Scene identity.")
         return None, "UNRESOLVED", warnings
     if matches:
         warnings.append(
-            "Matching Scene folder exists but is not an approved marked source root: "
+            "Matching structured folder exists but is not an approved marked source root: "
             + "; ".join(str(match) for match in matches)
         )
         return None, "UNRESOLVED", warnings
 
     warnings.append(stage_fallback_warning)
-    return stage_root, "STAGE", warnings
+    return stage_root, _anchor_scope_type(stage_root, stage.get("stage_key")), warnings

--- a/FieldWiring/Application/fieldwiring.js
+++ b/FieldWiring/Application/fieldwiring.js
@@ -16,6 +16,7 @@ const LIGHT_LOGO = 'https://webassets.sheboyganlights.org/images/branding/msb-bl
 const DARK_LOGO = 'https://webassets.sheboyganlights.org/images/branding/msb-white-logo-600-plain.svg';
 
 let stages = [];
+let browseNodes = [];
 let timer = null;
 let resolvedContext = null;
 
@@ -119,11 +120,12 @@ function showResolved(c) {
   resolvedContext = c;
   resolved.hidden = false;
   const isScene = c.scope_kind === 'Scene' && c.scene_name && c.scene_name.toLowerCase() !== 'root';
+  const wholeScope = c.owner_scope_type === 'SUBSTAGE' ? 'Whole Sub-stage' : 'Whole Stage';
   const rows = [];
   if (c.display_name) rows.push(['Display', c.display_name]);
   rows.push(
-    ['Stage', `${c.stage_key ? c.stage_key + ' · ' : ''}${c.stage_name || 'Unresolved'}`],
-    ['Scene / Area', isScene ? c.scene_name : 'Whole Stage'],
+    ['Stage / Area', `${c.stage_key ? c.stage_key + ' · ' : ''}${c.stage_name || 'Unresolved'}`],
+    ['Scene / Area', isScene ? c.scene_name : wholeScope],
     ['Wiring', c.context_type || 'Unknown']
   );
   resolvedGrid.innerHTML = rows.map(([label,value]) => `
@@ -148,42 +150,106 @@ function showResolved(c) {
   resolved.scrollIntoView({behavior:'smooth', block:'start'});
 }
 
+function flattenBrowseNodes(stageList) {
+  const nodes = [];
+  stageList.forEach(stage => {
+    nodes.push({
+      id: `STAGE:${stage.stage_id}`,
+      node: stage,
+      depth: 0
+    });
+    (stage.sub_stages || []).forEach(sub => {
+      nodes.push({
+        id: `SUBSTAGE:${sub.stage_id}`,
+        node: sub,
+        depth: 1
+      });
+    });
+  });
+  return nodes;
+}
+
+function browseContextChoices(node) {
+  const choices = [];
+  const ownerLabel = node.scope_type === 'SUBSTAGE' ? 'Whole Sub-stage' : 'Whole Stage';
+
+  (node.contexts || []).forEach(context => {
+    choices.push({
+      context: {
+        ...context,
+        scope_kind: 'Stage / Preview',
+        scene_name: null
+      },
+      label: ownerLabel,
+      badge: node.scope_type === 'SUBSTAGE' ? 'Sub-stage' : 'Stage'
+    });
+  });
+
+  (node.scenes || []).forEach(scene => {
+    (scene.contexts || []).forEach(context => {
+      choices.push({
+        context: {
+          ...context,
+          scope_kind: 'Scene',
+          scene_name: scene.label
+        },
+        label: scene.label,
+        badge: 'Scene'
+      });
+    });
+  });
+
+  return choices;
+}
+
 async function loadStages() {
   try {
     const payload = await api('api/stages');
     stages = payload.stages || [];
-    stageSelect.innerHTML = '<option value="">Select a Stage…</option>' +
-      stages.map(s => `<option value="${esc(s.stage_key)}">${esc(s.stage_key)} — ${esc(s.stage_name)}</option>`).join('');
+    browseNodes = flattenBrowseNodes(stages);
+
+    stageSelect.innerHTML = '<option value="">Select a Stage / Sub-stage…</option>' +
+      browseNodes.map(item => {
+        const prefix = item.depth ? '↳ ' : '';
+        return `<option value="${esc(item.id)}">${esc(prefix + item.node.label)}</option>`;
+      }).join('');
   } catch (err) {
     stageSelect.innerHTML = `<option value="">${esc(err.message)}</option>`;
   }
 }
 
 function renderStageContexts() {
-  const stage = stages.find(s => String(s.stage_key) === String(stageSelect.value));
-  if (!stage) {
+  const selected = browseNodes.find(item => item.id === stageSelect.value);
+  if (!selected) {
     stageContexts.innerHTML = '';
     return;
   }
-  stageContexts.innerHTML = stage.contexts.map((c, i) => {
-    const isScene = c.scope_kind === 'Scene' && c.scene_name && c.scene_name.toLowerCase() !== 'root';
-    const label = isScene ? c.scene_name : 'Whole Stage';
-    return `
+
+  const node = selected.node;
+  const choices = browseContextChoices(node);
+
+  if (!choices.length) {
+    stageContexts.innerHTML = '<div class="hint" style="padding:10px 4px">No current Field Wiring context is available for this Stage / Sub-stage.</div>';
+    return;
+  }
+
+  stageContexts.innerHTML = choices.map((choice, i) => `
       <div class="context-choice" data-context-index="${i}">
-        <span class="context-badge">${esc(c.context_type)}</span>
-        <span class="context-badge">${isScene ? 'Scene' : 'Stage'}</span>
-        <strong>${esc(label)}</strong>
-      </div>`;
-  }).join('');
-  stageContexts.querySelectorAll('.context-choice').forEach(node => {
-    node.addEventListener('click', () => {
-      const c = stage.contexts[Number(node.dataset.contextIndex)];
+        <span class="context-badge">${esc(choice.context.context_type || 'Wiring')}</span>
+        <span class="context-badge">${esc(choice.badge)}</span>
+        <strong>${esc(choice.label)}</strong>
+      </div>`).join('');
+
+  stageContexts.querySelectorAll('.context-choice').forEach(element => {
+    element.addEventListener('click', () => {
+      const choice = choices[Number(element.dataset.contextIndex)];
       showResolved({
-        ...c,
+        ...choice.context,
         source:'Stage / Scene browse',
-        stage_id:stage.stage_id,
-        stage_key:stage.stage_key,
-        stage_name:stage.stage_name,
+        stage_id:node.stage_id,
+        stage_key:node.stage_key,
+        stage_name:node.label,
+        owner_scope_type:node.scope_type,
         display_id:null,
         display_name:null,
         device_type:null

--- a/FieldWiring/Application/index.html
+++ b/FieldWiring/Application/index.html
@@ -32,11 +32,11 @@
 
     <section class="card">
       <h2>Browse Stage / Scene</h2>
-      <label for="stage-select">Stage</label>
+      <label for="stage-select">Stage / Sub-stage</label>
       <select id="stage-select">
         <option value="">Loading Stages…</option>
       </select>
-      <div class="hint">Choose the whole Stage or one of its wiring Scenes.</div>
+      <div class="hint">Choose a Stage or Sub-stage, then choose its whole-area wiring or a Scene.</div>
       <div id="stage-contexts" class="stage-contexts"></div>
     </section>
   </div>

--- a/FieldWiring/Application/test_field_context_hierarchy.py
+++ b/FieldWiring/Application/test_field_context_hierarchy.py
@@ -198,6 +198,33 @@ def test_scene_child_is_derived_from_path_string_not_drive_enumeration():
     assert scenes[0]["scope_path_evidence"].endswith(r"13-Christmas Story")
 
 
+def test_background_filename_with_stage_prefix_is_not_promoted_to_scene():
+    result = build_field_hierarchy(
+        [
+            raw_stage(
+                33,
+                "03",
+                "Show Background Stage 03 Welcome Area",
+                r"G:\Shared drives\Display Folders\03-Welcome Area-WA",
+                [
+                    context(
+                        "03-Welcome Area",
+                        stage_key="03",
+                        path=(
+                            r"G:\Shared drives\Display Folders\03-Welcome Area-WA"
+                            r"\PreviewBackground\03-welcome area.jpg"
+                        ),
+                    )
+                ],
+            )
+        ]
+    )
+
+    stage = result["stages"][0]
+    assert stage["scenes"] == []
+    assert [item["scene_name"] for item in stage["contexts"]] == ["03-Welcome Area"]
+
+
 def test_legacy_nested_scene_with_short_code_is_retained_when_path_proves_child():
     result = build_field_hierarchy(
         [

--- a/FieldWiring/Application/test_field_context_hierarchy.py
+++ b/FieldWiring/Application/test_field_context_hierarchy.py
@@ -1,16 +1,39 @@
-from pathlib import Path
-
 from field_context_hierarchy import build_field_hierarchy
-from field_context_resolver import MARKER_NAME
 
 
-def mark(path: Path) -> Path:
-    path.mkdir(parents=True, exist_ok=True)
-    (path / MARKER_NAME).write_text("marker", encoding="utf-8")
-    return path
+def context(
+    scene_name: str,
+    *,
+    stage_key: str,
+    path: str | None,
+    context_type: str = "Musical",
+    preview_uuid: str = "preview-1",
+    scene_uuid: str = "scene-1",
+):
+    return {
+        "preview": {
+            "preview_uuid": preview_uuid,
+            "preview_name": "2026 Master Musical Preview",
+            "preview_background_file": None,
+        },
+        "scene": {
+            "scene_uuid": scene_uuid,
+            "scene_name": scene_name,
+            "scene_stage_key": stage_key,
+            "scene_background_file": path,
+        },
+        "scope_kind": "Scene",
+        "context_type": context_type,
+    }
 
 
-def raw_stage(stage_id: int, key: str, name: str, folder_path: str | None):
+def raw_stage(
+    stage_id: int,
+    key: str,
+    name: str,
+    folder_path: str | None,
+    contexts=None,
+):
     return {
         "stage": {
             "stage_id": stage_id,
@@ -18,82 +41,246 @@ def raw_stage(stage_id: int, key: str, name: str, folder_path: str | None):
             "stage_name": name,
             "folder_path": folder_path,
         },
-        "contexts": [],
+        "contexts": list(contexts or []),
     }
 
 
-def test_valid_top_level_stage_remains_normal(tmp_path):
-    drive = tmp_path / "Display Folders"
-    root = mark(drive / "15-Church-Bells-CH")
-
-    result = build_field_hierarchy(
-        [raw_stage(15, "15", "LOR Church Name", str(root))],
-        drive,
-    )
-
-    assert [item["stage_key"] for item in result["stages"]] == ["15"]
-    assert result["stages"][0]["label"] == "15-Church-Bells-CH"
-    assert not any(
-        item["code"] == "PERSISTED_STAGE_PATH_REVIEW_REQUIRED"
-        for item in result["review_required"]
-    )
-
-
-def test_conflicting_top_level_stage_path_remains_browseable_with_review(tmp_path):
-    drive = tmp_path / "Display Folders"
-    expected = mark(drive / "39-Parade Float-PF")
-    other = mark(drive / "40-Parade Float-PF")
-
-    result = build_field_hierarchy(
-        [raw_stage(39, "39", "RGB Plus Stage 39 Parade Float", str(other))],
-        drive,
-    )
-
-    assert [item["stage_key"] for item in result["stages"]] == ["39"]
-    assert result["stages"][0]["scope_root"] == str(expected)
-    assert any(
-        item["code"] == "PERSISTED_STAGE_PATH_REVIEW_REQUIRED"
-        and str(item.get("stage_key")) == "39"
-        for item in result["review_required"]
-    )
-
-
-def test_missing_top_level_stage_path_remains_browseable_without_lor_requirement(tmp_path):
-    drive = tmp_path / "Display Folders"
-    expected = mark(drive / "40-CommandCenter")
-
-    result = build_field_hierarchy(
-        [raw_stage(40, "40", "CommandCenter-CC", None)],
-        drive,
-    )
-
-    assert [item["stage_key"] for item in result["stages"]] == ["40"]
-    assert result["stages"][0]["scope_root"] == str(expected)
-    assert result["stages"][0]["contexts"] == []
-    assert any(
-        item["code"] == "PERSISTED_STAGE_PATH_REVIEW_REQUIRED"
-        and str(item.get("stage_key")) == "40"
-        for item in result["review_required"]
-    )
-
-
-def test_nested_substage_with_missing_persisted_path_remains_browseable(tmp_path):
-    drive = tmp_path / "Display Folders"
-    stage_root = mark(drive / "07-Whoville-WV")
-    mark(stage_root / "07a-Who Forest-WF")
+def test_build_hierarchy_does_not_touch_drive_root():
+    class ForbiddenDriveRoot:
+        def __fspath__(self):
+            raise AssertionError("runtime browse must not touch Display Folders")
 
     result = build_field_hierarchy(
         [
-            raw_stage(7, "07", "Whoville", str(stage_root)),
-            raw_stage(70, "07a", "Who Forest", None),
+            raw_stage(
+                45,
+                "15",
+                "Show Background Stage 15 Church",
+                r"G:\Shared drives\Display Folders\15-Church-Bells-CH",
+            )
         ],
-        drive,
+        ForbiddenDriveRoot(),
+    )
+
+    assert [item["label"] for item in result["stages"]] == ["15-Church-Bells-CH"]
+
+
+def test_persisted_stage_folder_path_is_fast_field_label():
+    result = build_field_hierarchy(
+        [
+            raw_stage(
+                51,
+                "21",
+                "Show Background Stage 21 Polar Bears",
+                r"G:\Shared drives\Display Folders\21-Polar Bear Playground-PB",
+            )
+        ]
+    )
+
+    stage = result["stages"][0]
+    assert stage["label"] == "21-Polar Bear Playground-PB"
+    assert stage["label_basis"] == "PERSISTED_STAGE_PATH"
+
+
+def test_stale_stage_path_uses_stored_lor_path_string_without_filesystem_scan():
+    result = build_field_hierarchy(
+        [
+            raw_stage(
+                58,
+                "39",
+                "RGB Plus Stage 39 Parade Float",
+                r"G:\Shared drives\Display Folders\40-Parade Float-PF",
+                [
+                    context(
+                        "Parade Float",
+                        stage_key="39",
+                        path=(
+                            r"G:\Shared drives\Display Folders\39-Parade Float-PF"
+                            r"\Wiring\BackgroundStage\Parade.jpg"
+                        ),
+                    )
+                ],
+            )
+        ]
+    )
+
+    stage = result["stages"][0]
+    assert stage["label"] == "39-Parade Float-PF"
+    assert stage["label_basis"] == "LOR_PATH_EVIDENCE"
+
+
+def test_substage_is_nested_and_uses_lor_path_string_when_folder_path_missing():
+    result = build_field_hierarchy(
+        [
+            raw_stage(
+                37,
+                "07",
+                "Show Background Stage 07 WhoHouse Mt Crumpet",
+                r"G:\Shared drives\Display Folders\07-Whoville-WV",
+            ),
+            raw_stage(
+                59,
+                "07a",
+                "RGB Plus Stage 07a Who Forest",
+                None,
+                [
+                    context(
+                        "07a-Who Forest-WF",
+                        stage_key="07a",
+                        path=(
+                            r"G:\Shared drives\Display Folders\07-Whoville-WV"
+                            r"\07a-Who Forest-WF\PreviewBackground\Who-Forest.jpg"
+                        ),
+                    )
+                ],
+            ),
+        ]
     )
 
     assert [item["stage_key"] for item in result["stages"]] == ["07"]
-    assert [item["stage_key"] for item in result["stages"][0]["sub_stages"]] == ["07a"]
-    assert any(
-        item["code"] == "PERSISTED_SUBSTAGE_PATH_REVIEW_REQUIRED"
-        and str(item.get("stage_key")) == "07a"
-        for item in result["review_required"]
+    sub = result["stages"][0]["sub_stages"][0]
+    assert sub["stage_key"] == "07a"
+    assert sub["label"] == "07a-Who Forest-WF"
+    assert sub["label_basis"] == "LOR_PATH_EVIDENCE"
+
+
+def test_stage_binding_scene_collapses_to_stage_context_when_path_has_no_child():
+    result = build_field_hierarchy(
+        [
+            raw_stage(
+                45,
+                "15",
+                "Show Background Stage 15 Church",
+                r"G:\Shared drives\Display Folders\15-Church-Bells-CH",
+                [
+                    context(
+                        "15-Church-CH",
+                        stage_key="15",
+                        path=(
+                            r"G:\Shared drives\Display Folders\15-Church-Bells-CH"
+                            r"\PreviewBackground\Church.jpg"
+                        ),
+                    )
+                ],
+            )
+        ]
     )
+
+    stage = result["stages"][0]
+    assert stage["scenes"] == []
+    assert [item["scene_name"] for item in stage["contexts"]] == ["15-Church-CH"]
+
+
+def test_scene_child_is_derived_from_path_string_not_drive_enumeration():
+    result = build_field_hierarchy(
+        [
+            raw_stage(
+                43,
+                "13",
+                "Show Background Stage 13 Winter Wonderland",
+                r"G:\Shared drives\Display Folders\13-Winter Wonderland-WW",
+                [
+                    context(
+                        "13-Christmas Story",
+                        stage_key="13",
+                        path=(
+                            r"G:\Shared drives\Display Folders\13-Winter Wonderland-WW"
+                            r"\13-Christmas Story\PreviewBackground\Story.jpg"
+                        ),
+                    )
+                ],
+            )
+        ]
+    )
+
+    scenes = result["stages"][0]["scenes"]
+    assert [item["label"] for item in scenes] == ["13-Christmas Story"]
+    assert scenes[0]["scope_path_evidence"].endswith(r"13-Christmas Story")
+
+
+def test_legacy_nested_scene_with_short_code_is_retained_when_path_proves_child():
+    result = build_field_hierarchy(
+        [
+            raw_stage(
+                33,
+                "03",
+                "Show Background Stage 03 Welcome Area",
+                r"G:\Shared drives\Display Folders\03-Welcome Area-WA",
+                [
+                    context(
+                        "03-Mega Cube-MC",
+                        stage_key="03",
+                        path=(
+                            r"G:\Shared drives\Display Folders\03-Welcome Area-WA"
+                            r"\03-Mega Cube-MC\PreviewBackground\Mega.jpg"
+                        ),
+                    )
+                ],
+            )
+        ]
+    )
+
+    assert [item["label"] for item in result["stages"][0]["scenes"]] == [
+        "03-Mega Cube-MC"
+    ]
+
+
+def test_unprefixed_lor_group_is_context_evidence_not_browse_scene():
+    result = build_field_hierarchy(
+        [
+            raw_stage(
+                44,
+                "14",
+                "Show Background Stage 14 Icicle Tunnel",
+                r"G:\Shared drives\Display Folders\14-Icicle Tunnel-IT",
+                [
+                    context(
+                        "Anna",
+                        stage_key="14",
+                        path=(
+                            r"G:\Shared drives\Display Folders\14-Icicle Tunnel-IT"
+                            r"\Anna\PreviewBackground\Anna.jpg"
+                        ),
+                    )
+                ],
+            )
+        ]
+    )
+
+    stage = result["stages"][0]
+    assert stage["scenes"] == []
+    assert [item["scene_name"] for item in stage["contexts"]] == ["Anna"]
+
+
+def test_animation_only_rows_without_physical_stage_path_are_excluded():
+    result = build_field_hierarchy(
+        [
+            raw_stage(
+                91,
+                "90",
+                "Show Animation EL 90 Elf On Shelf-1",
+                None,
+                [
+                    context(
+                        "Root",
+                        stage_key="90",
+                        path=None,
+                        context_type="Animation",
+                    )
+                ],
+            )
+        ]
+    )
+
+    assert result["stages"] == []
+    assert result["review_required"][0]["code"] == "DATABASE_STAGE_NOT_IN_FIELD_HIERARCHY"
+
+
+def test_database_stage_without_lor_context_remains_browseable_for_manual_stage_use():
+    result = build_field_hierarchy(
+        [raw_stage(368, "40", "CommandCenter-CC", None, [])]
+    )
+
+    assert [item["stage_key"] for item in result["stages"]] == ["40"]
+    assert result["stages"][0]["label"] == "CommandCenter-CC"
+    assert result["review_required"][0]["code"] == "STAGE_PATH_EVIDENCE_REVIEW_REQUIRED"

--- a/FieldWiring/Application/test_field_context_operator_messages.py
+++ b/FieldWiring/Application/test_field_context_operator_messages.py
@@ -77,6 +77,41 @@ def test_takedown_and_inspection_paths_are_caller_selected():
     assert r"\Procedures\Inspection" in inspection
 
 
+def test_generic_task_content_code_uses_same_operator_contract():
+    diagnostic = {
+        "code": "TASK_CONTENT_NOT_FOUND",
+        "scene_name": "13-Christmas Story",
+        "scope_root": r"G:\Shared drives\Display Folders\13-Winter Wonderland-WW\13-Christmas Story",
+    }
+
+    assert operator_warning(
+        diagnostic,
+        task="Setup procedure",
+        task_relative_folder=r"Procedures\Setup",
+    ) == (
+        "Setup procedure not found for 13-Christmas Story in folder "
+        r"G:\Shared drives\Display Folders\13-Winter Wonderland-WW\13-Christmas Story\Procedures\Setup."
+    )
+
+
+def test_root_context_is_described_to_operator_as_stage():
+    diagnostic = {
+        "code": "TASK_CONTENT_NOT_FOUND",
+        "scene_name": "Root",
+        "stage_key": "15",
+        "scope_root": r"G:\Shared drives\Display Folders\15-Church-Bells-CH",
+    }
+
+    assert operator_warning(
+        diagnostic,
+        task="Takedown procedure",
+        task_relative_folder=r"Procedures\Takedown",
+    ) == (
+        "Takedown procedure not found for Stage 15 in folder "
+        r"G:\Shared drives\Display Folders\15-Church-Bells-CH\Procedures\Takedown."
+    )
+
+
 def test_unknown_engineering_code_never_leaks_and_keeps_expected_folder():
     diagnostic = {
         "code": "SOME_INTERNAL_ENGINEERING_CODE",

--- a/FieldWiring/Application/test_field_context_operator_messages.py
+++ b/FieldWiring/Application/test_field_context_operator_messages.py
@@ -1,0 +1,58 @@
+from field_context_operator_messages import operator_warning, with_operator_warning
+
+
+def test_scene_not_defined_maps_to_plain_wiring_warning():
+    diagnostic = {
+        "code": "LOR_CONTEXT_NOT_DEFINED_FIELD_SCENE",
+        "scene_name": "21-Sliding Penguins",
+        "scope_root": r"G:\Shared drives\Display Folders\21-Polar Bear Playground-PB",
+    }
+
+    message = operator_warning(diagnostic, task="Wiring")
+
+    assert message == (
+        "Wiring not found for 21-Sliding Penguins in folder "
+        r"G:\Shared drives\Display Folders\21-Polar Bear Playground-PB."
+    )
+    assert "LOR_CONTEXT_NOT_DEFINED_FIELD_SCENE" not in message
+
+
+def test_same_diagnostic_maps_to_procedure_specific_warning():
+    diagnostic = {
+        "code": "LOR_CONTEXT_NOT_DEFINED_FIELD_SCENE",
+        "scene_name": "13-Christmas Story",
+        "scope_root": r"G:\Shared drives\Display Folders\13-Winter Wonderland-WW",
+    }
+
+    assert operator_warning(diagnostic, task="Setup procedure") == (
+        "Setup procedure not found for 13-Christmas Story in folder "
+        r"G:\Shared drives\Display Folders\13-Winter Wonderland-WW."
+    )
+
+
+def test_unknown_engineering_code_never_leaks_to_operator():
+    diagnostic = {
+        "code": "SOME_INTERNAL_ENGINEERING_CODE",
+        "scene_name": "21-SnowballBears",
+    }
+
+    message = operator_warning(diagnostic, task="Wiring")
+
+    assert message == "Wiring is not available for 21-SnowballBears."
+    assert "SOME_INTERNAL_ENGINEERING_CODE" not in message
+
+
+def test_engineering_payload_can_keep_code_separate_from_operator_warning():
+    diagnostic = {
+        "code": "LOR_CONTEXT_UNRESOLVED",
+        "scene_name": "07-Who People",
+        "scope_root": r"G:\Shared drives\Display Folders\07-Whoville-WV",
+    }
+
+    result = with_operator_warning(diagnostic, task="Takedown procedure")
+
+    assert result["code"] == "LOR_CONTEXT_UNRESOLVED"
+    assert result["operator_warning"] == (
+        "Takedown procedure location could not be resolved for 07-Who People in folder "
+        r"G:\Shared drives\Display Folders\07-Whoville-WV."
+    )

--- a/FieldWiring/Application/test_field_context_operator_messages.py
+++ b/FieldWiring/Application/test_field_context_operator_messages.py
@@ -1,58 +1,133 @@
 from field_context_operator_messages import operator_warning, with_operator_warning
 
 
-def test_scene_not_defined_maps_to_plain_wiring_warning():
+def test_scene_not_defined_maps_to_exact_musical_wiring_folder():
     diagnostic = {
         "code": "LOR_CONTEXT_NOT_DEFINED_FIELD_SCENE",
         "scene_name": "21-Sliding Penguins",
         "scope_root": r"G:\Shared drives\Display Folders\21-Polar Bear Playground-PB",
     }
 
-    message = operator_warning(diagnostic, task="Wiring")
+    message = operator_warning(
+        diagnostic,
+        task="Wiring",
+        task_relative_folder=r"Wiring\MusicalStage",
+    )
 
     assert message == (
         "Wiring not found for 21-Sliding Penguins in folder "
-        r"G:\Shared drives\Display Folders\21-Polar Bear Playground-PB."
+        r"G:\Shared drives\Display Folders\21-Polar Bear Playground-PB\Wiring\MusicalStage."
     )
     assert "LOR_CONTEXT_NOT_DEFINED_FIELD_SCENE" not in message
 
 
-def test_same_diagnostic_maps_to_procedure_specific_warning():
+def test_same_diagnostic_maps_to_exact_background_wiring_folder():
+    diagnostic = {
+        "code": "LOR_CONTEXT_NOT_DEFINED_FIELD_SCENE",
+        "scene_name": "21-Sliding Penguins",
+        "scope_root": r"G:\Shared drives\Display Folders\21-Polar Bear Playground-PB",
+    }
+
+    assert operator_warning(
+        diagnostic,
+        task="Wiring",
+        task_relative_folder=r"Wiring\BackgroundStage",
+    ) == (
+        "Wiring not found for 21-Sliding Penguins in folder "
+        r"G:\Shared drives\Display Folders\21-Polar Bear Playground-PB\Wiring\BackgroundStage."
+    )
+
+
+def test_same_diagnostic_maps_to_exact_setup_procedure_folder():
     diagnostic = {
         "code": "LOR_CONTEXT_NOT_DEFINED_FIELD_SCENE",
         "scene_name": "13-Christmas Story",
         "scope_root": r"G:\Shared drives\Display Folders\13-Winter Wonderland-WW",
     }
 
-    assert operator_warning(diagnostic, task="Setup procedure") == (
+    assert operator_warning(
+        diagnostic,
+        task="Setup procedure",
+        task_relative_folder=r"Procedures\Setup",
+    ) == (
         "Setup procedure not found for 13-Christmas Story in folder "
-        r"G:\Shared drives\Display Folders\13-Winter Wonderland-WW."
+        r"G:\Shared drives\Display Folders\13-Winter Wonderland-WW\Procedures\Setup."
     )
 
 
-def test_unknown_engineering_code_never_leaks_to_operator():
-    diagnostic = {
-        "code": "SOME_INTERNAL_ENGINEERING_CODE",
-        "scene_name": "21-SnowballBears",
-    }
-
-    message = operator_warning(diagnostic, task="Wiring")
-
-    assert message == "Wiring is not available for 21-SnowballBears."
-    assert "SOME_INTERNAL_ENGINEERING_CODE" not in message
-
-
-def test_engineering_payload_can_keep_code_separate_from_operator_warning():
+def test_takedown_and_inspection_paths_are_caller_selected():
     diagnostic = {
         "code": "LOR_CONTEXT_UNRESOLVED",
         "scene_name": "07-Who People",
         "scope_root": r"G:\Shared drives\Display Folders\07-Whoville-WV",
     }
 
-    result = with_operator_warning(diagnostic, task="Takedown procedure")
+    takedown = operator_warning(
+        diagnostic,
+        task="Takedown procedure",
+        task_relative_folder=r"Procedures\Takedown",
+    )
+    inspection = operator_warning(
+        diagnostic,
+        task="Inspection procedure",
+        task_relative_folder=r"Procedures\Inspection",
+    )
+
+    assert r"\Procedures\Takedown" in takedown
+    assert r"\Procedures\Inspection" in inspection
+
+
+def test_unknown_engineering_code_never_leaks_and_keeps_expected_folder():
+    diagnostic = {
+        "code": "SOME_INTERNAL_ENGINEERING_CODE",
+        "scene_name": "21-SnowballBears",
+        "scope_root": r"G:\Shared drives\Display Folders\21-Polar Bear Playground-PB\21-SnowballBears",
+    }
+
+    message = operator_warning(
+        diagnostic,
+        task="Wiring",
+        task_relative_folder=r"Wiring\MusicalStage",
+    )
+
+    assert message == (
+        "Wiring is not available for 21-SnowballBears. Expected folder: "
+        r"G:\Shared drives\Display Folders\21-Polar Bear Playground-PB\21-SnowballBears\Wiring\MusicalStage."
+    )
+    assert "SOME_INTERNAL_ENGINEERING_CODE" not in message
+
+
+def test_engineering_payload_keeps_code_separate_from_operator_warning():
+    diagnostic = {
+        "code": "LOR_CONTEXT_UNRESOLVED",
+        "scene_name": "07-Who People",
+        "scope_root": r"G:\Shared drives\Display Folders\07-Whoville-WV",
+    }
+
+    result = with_operator_warning(
+        diagnostic,
+        task="Takedown procedure",
+        task_relative_folder=r"Procedures\Takedown",
+    )
 
     assert result["code"] == "LOR_CONTEXT_UNRESOLVED"
     assert result["operator_warning"] == (
-        "Takedown procedure location could not be resolved for 07-Who People in folder "
-        r"G:\Shared drives\Display Folders\07-Whoville-WV."
+        "Takedown procedure location could not be resolved for 07-Who People. Expected folder: "
+        r"G:\Shared drives\Display Folders\07-Whoville-WV\Procedures\Takedown."
     )
+
+
+def test_posix_scope_style_is_preserved_for_server_diagnostics():
+    diagnostic = {
+        "code": "LOR_CONTEXT_UNRESOLVED",
+        "scene_name": "21-Sliding Penguins",
+        "scope_root": "/mnt/msb-display-folders/21-Polar Bear Playground-PB",
+    }
+
+    message = operator_warning(
+        diagnostic,
+        task="Setup procedure",
+        task_relative_folder=r"Procedures\Setup",
+    )
+
+    assert "/mnt/msb-display-folders/21-Polar Bear Playground-PB/Procedures/Setup" in message

--- a/FieldWiring/Application/test_field_context_operator_messages.py
+++ b/FieldWiring/Application/test_field_context_operator_messages.py
@@ -117,7 +117,7 @@ def test_engineering_payload_keeps_code_separate_from_operator_warning():
     )
 
 
-def test_posix_scope_style_is_preserved_for_server_diagnostics():
+def test_server_mount_is_textually_translated_to_operator_drive_path():
     diagnostic = {
         "code": "LOR_CONTEXT_UNRESOLVED",
         "scene_name": "21-Sliding Penguins",
@@ -130,4 +130,22 @@ def test_posix_scope_style_is_preserved_for_server_diagnostics():
         task_relative_folder=r"Procedures\Setup",
     )
 
-    assert "/mnt/msb-display-folders/21-Polar Bear Playground-PB/Procedures/Setup" in message
+    assert (
+        r"G:\Shared drives\Display Folders\21-Polar Bear Playground-PB\Procedures\Setup"
+        in message
+    )
+    assert "/mnt/msb-display-folders" not in message
+
+
+def test_operator_mapper_is_formatting_only_source_contract():
+    source = __import__("pathlib").Path(
+        __file__
+    ).with_name("field_context_operator_messages.py").read_text(encoding="utf-8")
+
+    assert "psycopg" not in source
+    assert "sqlite" not in source
+    assert "requests" not in source
+    assert ".exists(" not in source
+    assert ".is_dir(" not in source
+    assert ".is_file(" not in source
+    assert ".iterdir(" not in source

--- a/FieldWiring/Application/test_field_context_resolver.py
+++ b/FieldWiring/Application/test_field_context_resolver.py
@@ -18,226 +18,270 @@ def _mark(path: Path, text: str = "marker") -> Path:
     return path
 
 
-def test_windows_path_translation_resolves_exact_marked_scene(tmp_path):
-    drive_root = tmp_path / "Display Folders"
-    stage_root = _mark(drive_root / "15-Church")
-    scene_root = _mark(stage_root / "15-Church-CH")
-    background = scene_root / "PreviewBackground"
-    background.mkdir()
-    (background / "Church Context.jpg").write_bytes(b"jpeg")
+def _file(path: Path, data: bytes = b"x") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+    return path
 
-    scope_root, scope_type, warnings = resolve_structured_scope(
-        {
-            "stage_key": "15",
-            "folder_path": WINDOWS_ROOT + r"\15-Church",
-        },
-        {
-            "scene_name": "15-Church-CH",
-            "scene_background_file": (
-                WINDOWS_ROOT
-                + r"\15-Church\15-Church-CH\PreviewBackground\Church Context.jpg"
-            ),
-        },
-        {"preview_background_file": None},
-        drive_root,
-        windows_drive_root=WINDOWS_ROOT,
+
+def test_stage_previewbackground_resolves_stage_without_drive_scan(tmp_path):
+    drive = tmp_path / "Display Folders"
+    stage = _mark(drive / "21-Polar Bear Playground-PB")
+    pointer = _file(stage / "PreviewBackground" / "Polar-Bear-Stage.jpg")
+
+    root, kind, warnings = resolve_structured_scope(
+        {"stage_key": "21", "folder_path": str(stage)},
+        {"scene_name": "Root", "scene_background_file": str(pointer)},
+        {},
+        drive,
     )
 
-    assert scope_type == "SCENE"
-    assert scope_root == scene_root
+    assert root == stage
+    assert kind == "STAGE"
     assert warnings == []
 
 
-def test_stale_stage_path_recovers_from_exact_path_evidence(tmp_path):
-    drive_root = tmp_path / "Display Folders"
-    stage_root = _mark(drive_root / "15-Church")
-    background = stage_root / "PreviewBackground"
-    background.mkdir()
-    pointer = background / "Context.jpg"
-    pointer.write_bytes(b"jpeg")
+def test_scene_previewbackground_walks_up_to_nearest_scene(tmp_path):
+    drive = tmp_path / "Display Folders"
+    stage = _mark(drive / "21-Polar Bear Playground-PB")
+    scene = _mark(stage / "21-Sliding Penguins")
+    pointer = _file(scene / "PreviewBackground" / "Sliding-Penguins.jpg")
 
-    scope_root, scope_type, warnings = resolve_structured_scope(
-        {
-            "stage_key": "15",
-            "folder_path": str(drive_root / "15-Old-Church"),
-        },
-        {"scene_name": "Root", "scene_background_file": str(pointer)},
-        {"preview_background_file": None},
-        drive_root,
+    root, kind, warnings = resolve_structured_scope(
+        {"stage_key": "21", "folder_path": str(stage)},
+        {"scene_name": "21-Sliding Penguins", "scene_background_file": str(pointer)},
+        {},
+        drive,
     )
 
-    assert scope_type == "STAGE"
-    assert scope_root == stage_root
+    assert root == scene
+    assert kind == "SCENE"
+    assert warnings == []
+
+
+def test_display_previewbackground_under_scene_climbs_to_scene(tmp_path):
+    drive = tmp_path / "Display Folders"
+    stage = _mark(drive / "21-Polar Bear Playground-PB")
+    scene = _mark(stage / "21-Sliding Penguins")
+    display = scene / "PB-SlidingPenguins-07"
+    pointer = _file(display / "PreviewBackground" / "Penguin-07.jpg")
+
+    root, kind, warnings = resolve_structured_scope(
+        {"stage_key": "21", "folder_path": str(stage)},
+        {"scene_name": "21-Sliding Penguins", "scene_background_file": str(pointer)},
+        {},
+        drive,
+    )
+
+    assert root == scene
+    assert kind == "SCENE"
+    assert warnings == []
+
+
+def test_display_previewbackground_directly_under_stage_climbs_to_stage(tmp_path):
+    drive = tmp_path / "Display Folders"
+    stage = _mark(drive / "21-Polar Bear Playground-PB")
+    display = stage / "PB-MommaBear"
+    pointer = _file(display / "PreviewBackground" / "MommaBear.jpg")
+
+    root, kind, warnings = resolve_structured_scope(
+        {"stage_key": "21", "folder_path": str(stage)},
+        {"scene_name": "PB-MommaBear", "scene_background_file": str(pointer)},
+        {},
+        drive,
+    )
+
+    assert root == stage
+    assert kind == "STAGE"
+    assert warnings == []
+
+
+def test_direct_scene_wiring_path_resolves_scene_then_task_adapter_owns_branch(tmp_path):
+    drive = tmp_path / "Display Folders"
+    stage = _mark(drive / "21-Polar Bear Playground-PB")
+    scene = _mark(stage / "21-Sliding Penguins")
+    pointer = _file(scene / "Wiring" / "BackgroundStage" / "Tagged.jpg")
+
+    root, kind, warnings = resolve_structured_scope(
+        {"stage_key": "21", "folder_path": str(stage)},
+        {"scene_name": "21-Sliding Penguins", "scene_background_file": str(pointer)},
+        {},
+        drive,
+        direct_owner_folder_name="Wiring",
+    )
+
+    assert root == scene
+    assert kind == "SCENE"
+    assert warnings == []
+
+
+def test_direct_stage_wiring_path_resolves_stage(tmp_path):
+    drive = tmp_path / "Display Folders"
+    stage = _mark(drive / "21-Polar Bear Playground-PB")
+    pointer = _file(stage / "Wiring" / "MusicalStage" / "Tagged.jpg")
+
+    root, kind, warnings = resolve_structured_scope(
+        {"stage_key": "21", "folder_path": str(stage)},
+        {"scene_name": "21-Polar-Bear-Stage-PB", "scene_background_file": str(pointer)},
+        {},
+        drive,
+    )
+
+    assert root == stage
+    assert kind == "STAGE"
+    assert warnings == []
+
+
+def test_substage_path_resolves_substage_without_parent_stage_fallback(tmp_path):
+    drive = tmp_path / "Display Folders"
+    stage = _mark(drive / "07-Whoville-WV")
+    substage = _mark(stage / "07a-Who Forest-WF")
+    pointer = _file(substage / "PreviewBackground" / "Who-Forest.jpg")
+
+    root, kind, warnings = resolve_structured_scope(
+        {"stage_key": "07a", "folder_path": None},
+        {"scene_name": "07a-Who Forest-WF", "scene_background_file": str(pointer)},
+        {},
+        drive,
+    )
+
+    assert root == substage
+    assert kind == "SUBSTAGE"
     assert warnings == [
         "Persisted Stage folder_path was unavailable or stale; current marked Stage root was recovered from exact LOR path evidence."
     ]
 
 
-def test_sourcedocs_is_truncated_and_preserves_existing_scope_classification(tmp_path):
-    drive_root = tmp_path / "Display Folders"
-    stage_root = _mark(drive_root / "15-Church")
-    source_docs = stage_root / "Procedures" / "Setup" / "SourceDocs"
-    hidden_scene = _mark(source_docs / "15-Church-CH")
-    pointer = hidden_scene / "legacy.pdf"
-    pointer.write_bytes(b"pdf")
+def test_stage_binding_master_scene_does_not_become_fake_child_scene(tmp_path):
+    drive = tmp_path / "Display Folders"
+    stage = _mark(drive / "15-Church-Bells-CH")
+    pointer = _file(stage / "PreviewBackground" / "Church.jpg")
 
-    scope_root, scope_type, warnings = resolve_structured_scope(
-        {"stage_key": "15", "folder_path": str(stage_root)},
+    root, kind, warnings = resolve_structured_scope(
+        {"stage_key": "15", "folder_path": str(stage)},
         {"scene_name": "15-Church-CH", "scene_background_file": str(pointer)},
-        {"preview_background_file": None},
-        drive_root,
+        {},
+        drive,
     )
 
-    # Production FieldWiring already canonicalizes 15-Church-CH to include
-    # 15-Church. After SourceDocs is truncated to Procedures/Setup, upward
-    # matching reaches the marked 15-Church Stage root and classifies that same
-    # path as SCENE. Preserve that classification during extraction; changing
-    # it here would redesign resolver behavior rather than extract it.
-    assert scope_type == "SCENE"
-    assert scope_root == stage_root
+    assert root == stage
+    assert kind == "STAGE"
+    assert warnings == []
+
+
+def test_nested_legacy_scene_with_short_code_is_scene_when_path_says_child(tmp_path):
+    drive = tmp_path / "Display Folders"
+    stage = _mark(drive / "03-Welcome Area-WA")
+    scene = _mark(stage / "03-Mega Cube-MC")
+    pointer = _file(scene / "PreviewBackground" / "Mega-Cube.jpg")
+
+    root, kind, warnings = resolve_structured_scope(
+        {"stage_key": "03", "folder_path": str(stage)},
+        {"scene_name": "03-Mega Cube-MC", "scene_background_file": str(pointer)},
+        {},
+        drive,
+    )
+
+    assert root == scene
+    assert kind == "SCENE"
+    assert warnings == []
+
+
+def test_sourcedocs_is_hard_boundary_but_allowed_ancestor_path_still_resolves(tmp_path):
+    drive = tmp_path / "Display Folders"
+    stage = _mark(drive / "21-Polar Bear Playground-PB")
+    scene = _mark(stage / "21-Sliding Penguins")
+    pointer = _file(
+        scene / "Wiring" / "MusicalStage" / "SourceDocs" / "Working.jpg"
+    )
+
+    root, kind, warnings = resolve_structured_scope(
+        {"stage_key": "21", "folder_path": str(stage)},
+        {"scene_name": "21-Sliding Penguins", "scene_background_file": str(pointer)},
+        {},
+        drive,
+    )
+
+    assert root == scene
+    assert kind == "SCENE"
     assert warnings == [
         "BackgroundFile path enters SourceDocs. Traversal stopped before SourceDocs; source content was not accessed."
     ]
 
 
-def test_stale_scene_pointer_uses_one_deterministic_marked_scene(tmp_path):
-    drive_root = tmp_path / "Display Folders"
-    stage_root = _mark(drive_root / "15-Church")
-    scene_root = _mark(stage_root / "15-Church-CH")
+def test_stale_pointer_recovery_is_bounded_inside_known_stage(tmp_path):
+    drive = tmp_path / "Display Folders"
+    stage = _mark(drive / "13-Winter Wonderland-WW")
+    scene = _mark(stage / "13-Christmas Story")
 
-    scope_root, scope_type, warnings = resolve_structured_scope(
-        {"stage_key": "15", "folder_path": str(stage_root)},
+    root, kind, warnings = resolve_structured_scope(
+        {"stage_key": "13", "folder_path": str(stage)},
         {
-            "scene_name": "15-Church-CH",
-            "scene_background_file": str(stage_root / "old" / "missing.jpg"),
+            "scene_name": "13-Christmas Story",
+            "scene_background_file": str(stage / "old" / "missing.jpg"),
         },
-        {"preview_background_file": None},
-        drive_root,
+        {},
+        drive,
     )
 
-    assert scope_type == "SCENE"
-    assert scope_root == scene_root
+    assert root == scene
+    assert kind == "SCENE"
     assert warnings == [
-        "Stored Scene BackgroundFile did not resolve exactly; one deterministic marked current Scene folder was used."
+        "Stored BackgroundFile did not resolve exactly; one deterministic marked current structured scope was used inside the known Stage."
     ]
 
 
-def test_ambiguous_marked_scene_matches_are_rejected(tmp_path):
-    drive_root = tmp_path / "Display Folders"
-    stage_root = _mark(drive_root / "15-Church")
-    _mark(stage_root / "Area-A" / "15-Church-CH")
-    _mark(stage_root / "Area-B" / "15-Church-CH")
+def test_missing_scene_folder_falls_back_to_known_stage(tmp_path):
+    drive = tmp_path / "Display Folders"
+    stage = _mark(drive / "21-Polar Bear Playground-PB")
 
-    scope_root, scope_type, warnings = resolve_structured_scope(
-        {"stage_key": "15", "folder_path": str(stage_root)},
-        {"scene_name": "15-Church-CH", "scene_background_file": None},
-        {"preview_background_file": None},
-        drive_root,
+    root, kind, warnings = resolve_structured_scope(
+        {"stage_key": "21", "folder_path": str(stage)},
+        {"scene_name": "21-Sliding Penguins", "scene_background_file": None},
+        {},
+        drive,
     )
 
-    assert scope_type == "UNRESOLVED"
-    assert scope_root is None
-    assert warnings == [
-        "More than one marked Scene folder matched the current Scene identity."
-    ]
-
-
-def test_exact_unmarked_scene_pointer_is_rejected(tmp_path):
-    drive_root = tmp_path / "Display Folders"
-    stage_root = _mark(drive_root / "15-Church")
-    scene_root = stage_root / "15-Church-CH"
-    scene_root.mkdir()
-    pointer = scene_root / "Context.jpg"
-    pointer.write_bytes(b"jpeg")
-
-    scope_root, scope_type, warnings = resolve_structured_scope(
-        {"stage_key": "15", "folder_path": str(stage_root)},
-        {"scene_name": "15-Church-CH", "scene_background_file": str(pointer)},
-        {"preview_background_file": None},
-        drive_root,
-    )
-
-    assert scope_type == "UNRESOLVED"
-    assert scope_root is None
-    assert warnings == [
-        f"Scene source-folder marker is missing: {scene_root / MARKER_NAME}"
-    ]
-
-
-def test_unmarked_bounded_scene_match_is_rejected_without_stage_fallback(tmp_path):
-    drive_root = tmp_path / "Display Folders"
-    stage_root = _mark(drive_root / "15-Church")
-    scene_root = stage_root / "15-Church-CH"
-    scene_root.mkdir()
-
-    scope_root, scope_type, warnings = resolve_structured_scope(
-        {"stage_key": "15", "folder_path": str(stage_root)},
-        {"scene_name": "15-Church-CH", "scene_background_file": None},
-        {"preview_background_file": None},
-        drive_root,
-    )
-
-    assert scope_type == "UNRESOLVED"
-    assert scope_root is None
-    assert warnings == [
-        "Matching Scene folder exists but is not an approved marked source root: "
-        + str(scene_root)
-    ]
-
-
-def test_scene_matching_remains_bounded_to_two_levels(tmp_path):
-    drive_root = tmp_path / "Display Folders"
-    stage_root = _mark(drive_root / "15-Church")
-    _mark(stage_root / "one" / "two" / "15-Church-CH")
-
-    scope_root, scope_type, warnings = resolve_structured_scope(
-        {"stage_key": "15", "folder_path": str(stage_root)},
-        {"scene_name": "15-Church-CH", "scene_background_file": None},
-        {"preview_background_file": None},
-        drive_root,
-    )
-
-    assert scope_type == "STAGE"
-    assert scope_root == stage_root
+    assert root == stage
+    assert kind == "STAGE"
     assert warnings == [DEFAULT_STAGE_FALLBACK_WARNING]
 
 
-def test_direct_owner_hint_is_generic_and_preserves_caller_warning(tmp_path):
-    drive_root = tmp_path / "Display Folders"
-    stage_root = _mark(drive_root / "15-Church")
-    task_root = stage_root / "TaskBranch"
-    task_root.mkdir()
-    artifact = task_root / "artifact.dat"
-    artifact.write_bytes(b"x")
+def test_unmarked_exact_scene_is_not_silently_promoted(tmp_path):
+    drive = tmp_path / "Display Folders"
+    stage = _mark(drive / "21-Polar Bear Playground-PB")
+    scene = stage / "21-Sliding Penguins"
+    pointer = _file(scene / "PreviewBackground" / "Sliding.jpg")
 
-    scope_root, scope_type, warnings = resolve_structured_scope(
-        {"stage_key": "15", "folder_path": str(stage_root)},
-        {"scene_name": "15-Church-CH", "scene_background_file": str(artifact)},
-        {"preview_background_file": None},
-        drive_root,
-        direct_owner_folder_name="TaskBranch",
-        direct_owner_warning="caller-specific direct-owner warning",
+    root, kind, warnings = resolve_structured_scope(
+        {"stage_key": "21", "folder_path": str(stage)},
+        {"scene_name": "21-Sliding Penguins", "scene_background_file": str(pointer)},
+        {},
+        drive,
     )
 
-    assert scope_type == "STAGE"
-    assert scope_root == stage_root
-    assert warnings == ["caller-specific direct-owner warning"]
-
-
-def test_missing_stage_anchor_fails_visibly_without_guessing(tmp_path):
-    drive_root = tmp_path / "Display Folders"
-    drive_root.mkdir()
-    missing = drive_root / "15-Missing"
-
-    scope_root, scope_type, warnings = resolve_structured_scope(
-        {"stage_key": "15", "folder_path": str(missing)},
-        {"scene_name": "Root", "scene_background_file": None},
-        {"preview_background_file": None},
-        drive_root,
-    )
-
-    assert scope_type == "UNRESOLVED"
-    assert scope_root is None
+    assert root is None
+    assert kind == "UNRESOLVED"
     assert warnings == [
-        f"Stage folder_path is unavailable or unmarked on this server: {missing}"
+        f"Structured source-folder marker is missing: {scene / MARKER_NAME}"
+    ]
+
+
+def test_stale_stage_path_recovers_only_from_supplied_pointer_not_root_enumeration(tmp_path):
+    drive = tmp_path / "Display Folders"
+    correct = _mark(drive / "17-Candyland-CL")
+    _mark(drive / "17-Other-XX")
+    pointer = _file(correct / "PreviewBackground" / "Candyland.jpg")
+
+    root, kind, warnings = resolve_structured_scope(
+        {"stage_key": "17", "folder_path": str(drive / "17-Candy Land-CL")},
+        {"scene_name": "Root", "scene_background_file": str(pointer)},
+        {},
+        drive,
+    )
+
+    assert root == correct
+    assert kind == "STAGE"
+    assert warnings == [
+        "Persisted Stage folder_path was unavailable or stale; current marked Stage root was recovered from exact LOR path evidence."
     ]

--- a/FieldWiring/Application/test_operator_ui_contract.py
+++ b/FieldWiring/Application/test_operator_ui_contract.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+
+from backend import operator_config_error, operator_wiring_error
+from repository import ConfigError
+from wiring import WiringError
+
+
+def test_config_error_hides_runtime_configuration_detail():
+    internal = ConfigError(
+        "Configure FIELDWIRING_DATABASE_DSN for PostgreSQL or FIELDWIRING_DEV_SNAPSHOT"
+    )
+
+    message = operator_config_error(internal)
+
+    assert "FIELDWIRING_DATABASE_DSN" not in message
+    assert "FIELDWIRING_DEV_SNAPSHOT" not in message
+    assert "temporarily unavailable" in message
+
+
+def test_invalid_link_error_is_actionable_not_parameter_oriented():
+    message = operator_wiring_error(WiringError("Invalid stage_id"))
+
+    assert message == (
+        "This Field Wiring link is invalid. Return to lookup and select the Display or Stage again."
+    )
+    assert "stage_id" not in message
+
+
+def test_dmx_engineering_failure_does_not_leak_parser_internals():
+    internal = WiringError(
+        "Current V7.0.11+ DMX source-detail rows are incomplete: display=1 source=blank"
+    )
+
+    message = operator_wiring_error(internal)
+
+    assert "V7.0.11" not in message
+    assert "source-detail" not in message
+    assert "engineering" in message.lower()
+
+
+def test_stale_context_error_tells_operator_to_reselect():
+    message = operator_wiring_error(
+        WiringError("Resolved Scene is not present in the current LOR snapshot")
+    )
+
+    assert "current approved data" in message
+    assert "Return to lookup" in message
+    assert "LOR snapshot" not in message
+
+
+def test_browser_primary_warning_path_never_reads_raw_image_warnings():
+    app_dir = Path(__file__).resolve().parent
+    js = (app_dir / "wiring.js").read_text(encoding="utf-8")
+
+    assert "packageData.images?.operator_warnings" in js
+    assert "packageData.images.warnings?.length" not in js
+
+
+def test_http_handlers_keep_engineering_detail_separate_from_operator_error():
+    source = (Path(__file__).resolve().parent / "backend.py").read_text(encoding="utf-8")
+
+    assert "error=operator_config_error(exc)" in source
+    assert "error=operator_wiring_error(exc)" in source
+    assert "engineering_error=str(exc)" in source

--- a/FieldWiring/Application/test_operator_ui_contract.py
+++ b/FieldWiring/Application/test_operator_ui_contract.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import backend
 from backend import operator_config_error, operator_wiring_error
 from repository import ConfigError
 from wiring import WiringError
@@ -62,3 +63,40 @@ def test_http_handlers_keep_engineering_detail_separate_from_operator_error():
     assert "error=operator_config_error(exc)" in source
     assert "error=operator_wiring_error(exc)" in source
     assert "engineering_error=str(exc)" in source
+
+
+def test_stage_api_uses_shared_fast_hierarchy(monkeypatch):
+    class FakeRepository:
+        def shared_stages(self):
+            return [
+                {
+                    "stage": {
+                        "stage_id": 51,
+                        "stage_key": "21",
+                        "stage_name": "Show Background Stage 21 Polar Bears",
+                        "folder_path": (
+                            r"G:\Shared drives\Display Folders\21-Polar Bear Playground-PB"
+                        ),
+                    },
+                    "contexts": [],
+                }
+            ]
+
+    monkeypatch.setattr(backend, "repository", lambda: FakeRepository())
+
+    response = backend.app.test_client().get("/api/stages")
+    payload = response.get_json()
+
+    assert response.status_code == 200
+    assert payload["review_required"] == []
+    assert payload["stages"][0]["label"] == "21-Polar Bear Playground-PB"
+    assert payload["stages"][0]["scope_type"] == "STAGE"
+
+
+def test_fieldwiring_browser_consumes_shared_hierarchy_shape():
+    source = (Path(__file__).resolve().parent / "fieldwiring.js").read_text(encoding="utf-8")
+
+    assert "stage.sub_stages || []" in source
+    assert "node.scenes || []" in source
+    assert "item.node.label" in source
+    assert "stage.stage_name" not in source

--- a/FieldWiring/Application/test_wiring_scope_resolution.py
+++ b/FieldWiring/Application/test_wiring_scope_resolution.py
@@ -39,6 +39,7 @@ def test_no_distinct_scene_folder_retains_stage_scope(tmp_path, monkeypatch):
     assert result["warnings"] == [
         "No distinct Scene folder matched the current Scene identity; known marked Stage root retained as the FieldWiring scope."
     ]
+    assert result["operator_warnings"] == []
 
 
 def test_direct_wiring_pointer_resolves_stage_owner_while_context_selects_branch(tmp_path, monkeypatch):
@@ -62,12 +63,14 @@ def test_direct_wiring_pointer_resolves_stage_owner_while_context_selects_branch
     assert musical_result["warnings"] == [
         "BackgroundFile points directly into the current Stage Wiring branch; the marked Stage root is the FieldWiring documentation scope."
     ]
+    assert musical_result["operator_warnings"] == []
 
     background_result = resolve_images(stage, scene, preview, "Background / Static")
     assert background_result["scope_type"] == "STAGE"
     assert background_result["scope_root"] == str(stage_root)
     assert [image["name"] for image in background_result["wiring_images"]] == ["church-background.png"]
     assert background_result["warnings"] == musical_result["warnings"]
+    assert background_result["operator_warnings"] == []
 
 
 def test_unmarked_matching_scene_does_not_fall_back_to_stage(tmp_path, monkeypatch):
@@ -92,6 +95,46 @@ def test_unmarked_matching_scene_does_not_fall_back_to_stage(tmp_path, monkeypat
         "Matching Scene folder exists but is not an approved marked source root: "
         + str(scene_root)
     ]
+    assert len(result["operator_warnings"]) == 1
+    assert "LOR_CONTEXT" not in result["operator_warnings"][0]
+    assert "15-Church-CH" in result["operator_warnings"][0]
+    assert result["operator_warnings"][0].endswith(
+        str(scene_root / "Wiring" / "MusicalStage") + "."
+    )
+
+
+def test_missing_wiring_image_reports_exact_selected_branch(tmp_path, monkeypatch):
+    root = tmp_path / "Display Folders"
+    root.mkdir()
+    stage_root = _stage(root)
+    (stage_root / "Wiring" / "MusicalStage" / "church.png").unlink()
+    monkeypatch.setenv("FIELDWIRING_DRIVE_ROOT", str(root))
+
+    result = resolve_images(
+        {"stage_key": "15", "folder_path": str(stage_root)},
+        {"scene_name": "Root", "scene_background_file": None},
+        {"preview_background_file": None},
+        "Musical",
+    )
+
+    assert result["scope_type"] == "STAGE"
+    assert result["wiring_images"] == []
+    assert result["operator_warnings"] == [
+        "Wiring not found for Stage 15 in folder "
+        + str(stage_root / "Wiring" / "MusicalStage")
+        + "."
+    ]
+
+
+def test_wiring_browser_uses_operator_notices_not_raw_resolver_warnings():
+    base = Path(__file__).resolve().parent
+    html = (base / "wiring.html").read_text(encoding="utf-8")
+    js = (base / "wiring.js").read_text(encoding="utf-8")
+
+    assert 'id="operator-notices"' in html
+    assert "packageData.images?.operator_warnings" in js
+    assert "renderOperatorNotices();" in js
+    assert "packageData.images.warnings?.length" not in js
 
 
 def test_wiring_images_delegates_structured_scope_to_shared_component():

--- a/FieldWiring/Application/wiring.html
+++ b/FieldWiring/Application/wiring.html
@@ -50,6 +50,8 @@
       </details>
     </section>
 
+    <section id="operator-notices" class="notice" hidden></section>
+
     <section id="currentness" class="currentness print-only">
       <strong>CURRENT FIELD COPY</strong>
       <span id="generated-at"></span>

--- a/FieldWiring/Application/wiring.js
+++ b/FieldWiring/Application/wiring.js
@@ -2,6 +2,7 @@ const params = new URLSearchParams(location.search);
 const loading = document.getElementById('loading');
 const errorBox = document.getElementById('error');
 const workspace = document.getElementById('workspace');
+const operatorNotices = document.getElementById('operator-notices');
 const imageSection = document.getElementById('image-section');
 const imagePane = document.getElementById('image-pane');
 const imageScroll = document.getElementById('image-scroll');
@@ -106,6 +107,11 @@ function renderContext() {
   document.getElementById('context-type').textContent = c.context_type || 'Unknown';
   document.getElementById('technical-context').innerHTML = contextRows(c).map(([label,value]) => `
     <div><span>${esc(label)}</span><strong>${esc(fmt(value))}</strong></div>`).join('');
+}
+function renderOperatorNotices() {
+  const messages = packageData.images?.operator_warnings || [];
+  operatorNotices.hidden = messages.length === 0;
+  operatorNotices.innerHTML = messages.map(message => `<div>${esc(message)}</div>`).join('');
 }
 async function installContextSwitch() {
   contextSwitch.hidden = true;
@@ -302,7 +308,7 @@ function showImage() {
     imageScroll.hidden = true;
     imageClassification.hidden = true;
     imageEmpty.hidden = false;
-    imageEmptyDetail.textContent = packageData.images.warnings?.length ? packageData.images.warnings.join(' ') : 'The hookup data remains current and usable without an image.';
+    imageEmptyDetail.textContent = 'The hookup data remains current and usable without an image. See the notice above for the expected Wiring folder.';
     return;
   }
   imageEmpty.hidden = true;
@@ -397,6 +403,7 @@ async function start() {
     const payload = await api(requestedPackageUrl());
     packageData = payload.wiring;
     renderContext();
+    renderOperatorNotices();
     renderCurrentness();
     renderGroups();
     renderEngineering();

--- a/FieldWiring/Application/wiring_images.py
+++ b/FieldWiring/Application/wiring_images.py
@@ -2,9 +2,11 @@
 from __future__ import annotations
 
 import os
-from pathlib import Path, PureWindowsPath
+import re
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any
 
+from field_context_operator_messages import operator_warning
 from field_context_resolver import resolve_structured_scope
 from wiring_common import DEFAULT_DRIVE_ROOT, IMAGE_EXTENSIONS, MARKER_NAME, WiringError
 
@@ -41,21 +43,83 @@ def _image_payload(path: Path, drive_root: Path, kind: str) -> dict[str, Any]:
     }
 
 
+def _join_path_text(base: str, child: str) -> str:
+    if "\\" in base or re.match(r"^[A-Za-z]:", base):
+        return str(PureWindowsPath(base, child))
+    if base.startswith("/"):
+        return str(PurePosixPath(base, child))
+    return base.rstrip("\\/") + "\\" + child
+
+
+def _unresolved_expected_scope(
+    stage: dict[str, Any],
+    scene: dict[str, Any] | None,
+) -> str | None:
+    """Construct an expected scope path from already-known text only."""
+    base = str(stage.get("folder_path") or "").strip()
+    if not base:
+        return None
+    scene_name = str((scene or {}).get("scene_name") or "").strip()
+    stage_key = str(stage.get("stage_key") or "").strip()
+    if (
+        scene_name
+        and scene_name.casefold() != "root"
+        and stage_key
+        and scene_name.casefold().startswith(stage_key.casefold() + "-")
+    ):
+        return _join_path_text(base, scene_name)
+    return base
+
+
+def _diagnostic(
+    code: str,
+    stage: dict[str, Any],
+    scene: dict[str, Any] | None,
+    *,
+    scope_root: str | Path | None,
+) -> dict[str, Any]:
+    return {
+        "code": code,
+        "stage_key": stage.get("stage_key"),
+        "scene_name": (scene or {}).get("scene_name"),
+        "scope_root": str(scope_root) if scope_root is not None else None,
+        "database_folder_path": stage.get("folder_path"),
+    }
+
+
 def resolve_images(
     stage: dict[str, Any],
     scene: dict[str, Any] | None,
     preview: dict[str, Any],
     selected_context: str,
 ) -> dict[str, Any]:
+    # FieldWiring already owns this branch choice. Operator-message formatting
+    # receives the same value and performs no additional lookup or resolution.
+    branch = "MusicalStage" if selected_context == "Musical" else "BackgroundStage"
+    task_relative_folder = f"Wiring\\{branch}"
+
     root_text = os.environ.get("FIELDWIRING_DRIVE_ROOT", DEFAULT_DRIVE_ROOT).strip()
     drive_root = Path(root_text)
     if not drive_root.is_dir():
+        diagnostic = _diagnostic(
+            "TASK_SCOPE_UNRESOLVED",
+            stage,
+            scene,
+            scope_root=_unresolved_expected_scope(stage, scene),
+        )
         return {
             "scope_type": "UNAVAILABLE",
             "scope_root": None,
             "wiring_images": [],
             "context_images": [],
             "warnings": [f"Display Folders root is not available on this server: {root_text}"],
+            "operator_warnings": [
+                operator_warning(
+                    diagnostic,
+                    task="Wiring",
+                    task_relative_folder=task_relative_folder,
+                )
+            ],
         }
 
     windows_root = (
@@ -73,24 +137,53 @@ def resolve_images(
         stage_fallback_warning=FIELDWIRING_STAGE_FALLBACK_WARNING,
     )
     if scope_root is None:
+        diagnostic = _diagnostic(
+            "TASK_SCOPE_UNRESOLVED",
+            stage,
+            scene,
+            scope_root=_unresolved_expected_scope(stage, scene),
+        )
         return {
             "scope_type": scope_type,
             "scope_root": None,
             "wiring_images": [],
             "context_images": [],
             "warnings": warnings,
+            "operator_warnings": [
+                operator_warning(
+                    diagnostic,
+                    task="Wiring",
+                    task_relative_folder=task_relative_folder,
+                )
+            ],
         }
 
     # Everything below this point is intentionally FieldWiring-specific. The
     # shared resolver has already fixed the Stage/Scene root; this adapter now
     # selects only the applicable Wiring branch and supplemental context images.
-    branch = "MusicalStage" if selected_context == "Musical" else "BackgroundStage"
     wiring_folder = scope_root / "Wiring" / branch
     wiring_images: list[Path] = []
+    operator_warnings: list[str] = []
     if (wiring_folder.parent / MARKER_NAME).is_file():
         wiring_images = _direct_images(wiring_folder)
     elif wiring_folder.exists():
         warnings.append(f"Unmarked Wiring source excluded: {wiring_folder}")
+        operator_warnings.append(
+            operator_warning(
+                _diagnostic("TASK_FOLDER_UNAPPROVED", stage, scene, scope_root=scope_root),
+                task="Wiring",
+                task_relative_folder=task_relative_folder,
+            )
+        )
+
+    if not wiring_images and not operator_warnings:
+        operator_warnings.append(
+            operator_warning(
+                _diagnostic("TASK_CONTENT_NOT_FOUND", stage, scene, scope_root=scope_root),
+                task="Wiring",
+                task_relative_folder=task_relative_folder,
+            )
+        )
 
     context_folder = scope_root / "PreviewBackground"
     context_images: list[Path] = []
@@ -105,6 +198,7 @@ def resolve_images(
         "wiring_images": [_image_payload(p, drive_root, "wiring") for p in wiring_images],
         "context_images": [_image_payload(p, drive_root, "context") for p in context_images],
         "warnings": warnings,
+        "operator_warnings": operator_warnings,
     }
 
 


### PR DESCRIPTION
Engineering recovery only; do not merge until local regression, fast lookup timing, and live path checks pass.

This PR restores the documented path-first shared resolver contract and removes Google Drive enumeration from the shared runtime lookup hierarchy.

Governing documents:
- Docs/00_Project_Overview/02-Google_Drive_Path_Resolution_Contract.md
- Docs/00_Project_Overview/06-Operator_UI_Message_Contract.md
- Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/Field_Context_Resolution_Contract.md
- Docs/02_Production_Database/01_System_Architecture/09_Wiring_System/FieldWiring_Drive_Context_Resolver_Engineering_Design.md

Key changes:
- shared scope resolution walks upward from supplied LOR path evidence;
- Display/group folders are ignored while walking to Scene/Sub-stage/Stage;
- SourceDocs remains a hard boundary;
- stale-pointer recovery remains bounded inside the known Stage;
- shared Stage/Sub-stage/Scene lookup is built from reconciled DB/LOR facts and stored path strings, with no runtime Drive scan;
- documented path examples are executable regression tests;
- prior runtime-crawler acceptance wording is explicitly superseded by a recovery note;
- operator-facing messages are separated from engineering diagnostics;
- Google Drive-backed warnings report the exact already-selected Wiring/Procedure folder in the canonical G:\\Shared drives\\Display Folders path;
- operator-message formatting is zero-I/O: no additional DB query, Drive access, filesystem check, network call, or resolver pass;
- FieldWiring browser/API now keeps engineering warnings separately and presents only operator-safe warnings/errors.

Procedure remains frozen at its reverted green baseline until this shared recovery is accepted.