### PR TITLE
Reconcile Procedure scan handoff and durable documentation rules

### DIFF
--- a/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/Deployed_Display_Scan_Runtime_Boundary.md
+++ b/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/Deployed_Display_Scan_Runtime_Boundary.md
@@ -2,8 +2,8 @@
 
 | Document control | Value |
 |---|---|
-| Status | CURRENT PRODUCTION DEPENDENCY — runtime reconstructed and cross-repository recovery documented |
-| Current revision | 2026-08-22 |
+| Status | CURRENT PRODUCTION DEPENDENCY — runtime and Git source boundary documented |
+| Current revision | 2026-08-23 |
 | Owner | MSB Database Administrator |
 | Production host | `msb-prod-db` |
 | Production runtime path | `/opt/directus/extensions/directus-extension-scan/` |
@@ -11,9 +11,9 @@
 
 ## Purpose
 
-This document records the cross-repository boundary for the **existing deployed Display QR lookup** that the Production Database, Testing, Work Orders, FieldWiring, and future Setup/Deployment scan workflows build upon.
+This document records the cross-repository boundary for the **existing deployed Display QR lookup** that the Production Database, Testing, Work Orders, FieldWiring, Procedures, and future Setup/Deployment scan workflows build upon.
 
-The scan capability predates the current source-control/documentation structure. Its current production behavior and runtime were reconstructed on 2026-08-22 so future work can extend the existing system instead of re-engineering it from memory.
+The scan capability predates the current source-control/documentation structure. Its current production behavior and runtime were reconstructed on 2026-08-22, then the accepted camera-enabled application source was recovered into Git and the FieldWiring integration was deployed and accepted. Future work must extend this documented system rather than re-engineering it from memory or from a live-only artifact.
 
 ## Verified Current Runtime
 
@@ -24,7 +24,6 @@ msb-prod-db
     -> /opt/directus/extensions/directus-extension-scan/
         -> package.json
         -> dist/index.js
-        -> dist/index-copy original-no-camera-scanning.js
 ```
 
 Directus executes:
@@ -33,15 +32,24 @@ Directus executes:
 dist/index.js
 ```
 
-The current production SHA-256 recorded on 2026-08-22 is:
+The current accepted production SHA-256 after FieldWiring integration and the Directus public-origin correction is:
 
 ```text
-824aa56857c3d52c3ba9186c4721313e2172dc24ec32653045bb7bf3b008d7af
+b4f6c27f4880a8eaf8a90d8d55c7939c5bd190645dca9329344a86c3175cb20f
 ```
 
-`package.json` declares `src/index.js`, but no deployed `src/` directory exists. The production deployment is therefore currently a built-only runtime artifact and must be recovered into a controlled Git source/deployment boundary before the scan platform is expanded substantially.
+The accepted application/business source is now version-controlled under:
 
-The older file:
+```text
+Scan/directus-extension-scan/
+    package.json
+    src/index.js
+    dist/index.js
+```
+
+The live deployment does not need to contain the development `src/` tree. Application source belongs in the Production Database repository; live deployment/recovery belongs in Server Management.
+
+The older file historically named:
 
 ```text
 dist/index-copy original-no-camera-scanning.js
@@ -49,7 +57,7 @@ dist/index-copy original-no-camera-scanning.js
 
 predates camera scanning and is **not** a valid rollback artifact for the current accepted system.
 
-Detailed Directus/runtime administration, hashes, restart, verification, and rollback requirements are owned by [MSB-Server-Management](https://github.com/Gregovate/MSB-Server-Management/blob/agent/scan-fieldwiring-runtime-integration/docs/directus/Display_Scan_Extension_Deployment_and_Recovery.md).
+Detailed Directus/runtime administration, current hashes, rollback copies, restart, verification, and Synology `/scan/` proxy requirements are owned by [MSB-Server-Management](https://github.com/Gregovate/MSB-Server-Management/blob/main/docs/directus/Display_Scan_Extension_Deployment_and_Recovery.md).
 
 ## Current Route Inventory
 
@@ -85,27 +93,37 @@ The current hub independently presents or resolves:
 - the Directus Display record;
 - the current Display Testing record/status when applicable;
 - the assigned Container;
-- active Work Orders.
+- active Work Orders; and
+- the accepted Field Wiring action.
 
-Testing, Container, and Work Order routes perform their own required database lookups after navigation. They do not depend on FieldWiring.
+Testing, Container, Work Order, and FieldWiring remain separate downstream actions. A failure in one downstream application must not make the basic Display hub or unrelated actions unavailable.
 
-This independence is a required failure boundary for future integrations.
+## Authentication and Public-Origin Boundary
 
-## Authentication Boundary
+The scan extension does not implement a separate authentication mechanism. It relies on the existing protected application boundary.
 
-The scan extension does not implement authentication itself. It relies on the existing protected Directus/application session and the current protected `my.sheboyganlights.org` access boundary.
+Current public origins are intentionally separate:
+
+```text
+Scan application         https://my.sheboyganlights.org/scan/
+FieldWiring              https://my.sheboyganlights.org/fieldwiring/
+Procedure                https://my.sheboyganlights.org/procedures/
+Directus administration  https://db.sheboyganlights.org/
+```
+
+Directus-facing scan destinations must continue to use the established `db.sheboyganlights.org` origin rather than assuming the Scan page shares the Directus origin.
 
 Authentication implementation, Cloudflare policy administration, Directus service operation, and server deployment mechanics are infrastructure/runtime concerns. Individual downstream field applications must not silently invent competing authentication behavior.
 
-## FieldWiring Integration Rule
+## FieldWiring Integration — Accepted Production
 
-FieldWiring is the current additive Display integration.
+FieldWiring is the first controlled additive Display integration and is now production-operational from the Display hub.
 
-Required direction:
+Accepted direction:
 
 ```text
 Existing Display QR
-    -> existing authenticated Directus scan endpoint
+    -> existing protected Directus scan endpoint
         -> permanent display_id resolved
             -> existing Display scan hub
                 -> Field Wiring action
@@ -113,13 +131,13 @@ Existing Display QR
                         -> FieldWiring resolves current Stage/Preview/Scene from PostgreSQL
 ```
 
-The verified FieldWiring direct-entry contract is:
+The accepted FieldWiring direct-entry contract is:
 
 ```text
 /fieldwiring/wiring.html?display_id=<permanent display_id>
 ```
 
-The scan hub should pass only the permanent `display_id`.
+The scan hub passes only the permanent `display_id`.
 
 Do not pass or encode:
 
@@ -131,11 +149,34 @@ Do not pass or encode:
 - controller address;
 - FieldWiring snapshot/import ID.
 
-FieldWiring must remain a downstream consumer. A FieldWiring outage must not disable Display, Testing, Container, Work Order, or other existing scan actions.
+FieldWiring remains a downstream consumer. A FieldWiring outage must not disable Display, Testing, Container, Work Order, or other existing scan actions.
 
-See [FieldWiring Scan Integration Engineering Handoff — 2026-08-22](FieldWiring_Scan_Integration_Engineering_Handoff_2026-08-22.md) for the current implementation/acceptance plan.
+See [FieldWiring Scan Integration Engineering Handoff — 2026-08-22](FieldWiring_Scan_Integration_Engineering_Handoff_2026-08-22.md) for the accepted implementation and production evidence.
 
-## Future Scan Platform Boundary
+## Procedure Display Scan Integration — Next Bounded Follow-On
+
+The standalone Procedure application is production-operational at:
+
+```text
+https://my.sheboyganlights.org/procedures/
+```
+
+Procedure already accepts permanent Display identity as an application entry input and owns its own shared Field Context resolution and Setup/Takedown/Inspection task behavior.
+
+The next bounded scan follow-on is to add the agreed Procedure action behavior to the existing Display hub using the already-resolved permanent `display_id`.
+
+This follow-on must preserve the same architectural rules proven by FieldWiring:
+
+- no physical QR change;
+- no second Display resolver;
+- no Stage/Scene/Google path encoded in the scan link;
+- no Procedure schema or generic document registry merely for scan integration;
+- no Procedure health/API call required just to render the Display hub; and
+- existing Display, Testing, Container, Work Order, and FieldWiring actions remain independently usable if Procedure is unavailable.
+
+The exact operator-facing Procedure action design must be confirmed from the current Procedure application and Setup/Deployment handoff before implementation. Do not invent a new scan workflow merely because Procedure supports multiple tasks.
+
+## Future Setup/Deployment Scan Platform Boundary
 
 The scan extension is expected to become more important during Setup/Deployment, where Container and Storage Location scanning may be frequent.
 
@@ -149,7 +190,7 @@ LOC:<location_code>
 
 Annual setup dates, load numbers, transient movement state, application-specific routes, and other workflow state must not become physical label identity.
 
-FieldWiring is the first controlled additive integration. Do not redesign the whole scan system merely to add this action. After FieldWiring integration is accepted, the separate Setup/Deployment engineering work should reconstruct the actual pull/stage/load/delivery scan workflow and then determine what shared scan-session/application structure is justified.
+The broader Setup/Deployment workflow remains separate from Procedure document lookup. Reconstruct the actual pull/stage/load/delivery process before deciding what shared scan-session/application structure, transaction semantics, or schema changes are justified.
 
 ## Cross-Repository Ownership
 
@@ -159,9 +200,9 @@ Owns:
 
 - permanent Display/Container/Location identity and relationships;
 - scan payload/business contracts;
-- Testing, Work Order, Container, FieldWiring, Setup/Deployment integration behavior;
-- shared field-context resolution;
-- the Git-controlled application source for Production Database scan behavior once recovered.
+- Git-controlled scan application source under `Scan/directus-extension-scan/`;
+- Testing, Work Order, Container, FieldWiring, Procedure, and Setup/Deployment integration behavior;
+- shared field-context resolution and downstream application contracts.
 
 ### MSB-Server-Management
 
@@ -171,25 +212,28 @@ Owns:
 - Directus container/image/mount relationship;
 - runtime hashes;
 - deployment/restart/recovery procedure;
-- backup/rollback procedure;
-- FieldWiring service/mount/proxy infrastructure.
+- backup/rollback procedure and artifacts;
+- Synology/WebStation `/scan/` reverse-proxy routing;
+- established Directus public-origin runtime; and
+- FieldWiring/Procedure service and proxy infrastructure.
 
 A server path does not transfer business-rule authority to the Server Management repository.
 
 ## Current Stop Point
 
-As of 2026-08-22:
+As of 2026-08-23:
 
-- current scan routes and Display action generation have been reconstructed;
-- current production hashes are recorded;
-- the missing deployed `src/` source boundary is identified;
-- FieldWiring is production-operational independently;
-- the correct FieldWiring `display_id` deep link is verified;
-- no Field Wiring action has been deployed to `/scan/DISP/:key` yet;
-- no scan-related Directus restart has occurred for this integration;
-- no schema change is required or approved.
+- current scan application source is recovered in Git;
+- FieldWiring Scan Integration is accepted production work;
+- current accepted live scan artifact hash is `b4f6c27f4880a8eaf8a90d8d55c7939c5bd190645dca9329344a86c3175cb20f`;
+- the Directus public-origin correction is accepted production behavior;
+- the `/scan/` Synology route is production-operational;
+- standalone Procedure field access is production-operational;
+- Procedure Display Scan Integration is the next bounded scan follow-on;
+- the broader Container/Location Setup/Deployment workflow remains separate engineering scope; and
+- no schema or physical QR change is required merely to begin Procedure scan integration reconnaissance.
 
-Resume with the [FieldWiring Scan Integration Engineering Handoff](FieldWiring_Scan_Integration_Engineering_Handoff_2026-08-22.md) and the corresponding Server Management runtime document rather than re-inspecting the system from scratch.
+Before changing Scan again, read the current Production Database scan/Procedure handoffs and the Server Management [Display Scan Extension Deployment and Recovery](https://github.com/Gregovate/MSB-Server-Management/blob/main/docs/directus/Display_Scan_Extension_Deployment_and_Recovery.md) runbook. Do not rediscover the Directus extension path, runtime hash, restart procedure, `/scan/` proxy, or rollback process from scratch unless the documented runtime is proven wrong.
 
 ## Related Documents
 
@@ -199,4 +243,4 @@ Resume with the [FieldWiring Scan Integration Engineering Handoff](FieldWiring_S
 - [Field Context Resolution Contract](Field_Context_Resolution_Contract.md)
 - [Wiring System](../09_Wiring_System/README.md)
 - [Setup and Deployment](../12_Setup_and_Deployment/README.md)
-- [MSB Server Management — Display Scan Extension Deployment and Recovery](https://github.com/Gregovate/MSB-Server-Management/blob/agent/scan-fieldwiring-runtime-integration/docs/directus/Display_Scan_Extension_Deployment_and_Recovery.md)
+- [MSB Server Management — Display Scan Extension Deployment and Recovery](https://github.com/Gregovate/MSB-Server-Management/blob/main/docs/directus/Display_Scan_Extension_Deployment_and_Recovery.md)

--- a/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/README.md
+++ b/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/README.md
@@ -8,21 +8,30 @@ Display and container label printing is an implemented production capability use
 
 **Display QR lookup is also an implemented production capability.** The current Display scan route is deployed as a Directus endpoint extension on `msb-prod-db` under `/opt/directus/extensions/directus-extension-scan/`. It resolves the permanent Production Database `display_id` and presents the existing Display scan hub.
 
-The deployed scan runtime was reconstructed and documented on 2026-08-22 before the FieldWiring integration. Current production routes, action generation, runtime hashes, the camera-scanning baseline, and the missing deployed `src/index.js` source boundary are now recorded. The current accepted `dist/index.js` must be preserved while the source/deployment workflow is recovered into Git.
+The accepted camera-enabled scan implementation has been recovered into Git-controlled application source under:
 
-**FieldWiring is production-operational independently of the scan hub.** The active scan work is one additive **Field Wiring** action using the already-resolved permanent `display_id`. No scan change has been deployed yet for that integration.
+```text
+Scan/directus-extension-scan/
+    package.json
+    src/index.js
+    dist/index.js
+```
 
-The current FieldWiring direct-entry contract is:
+The detailed deployed runtime hash, rollback artifacts, restart/recovery sequence, and Synology `/scan/` proxy behavior are maintained in `Gregovate/MSB-Server-Management`.
+
+**FieldWiring Scan Integration is accepted production work.** The Display scan hub currently includes the additive **Field Wiring** action using only the already-resolved permanent `display_id`:
 
 ```text
 /fieldwiring/wiring.html?display_id=<permanent display_id>
 ```
 
-The scan hub must remain independent of FieldWiring for Display Record, Testing, Container, Work Order, and other existing actions.
+The scan hub remains independent of FieldWiring for Display Record, Testing, Container, Work Order, and other existing actions. FieldWiring does not have to be healthy merely for the Display hub to render.
 
-The scan platform will become more important during Setup/Deployment, where high-volume Container and Storage Location scanning is expected. FieldWiring is therefore being integrated as the first controlled additive consumer rather than as a one-off replacement of the scan system. The later Setup/Deployment scan workflow must still be engineered from the real field process before broader scan-platform refactoring is approved.
+**Procedure is also production-operational independently at `https://my.sheboyganlights.org/procedures/`.** The next bounded scan follow-on is Procedure Display Scan Integration using the same permanent `display_id` identity already resolved by `/scan/DISP/:key`. The exact Scan-hub Procedure action UX must be confirmed from the current Procedure/Scan contracts before code changes; no physical QR redesign, second resolver, Procedure schema, alternate Google hierarchy, or duplicate document registry is implied by this integration.
 
-The deployed scan runtime predates the current documentation structure. Its server-side deployment, restart, hash, backup, and recovery details are maintained through the separate [MSB-Server-Management](https://github.com/Gregovate/MSB-Server-Management) project.
+The broader Setup/Deployment scan workflow remains separate engineering scope. High-volume Container and Storage Location scanning is expected during setup season, but the real pull/stage/load/delivery process must be reconstructed before broader scan-platform refactoring or transaction semantics are approved.
+
+The deployed scan runtime predates the current documentation structure. Its server-side deployment, restart, hash, backup, recovery, and reverse-proxy details are maintained through the separate [MSB-Server-Management](https://github.com/Gregovate/MSB-Server-Management) project.
 
 Label printing crosses a repository and service boundary:
 
@@ -34,10 +43,10 @@ The LabelPrintService is an external supporting subsystem. If it is unavailable,
 
 ## Start Here
 
-- [FieldWiring Scan Integration Engineering Handoff — 2026-08-22](FieldWiring_Scan_Integration_Engineering_Handoff_2026-08-22.md) — current scan implementation baseline, verified FieldWiring deep link, source-control recovery gap, acceptance matrix, and exact resume point.
+- [FieldWiring Scan Integration Engineering Handoff — 2026-08-22](FieldWiring_Scan_Integration_Engineering_Handoff_2026-08-22.md) — accepted production Scan/FieldWiring baseline, permanent `display_id` handoff, source-control boundary, failure boundary, acceptance matrix, and deferred regression cases.
+- [Deployed Display Scan Runtime Boundary](Deployed_Display_Scan_Runtime_Boundary.md) — current Directus scan endpoint, application/runtime ownership boundary, and current scan-extension resume point.
 - [Asset Identity and Scan Payload Standard](Asset_Identity_and_Scan_Payload_Standard.md) — durable asset/payload rules.
-- [Deployed Display Scan Runtime Boundary](Deployed_Display_Scan_Runtime_Boundary.md) — verified current Directus scan endpoint, runtime/source boundary, and cross-repository ownership.
-- [Field Context Resolution Contract](Field_Context_Resolution_Contract.md) — shared scan-to-Display/hierarchy contract used by Work Orders, FieldWiring, Setup, Takedown, Testing, and future field functions.
+- [Field Context Resolution Contract](Field_Context_Resolution_Contract.md) — shared scan-to-Display/hierarchy contract used by Work Orders, FieldWiring, Procedures, Testing, and future field functions.
 - [Field Document Publication and Currentness Contract](Field_Document_Publication_and_Currentness_Contract.md) — shared browser/PDF/offline/currentness rules for field documents reached through the scan/task workflow.
 - [Operational Label Printing SOPs](../../02_Operational_SOPs/Label_Printing/README.md) — current operator instructions.
 
@@ -60,8 +69,8 @@ For example, Wiring owns wiring information, Setup and Deployment owns setup/tak
 - [Database Foundation](../01_Database_Foundation/README.md)
 - [Containers and Storage](../04_Containers_and_Storage/README.md)
 - [People and Identity](../03_People_and_Identity/README.md) for authenticated operations where applicable
-- [Setup and Deployment](../12_Setup_and_Deployment/README.md) for the upcoming Container/Location setup-season workflow
-- [MSB-Server-Management](https://github.com/Gregovate/MSB-Server-Management) for the deployed `msb-prod-db` runtime, Directus server administration, and live `/opt/...` inspection/recovery documentation
+- [Setup and Deployment](../12_Setup_and_Deployment/README.md) for Procedure field-document behavior and the future Container/Location setup-season workflow
+- [MSB-Server-Management](https://github.com/Gregovate/MSB-Server-Management) for the deployed `msb-prod-db` runtime, Directus server administration, runtime hashes/recovery, and Synology proxy configuration
 
 ## Current Responsibilities
 
@@ -107,9 +116,9 @@ The current Display scan endpoint is deployed under:
 
 on `msb-prod-db`.
 
-The Production Database repository owns the permanent identity, application source/business behavior, and database contracts consumed by that endpoint. Server runtime administration, deployment/restart/recovery documentation, runtime hashes, and inspection of the live `/opt/...` implementation are owned by [MSB-Server-Management](https://github.com/Gregovate/MSB-Server-Management).
+The Production Database repository owns the permanent identity, Git-controlled scan application source/business behavior, and database contracts consumed by that endpoint. Server runtime administration, deployment/restart/recovery documentation, runtime hashes, backups, and inspection of the live `/opt/...` implementation are owned by [MSB-Server-Management](https://github.com/Gregovate/MSB-Server-Management).
 
-The current deployment has no `src/` directory even though `package.json` declares `src/index.js`. Recovering the accepted implementation into a Git-controlled source/deployment boundary is required before substantial scan-platform expansion.
+The live deployment executes `dist/index.js`; it does not need to contain the development `src/` tree. The accepted application source has been recovered under `Scan/directus-extension-scan/` in this repository, so future changes must begin from that source and the current Server Management runtime baseline rather than reconstructing the extension from the live artifact.
 
 See [Deployed Display Scan Runtime Boundary](Deployed_Display_Scan_Runtime_Boundary.md) and [FieldWiring Scan Integration Engineering Handoff](FieldWiring_Scan_Integration_Engineering_Handoff_2026-08-22.md).
 
@@ -141,11 +150,12 @@ A failure of LabelPrintService must not transfer data authority to the service o
 - [Deployed Display Scan Runtime Boundary](Deployed_Display_Scan_Runtime_Boundary.md)
 - [Field Context Resolution Contract](Field_Context_Resolution_Contract.md)
 - [Field Document Publication and Currentness Contract](Field_Document_Publication_and_Currentness_Contract.md)
+- current scan application source under `Scan/directus-extension-scan/`;
 - current PostgreSQL label-printing objects and request/batch records;
 - current Directus Display and Container print workflows;
 - current deployed Display scan extension on `msb-prod-db`;
 - current `MSB_LabelPrintService` implementation and operator documentation;
-- [MSB-Server-Management — Display Scan Extension Deployment and Recovery](https://github.com/Gregovate/MSB-Server-Management/blob/agent/scan-fieldwiring-runtime-integration/docs/directus/Display_Scan_Extension_Deployment_and_Recovery.md) for server/runtime administration and recovery.
+- [MSB-Server-Management — Display Scan Extension Deployment and Recovery](https://github.com/Gregovate/MSB-Server-Management/blob/main/docs/directus/Display_Scan_Extension_Deployment_and_Recovery.md) for server/runtime administration, accepted live hash, backup/rollback evidence, restart, and recovery.
 
 The former loose `H_Asset_ID_Labeling_and_Scanning_Plan.md` has been reconciled into this subsystem and archived as historical planning evidence.
 
@@ -165,25 +175,28 @@ The former loose `H_Asset_ID_Labeling_and_Scanning_Plan.md` has been reconciled 
 
 ## Resume Development
 
-### Scan Integration — current priority
+### Procedure Display Scan Integration — current priority
 
-Begin with:
+Standalone Procedure field access and FieldWiring Scan Integration are accepted production baselines. The next bounded scan follow-on is Procedure Display Scan Integration.
 
-1. [FieldWiring Scan Integration Engineering Handoff](FieldWiring_Scan_Integration_Engineering_Handoff_2026-08-22.md);
-2. [Deployed Display Scan Runtime Boundary](Deployed_Display_Scan_Runtime_Boundary.md);
-3. the current live scan-extension hash/runtime documented in MSB-Server-Management; and
-4. the current FieldWiring application contract in [Wiring System](../09_Wiring_System/README.md).
+Before changing the scan extension:
 
-Preserve/recover the accepted current scan implementation in Git, then add the minimal **Field Wiring** action using only permanent `display_id`. Do not refactor Testing, Container, Work Order, or camera-scanning behavior as part of that change.
+1. read the current [Setup and Deployment](../12_Setup_and_Deployment/README.md) Procedure/scan handoff;
+2. read the accepted [FieldWiring Scan Integration Engineering Handoff](FieldWiring_Scan_Integration_Engineering_Handoff_2026-08-22.md) so its deployment, identity, and failure-boundary lessons are preserved;
+3. read [Deployed Display Scan Runtime Boundary](Deployed_Display_Scan_Runtime_Boundary.md);
+4. read the current Procedure application README under `Procedures/Application/README.md` and confirm its existing permanent-`display_id` deep-link behavior;
+5. read the current `MSB-Server-Management` Display Scan Extension Deployment and Recovery runbook before any deployment planning;
+6. verify the exact current `Scan/directus-extension-scan/src/index.js` and `dist/index.js` source before editing; and
+7. confirm the exact operator-facing Procedure action behavior before implementation rather than inventing a new scan flow.
 
-### Setup/Deployment — next project
+Preserve the current physical `DISP:<display_id>` QR identity. Do not add a second resolver, Procedure schema, alternate Google hierarchy, direct Procedure-document URL in the QR, or a Procedure health/API dependency merely to render the Display scan hub.
 
-After FieldWiring Scan Integration is accepted and both repository handoffs are closed, start a separate Setup/Deployment engineering thread/branch from [Setup and Deployment](../12_Setup_and_Deployment/README.md).
+### Setup/Deployment operational scanning — separate project
 
-The expected setup-season workload includes substantial Container and Storage Location scanning. Reconstruct the real pull/stage/load/delivery workflow before designing schema, scan-session state, or a broader scan-platform refactor.
+The expected setup-season workload includes substantial Container and Storage Location scanning. Reconstruct the real pull/stage/load/delivery workflow before designing schema, scan-session state, transaction semantics, or a broader scan-platform refactor.
 
 ### Label printing
 
 For label printing, begin with the current PostgreSQL request/batch objects, [Asset Identity and Scan Payload Standard](Asset_Identity_and_Scan_Payload_Standard.md), and the current LabelPrintService implementation. Verify the actor-attribution contract and any retry/reprint behavior before changing the database or service.
 
-Material work is not complete until this README and the corresponding Server Management handoff are reviewed and updated so the next chat can resume from Git without reconstructing settled behavior.
+Material work is not complete until durable discoveries are recorded in the responsible engineering/runbook documentation as they are established, and this README plus the corresponding Server Management handoff are reviewed and updated so the next chat can resume from Git without reconstructing settled behavior.

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/README.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/README.md
@@ -2,7 +2,7 @@
 
 ## Current State
 
-**Status: DOCUMENTATION ACTIVE / PROCEDURE RESOLVER ENGINEERING READY**
+**Status: DOCUMENTATION ACTIVE / PROCEDURE FIELD ACCESS PRODUCTION-OPERATIONAL**
 
 This subsystem covers planning, scheduling, staging, loading, scanning, and moving tested displays and containers from storage to the park for annual setup, plus takedown-related field documentation where it belongs with the same Stage material.
 
@@ -10,7 +10,9 @@ The Stage-oriented folder structure already exists. Setup/Takedown instructions 
 
 The operational database/application workflow for scheduling, pick lists, load order, and forklift scanning is not yet fully engineered. No operator procedure should imply those planned functions are implemented until verified from the current database/application.
 
-**FieldWiring and the Display Scan integration are now accepted production baselines.** Procedure resolver engineering does not need to wait for, rediscover, or redesign either system. Start with [Procedure System Field Context Handoff — 2026-08-22](00_Procedure_System_Field_Context_Handoff_2026-08-22.md), which resolves older documentation conflicts and defines how Setup/Takedown/Inspection reuse the proven FieldWiring structured Stage/Sub-stage/Scene resolver.
+**FieldWiring, Display Scan, and the standalone Procedure application are accepted production baselines.** Procedure is production-operational at `https://my.sheboyganlights.org/procedures/` and uses the shared Field Context resolver plus the existing read-only Google `Display Folders` mount. Do not rediscover or redesign those accepted systems merely to continue Setup/Deployment work.
+
+The next bounded Procedure-related engineering follow-on is **Procedure Display Scan Integration** using the permanent `display_id` already resolved by the existing Display scan hub. Human Procedure-document authoring/alignment and the broader scheduling/pick/load/forklift workflow remain separate work streams.
 
 MSB has purchased a **Zebra DS3678-HD cordless ultra-rugged 1-D/2-D scanner kit** for the workshop forklift. It uses the Zebra 3600-series USB cradle and supports USB HID keyboard input. Because this is the **HD (High Density)** variant rather than an ER/XR extended-range model, its actual suitability from the forklift seat must be tested with real MSB Container and Storage Location labels before it is accepted as the final forklift-distance standard. See [Scanner Hardware and Tablet Integration](../07_Labeling_and_Scanning/Scanner_Hardware_and_Tablet_Integration.md).
 
@@ -72,13 +74,13 @@ The existing Google Shared Drive Stage/Scene folder structure is the human-facin
 - [Wiring System](../09_Wiring_System/README.md) owns wiring content in that structure.
 - Setup and Deployment owns setup/takedown instruction behavior and the application integration contract for finding applicable Procedure documents.
 - [Labeling and Scanning](../07_Labeling_and_Scanning/README.md) owns permanent QR/scanning integration patterns, but QR lookup does not become the content authority.
-- [Procedure System Field Context Handoff](00_Procedure_System_Field_Context_Handoff_2026-08-22.md) owns the current initial resolver/runtime handoff where older documents conflict.
+- [Procedure System Field Context Handoff](00_Procedure_System_Field_Context_Handoff_2026-08-22.md) remains the architecture handoff that resolved the original Procedure/FieldWiring conflicts.
 
 This framework does not by itself define or approve a new database schema.
 
 ## Document Resolution and Field UX
 
-The accepted initial field-access path is:
+The accepted current field-access path is:
 
 ```text
 Display QR or manual Display/Stage/Scene lookup
@@ -112,15 +114,15 @@ The QR code identifies the asset. It does not contain a Google Drive folder path
 
 The Production Database owns the durable identities and relationships used to determine the structured Stage/Scene context. The database does not become the editing system for Procedure content.
 
-For the **initial read-only Procedure browser**, a PostgreSQL row or stored Google document ID for every current published PDF is **not a prerequisite**. Once the current structured root and marked `Procedures` subsystem root are validated, the application selects the exact known `Setup`, `Takedown`, or `Inspection` child and may enumerate the current published files directly in that task folder while excluding `Archive` and `SourceDocs`.
+For the current read-only Procedure browser, a PostgreSQL row or stored Google document ID for every current published PDF is **not a prerequisite**. Once the current structured root and marked `Procedures` subsystem root are validated, the application selects the exact known `Setup`, `Takedown`, or `Inspection` child and enumerates the current published files directly in that task folder while excluding `Archive` and `SourceDocs`.
 
 Durable per-document metadata remains a future engineering option when approval workflow, revision history, source-to-publication lineage, supersession, audit, or stable document identity demonstrates a need for it. Do not create schema merely because older documentation listed document-ID storage as unresolved.
 
-`my.sheboyganlights.org` is the intended normal field presentation layer. Field volunteers should not need to understand the GitHub repository, database schema, Google Drive organization, or source-document mechanics to reach the current Setup instruction.
+`my.sheboyganlights.org` is the normal field presentation layer. Field volunteers should not need to understand the GitHub repository, database schema, Google Drive organization, or source-document mechanics to reach the current Setup instruction.
 
 ## Resolver Reuse Boundary
 
-Procedures must **reuse or extract the proven FieldWiring structured-scope resolver** rather than create a second independent Display-to-Stage/Scene algorithm.
+Procedure **reuses the proven shared FieldWiring structured-scope resolver** rather than maintaining a second independent Display-to-Stage/Scene algorithm.
 
 The shared resolver answers:
 
@@ -144,7 +146,9 @@ Both systems use the same subsystem-root marker pattern: the resolved structured
 
 ## Scan / Forklift Direction
 
-The permanent Display scan platform is already production-operational and resolves `DISP:<display_id>` using permanent Production Database identity. Future Procedure scan actions should consume that existing identity contract; no physical Display QR redesign is required.
+The permanent Display scan platform is production-operational and resolves `DISP:<display_id>` using permanent Production Database identity. Procedure Display Scan Integration must consume that existing identity contract; no physical Display QR redesign is required.
+
+The exact operator-facing Procedure action behavior still needs to be confirmed before the scan extension is changed. Do not invent a second resolver, encode Stage/Scene/Google paths in the QR, or make the Display hub depend on Procedure health merely to render a Procedure action.
 
 Setup is also expected to become a high-volume scan workflow for deployment operations rather than only document lookup.
 
@@ -225,13 +229,20 @@ The system should preserve the actual sequence used each year when that history 
 
 Legacy and superseded Setup instructions should be archived through the established Stage documentation process rather than deleted or left mixed with current field instructions.
 
-## Planned Responsibilities
+## Current and Planned Responsibilities
 
-The subsystem is expected to eventually support:
+Already production-operational:
 
 - current Setup/Takedown/Inspection document lookup by Display/Stage/Scene;
-- field-friendly Procedure presentation through `my.sheboyganlights.org`;
-- Procedure actions from the existing Display scan hub after standalone Procedure acceptance;
+- field-friendly Procedure presentation through `my.sheboyganlights.org/procedures/`;
+- shared Field Context resolution and read-only Google `Display Folders` consumption.
+
+Current bounded follow-on:
+
+- Procedure action behavior from the existing permanent-identity Display scan hub.
+
+Separate planned operational work includes:
+
 - setup season/session context;
 - calendar pull scheduling;
 - pick lists;
@@ -242,7 +253,7 @@ The subsystem is expected to eventually support:
 - prior-year sequence reference;
 - optional durable per-document publication metadata when a demonstrated workflow requires it.
 
-These are design targets, not implemented schema commitments unless verified in the current database.
+These planned operational items are design targets, not implemented schema commitments unless verified in the current database.
 
 ## System Boundaries and Dependencies
 
@@ -251,6 +262,7 @@ This subsystem depends on existing Production Database identities and relationsh
 - permanent Display identity and Stage/Scene relationships;
 - the accepted FieldWiring structured-context behavior;
 - the accepted Display scan platform;
+- the accepted standalone Procedure application;
 - the shared read-only Google `Display Folders` filesystem;
 - containers and storage locations;
 - testing readiness/state;
@@ -261,64 +273,63 @@ This subsystem depends on existing Production Database identities and relationsh
 
 It must not redefine permanent Display IDs, Container IDs, storage identities, LOR wiring/topology, or other identities already owned by existing subsystems.
 
-Containers of type **KIT** already exist and may hold loose setup materials instead of Displays. Detailed kit-contents inventory is a known future need but is not part of the first Procedure document-resolution proof.
+Containers of type **KIT** already exist and may hold loose setup materials instead of Displays. Detailed kit-contents inventory remains a separate future Setup/Deployment need.
 
 ## Known Limitations / Open Work
 
-**FieldWiring and Display Scan are no longer open prerequisites.** The immediate Procedure-document engineering work may proceed from their accepted production baseline.
+The standalone Procedure field-access application is accepted production work. Do not reopen its shared resolver, Google hierarchy, Procedure marker contract, or current-document discovery architecture unless a demonstrated production defect requires it.
 
-Open Procedure-document work includes:
+Current Procedure-related open work is separated into these scopes:
 
-- inspect/extract the reusable FieldWiring structured-scope boundary without changing its accepted behavior;
-- prove one read-only current Setup PDF lookup end-to-end from current PostgreSQL Stage/Scene context;
-- validate the resolved Stage/Sub-stage/Scene marker and the `Procedures` subsystem-root marker;
-- enforce `Archive` and `SourceDocs` exclusion at the normal Procedure endpoint;
-- define supported current field-document formats, beginning with PDF;
-- define the simple list behavior when more than one current Procedure applies;
-- define the missing-current-document user experience;
-- define the protected `my.sheboyganlights.org` Procedure route;
-- test PC/phone/tablet and print/offline behavior;
-- add a Procedure action to the existing Display scan hub only after standalone Procedure presentation is accepted;
-- complete the legacy Setup-document alignment/archive procedure already underway;
-- finalize the Stage Setup Instruction template and contributor/operator procedure;
-- determine the editable-source versus published-PDF relationship where Google Docs remain in use;
-- engineer durable Google document IDs / published references only if a demonstrated publication/history workflow requires them.
+- **Procedure Display Scan Integration** — add the agreed Procedure action behavior to the existing Display scan hub using permanent `display_id`, preserving existing scan actions and failure boundaries;
+- **Procedure document authoring/alignment** — continue the legacy Setup-document review, alignment, archive, and publication work in the existing Stage/Scene `Display Folders` hierarchy;
+- **Contributor/operator documentation** — finalize the Stage Setup Instruction contributor workflow and the editable-source versus published-PDF relationship where Google Docs remain in use;
+- **additional field acceptance as needed** — complete any broader PC/phone/tablet, print, or offline validation required for the 2026 field workflow; and
+- **durable document metadata only if justified** — engineer Google document IDs or published references only when a demonstrated publication/history requirement cannot be met by the current controlled-folder contract.
 
-Separate Setup/Deployment operational work still includes scheduling, readiness, pull/load planning, Container/Location movement semantics, forklift workflow, and hardware acceptance. Do not mix those business-process questions into the first Procedure document-resolution proof.
+Separate Setup/Deployment operational work still includes scheduling, readiness, pull/load planning, Container/Location movement semantics, forklift workflow, hardware acceptance, and related annual workflow state. Do not mix those business-process questions into Procedure Display Scan Integration.
 
 ## Resume Development
 
-### Current baseline — FieldWiring and Scan are complete
+### Current production baseline
 
-Begin from current `main`. Do not rediscover the old live-only scan extension, redesign the physical QR, or rebuild the Google filesystem connection.
+Begin from current `main` and the current responsible runbooks. Do not rediscover the old live-only scan extension, redesign the physical QR, rebuild the Google filesystem connection, or reconstruct Procedure deployment from chat history.
 
 Read first:
 
-1. [Procedure System Field Context Handoff — 2026-08-22](00_Procedure_System_Field_Context_Handoff_2026-08-22.md)
-2. [Field Context Resolution Contract](../07_Labeling_and_Scanning/Field_Context_Resolution_Contract.md)
-3. [FieldWiring Drive Context Resolver Engineering Design](../09_Wiring_System/FieldWiring_Drive_Context_Resolver_Engineering_Design.md)
-4. `FieldWiring/Application/wiring_images.py`
-5. `FieldWiring/Application/repository.py`
-6. [Google Drive Document Organization Procedure](../../../00_Project_Overview/01-Google_Drive_Document_Organization_Procedure.md)
-7. [Stage Setup Documentation Standard](../../../../System_Documentation/Project_Rules/Stage_Setup_Documentation_Standard.md)
-8. [FieldWiring Scan Integration Engineering Handoff](../07_Labeling_and_Scanning/FieldWiring_Scan_Integration_Engineering_Handoff_2026-08-22.md)
+1. [Procedure Application README](../../../../Procedures/Application/README.md) — current standalone Procedure application contract and production status;
+2. [Labeling and Scanning](../07_Labeling_and_Scanning/README.md) — current scan platform handoff and Procedure scan resume point;
+3. [Deployed Display Scan Runtime Boundary](../07_Labeling_and_Scanning/Deployed_Display_Scan_Runtime_Boundary.md) — current Git/runtime boundary and accepted scan baseline;
+4. [FieldWiring Scan Integration Engineering Handoff](../07_Labeling_and_Scanning/FieldWiring_Scan_Integration_Engineering_Handoff_2026-08-22.md) — accepted additive scan integration pattern and failure boundary;
+5. [Procedure System Field Context Handoff — 2026-08-22](00_Procedure_System_Field_Context_Handoff_2026-08-22.md) — architecture precedence for Procedure/Field Context;
+6. [Field Context Resolution Contract](../07_Labeling_and_Scanning/Field_Context_Resolution_Contract.md);
+7. [Stage Setup Documentation Standard](../../../../System_Documentation/Project_Rules/Stage_Setup_Documentation_Standard.md); and
+8. [MSB-Server-Management Display Scan Extension Deployment and Recovery](https://github.com/Gregovate/MSB-Server-Management/blob/main/docs/directus/Display_Scan_Extension_Deployment_and_Recovery.md) before any scan deployment planning.
 
-### First Procedure application proof
+### Procedure Display Scan Integration — current bounded engineering task
 
-The first application proof should remain narrow:
+The accepted identity handoff is:
 
 ```text
-Display / Stage / Scene lookup
-    -> shared structured-scope resolver
-    -> fixed current scope_root
-    -> validate scope_root marker
-    -> validate Procedures marker
-    -> select Procedures/Setup
-    -> enumerate current PDF(s)
-    -> protected browser presentation
+existing physical Display QR
+    -> DISP:<permanent display_id>
+    -> existing /scan/DISP/:key Display hub
+    -> agreed Procedure action
+    -> existing Procedure application receives permanent display_id
 ```
 
-Do not begin by creating Procedure schema, a generic document registry, a second resolver, or forklift/deployment transaction logic.
+The Procedure browser already accepts permanent Display identity as an entry input. Before changing Scan, confirm the exact operator-facing action behavior for Setup/Takedown/Inspection rather than inventing new routing or task semantics.
+
+This work must not create:
+
+- a new physical QR format;
+- a second Display/Stage/Scene resolver;
+- a Procedure-only Google hierarchy or mount;
+- a generic Procedure document registry;
+- a new Procedure database schema merely for scan integration; or
+- a Procedure health/API dependency that makes unrelated Scan actions unavailable.
+
+Follow the existing Server Management scan-extension runbook for live hash verification, rollback capture, staging, syntax validation, restart, and regression testing. Operational discoveries made during this work must be written into the responsible runbook before later steps depend on them.
 
 ### Setup workflow engineering
 
@@ -348,7 +359,7 @@ For Setup-document authoring/alignment work, continue with:
 4. the controlled [Stage Setup Instruction Template](../../../../System_Documentation/Templates/Stage_Setup_Instruction_Template.md); and
 5. the real Stage/Scene documents currently being reviewed and archived.
 
-Do not redesign the established Stage folder structure while solving Procedure resolution, QR integration, PDF publishing, or intranet UX.
+Do not redesign the established Stage folder structure while solving Procedure QR integration, PDF publishing, or intranet UX.
 
 ## Related Systems
 
@@ -363,13 +374,16 @@ Do not redesign the established Stage folder structure while solving Procedure r
 
 ## Related Documentation
 
+- [Procedure Application README](../../../../Procedures/Application/README.md)
 - [Procedure System Field Context Handoff — 2026-08-22](00_Procedure_System_Field_Context_Handoff_2026-08-22.md)
 - [Stage Setup Documentation Standard](../../../../System_Documentation/Project_Rules/Stage_Setup_Documentation_Standard.md)
 - [Stage Setup Instruction Template](../../../../System_Documentation/Templates/Stage_Setup_Instruction_Template.md)
 - [Google Drive Document Organization Procedure](../../../00_Project_Overview/01-Google_Drive_Document_Organization_Procedure.md)
 - [Field Context Resolution Contract](../07_Labeling_and_Scanning/Field_Context_Resolution_Contract.md)
 - [FieldWiring Drive Context Resolver Engineering Design](../09_Wiring_System/FieldWiring_Drive_Context_Resolver_Engineering_Design.md)
+- [Documentation Maintenance Rule](../../../../System_Documentation/Standards/Documentation_Maintenance_Rule.md)
 - [Document Control Standard](../../../../System_Documentation/Standards/Document_Control_Standard.md)
 - [Linking and Navigation Standard](../../../../System_Documentation/Standards/Linking_and_Navigation_Standard.md)
+- [MSB-Server-Management Display Scan Extension Deployment and Recovery](https://github.com/Gregovate/MSB-Server-Management/blob/main/docs/directus/Display_Scan_Extension_Deployment_and_Recovery.md)
 
 Repository Operational SOPs remain appropriate for database/application tasks in this subsystem when those tasks are implemented. They are not the storage or format model for the field-facing Stage Setup Instructions themselves.

--- a/System_Documentation/Standards/Documentation_Maintenance_Rule.md
+++ b/System_Documentation/Standards/Documentation_Maintenance_Rule.md
@@ -46,6 +46,26 @@ If work stops before implementation is complete, the repository must still conta
 
 For cross-repository systems, each repository must preserve the information it owns. Update or synchronize the responsible documents according to the documented ownership boundary rather than leaving the cross-repository state only in conversation history.
 
+## Operational and Runbook Knowledge
+
+Operational discovery is durable engineering knowledge and must be treated the same way as architecture or schema discovery.
+
+When work establishes or corrects how a production system is deployed, restarted, backed up, restored, verified, routed, upgraded, or safely modified, update the existing responsible runbook or runtime document as part of that work.
+
+Examples include:
+
+- the actual nginx configuration file and safe edit/reload procedure;
+- the correct reverse-proxy path and trailing-slash behavior;
+- the Directus extension deployment path, source/runtime ownership boundary, syntax check, restart sequence, and verification steps;
+- accepted production artifact hashes and rollback locations;
+- systemd service names, ports, environment files, mount dependencies, firewall rules, and health checks;
+- database backup/restore or migration safety gates; and
+- any production-specific failure or rollback condition discovered while troubleshooting.
+
+Once this information has been established and documented, future work must read the responsible runbook first and must not repeat broad reconnaissance merely because a new conversation does not remember the prior discovery.
+
+If an existing runbook is wrong or incomplete, correct that runbook before subsequent work depends on the corrected procedure. Do not leave the corrected sequence only in chat and do not create a competing second runbook for the same operation unless the documented ownership model requires a distinct artifact.
+
 ## Applies to Every Document Touched
 
 If a controlled document is edited during a conversation, review that document for discoveries made during the same work that affect information the document owns.
@@ -96,12 +116,13 @@ Prefer exact source-system names when discussing the source schema and establish
 Before closing material engineering work:
 
 1. Confirm that no durable discovery, accepted decision, corrected assumption, production fact, known limitation, or resume point remains only in conversation history.
-2. Review the controlled documents edited during the conversation.
-3. Identify durable discoveries made during the work that affect what those documents own.
-4. Add focused corrections or clarifications without unnecessarily rewriting valid documentation.
-5. Update the responsible subsystem documentation for discoveries that belong outside the files already being edited.
-6. Review navigation when a new controlled reference was created or moved.
-7. Commit the documentation with the engineering work or as a clearly related documentation commit.
+2. Confirm that operational or recovery procedures discovered during the work are recorded in the responsible current runbook/runtime document.
+3. Review the controlled documents edited during the conversation.
+4. Identify durable discoveries made during the work that affect what those documents own.
+5. Add focused corrections or clarifications without unnecessarily rewriting valid documentation.
+6. Update the responsible subsystem documentation for discoveries that belong outside the files already being edited.
+7. Review navigation when a new controlled reference was created or moved.
+8. Commit the documentation with the engineering work or as a clearly related documentation commit.
 
 Work is not fully documented if a future maintainer or future engineering session would have to reconstruct an established discovery from conversation history instead of finding it in the repository.
 

--- a/System_Documentation/Standards/Documentation_Maintenance_Rule.md
+++ b/System_Documentation/Standards/Documentation_Maintenance_Rule.md
@@ -5,6 +5,7 @@
 | Status | CURRENT — reusable documentation standard |
 | Scope | Version-controlled engineering projects using the MSB documentation framework |
 | Initial revision | 2026-08-21 |
+| Current revision | 2026-08-23 |
 | Owner | Project documentation owner / administrator |
 
 ## Purpose
@@ -18,6 +19,32 @@ This rule applies to engineering projects using this documentation framework and
 When engineering work reveals new information that improves, corrects, or materially clarifies the understanding of a system, data source, field meaning, relationship, workflow, boundary, naming translation, implementation behavior, or operating constraint, that discovery must be captured in the appropriate repository documentation before the work is considered complete.
 
 Conversation is a working and discovery environment. The repository is the durable project record.
+
+## No Chat-Only Project Memory
+
+Durable project knowledge must not remain only in ChatGPT conversation history, email, temporary notes, or another working communication channel.
+
+This includes, when material to future work:
+
+- verified current-state facts;
+- reverse-engineering discoveries;
+- accepted design or architecture decisions;
+- corrected assumptions;
+- identity, naming, path, schema, runtime, and ownership rules;
+- production constraints and failure boundaries;
+- validation results that establish a new accepted baseline;
+- known limitations and unresolved questions; and
+- the exact stop point or next engineering starting point.
+
+A chat summary is not a substitute for repository documentation.
+
+Do not defer a material discovery merely by planning to document it at the end of the project. When later engineering work will rely on a discovery, correction, or accepted decision, promote it into the responsible controlled repository document before proceeding past the point where that later work depends on it.
+
+If the correct documentation owner is not immediately obvious, identify the existing current authority first. Do not create an ad hoc document, duplicate a rule into multiple active documents, or invent a new structure simply to record the discovery.
+
+If work stops before implementation is complete, the repository must still contain the durable reconnaissance findings, known constraints, unresolved items, and resume point established during that work.
+
+For cross-repository systems, each repository must preserve the information it owns. Update or synchronize the responsible documents according to the documented ownership boundary rather than leaving the cross-repository state only in conversation history.
 
 ## Applies to Every Document Touched
 
@@ -68,12 +95,13 @@ Prefer exact source-system names when discussing the source schema and establish
 
 Before closing material engineering work:
 
-1. Review the controlled documents edited during the conversation.
-2. Identify durable discoveries made during the work that affect what those documents own.
-3. Add focused corrections or clarifications without unnecessarily rewriting valid documentation.
-4. Update the responsible subsystem documentation for discoveries that belong outside the files already being edited.
-5. Review navigation when a new controlled reference was created or moved.
-6. Commit the documentation with the engineering work or as a clearly related documentation commit.
+1. Confirm that no durable discovery, accepted decision, corrected assumption, production fact, known limitation, or resume point remains only in conversation history.
+2. Review the controlled documents edited during the conversation.
+3. Identify durable discoveries made during the work that affect what those documents own.
+4. Add focused corrections or clarifications without unnecessarily rewriting valid documentation.
+5. Update the responsible subsystem documentation for discoveries that belong outside the files already being edited.
+6. Review navigation when a new controlled reference was created or moved.
+7. Commit the documentation with the engineering work or as a clearly related documentation commit.
 
 Work is not fully documented if a future maintainer or future engineering session would have to reconstruct an established discovery from conversation history instead of finding it in the repository.
 

--- a/System_Documentation/Standards/Documentation_Standards.md
+++ b/System_Documentation/Standards/Documentation_Standards.md
@@ -103,6 +103,12 @@ When a discussion results in an accepted change to architecture, workflow, namin
 
 Do not leave a material decision only in conversation history.
 
+The same rule applies to verified discoveries and corrected assumptions, not only formal decisions. A production fact, reverse-engineering finding, ownership boundary, path rule, failure condition, validation result, known limitation, or resume point that later work depends on must be recorded in the responsible repository documentation.
+
+Do not use chat as a temporary holding area for material project knowledge with the intention of reconstructing it later. If a later engineering step depends on a discovery made during the current work, make that discovery durable in the repository before proceeding past that dependency point.
+
+If work ends before implementation is complete, the repository must still preserve the durable reconnaissance findings, unresolved items, constraints, and stop point established during that work.
+
 This rule serves two purposes:
 
 1. operators receive current instructions when engineering changes affect how they use the system; and
@@ -110,7 +116,7 @@ This rule serves two purposes:
 
 The responsible document may be an engineering design, operator procedure, standard, project rule, subsystem README, or another controlled artifact depending on what changed.
 
-Follow the document-control and README closeout standards when deciding where the durable update belongs.
+Follow [Documentation Maintenance Rule](Documentation_Maintenance_Rule.md), the document-control standard, and the README closeout standards when deciding where the durable update belongs.
 
 ## Related Systems and Related Documents
 

--- a/System_Documentation/Standards/Prompt_Guidelines.md
+++ b/System_Documentation/Standards/Prompt_Guidelines.md
@@ -13,6 +13,9 @@ The working contract is intentionally reusable. Project-specific repositories ma
 - Treat the current repository and its authoritative implementation artifacts as the durable source of truth; do not rely on conversation memory when the repository can answer the question.
 - Review the actual repository structure, responsible README, and current files before proposing changes.
 - Follow the project's documented standards before inventing new structure, terminology, or conventions.
+- Any durable discovery, accepted decision, corrected assumption, production fact, constraint, known limitation, or resume point established during chat must be promoted into the responsible controlled repository documentation. Chat is not a holding area for project memory.
+- When later engineering work will rely on a discovery made during the current conversation, document that discovery before proceeding past the point where the later work depends on it.
+- If the repository and the conversation disagree, stop relying on conversation memory, inspect the responsible current authority, and reconcile the repository deliberately before continuing.
 - Work one step at a time when the requested task is staged.
 - Gather evidence before redesigning or modifying production systems.
 - Do not change direction in the middle of an agreed task unless a real problem is found and discussed.
@@ -50,6 +53,7 @@ For repository engineering or documentation work, first determine:
 7. What document type is being changed: portal, procedure, SOP, design, runbook, report, or other technical reference.
 8. Who needs to read it.
 9. Whether the requested change affects links, document control, revision history, screenshots, related systems, or related documents.
+10. Whether the current conversation refers to a prior accepted discovery, decision, or baseline that is missing from the repository; if so, reconcile that repository documentation before relying on it for new work.
 
 Do not add complexity that does not help the intended reader or engineering task.
 
@@ -70,6 +74,22 @@ When making repository changes through GitHub or another version-control workflo
 
 The repository, not conversation history, is the durable source for these conventions and for the subsystem handoff.
 
+## Continuous Documentation Rule
+
+Repository maintenance is part of the engineering work, not a separate optional cleanup phase.
+
+During an engineering conversation:
+
+1. gather and verify evidence;
+2. identify whether the result materially changes or clarifies current project knowledge;
+3. identify the controlled document that owns that knowledge;
+4. update that document before subsequent engineering work begins to depend on the discovery; and
+5. continue implementation from the now-durable repository baseline.
+
+Do not accumulate a private backlog of material facts in chat with the intention of reconstructing them into documentation later. If the work stops unexpectedly, the repository should still contain the durable discoveries and stop point established up to that moment.
+
+For cross-repository systems, preserve each repository's own responsibility and update reciprocal handoffs when the accepted change affects both sides.
+
 ## Generic Project Engineering Prompt
 
 Use this prompt when starting or resuming work with ChatGPT on a version-controlled engineering project that follows these standards. Replace project-specific placeholders as needed. A repository may provide additional local standards or a subsystem-specific resume prompt.
@@ -85,6 +105,7 @@ Before making changes:
 5. Determine what is currently implemented, what is approved design, what is legacy/historical, what is planned, and what remains unresolved.
 6. Identify related systems and ownership boundaries before duplicating data, documentation, or responsibility.
 7. Gather evidence first. Do not redesign a production system or invent folders, schemas, naming conventions, or architecture simply because information appears incomplete.
+8. If the conversation refers to an accepted discovery or decision that is not present in the responsible repository documentation, reconcile the repository before relying on it for new work.
 
 Working rules:
 - Preserve established technical meaning, identities, terminology, safety controls, operational controls, and settled engineering decisions.
@@ -96,6 +117,8 @@ Working rules:
 - Preserve useful engineering history, but archive superseded material rather than leaving multiple active authorities.
 - Do not move or rename files, change architectural boundaries, or make production changes unless the current task authorizes them.
 - Work in focused steps and stop to discuss a real conflict or unexpected condition before changing direction.
+- Promote durable discoveries, accepted decisions, corrected assumptions, current-state facts, limitations, and resume points into the responsible repository documentation during the work. Do not leave them only in chat or defer them to an end-of-project memory dump.
+- Before later engineering steps depend on a newly established discovery, make that discovery durable in the repository first.
 
 Version-control rules:
 - Inspect current repository state before writes when local/remote divergence or uncommitted work could matter.
@@ -112,11 +135,12 @@ Documentation and navigation rules:
 - When a path changes, review dependent documentation, source references, and externally published navigation identified by the project.
 
 Mandatory closeout:
-1. Update the responsible engineering/design documents, procedures, SOPs, or references whose owned information changed.
-2. Review the subsystem README after the implementation and detailed documentation are current.
-3. Update that README so it accurately records the resulting current state, design intent where needed, authoritative sources, system boundaries/dependencies, known limitations/open work, and the next development starting point.
-4. Verify its navigation and related-system/document links.
-5. Commit the README handoff with the completed work.
+1. Confirm that no durable discovery, accepted decision, corrected assumption, production fact, known limitation, or resume point remains only in chat history.
+2. Update the responsible engineering/design documents, procedures, SOPs, or references whose owned information changed.
+3. Review the subsystem README after the implementation and detailed documentation are current.
+4. Update that README so it accurately records the resulting current state, design intent where needed, authoritative sources, system boundaries/dependencies, known limitations/open work, and the next development starting point.
+5. Verify its navigation and related-system/document links.
+6. Commit the README handoff with the completed work.
 
 Do not consider material subsystem work complete if the next session would have to reconstruct settled decisions from chat history, old commits, or obsolete documents instead of resuming from the repository.
 ```
@@ -143,6 +167,7 @@ A useful subsystem prompt should allow a new work session to read the README, fo
 For documentation-only work in the MSB Production Database Project, use the generic project engineering prompt above together with the current standards under `System_Documentation/Standards/`, especially:
 
 - `Documentation_Standards.md`;
+- `Documentation_Maintenance_Rule.md` for preserving discoveries and durable project knowledge during the work;
 - `README_Portal_Standard.md` when working on a README or portal;
 - `Linking_and_Navigation_Standard.md` when links or navigation are involved;
 - `Document_Control_Standard.md` when revision control applies;

--- a/System_Documentation/Standards/README.md
+++ b/System_Documentation/Standards/README.md
@@ -11,7 +11,7 @@ Start with [Documentation Standards](Documentation_Standards.md) for the project
 | I want to... | Go to |
 |---|---|
 | Understand the overall documentation rules | [Documentation Standards](Documentation_Standards.md) |
-| Preserve reverse-engineering discoveries and other durable system knowledge during engineering work | [Documentation Maintenance Rule](Documentation_Maintenance_Rule.md) |
+| Preserve reverse-engineering discoveries, runbook knowledge, and other durable system memory during engineering work | [Documentation Maintenance Rule](Documentation_Maintenance_Rule.md) |
 | Decide what belongs in the core repository versus a dedicated subsystem/application repository | [System Boundary and Repository Ownership Standard](System_Boundary_and_Repository_Ownership_Standard.md) |
 | Create or revise a README portal or engineering handoff | [README Portal Standard](README_Portal_Standard.md) |
 | Create or revise an operator procedure / SOP | [Operational SOP Standard](Operational_SOP_Standard.md) |


### PR DESCRIPTION
Documentation-only reconciliation from current main `af76f75dbb4803a33f585c6b9bbc1d9daac92076`.

This PR does not change Scan application code, Procedure code, PostgreSQL schema, Google Drive structure, or production runtime.

It:
- strengthens the reusable documentation rules so durable discoveries, accepted decisions, corrected assumptions, production facts, known limitations, runbook knowledge, and resume points cannot remain only in chat;
- makes documentation maintenance continuous during engineering work rather than an end-of-project cleanup step;
- explicitly classifies nginx, Directus extension deployment/restart, artifact hashes, rollback paths, systemd, ports, mounts, firewall rules, health checks, and similar operational discoveries as durable runbook knowledge;
- reconciles the Labeling and Scanning portal with the accepted FieldWiring Scan production state;
- updates the deployed Display Scan runtime boundary from the pre-FieldWiring state to the accepted current baseline;
- reconciles Setup and Deployment so standalone Procedure field access is recorded as production-operational;
- records Procedure Display Scan Integration as the next bounded follow-on using permanent `display_id` while keeping document authoring/alignment and broader Setup/Deployment workflows separate.

The purpose is to make the repository, not conversation history, the durable engineering memory and to prevent repeated rediscovery of already-established production procedures and architecture.