### PR TITLE
Add Procedures action to Display scan hub

### DIFF
--- a/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/Deployed_Display_Scan_Runtime_Boundary.md
+++ b/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/Deployed_Display_Scan_Runtime_Boundary.md
@@ -2,7 +2,7 @@
 
 | Document control | Value |
 |---|---|
-| Status | CURRENT PRODUCTION DEPENDENCY — runtime and Git source boundary documented |
+| Status | CURRENT PRODUCTION DEPENDENCY — Procedure source candidate ready; production deployment pending |
 | Current revision | 2026-08-23 |
 | Owner | MSB Database Administrator |
 | Production host | `msb-prod-db` |
@@ -38,7 +38,9 @@ The current accepted production SHA-256 after FieldWiring integration and the Di
 b4f6c27f4880a8eaf8a90d8d55c7939c5bd190645dca9329344a86c3175cb20f
 ```
 
-The accepted application/business source is now version-controlled under:
+That hash remains the accepted **live production baseline** until the Procedure-enabled candidate is actually deployed and accepted through the Server Management safety gate.
+
+The accepted application/business source is version-controlled under:
 
 ```text
 Scan/directus-extension-scan/
@@ -61,7 +63,7 @@ Detailed Directus/runtime administration, current hashes, rollback copies, resta
 
 ## Current Route Inventory
 
-Verified routes include:
+Verified production routes include:
 
 ```text
 /scan/
@@ -71,6 +73,8 @@ Verified routes include:
 /scan/DISP/:key/container
 /scan/DISP/:key/work-orders
 ```
+
+The Procedure source candidate does **not** add or replace a Scan route. It adds a Display-hub link to the already-deployed protected Procedure application.
 
 The scan landing page supports camera scanning, QR codes, 1-D barcodes, manual entry, and URL handling.
 
@@ -88,7 +92,7 @@ The physical Display QR must continue to represent the durable Display identity 
 
 ## Current Display Hub Behavior
 
-The current hub independently presents or resolves:
+The currently accepted production hub independently presents or resolves:
 
 - the Directus Display record;
 - the current Display Testing record/status when applicable;
@@ -96,7 +100,9 @@ The current hub independently presents or resolves:
 - active Work Orders; and
 - the accepted Field Wiring action.
 
-Testing, Container, Work Order, and FieldWiring remain separate downstream actions. A failure in one downstream application must not make the basic Display hub or unrelated actions unavailable.
+The Procedure-enabled source candidate adds one independent **Procedures** action without changing those existing actions.
+
+Testing, Container, Work Order, FieldWiring, and Procedure remain separate downstream actions. A failure in one downstream application must not make the basic Display hub or unrelated actions unavailable.
 
 ## Authentication and Public-Origin Boundary
 
@@ -153,7 +159,7 @@ FieldWiring remains a downstream consumer. A FieldWiring outage must not disable
 
 See [FieldWiring Scan Integration Engineering Handoff — 2026-08-22](FieldWiring_Scan_Integration_Engineering_Handoff_2026-08-22.md) for the accepted implementation and production evidence.
 
-## Procedure Display Scan Integration — Next Bounded Follow-On
+## Procedure Display Scan Integration — Source Candidate Ready
 
 The standalone Procedure application is production-operational at:
 
@@ -161,11 +167,43 @@ The standalone Procedure application is production-operational at:
 https://my.sheboyganlights.org/procedures/
 ```
 
-Procedure already accepts permanent Display identity as an application entry input and owns its own shared Field Context resolution and Setup/Takedown/Inspection task behavior.
+Procedure already accepts permanent Display identity as an application entry input and already owns its Setup/Takedown/Inspection task-selection UI.
 
-The next bounded scan follow-on is to add the agreed Procedure action behavior to the existing Display hub using the already-resolved permanent `display_id`.
+The agreed Display Scan UX is one additive **Procedures** button:
 
-This follow-on must preserve the same architectural rules proven by FieldWiring:
+```text
+Existing Display QR
+    -> /scan/DISP/:key
+        -> permanent display_id resolved
+            -> existing Display scan hub
+                -> Procedures
+                    -> /procedures/?display_id=<permanent display_id>
+                        -> existing Procedure page
+                            -> operator chooses Setup, Takedown, or Inspection
+```
+
+The Scan hub passes only the permanent `display_id`. It does not duplicate Setup/Takedown/Inspection buttons and does not call the Procedure API merely to determine whether the button should render.
+
+Git-controlled candidate source is on:
+
+```text
+branch: agent/procedure-scan-action
+implementation commit: 333f7c20a26e8ed2a0460ddbf309c167bffa2992
+```
+
+Both candidate files intentionally use the same Git blob:
+
+```text
+Scan/directus-extension-scan/src/index.js
+Scan/directus-extension-scan/dist/index.js
+Git blob: b3fd0e992b22407784e9da0dbc21d371c0d4a483
+```
+
+Compared with the current `main` baseline, each file has exactly one added line: the Procedures link. No existing Scan route or database query is changed.
+
+This is **not yet production acceptance**. The current live artifact remains the accepted hash `b4f6c27f4880a8eaf8a90d8d55c7939c5bd190645dca9329344a86c3175cb20f` until the Server Management deployment gate verifies the live baseline, creates a new rollback, stages and syntax-checks the candidate, restarts Directus, and completes regression acceptance.
+
+The Procedure follow-on preserves the architectural rules proven by FieldWiring:
 
 - no physical QR change;
 - no second Display resolver;
@@ -173,8 +211,6 @@ This follow-on must preserve the same architectural rules proven by FieldWiring:
 - no Procedure schema or generic document registry merely for scan integration;
 - no Procedure health/API call required just to render the Display hub; and
 - existing Display, Testing, Container, Work Order, and FieldWiring actions remain independently usable if Procedure is unavailable.
-
-The exact operator-facing Procedure action design must be confirmed from the current Procedure application and Setup/Deployment handoff before implementation. Do not invent a new scan workflow merely because Procedure supports multiple tasks.
 
 ## Future Setup/Deployment Scan Platform Boundary
 
@@ -229,11 +265,13 @@ As of 2026-08-23:
 - the Directus public-origin correction is accepted production behavior;
 - the `/scan/` Synology route is production-operational;
 - standalone Procedure field access is production-operational;
-- Procedure Display Scan Integration is the next bounded scan follow-on;
+- the Procedure Display Scan UX is now settled as one **Procedures** button that passes only permanent `display_id` and leaves Setup/Takedown/Inspection selection inside the existing Procedure application;
+- the Git-controlled Procedure-enabled Scan source candidate is implemented on `agent/procedure-scan-action`, with implementation commit `333f7c20a26e8ed2a0460ddbf309c167bffa2992`;
+- production deployment and regression acceptance of that candidate are still pending through the current Server Management runbook;
 - the broader Container/Location Setup/Deployment workflow remains separate engineering scope; and
-- no schema or physical QR change is required merely to begin Procedure scan integration reconnaissance.
+- no schema or physical QR change is part of this bounded integration.
 
-Before changing Scan again, read the current Production Database scan/Procedure handoffs and the Server Management [Display Scan Extension Deployment and Recovery](https://github.com/Gregovate/MSB-Server-Management/blob/main/docs/directus/Display_Scan_Extension_Deployment_and_Recovery.md) runbook. Do not rediscover the Directus extension path, runtime hash, restart procedure, `/scan/` proxy, or rollback process from scratch unless the documented runtime is proven wrong.
+Before deploying the candidate, read the current Server Management [Display Scan Extension Deployment and Recovery](https://github.com/Gregovate/MSB-Server-Management/blob/main/docs/directus/Display_Scan_Extension_Deployment_and_Recovery.md) runbook. Do not rediscover the Directus extension path, current runtime hash, restart procedure, `/scan/` proxy, or rollback process from scratch unless the documented runtime is proven wrong.
 
 ## Related Documents
 
@@ -243,4 +281,5 @@ Before changing Scan again, read the current Production Database scan/Procedure 
 - [Field Context Resolution Contract](Field_Context_Resolution_Contract.md)
 - [Wiring System](../09_Wiring_System/README.md)
 - [Setup and Deployment](../12_Setup_and_Deployment/README.md)
+- [Procedure Application](../../../../../Procedures/Application/README.md)
 - [MSB Server Management — Display Scan Extension Deployment and Recovery](https://github.com/Gregovate/MSB-Server-Management/blob/main/docs/directus/Display_Scan_Extension_Deployment_and_Recovery.md)

--- a/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/README.md
+++ b/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/README.md
@@ -27,7 +27,23 @@ The detailed deployed runtime hash, rollback artifacts, restart/recovery sequenc
 
 The scan hub remains independent of FieldWiring for Display Record, Testing, Container, Work Order, and other existing actions. FieldWiring does not have to be healthy merely for the Display hub to render.
 
-**Procedure is also production-operational independently at `https://my.sheboyganlights.org/procedures/`.** The next bounded scan follow-on is Procedure Display Scan Integration using the same permanent `display_id` identity already resolved by `/scan/DISP/:key`. The exact Scan-hub Procedure action UX must be confirmed from the current Procedure/Scan contracts before code changes; no physical QR redesign, second resolver, Procedure schema, alternate Google hierarchy, or duplicate document registry is implied by this integration.
+**Procedure is also production-operational independently at `https://my.sheboyganlights.org/procedures/`.** The Procedure Display Scan source candidate is implemented on branch `agent/procedure-scan-action` from current `main`. The agreed Scan UX is one additive **Procedures** button on the Display hub:
+
+```text
+/procedures/?display_id=<permanent display_id>
+```
+
+The Scan hub passes only the permanent `display_id`. Setup, Takedown, and Inspection selection remains inside the existing Procedure application, which already presents those three operator task choices. This avoids duplicating Procedure task-selection UI in Scan and does not add a Procedure API/health dependency merely to render the Display hub.
+
+Application-source implementation commit:
+
+```text
+333f7c20a26e8ed2a0460ddbf309c167bffa2992
+```
+
+This source candidate is **not yet a production-runtime acceptance record**. Until the documented Server Management deployment gate is executed and accepted, the current live Scan runtime remains the previously accepted FieldWiring-enabled artifact and hash.
+
+No physical QR redesign, second resolver, Procedure schema, alternate Google hierarchy, or duplicate document registry is part of this integration.
 
 The broader Setup/Deployment scan workflow remains separate engineering scope. High-volume Container and Storage Location scanning is expected during setup season, but the real pull/stage/load/delivery process must be reconstructed before broader scan-platform refactoring or transaction semantics are approved.
 
@@ -44,7 +60,7 @@ The LabelPrintService is an external supporting subsystem. If it is unavailable,
 ## Start Here
 
 - [FieldWiring Scan Integration Engineering Handoff — 2026-08-22](FieldWiring_Scan_Integration_Engineering_Handoff_2026-08-22.md) — accepted production Scan/FieldWiring baseline, permanent `display_id` handoff, source-control boundary, failure boundary, acceptance matrix, and deferred regression cases.
-- [Deployed Display Scan Runtime Boundary](Deployed_Display_Scan_Runtime_Boundary.md) — current Directus scan endpoint, application/runtime ownership boundary, and current scan-extension resume point.
+- [Deployed Display Scan Runtime Boundary](Deployed_Display_Scan_Runtime_Boundary.md) — current Directus scan endpoint, application/runtime ownership boundary, Procedure source-candidate state, and current scan-extension resume point.
 - [Asset Identity and Scan Payload Standard](Asset_Identity_and_Scan_Payload_Standard.md) — durable asset/payload rules.
 - [Field Context Resolution Contract](Field_Context_Resolution_Contract.md) — shared scan-to-Display/hierarchy contract used by Work Orders, FieldWiring, Procedures, Testing, and future field functions.
 - [Field Document Publication and Currentness Contract](Field_Document_Publication_and_Currentness_Contract.md) — shared browser/PDF/offline/currentness rules for field documents reached through the scan/task workflow.
@@ -58,7 +74,7 @@ The operator-facing Production Database procedure should stop at requesting labe
 
 Display-linked documents and field information are not intended to become a generic database document-management system. Their operational purpose is to support QR-based lookup from the physical Display or Container to the information needed in the field. The subsystem that owns the actual content remains authoritative for that content.
 
-A Display scan establishes the permanent Display identity through the existing deployed Directus scan endpoint. The resulting Display scan hub then allows the operator to choose the task they need. Work Orders, FieldWiring, Setup, Takedown, Testing, and future field functions must consume that resolved identity/context rather than maintaining separate QR-resolution logic.
+A Display scan establishes the permanent Display identity through the existing deployed Directus scan endpoint. The resulting Display scan hub then allows the operator to choose the task they need. Work Orders, FieldWiring, Procedures, Testing, and future field functions must consume that resolved identity/context rather than maintaining separate QR-resolution logic. Procedure-specific Setup/Takedown/Inspection task selection remains inside the Procedure application.
 
 For document-style task results, the shared field publication contract defines the common current browser presentation, self-contained PDF/offline direction, visible expiration/currentness metadata, and supersession behavior. The responsible subsystem still owns the actual document/data content and its task-specific expiration interval.
 
@@ -175,19 +191,29 @@ The former loose `H_Asset_ID_Labeling_and_Scanning_Plan.md` has been reconciled 
 
 ## Resume Development
 
-### Procedure Display Scan Integration — current priority
+### Procedure Display Scan Integration — source candidate ready; deployment/acceptance pending
 
-Standalone Procedure field access and FieldWiring Scan Integration are accepted production baselines. The next bounded scan follow-on is Procedure Display Scan Integration.
+Standalone Procedure field access and FieldWiring Scan Integration are accepted production baselines. Procedure Display Scan Integration now has an application-source candidate on branch `agent/procedure-scan-action`.
 
-Before changing the scan extension:
+Agreed operator behavior:
 
-1. read the current [Setup and Deployment](../12_Setup_and_Deployment/README.md) Procedure/scan handoff;
-2. read the accepted [FieldWiring Scan Integration Engineering Handoff](FieldWiring_Scan_Integration_Engineering_Handoff_2026-08-22.md) so its deployment, identity, and failure-boundary lessons are preserved;
-3. read [Deployed Display Scan Runtime Boundary](Deployed_Display_Scan_Runtime_Boundary.md);
-4. read the current Procedure application README under `Procedures/Application/README.md` and confirm its existing permanent-`display_id` deep-link behavior;
-5. read the current `MSB-Server-Management` Display Scan Extension Deployment and Recovery runbook before any deployment planning;
-6. verify the exact current `Scan/directus-extension-scan/src/index.js` and `dist/index.js` source before editing; and
-7. confirm the exact operator-facing Procedure action behavior before implementation rather than inventing a new scan flow.
+```text
+Display scan hub
+    -> Procedures
+        -> /procedures/?display_id=<permanent display_id>
+            -> existing Procedure page
+                -> operator chooses Setup, Takedown, or Inspection
+```
+
+The source candidate adds exactly one Display-hub link in both Git-controlled `src/index.js` and `dist/index.js`. It does not call Procedure to decide whether to render the button and does not change any existing Scan route.
+
+Application-source commit:
+
+```text
+333f7c20a26e8ed2a0460ddbf309c167bffa2992
+```
+
+Next step is deployment/acceptance through the current `MSB-Server-Management` Display Scan Extension Deployment and Recovery runbook. Before live replacement, verify the live artifact still matches the documented accepted baseline, create a new timestamped rollback, stage/syntax-check the candidate, and regression-test Display Record, Testing, Container, Work Orders, Field Wiring, manual/camera Scan behavior as applicable, plus the new Procedures action.
 
 Preserve the current physical `DISP:<display_id>` QR identity. Do not add a second resolver, Procedure schema, alternate Google hierarchy, direct Procedure-document URL in the QR, or a Procedure health/API dependency merely to render the Display scan hub.
 

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/README.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/README.md
@@ -12,7 +12,7 @@ The operational database/application workflow for scheduling, pick lists, load o
 
 **FieldWiring, Display Scan, and the standalone Procedure application are accepted production baselines.** Procedure is production-operational at `https://my.sheboyganlights.org/procedures/` and uses the shared Field Context resolver plus the existing read-only Google `Display Folders` mount. Do not rediscover or redesign those accepted systems merely to continue Setup/Deployment work.
 
-The next bounded Procedure-related engineering follow-on is **Procedure Display Scan Integration** using the permanent `display_id` already resolved by the existing Display scan hub. Human Procedure-document authoring/alignment and the broader scheduling/pick/load/forklift workflow remain separate work streams.
+The bounded **Procedure Display Scan Integration** UX is now settled and its application-source candidate is implemented on `agent/procedure-scan-action`: the existing Display scan hub gets one **Procedures** button that passes only permanent `display_id` to `/procedures/?display_id=<display_id>`. Setup/Takedown/Inspection selection remains inside the existing Procedure page. Production deployment/regression acceptance of that Scan candidate is still pending through the current Server Management runbook. Human Procedure-document authoring/alignment and the broader scheduling/pick/load/forklift workflow remain separate work streams.
 
 MSB has purchased a **Zebra DS3678-HD cordless ultra-rugged 1-D/2-D scanner kit** for the workshop forklift. It uses the Zebra 3600-series USB cradle and supports USB HID keyboard input. Because this is the **HD (High Density)** variant rather than an ER/XR extended-range model, its actual suitability from the forklift seat must be tested with real MSB Container and Storage Location labels before it is accepted as the final forklift-distance standard. See [Scanner Hardware and Tablet Integration](../07_Labeling_and_Scanning/Scanner_Hardware_and_Tablet_Integration.md).
 
@@ -146,9 +146,19 @@ Both systems use the same subsystem-root marker pattern: the resolved structured
 
 ## Scan / Forklift Direction
 
-The permanent Display scan platform is production-operational and resolves `DISP:<display_id>` using permanent Production Database identity. Procedure Display Scan Integration must consume that existing identity contract; no physical Display QR redesign is required.
+The permanent Display scan platform is production-operational and resolves `DISP:<display_id>` using permanent Production Database identity. Procedure Display Scan Integration consumes that existing identity contract; no physical Display QR redesign is required.
 
-The exact operator-facing Procedure action behavior still needs to be confirmed before the scan extension is changed. Do not invent a second resolver, encode Stage/Scene/Google paths in the QR, or make the Display hub depend on Procedure health merely to render a Procedure action.
+The agreed operator-facing Scan behavior is:
+
+```text
+Display scan hub
+    -> Procedures
+        -> /procedures/?display_id=<permanent display_id>
+            -> existing Procedure page
+                -> operator chooses Setup, Takedown, or Inspection
+```
+
+The Scan hub passes only `display_id`, does not duplicate the three Procedure task buttons, and does not call Procedure merely to decide whether the link should render. The source candidate is implemented on `agent/procedure-scan-action` with implementation commit `333f7c20a26e8ed2a0460ddbf309c167bffa2992`; production deployment/acceptance is still pending. Do not invent a second resolver, encode Stage/Scene/Google paths in the QR, or make the Display hub depend on Procedure health merely to render the Procedures action.
 
 Setup is also expected to become a high-volume scan workflow for deployment operations rather than only document lookup.
 
@@ -239,7 +249,7 @@ Already production-operational:
 
 Current bounded follow-on:
 
-- Procedure action behavior from the existing permanent-identity Display scan hub.
+- deploy and accept the implemented one-button Procedure action from the existing permanent-identity Display scan hub.
 
 Separate planned operational work includes:
 
@@ -281,7 +291,7 @@ The standalone Procedure field-access application is accepted production work. D
 
 Current Procedure-related open work is separated into these scopes:
 
-- **Procedure Display Scan Integration** — add the agreed Procedure action behavior to the existing Display scan hub using permanent `display_id`, preserving existing scan actions and failure boundaries;
+- **Procedure Display Scan Integration** — source candidate is implemented as one Display-hub **Procedures** action using permanent `display_id`; remaining work is Directus Scan deployment and regression acceptance through the Server Management safety gate;
 - **Procedure document authoring/alignment** — continue the legacy Setup-document review, alignment, archive, and publication work in the existing Stage/Scene `Display Folders` hierarchy;
 - **Contributor/operator documentation** — finalize the Stage Setup Instruction contributor workflow and the editable-source versus published-PDF relationship where Google Docs remain in use;
 - **additional field acceptance as needed** — complete any broader PC/phone/tablet, print, or offline validation required for the 2026 field workflow; and
@@ -297,28 +307,30 @@ Begin from current `main` and the current responsible runbooks. Do not rediscove
 
 Read first:
 
-1. [Procedure Application README](../../../../Procedures/Application/README.md) — current standalone Procedure application contract and production status;
-2. [Labeling and Scanning](../07_Labeling_and_Scanning/README.md) — current scan platform handoff and Procedure scan resume point;
-3. [Deployed Display Scan Runtime Boundary](../07_Labeling_and_Scanning/Deployed_Display_Scan_Runtime_Boundary.md) — current Git/runtime boundary and accepted scan baseline;
+1. [Procedure Application README](../../../../Procedures/Application/README.md) — current standalone Procedure application contract, production status, and Scan entry contract;
+2. [Labeling and Scanning](../07_Labeling_and_Scanning/README.md) — current scan platform handoff and Procedure scan candidate state;
+3. [Deployed Display Scan Runtime Boundary](../07_Labeling_and_Scanning/Deployed_Display_Scan_Runtime_Boundary.md) — current Git/runtime boundary, accepted live Scan baseline, and Procedure source candidate;
 4. [FieldWiring Scan Integration Engineering Handoff](../07_Labeling_and_Scanning/FieldWiring_Scan_Integration_Engineering_Handoff_2026-08-22.md) — accepted additive scan integration pattern and failure boundary;
 5. [Procedure System Field Context Handoff — 2026-08-22](00_Procedure_System_Field_Context_Handoff_2026-08-22.md) — architecture precedence for Procedure/Field Context;
 6. [Field Context Resolution Contract](../07_Labeling_and_Scanning/Field_Context_Resolution_Contract.md);
 7. [Stage Setup Documentation Standard](../../../../System_Documentation/Project_Rules/Stage_Setup_Documentation_Standard.md); and
-8. [MSB-Server-Management Display Scan Extension Deployment and Recovery](https://github.com/Gregovate/MSB-Server-Management/blob/main/docs/directus/Display_Scan_Extension_Deployment_and_Recovery.md) before any scan deployment planning.
+8. [MSB-Server-Management Display Scan Extension Deployment and Recovery](https://github.com/Gregovate/MSB-Server-Management/blob/main/docs/directus/Display_Scan_Extension_Deployment_and_Recovery.md) before any scan deployment.
 
-### Procedure Display Scan Integration — current bounded engineering task
+### Procedure Display Scan Integration — deployment/acceptance is the current bounded task
 
-The accepted identity handoff is:
+The accepted identity and UX handoff is:
 
 ```text
 existing physical Display QR
     -> DISP:<permanent display_id>
     -> existing /scan/DISP/:key Display hub
-    -> agreed Procedure action
+    -> Procedures
+    -> /procedures/?display_id=<permanent display_id>
     -> existing Procedure application receives permanent display_id
+    -> operator chooses Setup, Takedown, or Inspection
 ```
 
-The Procedure browser already accepts permanent Display identity as an entry input. Before changing Scan, confirm the exact operator-facing action behavior for Setup/Takedown/Inspection rather than inventing new routing or task semantics.
+The source candidate is already implemented on `agent/procedure-scan-action`; implementation commit `333f7c20a26e8ed2a0460ddbf309c167bffa2992`. The next step is not additional architecture reconnaissance: it is the documented Server Management deployment gate and regression acceptance.
 
 This work must not create:
 

--- a/Procedures/Application/README.md
+++ b/Procedures/Application/README.md
@@ -151,6 +151,42 @@ Result:
 PROCEDURE PRODUCTION DEPLOYMENT: ACCEPTED
 ```
 
+## Display Scan Entry Contract
+
+The Procedure page already owns operator task selection:
+
+```text
+What do you need to do?
+    Setup
+    Takedown
+    Inspection
+```
+
+Its existing deep-link behavior accepts permanent Display identity:
+
+```text
+/procedures/?display_id=<permanent display_id>
+```
+
+and optionally a task parameter when another approved caller has a reason to preselect one:
+
+```text
+/procedures/?display_id=<permanent display_id>&task=Setup
+/procedures/?display_id=<permanent display_id>&task=Takedown
+/procedures/?display_id=<permanent display_id>&task=Inspection
+```
+
+For the current Display Scan integration, the agreed UX is **one `Procedures` button** on the Display scan hub. It passes only `display_id` and leaves Setup/Takedown/Inspection selection inside this existing Procedure page. Scan does not duplicate these three task buttons and does not call the Procedure API merely to decide whether the button should render.
+
+Source candidate branch and implementation commit:
+
+```text
+agent/procedure-scan-action
+333f7c20a26e8ed2a0460ddbf309c167bffa2992
+```
+
+This is an application-source candidate until the Directus Scan deployment/regression gate is completed and accepted. The standalone Procedure service itself does not require redesign or redeployment for this Scan link.
+
 ## Tests
 
 Procedure-specific and shared integration tests live under:
@@ -165,7 +201,7 @@ The final production candidate was accepted together with the complete FieldWiri
 
 The standalone Procedure field-access application is production-operational. Remaining work is separate follow-on scope, including:
 
-- add Procedure actions to the existing Display Scan hub using permanent `display_id` without changing physical QR identity;
+- deploy and accept the additive Display Scan **Procedures** action through the current Server Management Directus Scan safety gate;
 - continue human Procedure-document authoring/alignment/archive work in Google `Display Folders`;
 - complete any broader PC/phone/tablet operator acceptance needed for the 2026 field workflow; and
 - engineer scheduling, pick/load, forklift, Container/Location, and other Setup/Deployment operational workflows separately from Procedure document lookup.
@@ -184,5 +220,6 @@ Read first:
 6. `FieldWiring/Application/field_context_repository.py`
 7. `Gregovate/MSB-Server-Management: docs/server/Procedure_Production_Runtime.md`
 8. `Gregovate/MSB-Server-Management: docs/server/Synology_Protected_Application_Reverse_Proxy.md`
+9. `Gregovate/MSB-Server-Management: docs/directus/Display_Scan_Extension_Deployment_and_Recovery.md` for the pending Scan source-candidate deployment.
 
 Historical dated Procedure acceptance documents in `12_Setup_and_Deployment/` remain valid as records of the engineering stages they describe; when they say deployment had not yet occurred, that statement applies to that historical acceptance stage, not the current production state.

--- a/Scan/directus-extension-scan/dist/index.js
+++ b/Scan/directus-extension-scan/dist/index.js
@@ -536,6 +536,7 @@ export default {
               <a class="btn" href="https://db.sheboyganlights.org/admin/content/display/${encodeURIComponent(display.display_id)}">Open Display Record</a>
               ${testButtonHtml}
               <a class="btn secondary" href="/fieldwiring/wiring.html?display_id=${encodeURIComponent(display.display_id)}">Field Wiring</a>
+              <a class="btn secondary" href="/procedures/?display_id=${encodeURIComponent(display.display_id)}">Procedures</a>
               <a class="btn secondary" href="/scan/DISP/${encodeURIComponent(display.display_id)}/container">Open Container</a>
                 ${woCount > 0
             ? `<a class="btn secondary" href="/scan/DISP/${encodeURIComponent(display.display_id)}/work-orders">

--- a/Scan/directus-extension-scan/src/index.js
+++ b/Scan/directus-extension-scan/src/index.js
@@ -536,6 +536,7 @@ export default {
               <a class="btn" href="https://db.sheboyganlights.org/admin/content/display/${encodeURIComponent(display.display_id)}">Open Display Record</a>
               ${testButtonHtml}
               <a class="btn secondary" href="/fieldwiring/wiring.html?display_id=${encodeURIComponent(display.display_id)}">Field Wiring</a>
+              <a class="btn secondary" href="/procedures/?display_id=${encodeURIComponent(display.display_id)}">Procedures</a>
               <a class="btn secondary" href="/scan/DISP/${encodeURIComponent(display.display_id)}/container">Open Container</a>
                 ${woCount > 0
             ? `<a class="btn secondary" href="/scan/DISP/${encodeURIComponent(display.display_id)}/work-orders">


### PR DESCRIPTION
## Summary

Adds the bounded Procedure Display Scan integration to the existing Display QR hub.

### Operator behavior

The Display hub gets one additive **Procedures** button:

```text
/procedures/?display_id=<permanent display_id>
```

The existing Procedure application continues to own the Setup / Takedown / Inspection task choice. Scan passes only permanent `display_id` and does not duplicate Procedure task-selection UI.

### Code change

- `Scan/directus-extension-scan/src/index.js`: +1 line
- `Scan/directus-extension-scan/dist/index.js`: +1 identical line
- both candidate files intentionally use the same Git blob
- no Scan route, database query, physical QR payload, resolver, schema, Google hierarchy, or Procedure API dependency changed

Application implementation commit:

```text
333f7c20a26e8ed2a0460ddbf309c167bffa2992
```

### Documentation

Updates the current Labeling/Scanning, deployed Scan boundary, Setup/Deployment, and Procedure application authorities so the settled UX and pending deployment state do not remain only in chat.

### Production state

This PR does **not** claim production deployment. Current accepted live Scan SHA-256 remains:

```text
b4f6c27f4880a8eaf8a90d8d55c7939c5bd190645dca9329344a86c3175cb20f
```

After merge, deployment must follow the current `MSB-Server-Management` Display Scan Extension Deployment and Recovery safety gate: verify live baseline, create a new timestamped rollback, stage/syntax-check, restart Directus, and regression-test existing Display Record, Testing, Container, Work Order, FieldWiring, manual/camera behavior as applicable plus the new Procedures action.
