### PR TITLE
Fix Scan field-app links for physical QR origin

### DIFF
--- a/Scan/directus-extension-scan/dist/index.js
+++ b/Scan/directus-extension-scan/dist/index.js
@@ -535,8 +535,8 @@ export default {
 
               <a class="btn" href="https://db.sheboyganlights.org/admin/content/display/${encodeURIComponent(display.display_id)}">Open Display Record</a>
               ${testButtonHtml}
-              <a class="btn secondary" href="/fieldwiring/wiring.html?display_id=${encodeURIComponent(display.display_id)}">Field Wiring</a>
-              <a class="btn secondary" href="/procedures/?display_id=${encodeURIComponent(display.display_id)}">Procedures</a>
+              <a class="btn secondary" href="https://my.sheboyganlights.org/fieldwiring/wiring.html?display_id=${encodeURIComponent(display.display_id)}">Field Wiring</a>
+              <a class="btn secondary" href="https://my.sheboyganlights.org/procedures/?display_id=${encodeURIComponent(display.display_id)}">Procedures</a>
               <a class="btn secondary" href="/scan/DISP/${encodeURIComponent(display.display_id)}/container">Open Container</a>
                 ${woCount > 0
             ? `<a class="btn secondary" href="/scan/DISP/${encodeURIComponent(display.display_id)}/work-orders">

--- a/Scan/directus-extension-scan/src/index.js
+++ b/Scan/directus-extension-scan/src/index.js
@@ -535,8 +535,8 @@ export default {
 
               <a class="btn" href="https://db.sheboyganlights.org/admin/content/display/${encodeURIComponent(display.display_id)}">Open Display Record</a>
               ${testButtonHtml}
-              <a class="btn secondary" href="/fieldwiring/wiring.html?display_id=${encodeURIComponent(display.display_id)}">Field Wiring</a>
-              <a class="btn secondary" href="/procedures/?display_id=${encodeURIComponent(display.display_id)}">Procedures</a>
+              <a class="btn secondary" href="https://my.sheboyganlights.org/fieldwiring/wiring.html?display_id=${encodeURIComponent(display.display_id)}">Field Wiring</a>
+              <a class="btn secondary" href="https://my.sheboyganlights.org/procedures/?display_id=${encodeURIComponent(display.display_id)}">Procedures</a>
               <a class="btn secondary" href="/scan/DISP/${encodeURIComponent(display.display_id)}/container">Open Container</a>
                 ${woCount > 0
             ? `<a class="btn secondary" href="/scan/DISP/${encodeURIComponent(display.display_id)}/work-orders">


### PR DESCRIPTION
Fixes #52.

Physical Display QR testing exposed that LabelPrintService currently prints full Scan URLs on `https://db.sheboyganlights.org/scan/...`. The existing root-relative FieldWiring link therefore resolved against the Directus origin and failed with `ROUTE_NOT_FOUND`. The newly added Procedures link would have failed the same way.

This PR changes only the two downstream field-app href values in both Git-controlled Scan files:

```text
Field Wiring -> https://my.sheboyganlights.org/fieldwiring/wiring.html?display_id=<id>
Procedures   -> https://my.sheboyganlights.org/procedures/?display_id=<id>
```

Directus-facing actions remain on `https://db.sheboyganlights.org/`. Existing printed QR labels remain usable. No QR reprint, resolver, schema, Procedure/FieldWiring service, nginx route, or database query change is included.

Source commit:

```text
7f8e63901d2c99b3821c3c3b8649e2042d745ddc
```

The old staged Procedure candidate `/tmp/directus-scan-index-0972db0.js` must NOT be deployed. After merge, stage the corrected `dist/index.js` from the new merge commit and continue the existing Server Management safety gate using the rollback already captured at:

```text
/home/msbadmin/backups/directus-scan/pre-procedures-20260824T004146Z/index.js
```

Physical QR regression from the `db.` label origin is required before production acceptance.

Cross-repository future QR-origin cleanup is tracked in `Gregovate/MSB_LabelPrintService` issue #2.