### PR TITLE
Fix FieldWiring Display scan operational scope

### DIFF
--- a/FieldWiring/Application/field_context_hierarchy.py
+++ b/FieldWiring/Application/field_context_hierarchy.py
@@ -124,6 +124,21 @@ def _context_summary(context: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _whole_scope_context_summary(context: dict[str, Any]) -> dict[str, Any]:
+    """Normalize raw LOR occurrence context to one Stage/Sub-stage package."""
+    summary = _context_summary(context)
+    summary.update(
+        {
+            "scene_uuid": None,
+            "scene_name": None,
+            "scene_stage_key": None,
+            "scene_background_file": None,
+            "scope_kind": "Stage / Preview",
+        }
+    )
+    return summary
+
+
 def _scene_child_from_pointer(
     context: dict[str, Any],
     owner_key: str,
@@ -204,23 +219,68 @@ def _scene_name_candidate(scene_name: str | None, owner_key: str, owner_label: s
     return name
 
 
+def _formal_scene_label(
+    context: dict[str, Any],
+    owner_key: str,
+    owner_label: str,
+) -> tuple[str | None, str | None]:
+    child_label, child_path = _scene_child_from_pointer(context, owner_key, owner_label)
+    if child_label is not None:
+        return child_label, child_path
+    scene = context.get("scene") or {}
+    return _scene_name_candidate(scene.get("scene_name"), owner_key, owner_label), None
+
+
+def resolve_display_operational_context(shared: dict[str, Any]) -> dict[str, Any] | None:
+    """Resolve one Display to its formal operational wiring context.
+
+    Raw LOR Scene records are evidence, not automatic field Scene ownership.
+    A Display narrows to Scene only when the shared hierarchy rules prove a
+    formal Scene.  Otherwise the selected Preview is retained while Scene is
+    cleared so callers load the whole owning Stage/Sub-stage package.
+    """
+    stage = shared.get("stage") or {}
+    contexts = list(shared.get("contexts") or [])
+    if not contexts:
+        return None
+
+    owner_key = str(stage.get("stage_key") or "").strip()
+    owner_label, _, _ = _node_label_and_path(stage, contexts)
+
+    for context in contexts:
+        child_label, _ = _formal_scene_label(context, owner_key, owner_label)
+        if child_label is None:
+            continue
+        selected = dict(context)
+        scene = dict(selected.get("scene") or {})
+        scene["scene_name"] = child_label
+        selected["scene"] = scene
+        selected["scope_kind"] = "Scene"
+        return selected
+
+    selected = dict(contexts[0])
+    selected["scene"] = None
+    selected["scope_kind"] = "Stage / Preview"
+    return selected
+
+
 def _attach_contexts(node: dict[str, Any], contexts: list[dict[str, Any]]) -> None:
     owner_key = str(node.get("stage_key") or "")
     owner_label = str(node.get("label") or "")
     scene_nodes: dict[str, dict[str, Any]] = {}
+    whole_context_keys: set[tuple[str, str]] = set()
 
     for context in contexts:
-        child_label, child_path = _scene_child_from_pointer(context, owner_key, owner_label)
-        if child_label is None:
-            scene = context.get("scene") or {}
-            child_label = _scene_name_candidate(
-                scene.get("scene_name"),
-                owner_key,
-                owner_label,
-            )
+        child_label, child_path = _formal_scene_label(context, owner_key, owner_label)
 
         if child_label is None:
-            node["contexts"].append(_context_summary(context))
+            summary = _whole_scope_context_summary(context)
+            preview_identity = str(summary.get("preview_uuid") or summary.get("preview_name") or "")
+            context_identity = str(summary.get("context_type") or "")
+            key = (preview_identity, context_identity)
+            if key not in whole_context_keys:
+                whole_context_keys.add(key)
+                node["contexts"].append(summary)
             continue
 
         key = child_label.casefold()

--- a/FieldWiring/Application/repository.py
+++ b/FieldWiring/Application/repository.py
@@ -5,6 +5,7 @@ import sqlite3
 from pathlib import Path
 from typing import Any
 
+from field_context_hierarchy import resolve_display_operational_context
 from field_context_repository import (
     ConfigError,
     PostgresFieldContextRepository,
@@ -21,8 +22,7 @@ def _flatten_fieldwiring_context(
 ) -> dict[str, Any]:
     """Adapt shared identity/context facts to FieldWiring's legacy flat shape."""
     stage = shared.get("stage") or {}
-    contexts = shared.get("contexts") or []
-    selected = contexts[0] if contexts else None
+    selected = resolve_display_operational_context(shared)
     preview = (selected or {}).get("preview") or {}
     scene = (selected or {}).get("scene") or {}
     scene_name = scene.get("scene_name")

--- a/FieldWiring/Application/test_field_context_hierarchy.py
+++ b/FieldWiring/Application/test_field_context_hierarchy.py
@@ -1,4 +1,7 @@
-from field_context_hierarchy import build_field_hierarchy
+from field_context_hierarchy import (
+    build_field_hierarchy,
+    resolve_display_operational_context,
+)
 
 
 def context(
@@ -168,7 +171,9 @@ def test_stage_binding_scene_collapses_to_stage_context_when_path_has_no_child()
 
     stage = result["stages"][0]
     assert stage["scenes"] == []
-    assert [item["scene_name"] for item in stage["contexts"]] == ["15-Church-CH"]
+    assert [item["scene_name"] for item in stage["contexts"]] == [None]
+    assert [item["scene_uuid"] for item in stage["contexts"]] == [None]
+    assert [item["scope_kind"] for item in stage["contexts"]] == ["Stage / Preview"]
 
 
 def test_scene_child_is_derived_from_path_string_not_drive_enumeration():
@@ -222,7 +227,7 @@ def test_background_filename_with_stage_prefix_is_not_promoted_to_scene():
 
     stage = result["stages"][0]
     assert stage["scenes"] == []
-    assert [item["scene_name"] for item in stage["contexts"]] == ["03-Welcome Area"]
+    assert [item["scene_name"] for item in stage["contexts"]] == [None]
 
 
 def test_legacy_nested_scene_with_short_code_is_retained_when_path_proves_child():
@@ -276,7 +281,135 @@ def test_unprefixed_lor_group_is_context_evidence_not_browse_scene():
 
     stage = result["stages"][0]
     assert stage["scenes"] == []
-    assert [item["scene_name"] for item in stage["contexts"]] == ["Anna"]
+    assert [item["scene_name"] for item in stage["contexts"]] == [None]
+
+
+def test_duplicate_nonformal_lor_scenes_collapse_to_one_whole_stage_context():
+    result = build_field_hierarchy(
+        [
+            raw_stage(
+                54,
+                "24",
+                "Show Background Stage 24 Traditional Christmas",
+                r"G:\Shared drives\Display Folders\24-Traditional Christmas-TC",
+                [
+                    context(
+                        "ChristmasHippo",
+                        stage_key="24",
+                        path=(
+                            r"G:\Shared drives\Display Folders\24-Traditional Christmas-TC"
+                            r"\ChristmasHippo\PreviewBackground\Hippo.jpg"
+                        ),
+                        context_type="Background / Static",
+                        preview_uuid="preview-24-background",
+                        scene_uuid="scene-hippo",
+                    ),
+                    context(
+                        "ChristmasTree",
+                        stage_key="24",
+                        path=(
+                            r"G:\Shared drives\Display Folders\24-Traditional Christmas-TC"
+                            r"\ChristmasTree\PreviewBackground\Tree.jpg"
+                        ),
+                        context_type="Background / Static",
+                        preview_uuid="preview-24-background",
+                        scene_uuid="scene-tree",
+                    ),
+                    context(
+                        "24-Nutcracker-Ornaments",
+                        stage_key="24",
+                        path=(
+                            r"G:\Shared drives\Display Folders\24-Traditional Christmas-TC"
+                            r"\24-Nutcracker-Ornaments\PreviewBackground\Nutcracker.jpg"
+                        ),
+                        context_type="Background / Static",
+                        preview_uuid="preview-24-background",
+                        scene_uuid="scene-nutcracker",
+                    ),
+                    context(
+                        "24-SnowFamily and 10YrStocking",
+                        stage_key="24",
+                        path=(
+                            r"G:\Shared drives\Display Folders\24-Traditional Christmas-TC"
+                            r"\24-SnowFamily and 10YrStocking\PreviewBackground\Snow.jpg"
+                        ),
+                        context_type="Background / Static",
+                        preview_uuid="preview-24-background",
+                        scene_uuid="scene-snow",
+                    ),
+                ],
+            )
+        ]
+    )
+
+    stage = result["stages"][0]
+    assert len(stage["contexts"]) == 1
+    assert stage["contexts"][0]["scene_uuid"] is None
+    assert stage["contexts"][0]["scene_name"] is None
+    assert [scene["label"] for scene in stage["scenes"]] == [
+        "24-Nutcracker-Ornaments",
+        "24-SnowFamily and 10YrStocking",
+    ]
+
+
+def test_display_with_unprefixed_lor_scene_resolves_to_whole_stage_package():
+    shared = raw_stage(
+        54,
+        "24",
+        "Show Background Stage 24 Traditional Christmas",
+        r"G:\Shared drives\Display Folders\24-Traditional Christmas-TC",
+        [
+            context(
+                "ChristmasHippo",
+                stage_key="24",
+                path=(
+                    r"G:\Shared drives\Display Folders\24-Traditional Christmas-TC"
+                    r"\ChristmasHippo\PreviewBackground\Hippo.jpg"
+                ),
+                context_type="Background / Static",
+                preview_uuid="preview-24-background",
+                scene_uuid="scene-hippo",
+            )
+        ],
+    )
+    shared.update({"display_id": 141, "display_name": "TC-ChristmasHippo"})
+
+    selected = resolve_display_operational_context(shared)
+
+    assert selected is not None
+    assert selected["scope_kind"] == "Stage / Preview"
+    assert selected["preview"]["preview_uuid"] == "preview-24-background"
+    assert selected["scene"] is None
+
+
+def test_display_in_formal_scene_resolves_to_entire_scene_package():
+    shared = raw_stage(
+        54,
+        "24",
+        "Show Background Stage 24 Traditional Christmas",
+        r"G:\Shared drives\Display Folders\24-Traditional Christmas-TC",
+        [
+            context(
+                "24-Nutcracker-Ornaments",
+                stage_key="24",
+                path=(
+                    r"G:\Shared drives\Display Folders\24-Traditional Christmas-TC"
+                    r"\24-Nutcracker-Ornaments\PreviewBackground\Nutcracker.jpg"
+                ),
+                context_type="Background / Static",
+                preview_uuid="preview-24-background",
+                scene_uuid="scene-nutcracker",
+            )
+        ],
+    )
+    shared.update({"display_id": 142, "display_name": "TC-Nutcracker-01"})
+
+    selected = resolve_display_operational_context(shared)
+
+    assert selected is not None
+    assert selected["scope_kind"] == "Scene"
+    assert selected["scene"]["scene_uuid"] == "scene-nutcracker"
+    assert selected["scene"]["scene_name"] == "24-Nutcracker-Ornaments"
 
 
 def test_animation_only_rows_without_physical_stage_path_are_excluded():

--- a/FieldWiring/Application/test_operational_wiring_scope.py
+++ b/FieldWiring/Application/test_operational_wiring_scope.py
@@ -1,0 +1,135 @@
+from field_context_hierarchy import build_field_hierarchy
+from repository import _flatten_fieldwiring_context
+
+
+def _context(
+    scene_name: str,
+    *,
+    scene_uuid: str,
+    path: str,
+    preview_uuid: str = "preview-24-background",
+):
+    return {
+        "preview": {
+            "preview_uuid": preview_uuid,
+            "preview_name": "Show Background Stage 24 Traditional Christmas",
+            "preview_background_file": None,
+        },
+        "scene": {
+            "scene_uuid": scene_uuid,
+            "scene_name": scene_name,
+            "scene_stage_key": "24",
+            "scene_background_file": path,
+        },
+        "scope_kind": "Scene",
+        "context_type": "Background / Static",
+    }
+
+
+def _shared_display(contexts):
+    return {
+        "display_id": 141,
+        "display_name": "TC-ChristmasHippo",
+        "stage": {
+            "stage_id": 54,
+            "stage_key": "24",
+            "stage_name": "Show Background Stage 24 Traditional Christmas",
+            "folder_path": r"G:\Shared drives\Display Folders\24-Traditional Christmas-TC",
+        },
+        "contexts": contexts,
+    }
+
+
+def test_display_adapter_uses_whole_stage_for_unprefixed_lor_scene():
+    shared = _shared_display(
+        [
+            _context(
+                "ChristmasHippo",
+                scene_uuid="scene-hippo",
+                path=(
+                    r"G:\Shared drives\Display Folders\24-Traditional Christmas-TC"
+                    r"\ChristmasHippo\PreviewBackground\Hippo.jpg"
+                ),
+            )
+        ]
+    )
+
+    result = _flatten_fieldwiring_context(shared, "LOR")
+
+    assert result["display_id"] == 141
+    assert result["preview_uuid"] == "preview-24-background"
+    assert result["scene_uuid"] is None
+    assert result["scene_name"] is None
+    assert result["scope_kind"] == "Stage / Preview"
+    assert result["context_type"] == "Background / Static"
+
+
+def test_display_adapter_keeps_formal_scene_scope():
+    shared = _shared_display(
+        [
+            _context(
+                "24-Nutcracker-Ornaments",
+                scene_uuid="scene-nutcracker",
+                path=(
+                    r"G:\Shared drives\Display Folders\24-Traditional Christmas-TC"
+                    r"\24-Nutcracker-Ornaments\PreviewBackground\Nutcracker.jpg"
+                ),
+            )
+        ]
+    )
+
+    result = _flatten_fieldwiring_context(shared, "LOR")
+
+    assert result["scene_uuid"] == "scene-nutcracker"
+    assert result["scene_name"] == "24-Nutcracker-Ornaments"
+    assert result["scope_kind"] == "Scene"
+
+
+def test_stage24_browse_has_one_whole_stage_and_two_formal_scenes():
+    contexts = [
+        _context(
+            "ChristmasHippo",
+            scene_uuid="scene-hippo",
+            path=(
+                r"G:\Shared drives\Display Folders\24-Traditional Christmas-TC"
+                r"\ChristmasHippo\PreviewBackground\Hippo.jpg"
+            ),
+        ),
+        _context(
+            "ChristmasTree",
+            scene_uuid="scene-tree",
+            path=(
+                r"G:\Shared drives\Display Folders\24-Traditional Christmas-TC"
+                r"\ChristmasTree\PreviewBackground\Tree.jpg"
+            ),
+        ),
+        _context(
+            "24-Nutcracker-Ornaments",
+            scene_uuid="scene-nutcracker",
+            path=(
+                r"G:\Shared drives\Display Folders\24-Traditional Christmas-TC"
+                r"\24-Nutcracker-Ornaments\PreviewBackground\Nutcracker.jpg"
+            ),
+        ),
+        _context(
+            "24-SnowFamily and 10YrStocking",
+            scene_uuid="scene-snow",
+            path=(
+                r"G:\Shared drives\Display Folders\24-Traditional Christmas-TC"
+                r"\24-SnowFamily and 10YrStocking\PreviewBackground\Snow.jpg"
+            ),
+        ),
+    ]
+    raw = {
+        "stage": _shared_display([])["stage"],
+        "contexts": contexts,
+    }
+
+    stage = build_field_hierarchy([raw])["stages"][0]
+
+    assert len(stage["contexts"]) == 1
+    assert stage["contexts"][0]["scene_uuid"] is None
+    assert [scene["label"] for scene in stage["scenes"]] == [
+        "24-Nutcracker-Ornaments",
+        "24-SnowFamily and 10YrStocking",
+    ]

--- a/FieldWiring/Application/test_repository.py
+++ b/FieldWiring/Application/test_repository.py
@@ -96,13 +96,13 @@ def test_canonical_display_id_lookup(repo):
     assert [row["display_id"] for row in rows] == [309]
 
 
-def test_display_context_is_field_friendly(repo):
+def test_display_context_treats_stage_binding_lor_scene_as_stage_scope(repo):
     context = repo.display_context(309)
     assert context is not None
     assert context["stage_key"] == "15"
-    assert context["scene_name"] == "15-Church-CH"
+    assert context["scene_name"] is None
     assert context["context_type"] == "Musical"
-    assert context["scope_kind"] == "Scene"
+    assert context["scope_kind"] == "Stage / Preview"
 
 
 def test_inventory_only_display_resolves_shared_context_but_not_fieldwiring(repo):

--- a/FieldWiring/Application/test_wiring_data_scope.py
+++ b/FieldWiring/Application/test_wiring_data_scope.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import sqlite3
+from contextlib import contextmanager
+
+from wiring_data import load_wiring_data
+
+
+class SQLiteSnapshotRepository:
+    def __init__(self, path):
+        self.path = path
+
+    @contextmanager
+    def connect(self):
+        conn = sqlite3.connect(self.path)
+        conn.row_factory = sqlite3.Row
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+
+def test_whole_preview_package_is_bounded_to_resolved_stage(tmp_path):
+    path = tmp_path / "scope.db"
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE lor_snap__v_current_previews (
+            import_run_id INTEGER, id TEXT, name TEXT, revision TEXT,
+            background_file TEXT, source_filename TEXT
+        );
+        CREATE TABLE ref__stage (
+            stage_id INTEGER PRIMARY KEY, stage_key TEXT, stage_name TEXT,
+            folder_path TEXT
+        );
+        CREATE TABLE ref__display (
+            display_id INTEGER PRIMARY KEY, display_name TEXT, stage_id INTEGER,
+            lor_prop_id TEXT, display_status_id INTEGER
+        );
+        CREATE TABLE lor_snap__v_current_props (
+            preview_id TEXT, prop_id TEXT, raw_prop_id TEXT, lor_comment TEXT,
+            string_type TEXT, device_type TEXT
+        );
+        CREATE TABLE lor_snap__preview_wiring_fieldlead_v6 (
+            preview_name TEXT, source TEXT, channel_name TEXT, display_name TEXT,
+            network TEXT, controller TEXT, start_channel INTEGER, end_channel INTEGER,
+            color TEXT, device_type TEXT, lor_tag TEXT, connection_type TEXT,
+            cross_display INTEGER, lead_rank INTEGER
+        );
+        CREATE TABLE lor_snap__v_current_run (
+            import_run_id INTEGER, run_ts TEXT, parser_version TEXT,
+            parser_completed_at TEXT, source_preview_folder TEXT,
+            ingest_script_version TEXT, ingest_completed_at TEXT
+        );
+        CREATE TABLE lor_snap__v_current_scenes (
+            preview_id TEXT, scene_id TEXT, name TEXT, stage_id TEXT,
+            background_file TEXT
+        );
+        CREATE TABLE lor_snap__v_current_scene_lor_props (
+            preview_id TEXT, scene_id TEXT, prop_id TEXT, raw_prop_id TEXT
+        );
+
+        INSERT INTO lor_snap__v_current_previews
+        VALUES (51, 'shared-preview', 'Shared Master Preview', '1', NULL, 'shared.lorprev');
+        INSERT INTO lor_snap__v_current_run
+        VALUES (51, 'x', 'V7.0.11', 'x', 'folder', 'V0.4.2', 'x');
+
+        INSERT INTO ref__stage VALUES (24, '24', 'Traditional Christmas', 'stage24');
+        INSERT INTO ref__stage VALUES (25, '25', 'Other Stage', 'stage25');
+
+        INSERT INTO ref__display VALUES (141, 'TC-ChristmasHippo', 24, 'raw-141', 1);
+        INSERT INTO ref__display VALUES (999, 'OTHER-Display', 25, 'raw-999', 1);
+
+        INSERT INTO lor_snap__v_current_props
+        VALUES ('shared-preview', 'p141', 'raw-141', 'TC-ChristmasHippo', 'Traditional', 'LOR');
+        INSERT INTO lor_snap__v_current_props
+        VALUES ('shared-preview', 'p999', 'raw-999', 'OTHER-Display', 'Traditional', 'LOR');
+
+        INSERT INTO lor_snap__preview_wiring_fieldlead_v6
+        VALUES ('Shared Master Preview', 'PROP', 'Hippo', 'TC-ChristmasHippo',
+                'Regular', '7B', 1, 1, NULL, 'LOR', '', 'FIELD', 0, 1);
+        INSERT INTO lor_snap__preview_wiring_fieldlead_v6
+        VALUES ('Shared Master Preview', 'PROP', 'Other', 'OTHER-Display',
+                'Regular', '7C', 1, 1, NULL, 'LOR', '', 'FIELD', 0, 1);
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    package = load_wiring_data(
+        SQLiteSnapshotRepository(path),
+        "shared-preview",
+        None,
+        24,
+    )
+
+    assert package["scene"] is None
+    assert [row["display_id"] for row in package["rows"]] == [141]
+    assert [row["display_name"] for row in package["rows"]] == ["TC-ChristmasHippo"]

--- a/FieldWiring/Application/wiring_data.py
+++ b/FieldWiring/Application/wiring_data.py
@@ -85,6 +85,9 @@ def _sqlite_package(repo: Any, preview_uuid: str, scene_uuid: str | None, stage_
             """
             rows = _sqlite_rows(conn, members_sql, (preview_uuid, scene_uuid, preview["preview_name"]))
         else:
+            # Whole Stage/Sub-stage scope must remain bounded to the resolved
+            # Production Database stage_id even when the selected Preview is a
+            # shared/master Preview containing Displays from other Stages.
             members_sql = """
                 WITH members AS (
                     SELECT DISTINCT d.display_id,
@@ -93,6 +96,7 @@ def _sqlite_package(repo: Any, preview_uuid: str, scene_uuid: str | None, stage_
                     FROM lor_snap__v_current_props p
                     JOIN ref__display d ON d.lor_prop_id = p.raw_prop_id
                     WHERE p.preview_id = ?
+                      AND d.stage_id = ?
                       AND d.display_status_id = 1
                       AND upper(coalesce(p.device_type, '')) <> 'NONE'
                 )
@@ -107,7 +111,7 @@ def _sqlite_package(repo: Any, preview_uuid: str, scene_uuid: str | None, stage_
                  AND fw.display_name = replace(trim(m.lor_comment), ' ', '-')
                 ORDER BY fw.network, fw.controller, fw.start_channel, m.production_display_name
             """
-            rows = _sqlite_rows(conn, members_sql, (preview_uuid, preview["preview_name"]))
+            rows = _sqlite_rows(conn, members_sql, (preview_uuid, stage_id, preview["preview_name"]))
 
         run = _sqlite_one(conn, """
             SELECT import_run_id, run_ts, parser_version, parser_completed_at,
@@ -183,6 +187,9 @@ def _postgres_package(repo: Any, preview_uuid: str, scene_uuid: str | None, stag
                     ORDER BY fw.network, fw.controller, fw.start_channel, m.production_display_name
                 """, (preview_uuid, scene_uuid, preview["preview_name"]))
             else:
+                # Whole Stage/Sub-stage scope must remain bounded to the resolved
+                # Production Database stage_id even when the selected Preview is a
+                # shared/master Preview containing Displays from other Stages.
                 cur.execute("""
                     WITH members AS (
                         SELECT DISTINCT d.display_id,
@@ -191,6 +198,7 @@ def _postgres_package(repo: Any, preview_uuid: str, scene_uuid: str | None, stag
                         FROM lor_snap.v_current_props p
                         JOIN ref.display d ON d.lor_prop_id = p.raw_prop_id
                         WHERE p.preview_id = %s
+                          AND d.stage_id = %s
                           AND d.display_status_id = 1
                           AND upper(coalesce(p.device_type, '')) <> 'NONE'
                     )
@@ -204,7 +212,7 @@ def _postgres_package(repo: Any, preview_uuid: str, scene_uuid: str | None, stag
                       ON fw.preview_name = %s
                      AND fw.display_name = replace(btrim(m.lor_comment), ' ', '-')
                     ORDER BY fw.network, fw.controller, fw.start_channel, m.production_display_name
-                """, (preview_uuid, preview["preview_name"]))
+                """, (preview_uuid, stage_id, preview["preview_name"]))
             rows = [dict(row) for row in cur.fetchall()]
 
             cur.execute("""


### PR DESCRIPTION
Fixes #55.

Physical Display QR testing exposed that FieldWiring was treating any non-Root LOR Scene occurrence as an operational field Scene. That caused `DISP:141` / `TC-ChristmasHippo` to show Hippo-only wiring even though ChristmasHippo is not one of Stage 24's formal Scenes, and it caused repeated `Whole Stage` cards in Stage browse.

## Governing behavior

A Display scan is a shortcut to the operational wiring package, not a one-Display wiring lookup:

- formal Scene -> entire Scene package;
- formal Sub-stage with no narrower Scene -> entire Sub-stage package;
- otherwise -> entire Stage package;
- scanned Display remains available for highlighting inside the package;
- `Find another` is the deliberate reset to resolve another area.

## Candidate changes

- raw LOR Scene occurrence no longer automatically creates field Scene ownership;
- a Display narrows to Scene only when the existing formal hierarchy/path rules prove that Scene;
- otherwise the Preview is retained but Scene is cleared so the whole owning Stage/Sub-stage package is loaded;
- non-formal LOR contexts for the same Preview/context type collapse to one whole-area browse context;
- formal Scenes remain separate;
- whole Stage/Sub-stage wiring-row loading is additionally bounded by the resolved Production Database `stage_id`, so clearing a raw Scene cannot widen a shared/master Preview into other Stages;
- no parser, PostgreSQL schema, QR payload, physical label, Google Drive hierarchy, Scan extension, Procedure service, or Controller Inventory change is included.

## Regression coverage

Added/updated tests cover:

- unprefixed `ChristmasHippo` -> whole Stage package;
- formal `24-Nutcracker-Ornaments` -> Scene package;
- multiple non-formal Stage 24 LOR contexts -> one Whole Stage choice;
- the two formal Stage 24 Scenes remain separate;
- repository adapter deep-link context preserves the scanned Display while clearing non-formal Scene scope;
- whole-scope loading from a shared Preview returns only Displays whose `ref.display.stage_id` matches the resolved Stage;
- accepted Stage-root binding case `15-Church-CH` remains raw LOR evidence but resolves operationally to Stage scope.

## Test-gate history

First full production-environment candidate run against `c411ad620d9f981a5c902772e9eedd73c87b70f1`:

```text
1 failed, 111 passed in 2.22s
```

The only failure was an older regression that still expected `15-Church-CH` to be exposed as a Scene. That conflicts with the already accepted Stage 15 Stage-root deduplication contract. The stale expectation was corrected without changing raw LOR evidence behavior.

Final pre-merge candidate head:

```text
8ddc63b6c41c80385075b9ee845f25fa11cac6f5
```

Final production-environment regression using detached temporary worktrees under the documented root-through-`sudo git` checkout administration boundary:

```text
FieldWiring: 112 passed in 2.12s
Procedures:   45 passed in 0.16s
Combined:    157 passed
```

The live production checkout remained at `9a19639ae0af6cd5bbaf162fe236e14c1b88722d` on `agent/fieldwiring-server-deployment-reconnaissance`; neither `fieldwiring.service` nor `msb-procedures.service` was restarted during candidate testing.

Production deployment must follow `Gregovate/MSB-Server-Management/docs/server/FieldWiring_Production_Runtime.md`, including the recovered root-through-`sudo git` checkout administration pattern, exact merged-main SHA verification, no parent-shell `exit`, PostgreSQL health, representative live behavior, and documented rollback.