### PR TITLE
Clarify Google Drive operator instructions

### DIFF
--- a/Docs/00_Project_Overview/Google_Drive/README.md
+++ b/Docs/00_Project_Overview/Google_Drive/README.md
@@ -48,22 +48,6 @@ The normal team workflow should use those field systems to find current Wiring a
 
 Putting a current field document in `Archive` or `SourceDocs` can prevent the field application from presenting it as current material.
 
-## Documentation Layout
-
-```text
-Google_Drive/
-├── README.md                  this operator/user portal
-├── operatorSOP/
-│   ├── README.md              operator procedure index
-│   └── ...
-├── engineering/
-│   ├── README.md              engineering handoff
-│   └── ...
-└── images/                    Google Drive documentation images
-```
-
-The `images/` folder above contains images used by repository documentation. It is separate from field-content folders such as `Procedures\Setup\images` inside the Google Shared Drive.
-
 ## Engineering
 
 Engineering documentation is intentionally separate from the operator procedures.

--- a/Docs/00_Project_Overview/Google_Drive/operatorSOP/Align_Legacy_Setup_Documents.md
+++ b/Docs/00_Project_Overview/Google_Drive/operatorSOP/Align_Legacy_Setup_Documents.md
@@ -8,7 +8,7 @@
 | Audience | Production documentation maintainers and Folder Alignment reviewers |
 | Status | CURRENT |
 | Owner | Production documentation owner / administrator |
-| Last Reviewed | 2026-08-23 |
+| Last Reviewed | 2026-08-24 |
 | Keywords | legacy Setup, Google Drive, Archive, Folder Alignment, Stage, Scene |
 
 [↑ Google Drive / Display Folder Operations](../README.md)
@@ -21,7 +21,7 @@ This task records **where the old document belongs**. It does not make the old d
 
 ## Before You Start
 
-- Open the current **Documentation Alignment Worklist**.
+- Open the current [**Documentation Alignment Worklist**](../../../01_LOR_System/02_Data_Extraction/Folder_Alignment/operatorSOP/Review_Folder_Alignment_Worklist.md). If you need a fresh worklist, use [Run Folder Alignment](../../../01_LOR_System/02_Data_Extraction/Folder_Alignment/operatorSOP/Run_Folder_Alignment.md).
 - Work on one Stage at a time.
 - Use the real current Stage/Scene organization, not only a similar filename.
 - If ownership is uncertain, leave the document where it is and flag it for review.

--- a/Docs/01_LOR_System/02_Data_Extraction/Folder_Alignment/README.md
+++ b/Docs/01_LOR_System/02_Data_Extraction/Folder_Alignment/README.md
@@ -33,22 +33,6 @@ Use the responsible Google Drive operator procedure
 Run Folder Alignment again when a fresh worklist is useful
 ```
 
-## Documentation Layout
-
-```text
-Folder_Alignment/
-├── README.md                  this operator/user portal
-├── operatorSOP/
-│   ├── README.md              operator procedure index
-│   └── ...
-├── engineering/
-│   ├── README.md              engineering handoff
-│   └── ...
-└── images/                    Folder Alignment documentation images, when needed
-```
-
-The Python implementation remains in the subsystem root. Operator documentation does not explain or require understanding that implementation.
-
 ## Engineering
 
 For design, resolver/classification behavior, report model, regression fixtures, or code changes, use:


### PR DESCRIPTION
## Purpose

Small follow-up to merged PR #62 to remove repository-layout information from operator-facing Google Drive / Folder Alignment portals and make the legacy Setup workflow link directly to the current Folder Alignment worklist procedure.

## Changes

- Remove the Git repository `README/operatorSOP/engineering/images` tree from the Google Drive operator portal. That structure belongs to repository documentation governance/engineering, not to instructions about the Google Shared Drive.
- Remove the same repository-layout section from the Folder Alignment operator portal.
- Link **Documentation Alignment Worklist** in `Align_Legacy_Setup_Documents.md` to the current Folder Alignment review procedure.
- Add a separate **Run Folder Alignment** link for generating a fresh worklist when needed.
- Leave the correct field-content example under `Procedures\Setup` unchanged.

## Boundary

Documentation clarity only. No application, schema, parser, Folder Alignment script, launcher, Google Drive runtime hierarchy, or Backbone behavior changes.