### PR TITLE
Add issue management and closeout governance

### DIFF
--- a/System_Documentation/Project_Rules/Issue_Management_and_Closeout_Rule.md
+++ b/System_Documentation/Project_Rules/Issue_Management_and_Closeout_Rule.md
@@ -1,0 +1,93 @@
+# Issue Management and Closeout Rule
+
+| Document Control | Value |
+|---|---|
+| Document Type | Project Rule |
+| Repository | MSB Production Database Project |
+| Status | CURRENT |
+| Owner | Production project owner / administrator |
+| Last Reviewed | 2026-08-24 |
+
+## Purpose
+
+This rule defines how GitHub issues are used and closed in the MSB Production Database Project so the issue list remains a useful record of real remaining work rather than an accumulating history of every discussion point.
+
+Issues are durable work items. They are not a substitute for controlled repository documentation.
+
+## When to Create an Issue
+
+Create a separate issue when the work can reasonably be scheduled, implemented, accepted, deferred, or closed independently from the current work item.
+
+Examples include:
+
+- a separate application retirement;
+- a database compatibility migration;
+- a distinct subsystem documentation conversion;
+- a production defect requiring its own validation and acceptance; or
+- future engineering work that should remain visible after the current project closes.
+
+Do not create a new issue merely because a useful thought, discovery, or small follow-up occurred during a conversation. When the item belongs to an existing active issue, add it to that issue's scope, checklist, or comments as appropriate.
+
+## Issues Do Not Replace Documentation
+
+A GitHub issue records work to be done and its completion state. It does not become the authoritative location for architecture, operating rules, procedures, current production facts, naming rules, or other durable project knowledge.
+
+When work or discussion establishes information that belongs in controlled documentation, follow the Documentation Maintenance Rule and update the responsible repository document during the work.
+
+A comment on an issue may preserve context for the work item, but it is not a substitute for updating the controlled document that owns the rule or system fact.
+
+## Keep Related Work Together
+
+Prefer one active issue for one coherent piece of work.
+
+Use an umbrella issue when a larger project contains several independently completable work items. Create child/separate issues only when those items truly need independent scheduling, acceptance, or closeout.
+
+Do not split one normal engineering task into many small issues solely to record every finding.
+
+## Closeout Is Part of the Work
+
+An issue is not finished merely because the code, documentation, or deployment change was made.
+
+Before leaving a completed work item:
+
+1. review the issue's acceptance criteria and current comments;
+2. confirm the responsible controlled documentation has been updated for durable discoveries or decisions;
+3. identify the pull request, merge commit, deployment acceptance, or other evidence that completed the work;
+4. record any deliberately deferred item and create a separate issue only when it is truly independent future work;
+5. close duplicate, superseded, completed, or no-longer-planned issues using the appropriate GitHub close reason; and
+6. leave an issue open only when real work remains, with a clear next step or unresolved acceptance item.
+
+The goal is that the open-issue list represents actual remaining work.
+
+## Sub-project Closeout Review
+
+Before a project or sub-project is considered complete, review the GitHub issues associated with that work.
+
+Each related issue must be in one of these states:
+
+- **Closed — completed:** its acceptance criteria are satisfied and the durable repository documentation is current.
+- **Closed — duplicate/not planned:** the issue is no longer an independent work item and the reason is recorded.
+- **Open — real work remains:** the remaining scope and next step are explicit.
+
+Do not leave completed issues open merely because issue cleanup was deferred to a later conversation.
+
+## Relationship to Documentation Closeout
+
+Issue closeout and documentation closeout are separate requirements that support each other:
+
+```text
+engineering discovery / decision
+    -> update responsible controlled documentation
+
+work item completed
+    -> record acceptance/evidence
+    -> close or deliberately retain the GitHub issue
+```
+
+Neither step replaces the other.
+
+## Related Standards and Rules
+
+- [Documentation Maintenance Rule](../Standards/Documentation_Maintenance_Rule.md)
+- [Repository Change Workflow](Repository_Change_Workflow.md)
+- [Documentation Subsystem Conversion Tracker](Documentation_Subsystem_Conversion_Tracker.md)

--- a/System_Documentation/Project_Rules/README.md
+++ b/System_Documentation/Project_Rules/README.md
@@ -7,6 +7,7 @@ Reusable rules that should apply across multiple repositories belong under [`../
 ## Current Project Rules
 
 - [Repository Change Workflow](Repository_Change_Workflow.md) — requires refreshing current remote `main`, reviewing the latest affected files, and resolving stale-branch/concurrent-work issues before changing code, schema, configuration, or controlled documentation.
+- [Issue Management and Closeout Rule](Issue_Management_and_Closeout_Rule.md) — defines when a separate GitHub issue is warranted, requires durable discoveries to be promoted into controlled documentation rather than left only in issues/chat, and makes issue review/closure part of project and sub-project closeout.
 - [Production Operational Documentation Rule](Operational_Documentation_Rule.md) — defines Production-specific SOP ownership, `my.sheboyganlights.org` discovery, Display Folder procedure boundaries, and the rule that the existing central SOP tree is not the mandatory home for every operator procedure.
 - [Stage Setup Documentation Standard](Stage_Setup_Documentation_Standard.md) — governs how Stage/Scene setup instructions relate to the established Google Shared Drive structure, controlled templates, Production Database identity, QR resolution, and the `my.sheboyganlights.org` presentation layer.
 


### PR DESCRIPTION
## Purpose

Add a Production Database project rule for GitHub issue lifecycle so completed work does not accumulate as stale open issues and so issue comments are not mistaken for durable system documentation.

## Changes

- adds `System_Documentation/Project_Rules/Issue_Management_and_Closeout_Rule.md`;
- defines when a separate issue is warranted versus adding scope/context to an existing issue;
- makes issue review and closure part of project/sub-project closeout;
- explicitly states that durable discoveries and accepted decisions must still be promoted into the responsible controlled repository documentation;
- links the new rule from the Project Rules portal.

## Relationship to current documentation reconciliation

This is a focused governance correction discovered during issue #49. It does **not** settle the still-open LOR-vs-Production-Database documentation-tree question and does not change application/documentation placement.

Related: #49
