### PR TITLE
Add Scan operator documentation foundation

### DIFF
--- a/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/Scan_Operator_Documentation_and_Backbone_Handoff.md
+++ b/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/Scan_Operator_Documentation_and_Backbone_Handoff.md
@@ -1,0 +1,185 @@
+# Scan Operator Documentation and Backbone Handoff
+
+| Document Control | Value |
+|---|---|
+| Document Type | Engineering / Documentation Handoff |
+| System | Labeling and Scanning |
+| Status | CURRENT — placement decision accepted; operator content in progress |
+| Owner | MSB Database Administrator |
+| Last Reviewed | 2026-08-24 |
+| Related Work | Production Database issue #67 |
+
+## Purpose
+
+Preserve the accepted documentation ownership and presentation boundary for the MSB Scan system so future documentation work does not have to reconstruct the decision from chat history.
+
+This handoff is intentionally limited to Scan. It does not settle the broader documentation-tree question for the older LOR umbrella system.
+
+## Accepted Scan Documentation Boundary
+
+The application remains at the repository root:
+
+```text
+Scan/
+```
+
+Do not move the application merely to make documentation folders look uniform.
+
+Scan engineering documentation remains in the established Production Database engineering area:
+
+```text
+Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/
+```
+
+Scan operator documentation is owned in the established Production Database operational area:
+
+```text
+Docs/02_Production_Database/02_Operational_SOPs/Scanning/
+```
+
+The Production Database operator index remains:
+
+```text
+Docs/02_Production_Database/02_Operational_SOPs/README.md
+```
+
+That README is the source-side operator table of contents. `Scanning/README.md` is the Scan-specific operator introduction/task index.
+
+## Accepted Operator Document Set
+
+The first Scan operator set covers:
+
+1. introduction to the Scan system;
+2. manual Scan entry;
+3. QR/code types and meanings;
+4. phone/tablet camera setup;
+5. what to do after scanning an item.
+
+Current source paths are:
+
+```text
+Docs/02_Production_Database/02_Operational_SOPs/Scanning/
+├── README.md
+├── Use_Scan_Manually.md
+├── QR_Code_Types_and_Meanings.md
+├── Set_Up_Phone_or_Tablet_for_Scanning.md
+├── What_To_Do_After_You_Scan.md
+└── images/
+```
+
+## Image Ownership
+
+Screenshots used by these Scan operator documents must remain physically close to the Markdown that uses them.
+
+For this Scan operator set, the local image owner is:
+
+```text
+Docs/02_Production_Database/02_Operational_SOPs/Scanning/images/
+```
+
+Do not place new Scan operator screenshots in a generic global image bucket when the image is owned only by this operator documentation.
+
+This is a Scan-specific application of the broader documentation-image locality discussion tracked under documentation reconciliation issue #49.
+
+## Operator Mental Model
+
+Volunteers must not be expected to know or navigate:
+
+- repository folder paths;
+- branches or commits;
+- GitHub engineering navigation;
+- the distinction between application source folders and documentation folders.
+
+Those structures exist for maintainers.
+
+The volunteer mental model should be task-oriented, for example:
+
+```text
+Scanning
+    -> About Scan
+    -> Scan something manually
+    -> Understand the QR codes
+    -> Set up my phone/tablet
+    -> What do I do after I scan something?
+```
+
+## One Authoritative Document Source
+
+The Production Database repository remains the authoritative editable source for the Scan operator Markdown.
+
+`my.sheboyganlights.org` is the normal discovery/presentation/search layer.
+
+The intranet must not create a second independently maintained copy of the operator manual. A rendered or automatically published presentation derived from the authoritative Markdown is acceptable; a separate hand-maintained HTML/manual copy is not.
+
+## Existing Backbone Capability Verified
+
+The current `Gregovate/MSB-Internal-Web-Backbone` repository already contains a Docsify documentation reader at:
+
+```text
+my/read/
+```
+
+Its current `my/read/index.html` loads the Docsify search plugin and exposes a `Search docs…` search box.
+
+Therefore the remaining engineering problem is not to build a documentation reader/search engine from scratch. It is to define and implement a controlled single-source publication/rendering path from authoritative Production Database operator Markdown into the existing Backbone reader/search experience.
+
+## Search / Discovery Direction
+
+Normal volunteer search should prioritize current operator material using metadata such as:
+
+- Document Type;
+- System;
+- Task;
+- Audience;
+- Status;
+- Owner;
+- Last Reviewed;
+- Keywords.
+
+Engineering contracts, implementation notes, dated acceptance records, compatibility pointers, and historical material must not appear as equivalent normal operator task choices.
+
+Useful Scan search intents include:
+
+- scan a display;
+- scan a container;
+- QR code;
+- enter a scan manually;
+- set up phone camera;
+- field wiring;
+- procedures;
+- testing;
+- work orders.
+
+## Current Verified Scan Boundary Used By The Operator Draft
+
+The current Scan application verifies:
+
+- the **MSB Scan** page;
+- **Scan code or paste URL**;
+- **Go**;
+- **Scan with Camera**;
+- current Display Scan landing behavior;
+- current Container Scan landing behavior.
+
+The approved identity standard includes `DISP`, `CONT`, `LOC`, and `CTRL`, but the operator documentation must distinguish approved identity types from workflows actually deployed and accepted.
+
+Do not document a complete `LOC` or `CTRL` operator workflow until the implementation is verified.
+
+## Remaining Acceptance Work
+
+Before the Scan operator set becomes CURRENT:
+
+1. review the wording with an operator/volunteer audience in mind;
+2. capture current screenshots from the real Scan UI;
+3. physically verify phone/tablet camera permission and successful scanning on the device types volunteers use;
+4. add those screenshots under `Scanning/images/` and verify Markdown rendering;
+5. complete the Backbone single-source publication/rendering decision;
+6. create/link the corresponding Backbone implementation work when the source-side package is ready;
+7. verify volunteer search/navigation on deployed `my.sheboyganlights.org`.
+
+## Related Documents
+
+- [Labeling and Scanning Engineering Handoff](README.md)
+- [Asset Identity and Scan Payload Standard](Asset_Identity_and_Scan_Payload_Standard.md)
+- [Deployed Display Scan Runtime Boundary](Deployed_Display_Scan_Runtime_Boundary.md)
+- [Production Database Operator Scan Guide](../../02_Operational_SOPs/Scanning/README.md)

--- a/Docs/02_Production_Database/02_Operational_SOPs/README.md
+++ b/Docs/02_Production_Database/02_Operational_SOPs/README.md
@@ -6,6 +6,7 @@ These procedures are for people performing day-to-day production database tasks.
 
 | I want to... | Go to |
 |---|---|
+| Scan a Display, Container, or other MSB code and choose the next action | [Scanning](Scanning/README.md) |
 | Create or maintain container records and display assignments | [Containers](Containers/README.md) |
 | Complete or maintain Production Database information about displays | [Displays](Displays/README.md) |
 | Run the LOR parser, ingest, and reconciliation workflow | [LOR2DB](LOR2DB/README.md) |
@@ -17,6 +18,7 @@ These procedures are for people performing day-to-day production database tasks.
 
 | Folder | What it contains |
 |---|---|
+| [Scanning](Scanning/README.md) | Operator guidance for manual Scan entry, QR/code meanings, phone/tablet camera setup, and choosing what to do after a scan |
 | [Containers](Containers/README.md) | Procedures for creating and maintaining containers, storage information, dimensions, labels, and display assignments |
 | [Displays](Displays/README.md) | Procedures for completing and maintaining Production Database display information |
 | [LOR2DB](LOR2DB/README.md) | Browser-operated LOR parser, PostgreSQL ingest, reconciliation, and reporting procedure |

--- a/Docs/02_Production_Database/02_Operational_SOPs/Scanning/QR_Code_Types_and_Meanings.md
+++ b/Docs/02_Production_Database/02_Operational_SOPs/Scanning/QR_Code_Types_and_Meanings.md
@@ -1,0 +1,104 @@
+# QR Code Types and Meanings
+
+| Document Control | Value |
+|---|---|
+| Document Type | Operator Reference |
+| System | Production Database — Scan |
+| Task | Understand MSB scan-code prefixes |
+| Audience | MSB volunteers and operators |
+| Status | DRAFT — operator review required |
+| Owner | MSB Database Administrator |
+| Last Reviewed | 2026-08-24 |
+| Keywords | QR code, scan code, DISP, CONT, LOC, CTRL, display, container, location, controller |
+
+## Purpose
+
+MSB labels use a short type code before the item identifier.
+
+The normal pattern is:
+
+```text
+TYPE:KEY
+```
+
+You usually do not need to memorize the prefixes. They simply tell you what kind of thing the label identifies.
+
+## Current Approved Types
+
+| Prefix | Means | Example | Current Scan status |
+|---|---|---|---|
+| `DISP` | Display | `DISP:251` | Current Display Scan hub is deployed and verified |
+| `CONT` | Container | `CONT:587` | Current Container Scan landing page exists and opens the Container record |
+| `LOC` | Storage Location | `LOC:RA-01-A-03` | Approved identity type; broader operator Scan workflow is not yet documented as fully deployed |
+| `CTRL` | Controller | `CTRL:CL-042` | Approved identity direction; complete operator Scan workflow depends on the Controller Inventory implementation |
+
+## What The Code Does
+
+The code identifies the item. It should not permanently lock the label to one specific screen or application.
+
+For example, a Display QR identifies the permanent Display. The Scan system can then offer several useful actions for that same Display.
+
+## Display Codes
+
+A Display code begins with:
+
+```text
+DISP:
+```
+
+After scanning a current Display label, the Scan hub can provide actions such as:
+
+- **Open Display Record**;
+- current testing when available;
+- **Field Wiring**;
+- **Procedures**;
+- **Open Container**; and
+- **Open Work Orders** when active work orders exist.
+
+See [What To Do After You Scan](What_To_Do_After_You_Scan.md).
+
+## Container Codes
+
+A Container code begins with:
+
+```text
+CONT:
+```
+
+The current Container Scan page provides **Open Container Record** and **Back to Scan**.
+
+## Location Codes
+
+A Storage Location code begins with:
+
+```text
+LOC:
+```
+
+These identify discrete operational locations such as storage or rack positions.
+
+Do not assume every `LOC` workflow is available in Scan yet merely because the identifier is approved.
+
+## Controller Codes
+
+A Controller code begins with:
+
+```text
+CTRL:
+```
+
+This is the approved identity pattern for Controller Inventory. The operator Scan behavior should be documented only after that workflow is implemented and accepted.
+
+## Expected Result
+
+When you see an MSB code, you should be able to tell what kind of item it identifies before deciding what to do next.
+
+## If Something Is Wrong
+
+If the printed human-readable information and the QR result appear to identify different things, stop and report the label for review. Do not relabel the item or substitute another ID unless the responsible workflow tells you to do so.
+
+## Related Documents
+
+- [MSB Scan — Operator Guide](README.md)
+- [Use Scan Manually](Use_Scan_Manually.md)
+- [What To Do After You Scan](What_To_Do_After_You_Scan.md)

--- a/Docs/02_Production_Database/02_Operational_SOPs/Scanning/README.md
+++ b/Docs/02_Production_Database/02_Operational_SOPs/Scanning/README.md
@@ -1,0 +1,65 @@
+# MSB Scan — Operator Guide
+
+| Document Control | Value |
+|---|---|
+| Document Type | Operator Portal |
+| System | Production Database — Scan |
+| Task | Find and use current Scan instructions |
+| Audience | MSB volunteers, operators, and managers |
+| Status | DRAFT — operator review and screenshots required |
+| Owner | MSB Database Administrator |
+| Last Reviewed | 2026-08-24 |
+| Keywords | scan, scanning, QR code, display, container, phone, tablet, camera, manual entry, field wiring, procedures |
+
+## What Is MSB Scan?
+
+MSB Scan gives volunteers one place to scan or enter an MSB asset code and then choose the task they need to perform.
+
+A permanent QR code identifies the item. The Scan system decides what useful actions are available for that item.
+
+For example, scanning a Display can take you to its Display record, current testing record, Field Wiring, Procedures, assigned Container, or open Work Orders.
+
+You do **not** need to understand database IDs, application routes, or the repository structure to use Scan.
+
+## Open Scan
+
+Open:
+
+**https://db.sheboyganlights.org/scan/**
+
+The Scan page provides two normal ways to start:
+
+- enter or paste a code and press **Go**;
+- press **Scan with Camera** and scan the label with a phone or tablet camera.
+
+## What Do You Need To Do?
+
+| I want to... | Go to |
+|---|---|
+| Enter a code instead of using the camera | [Use Scan Manually](Use_Scan_Manually.md) |
+| Understand what `DISP`, `CONT`, `LOC`, and `CTRL` mean | [QR Code Types and Meanings](QR_Code_Types_and_Meanings.md) |
+| Set up a phone or tablet to scan labels | [Set Up a Phone or Tablet for Scanning](Set_Up_Phone_or_Tablet_for_Scanning.md) |
+| Know which button to choose after I scan something | [What To Do After You Scan](What_To_Do_After_You_Scan.md) |
+
+## Current Production Boundary
+
+Display scanning is the most complete current Scan workflow.
+
+Container scanning also has a current Scan landing page that opens the Container record.
+
+`LOC` and `CTRL` are approved MSB identity types, but their broader operator workflows must not be assumed to be complete merely because the identifiers exist. The QR Code reference explains that distinction.
+
+## Expected Result
+
+A volunteer should be able to start at Scan, identify an item, and reach the correct next task without needing to know where the underlying application or documentation is stored.
+
+## If Something Is Wrong
+
+If a code will not scan, try entering it manually using [Use Scan Manually](Use_Scan_Manually.md).
+
+If the system says an item cannot be found or an action is unavailable, do not substitute a different ID. Verify the label and ask the responsible manager for help if needed.
+
+## Related Documents
+
+- [Production Database Operational SOPs](../README.md)
+- [Label Printing](../Label_Printing/README.md)

--- a/Docs/02_Production_Database/02_Operational_SOPs/Scanning/Set_Up_Phone_or_Tablet_for_Scanning.md
+++ b/Docs/02_Production_Database/02_Operational_SOPs/Scanning/Set_Up_Phone_or_Tablet_for_Scanning.md
@@ -1,0 +1,105 @@
+# Set Up a Phone or Tablet for Scanning
+
+| Document Control | Value |
+|---|---|
+| Document Type | Operational SOP |
+| System | Production Database — Scan |
+| Task | Prepare a phone or tablet to scan MSB labels with the camera |
+| Audience | MSB volunteers and operators |
+| Status | DRAFT — physical device acceptance and screenshots required |
+| Owner | MSB Database Administrator |
+| Last Reviewed | 2026-08-24 |
+| Keywords | phone, tablet, camera, QR code, scan with camera, camera permission, mobile scanning |
+
+## Purpose
+
+Use this procedure to prepare a phone or tablet for camera scanning with MSB Scan.
+
+## Before You Start
+
+The device must:
+
+- have a working rear camera;
+- be connected to a network that can reach the MSB Scan site; and
+- use a browser that allows camera access to the Scan page.
+
+Open:
+
+**https://db.sheboyganlights.org/scan/**
+
+Camera scanning requires the secure HTTPS Scan page.
+
+## Procedure
+
+### 1. Open MSB Scan
+
+Open the Scan page in the device's normal web browser.
+
+You should see **MSB Scan** and the **Scan with Camera** button.
+
+### 2. Press Scan with Camera
+
+Tap **Scan with Camera**.
+
+The browser may ask whether the site is allowed to use the camera.
+
+### 3. Allow camera access
+
+Choose the option that allows the Scan site to use the camera.
+
+The current Scan page is designed to use the rear-facing camera when available.
+
+When the camera starts successfully, the page should show:
+
+**Camera ready**
+
+### 4. Point the camera at the label
+
+Hold the device so the QR code is clearly visible in the camera area.
+
+You do not need to press another button after the code is recognized. Scan should detect the code, stop the camera, and open the matching Scan route automatically.
+
+### 5. Confirm the correct item opened
+
+Before choosing the next action, verify the item name or code shown on the page matches the label you intended to scan.
+
+## Expected Result
+
+The device camera opens from **Scan with Camera**, recognizes the label, and takes you to the correct Scan page.
+
+## If Something Is Wrong
+
+### The browser asks for camera permission
+
+Allow camera access for the Scan site.
+
+If camera access was previously denied, the browser or device may require you to re-enable camera permission for this site. The exact steps vary by device and browser and should be added here after physical iPhone/iPad and Android acceptance screenshots are captured.
+
+### You see “Browser does not support camera access”
+
+Use a supported current browser or use [Use Scan Manually](Use_Scan_Manually.md) until the device can be corrected.
+
+### You see “Camera start failed”
+
+Check that another application is not using the camera and that camera permission is enabled for the Scan site. If the problem continues, use manual entry and report the device/browser for review.
+
+### The camera opens but will not recognize the label
+
+Try:
+
+- moving slightly closer or farther away;
+- improving the lighting;
+- holding the device steady; or
+- entering the printed code manually.
+
+Do not replace the label merely because one device has difficulty reading it.
+
+## Screenshot Acceptance Still Needed
+
+Before this SOP becomes CURRENT, capture and verify the normal camera-permission and successful-scan screens on the actual phone/tablet types used by volunteers.
+
+## Related Documents
+
+- [MSB Scan — Operator Guide](README.md)
+- [Use Scan Manually](Use_Scan_Manually.md)
+- [What To Do After You Scan](What_To_Do_After_You_Scan.md)

--- a/Docs/02_Production_Database/02_Operational_SOPs/Scanning/Use_Scan_Manually.md
+++ b/Docs/02_Production_Database/02_Operational_SOPs/Scanning/Use_Scan_Manually.md
@@ -1,0 +1,94 @@
+# Use Scan Manually
+
+| Document Control | Value |
+|---|---|
+| Document Type | Operational SOP |
+| System | Production Database — Scan |
+| Task | Enter an MSB scan code manually |
+| Audience | MSB volunteers and operators |
+| Status | DRAFT — operator review and screenshots required |
+| Owner | MSB Database Administrator |
+| Last Reviewed | 2026-08-24 |
+| Keywords | manual scan, enter code, paste URL, DISP, CONT, scan without camera |
+
+## Purpose
+
+Use this procedure when you know the MSB code or have a scan URL but do not want to use the camera.
+
+Manual entry and camera scanning use the same item identity. Entering `DISP:141` should identify the same Display as scanning its QR code.
+
+## Before You Start
+
+Open:
+
+**https://db.sheboyganlights.org/scan/**
+
+You should see:
+
+- **MSB Scan**;
+- a box labeled **Scan code or paste URL**;
+- a **Go** button; and
+- a **Scan with Camera** button.
+
+## Procedure
+
+### 1. Click or tap the entry box
+
+Select **Scan code or paste URL**.
+
+### 2. Enter the code
+
+Enter the code exactly as shown on the label or in the information you were given.
+
+Current examples include:
+
+```text
+DISP:141
+CONT:238
+```
+
+You may also paste a full MSB scan URL.
+
+### 3. Press Go
+
+Press **Go**.
+
+Scan will open the landing page for the item type and identifier you entered when that route is currently supported.
+
+### 4. Choose what you need to do
+
+For a Display, use [What To Do After You Scan](What_To_Do_After_You_Scan.md) to choose the correct action.
+
+For a Container, the current Scan page provides **Open Container Record** and **Back to Scan**.
+
+## Expected Result
+
+The system opens the correct item or task page for the code you entered.
+
+## If Something Is Wrong
+
+### You see “Unrecognized scan format”
+
+Check that the code includes both the type and the key, separated by a colon.
+
+For example:
+
+```text
+DISP:141
+```
+
+Do not enter only `141`.
+
+### The item cannot be found
+
+Check the label or code and try again. Do not guess a different ID.
+
+### A code type does not open a useful page
+
+Some approved MSB identity types exist before their complete operator Scan workflow is deployed. See [QR Code Types and Meanings](QR_Code_Types_and_Meanings.md).
+
+## Related Documents
+
+- [MSB Scan — Operator Guide](README.md)
+- [QR Code Types and Meanings](QR_Code_Types_and_Meanings.md)
+- [What To Do After You Scan](What_To_Do_After_You_Scan.md)

--- a/Docs/02_Production_Database/02_Operational_SOPs/Scanning/What_To_Do_After_You_Scan.md
+++ b/Docs/02_Production_Database/02_Operational_SOPs/Scanning/What_To_Do_After_You_Scan.md
@@ -1,0 +1,112 @@
+# What To Do After You Scan
+
+| Document Control | Value |
+|---|---|
+| Document Type | Operational SOP |
+| System | Production Database — Scan |
+| Task | Choose the correct action after scanning an MSB item |
+| Audience | MSB volunteers and operators |
+| Status | DRAFT — operator review and screenshots required |
+| Owner | MSB Database Administrator |
+| Last Reviewed | 2026-08-24 |
+| Keywords | after scan, display record, testing, field wiring, procedures, container, work orders |
+
+## Purpose
+
+Use this guide after Scan has identified an item and shown the available actions.
+
+The most complete current landing page is the Display Scan hub.
+
+## After Scanning a Display
+
+A current Display Scan page shows the Display name, its `DISP` code, assigned Container when available, and the available actions.
+
+Choose the action that matches what you are trying to do.
+
+### Open Display Record
+
+Choose **Open Display Record** when you need to view or maintain the normal Production Database information for the Display.
+
+Examples include checking the Display record, container assignment, notes, or other information maintained there.
+
+### Open Current Test Record / View Test Record
+
+When current testing is available, Scan shows either:
+
+- **Open Current Test Record** — the Display is in the active test session and still needs a test result; or
+- **View Test Record** — a test result already exists for that active record.
+
+If testing is not currently available, the testing button is greyed out and the text explains why. Examples include **No Container Assigned**, **No Container Test Session**, **Container Not Started**, **Container Testing Complete**, **Testing Not Required**, or **Testing Deferred**.
+
+Do not try to work around a greyed-out testing state by opening a different Display or Container.
+
+### Field Wiring
+
+Choose **Field Wiring** when you need the current wiring information used to connect or troubleshoot the Display in the field.
+
+### Procedures
+
+Choose **Procedures** when you need the current field procedure package associated with the Display, such as available setup, takedown, or inspection material.
+
+### Open Container
+
+Choose **Open Container** when you need the Container currently assigned to the Display.
+
+If no Container is assigned, the system cannot open one from the Display.
+
+### Open Work Orders
+
+Choose **Open Work Orders** when you need to review an active problem or repair record for the Display.
+
+The button shows the number of active Work Orders.
+
+Examples:
+
+```text
+Open Work Orders (2)
+Open Work Orders (0)
+```
+
+When there are no active Work Orders, the button is disabled.
+
+If there is one active Work Order, Scan opens it directly. If there is more than one, Scan shows a list so you can choose the correct Work Order.
+
+## After Scanning a Container
+
+The current Container Scan landing page provides:
+
+- **Open Container Record** — open the Production Database Container record; and
+- **Back to Scan** — return to the Scan start page.
+
+Do not assume additional Container movement/setup actions are available through Scan until those workflows are implemented and documented.
+
+## Location and Controller Codes
+
+`LOC` and `CTRL` are approved MSB identity types, but their complete operator Scan workflows are not yet documented as fully deployed.
+
+See [QR Code Types and Meanings](QR_Code_Types_and_Meanings.md) for the current boundary.
+
+## Expected Result
+
+After scanning an item, you should be able to choose the task you actually need without having to search through unrelated application menus.
+
+## If Something Is Wrong
+
+### The scanned item is not the item you expected
+
+Stop before making changes. Recheck the physical label and the name/code shown on screen.
+
+### The action you need is greyed out
+
+Read the text shown on the disabled button. It normally explains why that action is unavailable in the current workflow state.
+
+### An expected action is missing
+
+Do not guess another route or substitute another record. Report what you scanned and what you expected to see so the current data/workflow can be checked.
+
+## Related Documents
+
+- [MSB Scan — Operator Guide](README.md)
+- [Use Scan Manually](Use_Scan_Manually.md)
+- [QR Code Types and Meanings](QR_Code_Types_and_Meanings.md)
+- [Set Up a Phone or Tablet for Scanning](Set_Up_Phone_or_Tablet_for_Scanning.md)

--- a/Docs/02_Production_Database/02_Operational_SOPs/Scanning/images/README.md
+++ b/Docs/02_Production_Database/02_Operational_SOPs/Scanning/images/README.md
@@ -1,0 +1,7 @@
+# Scan Operator Documentation Images
+
+This folder owns screenshots and other image assets used by the Scan operator documentation in the parent `Scanning/` folder.
+
+Keep image filenames descriptive and stable. When adding or replacing a screenshot, update the Markdown document that uses it and verify the rendered result.
+
+Do not place unrelated engineering diagrams or other subsystem images here.


### PR DESCRIPTION
## Purpose

Build the first operator-documentation package for the current MSB Scan system and preserve the accepted source/presentation boundary discovered during Display Scan Integration.

Closes part of #67; issue remains open until screenshots, device acceptance, and Backbone presentation/search integration are verified.

## Source structure

- root `Scan/` application remains unchanged;
- engineering docs remain under `01_System_Architecture/07_Labeling_and_Scanning/`;
- operator docs are added under `02_Operational_SOPs/Scanning/`;
- `02_Operational_SOPs/README.md` now exposes Scanning as an operator task area;
- operator screenshots are owned locally under `Scanning/images/`.

## Operator content added

- Scan introduction/task portal;
- manual Scan entry SOP;
- QR/code type reference;
- phone/tablet camera setup SOP;
- post-scan action guidance.

## Engineering handoff added

`Scan_Operator_Documentation_and_Backbone_Handoff.md` records:

- application vs engineering vs operator documentation ownership;
- local image ownership;
- operator task-oriented mental model;
- one-authoritative-Markdown rule;
- `my.sheboyganlights.org` presentation/search direction;
- verified existence of the current Docsify reader/search foundation;
- remaining screenshot/device/Backbone acceptance work.

## Boundaries

This PR does not move the Scan application, redesign Scan behavior, or settle the older LOR umbrella documentation structure.

Related: #49, #67.