### PR TITLE
Allow approved-version preview maintenance

### DIFF
--- a/Docs/01_LOR_System/02_Data_Extraction/LOR_Approved_Version_Maintenance_Compatibility_Rule_2026-08-25.md
+++ b/Docs/01_LOR_System/02_Data_Extraction/LOR_Approved_Version_Maintenance_Compatibility_Rule_2026-08-25.md
@@ -1,0 +1,72 @@
+# LOR Approved-Version Maintenance Compatibility Rule — 2026-08-25
+
+| Item | Value |
+|---|---|
+| Status | IMPLEMENTED AND LOCALLY TESTED |
+| Checker | `lor_version_checker.py` V1.4.0 |
+| Production parser | V7.0.11 |
+| Approved LOR version | 6.6.10 |
+
+## Decision
+
+Routine preview authoring under the already-approved Light-O-Rama version is
+content maintenance, not a software-version schema migration.
+
+The production operator may therefore:
+
+- add or remove Displays;
+- add or remove Scenes and change their membership;
+- add or remove Motion FX rows;
+- populate or clear nullable text/path attributes;
+- use integer or decimal authoring values where LOR emits either representation;
+- change record counts or token counts inside parser-ignored delimiter payloads; and
+- populate or clear the optional sixth `ChannelGrid` color position.
+
+The compatibility checker continues to inventory these differences, but it
+records them as informational evidence and does not stop the approved-version
+parser run.
+
+## Blocking Boundary
+
+Same-version comparison remains fail-closed for newly encountered XML
+vocabulary such as an element, attribute, namespace, or parent/child path that
+is absent from the approved folder-wide contract. Removal of an optional
+structure is informational because an XML instance no longer exercising a
+feature does not remove that feature from the LOR schema.
+
+The separate **Check new version** workflow remains fully strict. When the LOR
+software versions differ, element, attribute, ordering, value-shape,
+delimiter-layout, and `ChannelGrid` differences remain blocking until reviewed
+and resolved.
+
+Malformed XML and duplicate `PreviewClass` identity checks still fail while the
+manifest is built, before comparison or parser execution.
+
+## Triggering Evidence
+
+Adding Displays to `Show Background Stage 30-Santa's Station-QV.lorprev`
+introduced values that were not represented in the approved instance sample:
+
+- nullable `PropClass.Tag` and `PropClass.TraditionalColors` text;
+- nullable `shape.BackgroundImage` and `shape.CustomGrid` content;
+- decimal `shape.OffsetX`, `OffsetY`, `ScaleX`, and `ScaleY` values;
+- blank/nonblank optional `PropClass.ChannelGrid` color values; and
+- new `shape.CustomGrid` comma/semicolon counts.
+
+None changed the XML vocabulary. The V7 parser stores `Tag` and
+`TraditionalColors` as nullable text, accepts the optional sixth `ChannelGrid`
+color token, and does not consume the listed `shape` attributes. Treating those
+content observations as parser-breaking schema changes was incorrect.
+
+## Regression Boundary
+
+`test_lor_version_checker_maintenance.py` verifies:
+
+1. same-version Display addition and the complete triggering value set are informational;
+2. same-version Display removal is informational;
+3. same-version `CustomGrid` record/token-count changes are informational;
+4. the same differences remain blocking across different LOR versions; and
+5. genuinely new XML vocabulary remains blocking in an approved-version run.
+
+The existing Motion FX tests continue to verify same-version row growth is
+informational while different-version comparison remains strict.

--- a/Docs/01_LOR_System/02_Data_Extraction/LOR_Preview_Version_Compatibility_Review.md
+++ b/Docs/01_LOR_System/02_Data_Extraction/LOR_Preview_Version_Compatibility_Review.md
@@ -4,7 +4,7 @@
 |---|---|
 | Status | CURRENT — controlled engineering procedure |
 | Applies to | Any new Light-O-Rama release that can change `.lorprev` output |
-| Current revision | 2026-08-17 |
+| Current revision | 2026-08-25 |
 | Owner | MSB Database Administrator |
 
 ## Purpose
@@ -92,6 +92,12 @@ finding is explicitly recorded as resolved.
 
 The XML check occurs before the parser. A successful parser run cannot override
 a failed XML compatibility check.
+
+These strict candidate rules apply when the Current and New LOR software
+versions differ. They do not turn routine preview authoring under the already
+approved version into a candidate-version approval event. Same-version Display,
+Scene, value, delimiter-payload, and Motion FX maintenance follows the
+[approved-version maintenance rule](LOR_Approved_Version_Maintenance_Compatibility_Rule_2026-08-25.md).
 
 ## Test Preview Selection
 

--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/README.md
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/README.md
@@ -9,9 +9,11 @@ tools for operator convenience but does not own their XML interpretation.
 | File | Purpose |
 |---|---|
 | `parse_props_v7_scene_parser.py` | Canonical V7 parser; atomically publishes only a fully validated SQLite snapshot |
-| `lor_version_checker.py` | Parser-independent complete XML manifest and Current/New LOR compatibility comparison |
+| `lor_version_checker.py` | Parser-independent complete XML manifest; approved-version maintenance classification and strict New LOR compatibility comparison |
 | `lor_operator_runner.py` | Restricted Windows/G-drive API, single-operation lock, durable read-only parser and ingest console records, digest-locked PostgreSQL ingest, candidate stale-manifest guard, approved-version structural guard, and same-parser SQLite output comparison used by the authenticated LOR2DB website |
 | `test_lor_version_checker.py` | Regression tests for Scene count/structure, unused fields, ChannelGrid, and other delimiter-position changes |
+| `test_lor_version_checker_maintenance.py` | Regression tests proving same-version display additions/removals and authored value diversity remain nonblocking |
+| `test_lor_version_checker_motion_fx.py` | Regression tests proving same-version Motion FX row maintenance remains nonblocking |
 | `test_lor_operator_runner.py` | Regression tests for version-scoped paths, stale manifests, SQLite output comparison, Revision handling, and approval history |
 | `test_parse_props_console_encoding.py` | Regression test preventing Windows console/log encoding from aborting parser execution |
 | `test_parse_props_atomic_publish.py` | Regression tests for transient Windows file-lock retry and fail-closed atomic publication |
@@ -36,10 +38,14 @@ runner changes any stale `RUNNING` marker to `INTERRUPTED` rather than leaving
 the website in a false running state.
 
 An approved Current LOR folder may receive ordinary preview-authoring edits and
-be parsed repeatedly. Each run rebuilds the live manifest and rejects only a
-parser-breaking XML contract change relative to the approved LOR manifest. A
-New LOR candidate remains stricter: changing any reviewed candidate file after
-Version Check invalidates that check and requires it to be rerun.
+be parsed repeatedly. Adding/removing Displays or Scenes, changing nullable
+attribute values, using different integer/decimal authoring values, changing
+non-parser delimiter payloads, and adding/removing Motion FX rows remain
+inventoried as informational evidence. They do not block the approved-version
+parser run. Newly encountered XML vocabulary remains blocking because it can
+indicate a parser contract change. A New LOR candidate remains fully strict:
+changing any reviewed candidate file after Version Check invalidates that check
+and requires it to be rerun.
 
 The production runner task uses the logged-in Greg account because that Windows
 session owns the mapped `G:` drive. Screen locking does not stop the task. After
@@ -52,6 +58,7 @@ See:
 - [Parser architecture](../LOR_Preview_Parser_Architecture.md)
 - [XML structure specification](../LOR_Preview_File_Structure_Specification.md)
 - [Version compatibility procedure](../LOR_Preview_Version_Compatibility_Review.md)
+- [Approved-version maintenance rule](../LOR_Approved_Version_Maintenance_Compatibility_Rule_2026-08-25.md)
 - [SQLite output contract](../LOR_SQLite_Output_Database_Structure.md)
 - [LOR2DB ingest handoff](../../../../LOR2DB/01_Ingest/README.md)
 - [Office PC runner operations and disaster recovery](../../../../LOR2DB/Application/Office_PC_Runner_Operations_and_Disaster_Recovery.md)

--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/lor_version_checker.py
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/lor_version_checker.py
@@ -3,8 +3,11 @@
 Initial release: 2026-08-13 V1.0.0
 
 This checker is deliberately parser-independent. It inventories the complete
-XML contract, including fields the production parser does not consume, before
-the candidate preview set is allowed to exercise the parser.
+XML contract, including fields the production parser does not consume. A
+different-version candidate is compared strictly with the approved manifest;
+same-approved-version production maintenance keeps content drift visible but
+blocks only newly encountered XML vocabulary or another structural condition
+that can indicate a parser contract change.
 """
 
 from __future__ import annotations
@@ -23,7 +26,7 @@ from pathlib import Path
 from typing import Any, Iterable
 
 
-CHECKER_VERSION = "V1.3.1"
+CHECKER_VERSION = "V1.4.0"
 MANIFEST_VERSION = 4
 CRITICAL_ELEMENTS = {"PreviewClass", "Scene", "PropClass"}
 UUID_RE = re.compile(
@@ -371,7 +374,13 @@ class Finding:
 
 
 def _same_version_authoring_finding(finding: Finding) -> Finding:
-    """Keep normal Motion FX authoring visible without blocking same-version runs."""
+    """Keep parser-ignored Motion FX structure nonblocking for approved versions.
+
+    MotionRowDefault elements can appear or disappear as authors add/remove
+    Motion FX rows. Aggregate structural comparisons cannot infer from an XML
+    instance that this is already-known LOR vocabulary, so retain this explicit
+    parser contract exception in addition to the general content rules below.
+    """
     if finding.severity != "BLOCKING":
         return finding
     evidence = f"{finding.area} {finding.message}"
@@ -387,24 +396,41 @@ def _same_version_authoring_finding(finding: Finding) -> Finding:
 
 
 def set_difference_findings(
-    baseline: Iterable[str], candidate: Iterable[str], area: str, noun: str
+    baseline: Iterable[str],
+    candidate: Iterable[str],
+    area: str,
+    noun: str,
+    *,
+    added_severity: str = "BLOCKING",
+    removed_severity: str = "BLOCKING",
 ) -> list[Finding]:
     old, new = set(baseline), set(candidate)
     findings: list[Finding] = []
     for value in sorted(new - old):
         findings.append(Finding(
-            "BLOCKING", area, f"New {noun}: {value}",
-            f"Review and explicitly support or reject {noun} {value!r} before production.",
+            added_severity, area, f"New {noun}: {value}",
+            (
+                f"Review and explicitly support or reject {noun} {value!r} before production."
+                if added_severity == "BLOCKING" else None
+            ),
         ))
     for value in sorted(old - new):
         findings.append(Finding(
-            "BLOCKING", area, f"Removed {noun}: {value}",
-            f"Update the parser contract for removed {noun} {value!r}, or restore it in LOR.",
+            removed_severity, area, f"Removed {noun}: {value}",
+            (
+                f"Update the parser contract for removed {noun} {value!r}, or restore it in LOR."
+                if removed_severity == "BLOCKING" else None
+            ),
         ))
     return findings
 
 
-def compare_shapes(baseline: dict[str, Any], candidate: dict[str, Any]) -> list[Finding]:
+def compare_shapes(
+    baseline: dict[str, Any],
+    candidate: dict[str, Any],
+    *,
+    severity: str = "BLOCKING",
+) -> list[Finding]:
     findings: list[Finding] = []
     all_tags = sorted(set(baseline) | set(candidate))
     for tag in all_tags:
@@ -415,30 +441,43 @@ def compare_shapes(baseline: dict[str, Any], candidate: dict[str, Any]) -> list[
             new_shapes = set(new_attributes.get(attribute, {}))
             if old_shapes != new_shapes:
                 findings.append(Finding(
-                    "BLOCKING", f"{tag}.{attribute}",
+                    severity, f"{tag}.{attribute}",
                     f"Value shapes changed from {sorted(old_shapes)} to {sorted(new_shapes)}.",
-                    f"Confirm parsing and materialization of {tag}.{attribute} for every new value shape.",
+                    (
+                        f"Confirm parsing and materialization of {tag}.{attribute} for every new value shape."
+                        if severity == "BLOCKING" else None
+                    ),
                 ))
     return findings
 
 
 def compare_delimited_fields(
-    baseline: dict[str, Any], candidate: dict[str, Any], area_prefix: str = ""
+    baseline: dict[str, Any],
+    candidate: dict[str, Any],
+    area_prefix: str = "",
+    *,
+    severity: str = "BLOCKING",
 ) -> list[Finding]:
     """Detect positional contract drift in every comma/semicolon-encoded field."""
     findings: list[Finding] = []
     old_fields, new_fields = set(baseline), set(candidate)
     for field in sorted(new_fields - old_fields):
         findings.append(Finding(
-            "BLOCKING", area_prefix + field,
+            severity, area_prefix + field,
             f"New delimiter-encoded field layout: {field}.",
-            f"Document and support the positional layout of {field} before production.",
+            (
+                f"Document and support the positional layout of {field} before production."
+                if severity == "BLOCKING" else None
+            ),
         ))
     for field in sorted(old_fields - new_fields):
         findings.append(Finding(
-            "BLOCKING", area_prefix + field,
+            severity, area_prefix + field,
             f"Delimiter-encoded field layout disappeared: {field}.",
-            f"Update code that relies on positional layout in {field} before production.",
+            (
+                f"Update code that relies on positional layout in {field} before production."
+                if severity == "BLOCKING" else None
+            ),
         ))
     for field in sorted(old_fields & new_fields):
         # ChannelGrid retains its dedicated, explicit comparison and report area.
@@ -450,7 +489,9 @@ def compare_delimited_fields(
             ("token_counts", "comma token count"),
         ):
             findings.extend(set_difference_findings(
-                old[key], new[key], area_prefix + field, noun
+                old[key], new[key], area_prefix + field, noun,
+                added_severity=severity,
+                removed_severity=severity,
             ))
         positions = sorted(
             set(old["position_shapes"]) | set(new["position_shapes"]), key=int
@@ -460,15 +501,23 @@ def compare_delimited_fields(
             new_shapes = set(new["position_shapes"].get(position, {}))
             if old_shapes != new_shapes:
                 findings.append(Finding(
-                    "BLOCKING", f"{area_prefix}{field} position {position}",
+                    severity, f"{area_prefix}{field} position {position}",
                     f"Delimited value shapes changed from {sorted(old_shapes)} "
                     f"to {sorted(new_shapes)}.",
-                    f"Confirm the positional meaning and parsing of {field} position {position}.",
+                    (
+                        f"Confirm the positional meaning and parsing of {field} position {position}."
+                        if severity == "BLOCKING" else None
+                    ),
                 ))
     return findings
 
 
-def compare_file_contracts(baseline: dict[str, Any], candidate: dict[str, Any]) -> list[Finding]:
+def compare_file_contracts(
+    baseline: dict[str, Any],
+    candidate: dict[str, Any],
+    *,
+    same_version: bool = False,
+) -> list[Finding]:
     """Compare every matching preview, not only the aggregate/deep preview."""
     findings: list[Finding] = []
     old_files = {preview_identity(item): item for item in baseline["files"]}
@@ -501,6 +550,7 @@ def compare_file_contracts(baseline: dict[str, Any], candidate: dict[str, Any]) 
         findings.extend(set_difference_findings(
             [old["root_element"]], [new["root_element"]], prefix + "document", "root element"
         ))
+        instance_severity = "INFO" if same_version else "BLOCKING"
         for key, area, noun in (
             ("namespaces", "document", "namespace"),
             ("element_counts", "XML", "element"),
@@ -509,14 +559,21 @@ def compare_file_contracts(baseline: dict[str, Any], candidate: dict[str, Any]) 
             ("transitions", "XML ordering", "sibling transition"),
         ):
             findings.extend(set_difference_findings(
-                old[key], new[key], prefix + area, noun
+                old[key], new[key], prefix + area, noun,
+                added_severity=instance_severity,
+                removed_severity=instance_severity,
             ))
         for tag in sorted(set(old["attributes"]) | set(new["attributes"])):
             findings.extend(set_difference_findings(
                 old["attributes"].get(tag, []), new["attributes"].get(tag, []),
                 prefix + tag, "attribute",
+                added_severity=instance_severity,
+                removed_severity=instance_severity,
             ))
-        for item in compare_shapes(old["attribute_shapes"], new["attribute_shapes"]):
+        for item in compare_shapes(
+            old["attribute_shapes"], new["attribute_shapes"],
+            severity=instance_severity,
+        ):
             findings.append(Finding(
                 item.severity, prefix + item.area, item.message,
                 item.parser_modification_required,
@@ -526,28 +583,32 @@ def compare_file_contracts(baseline: dict[str, Any], candidate: dict[str, Any]) 
             new_count = new["element_counts"].get(tag, 0)
             if old_count != new_count:
                 findings.append(Finding(
-                    "REVIEW", prefix + tag,
+                    "INFO" if same_version else "REVIEW", prefix + tag,
                     f"{tag} count changed from {old_count} to {new_count}.",
                 ))
             old_ids = set(old["ids"].get(tag, []))
             new_ids = set(new["ids"].get(tag, []))
             if old_ids != new_ids:
                 findings.append(Finding(
-                    "REVIEW", prefix + f"{tag} identity",
+                    "INFO" if same_version else "REVIEW", prefix + f"{tag} identity",
                     f"{len(old_ids - new_ids)} IDs were removed and "
                     f"{len(new_ids - old_ids)} IDs were added.",
                 ))
         findings.extend(compare_delimited_fields(
-            old["delimited_fields"], new["delimited_fields"], prefix
+            old["delimited_fields"], new["delimited_fields"], prefix,
+            severity=instance_severity,
         ))
         old_grid, new_grid = old["channel_grid"], new["channel_grid"]
         findings.extend(set_difference_findings(
             old_grid["token_counts"], new_grid["token_counts"],
             prefix + "PropClass.ChannelGrid", "record token count",
+            added_severity=instance_severity,
+            removed_severity=instance_severity,
         ))
         for item in compare_shapes(
             {"PropClass.ChannelGrid": old_grid["position_shapes"]},
             {"PropClass.ChannelGrid": new_grid["position_shapes"]},
+            severity=instance_severity,
         ):
             findings.append(Finding(
                 item.severity, prefix + item.area, item.message,
@@ -559,32 +620,55 @@ def compare_file_contracts(baseline: dict[str, Any], candidate: dict[str, Any]) 
 def compare_manifests(baseline: dict[str, Any], candidate: dict[str, Any]) -> list[Finding]:
     old = baseline["aggregate"]
     new = candidate["aggregate"]
+    same_version = baseline.get("lor_version") == candidate.get("lor_version")
+    content_severity = "INFO" if same_version else "BLOCKING"
+    removed_structure_severity = "INFO" if same_version else "BLOCKING"
     findings: list[Finding] = []
-    findings.extend(compare_file_contracts(baseline, candidate))
+    findings.extend(compare_file_contracts(
+        baseline, candidate, same_version=same_version
+    ))
     findings.extend(set_difference_findings(old["root_elements"], new["root_elements"], "document", "root element"))
-    findings.extend(set_difference_findings(old["namespaces"], new["namespaces"], "document", "namespace"))
-    findings.extend(set_difference_findings(old["element_counts"], new["element_counts"], "XML", "element"))
-    findings.extend(set_difference_findings(old["path_counts"], new["path_counts"], "XML hierarchy", "element path"))
-    findings.extend(set_difference_findings(old["edges"], new["edges"], "XML hierarchy", "parent/child edge"))
-    findings.extend(set_difference_findings(old["transitions"], new["transitions"], "XML ordering", "sibling transition"))
+    for key, area, noun in (
+        ("namespaces", "document", "namespace"),
+        ("element_counts", "XML", "element"),
+        ("path_counts", "XML hierarchy", "element path"),
+        ("edges", "XML hierarchy", "parent/child edge"),
+    ):
+        findings.extend(set_difference_findings(
+            old[key], new[key], area, noun,
+            removed_severity=removed_structure_severity,
+        ))
+    findings.extend(set_difference_findings(
+        old["transitions"], new["transitions"], "XML ordering", "sibling transition",
+        added_severity=content_severity,
+        removed_severity=content_severity,
+    ))
 
     all_tags = sorted(set(old["attributes"]) | set(new["attributes"]))
     for tag in all_tags:
         findings.extend(set_difference_findings(
-            old["attributes"].get(tag, []), new["attributes"].get(tag, []), tag, "attribute"
+            old["attributes"].get(tag, []), new["attributes"].get(tag, []), tag, "attribute",
+            removed_severity=removed_structure_severity,
         ))
-    findings.extend(compare_shapes(old["attribute_shapes"], new["attribute_shapes"]))
+    findings.extend(compare_shapes(
+        old["attribute_shapes"], new["attribute_shapes"],
+        severity=content_severity,
+    ))
     findings.extend(compare_delimited_fields(
-        old["delimited_fields"], new["delimited_fields"]
+        old["delimited_fields"], new["delimited_fields"],
+        severity=content_severity,
     ))
 
     old_grid, new_grid = old["channel_grid"], new["channel_grid"]
     findings.extend(set_difference_findings(
-        old_grid["token_counts"], new_grid["token_counts"], "PropClass.ChannelGrid", "record token count"
+        old_grid["token_counts"], new_grid["token_counts"], "PropClass.ChannelGrid", "record token count",
+        added_severity=content_severity,
+        removed_severity=content_severity,
     ))
     findings.extend(compare_shapes(
         {"ChannelGrid": old_grid["position_shapes"]},
         {"ChannelGrid": new_grid["position_shapes"]},
+        severity=content_severity,
     ))
 
     if baseline["file_count"] != candidate["file_count"]:
@@ -599,18 +683,18 @@ def compare_manifests(baseline: dict[str, Any], candidate: dict[str, Any]) -> li
         new_count = new_deep["element_counts"].get(tag, 0)
         if old_count != new_count:
             findings.append(Finding(
-                "REVIEW", f"deep preview {tag}",
+                "INFO" if same_version else "REVIEW", f"deep preview {tag}",
                 f"{tag} count changed from {old_count} to {new_count} in the deep preview.",
             ))
         old_ids = set(old_deep["ids"].get(tag, []))
         new_ids = set(new_deep["ids"].get(tag, []))
         if old_ids != new_ids:
             findings.append(Finding(
-                "REVIEW", f"deep preview {tag} identity",
+                "INFO" if same_version else "REVIEW", f"deep preview {tag} identity",
                 f"{len(old_ids - new_ids)} IDs were removed and {len(new_ids - old_ids)} IDs were added.",
             ))
 
-    if baseline.get("lor_version") == candidate.get("lor_version"):
+    if same_version:
         findings = [_same_version_authoring_finding(item) for item in findings]
     return findings
 

--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/test_lor_version_checker_maintenance.py
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/test_lor_version_checker_maintenance.py
@@ -1,0 +1,153 @@
+"""Regression tests for approved-version preview maintenance."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("lor_version_checker.py")
+SPEC = importlib.util.spec_from_file_location(
+    "lor_version_checker_maintenance", MODULE_PATH
+)
+checker = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+sys.modules[SPEC.name] = checker
+SPEC.loader.exec_module(checker)
+
+
+BLANK_DISPLAY = '''
+  <PropClass id="22222222-2222-4222-8222-222222222222" Name="A"
+    Comment="Display A" DeviceType="LOR"
+    ChannelGrid="Regular,01,1,16,0," Tag="" TraditionalColors="">
+    <shape BackgroundImage="" CustomGrid="" OffsetX="0" OffsetY="0"
+      ScaleX="1" ScaleY="1" />
+  </PropClass>
+'''
+
+AUTHORED_DISPLAY = '''
+  <PropClass id="33333333-3333-4333-8333-333333333333" Name="B"
+    Comment="Display B" DeviceType="LOR"
+    ChannelGrid="Regular,02,17,32,0,FFFFFF" Tag="station"
+    TraditionalColors="Red,Green,White">
+    <shape BackgroundImage="G:\\Displays\\station.png"
+      CustomGrid="0,0;1,1;2,2" OffsetX="0.5" OffsetY="1.5"
+      ScaleX="1.25" ScaleY="0.75" />
+  </PropClass>
+'''
+
+
+def preview(*displays: str, extra: str = "") -> str:
+    return (
+        '<?xml version="1.0"?>\n'
+        '<PreviewClass id="11111111-1111-4111-8111-111111111111" '
+        'Name="Stage 30" Revision="1">\n'
+        + "".join(displays)
+        + extra
+        + "</PreviewClass>\n"
+    )
+
+
+class ApprovedVersionMaintenanceTests(unittest.TestCase):
+    def manifest(self, xml: str, version: str = "6.6.10"):
+        temporary = tempfile.TemporaryDirectory()
+        folder = Path(temporary.name)
+        filename = "Show Background Stage 30-Santa's Station-QV.lorprev"
+        (folder / filename).write_text(xml, encoding="utf-8")
+        manifest = checker.build_manifest(folder, version, filename)
+        return temporary, manifest
+
+    def compare(self, old_xml: str, new_xml: str, new_version: str = "6.6.10"):
+        old_temp, baseline = self.manifest(old_xml)
+        new_temp, candidate = self.manifest(new_xml, new_version)
+        self.addCleanup(old_temp.cleanup)
+        self.addCleanup(new_temp.cleanup)
+        findings = checker.compare_manifests(baseline, candidate)
+        return findings, checker.report_document(baseline, candidate, findings)
+
+    def test_same_version_display_addition_and_authored_values_are_informational(self) -> None:
+        findings, report = self.compare(
+            preview(BLANK_DISPLAY),
+            preview(BLANK_DISPLAY, AUTHORED_DISPLAY),
+        )
+
+        evidence = "\n".join(
+            f"{finding.area}: {finding.message}" for finding in findings
+        )
+        for expected in (
+            "PropClass.Tag",
+            "PropClass.TraditionalColors",
+            "shape.BackgroundImage",
+            "shape.CustomGrid",
+            "shape.OffsetX",
+            "shape.OffsetY",
+            "shape.ScaleX",
+            "shape.ScaleY",
+            "PropClass.ChannelGrid.6",
+            "New delimiter-encoded field layout: shape.CustomGrid",
+        ):
+            self.assertIn(expected, evidence)
+        self.assertTrue(findings)
+        self.assertTrue(all(finding.severity == "INFO" for finding in findings))
+        self.assertEqual(report["status"], "PASSED")
+        self.assertFalse(report["approval_blocked"])
+
+    def test_same_version_custom_grid_record_and_token_counts_are_informational(self) -> None:
+        old_display = BLANK_DISPLAY.replace('CustomGrid=""', 'CustomGrid="0;1"')
+        new_display = BLANK_DISPLAY.replace(
+            'CustomGrid=""', 'CustomGrid="0,0;1,1;2,2"'
+        )
+        findings, report = self.compare(
+            preview(old_display),
+            preview(new_display),
+        )
+
+        evidence = "\n".join(finding.message for finding in findings)
+        self.assertIn("semicolon record count", evidence)
+        self.assertIn("comma token count", evidence)
+        self.assertTrue(all(finding.severity == "INFO" for finding in findings))
+        self.assertEqual(report["status"], "PASSED")
+        self.assertFalse(report["approval_blocked"])
+
+    def test_same_version_display_removal_is_informational(self) -> None:
+        findings, report = self.compare(
+            preview(BLANK_DISPLAY, AUTHORED_DISPLAY),
+            preview(BLANK_DISPLAY),
+        )
+
+        self.assertTrue(findings)
+        self.assertTrue(all(finding.severity == "INFO" for finding in findings))
+        self.assertEqual(report["status"], "PASSED")
+        self.assertFalse(report["approval_blocked"])
+
+    def test_different_version_keeps_the_same_content_differences_strict(self) -> None:
+        findings, report = self.compare(
+            preview(BLANK_DISPLAY),
+            preview(BLANK_DISPLAY, AUTHORED_DISPLAY),
+            new_version="6.6.11",
+        )
+
+        self.assertTrue(any(finding.severity == "BLOCKING" for finding in findings))
+        self.assertEqual(report["status"], "FAILED")
+        self.assertTrue(report["approval_blocked"])
+
+    def test_same_version_new_xml_vocabulary_remains_blocking(self) -> None:
+        findings, report = self.compare(
+            preview(BLANK_DISPLAY),
+            preview(BLANK_DISPLAY, extra='  <UnknownField value="1" />\n'),
+        )
+
+        self.assertTrue(any(
+            finding.severity == "BLOCKING"
+            and "UnknownField" in f"{finding.area} {finding.message}"
+            for finding in findings
+        ))
+        self.assertEqual(report["status"], "FAILED")
+        self.assertTrue(report["approval_blocked"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- classify same-approved-version Display and Scene count/identity changes as informational
- classify value-shape and delimiter-payload variation as informational during routine approved-version runs
- preserve nonblocking Motion FX row maintenance
- keep different-LOR-version compatibility comparison fully strict
- keep genuinely new XML vocabulary blocking
- bump `lor_version_checker.py` to V1.4.0 and document the operating boundary

## Triggering incident

A routine LOR 6.6.10 update to `Show Background Stage 30-Santa's Station-QV.lorprev` was incorrectly blocked because newly authored values expanded observed value shapes and `CustomGrid` delimiter counts. The parser already accepts or ignores every reported field; the instance-data profile was being mistaken for an XML schema change.

## Validation

```text
python -m unittest discover -s Docs/01_LOR_System/02_Data_Extraction/Parser -p 'test_*.py'
Ran 40 tests
OK
```

The new regression suite covers the exact `Tag`, `TraditionalColors`, `BackgroundImage`, `CustomGrid`, decimal offset/scale, optional `ChannelGrid.6`, and delimiter-count findings; Display addition/removal; strict different-version behavior; and the new-vocabulary blocker.