### PR TITLE
Add unattended PRINT-SERVER LOR runner profile

### DIFF
--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/README.md
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/README.md
@@ -19,9 +19,9 @@ tools for operator convenience but does not own their XML interpretation.
 | `test_parse_props_atomic_publish.py` | Regression tests for transient Windows file-lock retry and fail-closed atomic publication |
 
 The repository-root `run_lor_runner.ps1` is the canonical deployment and
-runtime launcher. It owns DPAPI secret storage, the logged-in-user Scheduled
-Task, authenticated status checks, and SSH pairing to the Linux API. Do not
-assemble runner environment variables or tokens manually.
+runtime launcher. It owns DPAPI secret storage, both reviewed Scheduled Task
+profiles, authenticated status checks, and SSH pairing to the Linux API. Do
+not assemble runner environment variables or tokens manually.
 
 ## Operating Boundary
 
@@ -55,12 +55,14 @@ already committed snapshot.
 
 That Office Desktop deployment is temporary/test infrastructure. The approved
 permanent host is `PRINT-SERVER` (`192.168.5.56`) under a separate unattended
-Scheduled Task. The transfer is not yet deployed. Before cutover, the
-`PRINT-SERVER\Print Service` task context must have durable headless access to
-the approved preview/state/output paths, and the runner launcher must support
-the accepted at-startup noninteractive task model. Do not disable the Office
-Desktop listener or re-pair Linux until the controlled transfer acceptance
-gates pass.
+Scheduled Task. On 2026-08-25, a Password-logon task running as
+`PRINT-SERVER\Print Service` passed the headless `G:` path gate in Session 0
+with no interactive user. Launcher V1.6.0 now provides the reviewed
+`PrintServerUnattended` at-startup profile while retaining
+`OfficeInteractive` for rollback. The production transfer remains incomplete
+until deployment, Linux re-pairing, dashboard validation, controlled parser
+validation, and reboot acceptance pass. Do not disable the Office Desktop
+listener or re-pair Linux early.
 
 See:
 

--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/lor_operator_runner.py
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/lor_operator_runner.py
@@ -2,7 +2,7 @@
 
 Initial release: 2026-08-13 V1.0.0
 
-Current version: 2026-08-16 V1.5.1
+Current version: 2026-08-25 V1.6.0
 
 V1.5.0 adds the fixed, digest-locked PostgreSQL ingest operation and bounded
 read-only ingest console. Parser execution remains repeatable and never starts
@@ -10,6 +10,10 @@ ingest automatically.
 
 V1.5.1 pairs that operation with ingest V0.4.1, whose digest-idempotent recovery
 recognizes an already-committed snapshot after a console/reporting failure.
+
+V1.6.0 adds the reviewed dual-host launcher contract: the existing Office
+interactive recovery profile remains available, while PRINT-SERVER uses a
+separate at-startup Password-logon task under Print Service.
 
 The production LOR2DB API runs on Linux. This small internal service owns the
 Windows/G-drive execution boundary and exposes only version-scoped operations;
@@ -39,7 +43,7 @@ from urllib.parse import urlparse
 from lor_version_checker import build_manifest, compare_manifests, manifest_source_signature, write_json
 
 
-RUNNER_VERSION = "V1.5.1"
+RUNNER_VERSION = "V1.6.0"
 MAX_BROWSER_CONSOLE_CHARACTERS = 500_000
 
 AUTHORITATIVE_OUTPUT_TABLES = (

--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/test_lor_operator_runner.py
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/test_lor_operator_runner.py
@@ -79,6 +79,15 @@ class OperatorRunnerTests(unittest.TestCase):
         self.assertIn("ConfigureIngest", source)
         self.assertIn("postgres-ingest-password.dpapi", source)
         self.assertIn("LOR_INGEST_PG_PASSWORD", source)
+        self.assertIn("PrintServerUnattended", source)
+        self.assertIn("New-ScheduledTaskTrigger -AtStartup", source)
+        self.assertIn("$trigger.Delay = 'PT1M'", source)
+        self.assertIn("-LogonType Interactive", source)
+        self.assertIn("-Password $taskPassword", source)
+        self.assertIn("-RunLevel Highest", source)
+        self.assertIn("PRINT-SERVER\\Print Service", source)
+        self.assertIn("192.168.5.56", source)
+        self.assertIn("192.168.5.55", source)
 
     def test_http_access_log_uses_stdout_not_stderr(self) -> None:
         """A successful request must not become a PowerShell native error."""

--- a/Docs/01_LOR_System/02_Data_Extraction/README.md
+++ b/Docs/01_LOR_System/02_Data_Extraction/README.md
@@ -15,7 +15,7 @@ separate SQLite-to-PostgreSQL ingest.
 | Understand the `.lorprev` structure the parser depends on | [LOR Preview File Structure Specification](LOR_Preview_File_Structure_Specification.md) |
 | Evaluate and approve a new Light-O-Rama version | [LOR Preview Version Compatibility Review](LOR_Preview_Version_Compatibility_Review.md) |
 | Review the current parser/checker implementation | [Parser](Parser/) |
-| Install, restart, or recover the Office PC listener | [Office PC Runner Operations and Disaster Recovery](../../../LOR2DB/Application/Office_PC_Runner_Operations_and_Disaster_Recovery.md) |
+| Install, transfer, restart, or recover the Windows LOR runner | [LOR Runner Operations and Disaster Recovery](../../../LOR2DB/Application/Office_PC_Runner_Operations_and_Disaster_Recovery.md) |
 | Review the separate PostgreSQL ingest | [LOR2DB Ingest](../../../LOR2DB/01_Ingest/README.md) |
 
 ## Engineering Boundary

--- a/LOR2DB/Application/Office_PC_Runner_Operations_and_Disaster_Recovery.md
+++ b/LOR2DB/Application/Office_PC_Runner_Operations_and_Disaster_Recovery.md
@@ -4,7 +4,7 @@
 |---|---|
 | Repository path | `LOR2DB/Application/Office_PC_Runner_Operations_and_Disaster_Recovery.md` |
 | Document type | Engineering operations and recovery runbook |
-| Status | CURRENT — temporary host pending controlled PRINT-SERVER transfer |
+| Status | CURRENT — PRINT-SERVER implementation ready; production cutover pending |
 | Owner | MSB Database Administrator |
 | Initial release / current revision | 2026-08-17 / 2026-08-25 |
 
@@ -12,6 +12,7 @@
 
 | Date | Change |
 |---|---|
+| 2026-08-25 | Recorded the passing PRINT-SERVER Session-0 path probe and added the V1.6.0 `PrintServerUnattended` installation and cutover procedure. |
 | 2026-08-25 | Recorded the Office Desktop as a temporary/test host and PRINT-SERVER as the approved permanent production host; added transfer prerequisites and acceptance boundary. |
 | 2026-08-17 | Initial controlled runbook for installation, restart, credential recovery, network failure, and replacement-PC transfer. |
 
@@ -27,7 +28,7 @@ This is not a normal operator procedure. Authorized operators use the LOR2DB
 website. Use this document only to maintain or recover the engineering service
 boundary behind that website.
 
-## Approved Host Transition — Not Yet Deployed
+## Approved Host Transition — Implementation Ready, Not Yet Deployed
 
 The Office Desktop deployment is now classified as temporary/test
 infrastructure. It is not the accepted permanent production host.
@@ -36,7 +37,7 @@ infrastructure. It is not the accepted permanent production host.
 Current temporary host: MSB-OFFICE-PC (192.168.5.55)
 Approved permanent host: PRINT-SERVER (192.168.5.56)
 Permanent task account: PRINT-SERVER\Print Service
-Transfer status: PLANNED — NOT YET INSTALLED OR ACCEPTED
+Transfer status: IMPLEMENTATION READY — NOT YET INSTALLED OR ACCEPTED
 ```
 
 On 2026-08-25, closing the interactive PowerShell window that owned the Office
@@ -54,6 +55,47 @@ This section records a hosting decision, not a completed deployment. Until the
 cutover acceptance gates pass, Linux remains configured for the temporary
 Office Desktop runner and the website may report the runner offline when that
 temporary listener is stopped.
+
+### Headless Shared-Drive Gate — PASSED 2026-08-25
+
+A temporary Password-logon Scheduled Task was run as
+`PRINT-SERVER\Print Service` with `RunLevel: Highest`. The task completed with
+`LastTaskResult: 0` and recorded:
+
+```text
+Identity=PRINT-SERVER\Print Service
+SessionId=0
+UserInteractive=False
+GDrivePresent=True
+```
+
+The same headless task confirmed all required paths:
+
+```text
+G:\Shared drives\MSB Database
+G:\Shared drives\MSB Database\Database Previews V6.6.10
+G:\Shared drives\MSB Database\LOR Version Reviews
+G:\Shared drives\MSB Database\LOR Version Reviews\runner-state.json
+G:\Shared drives\MSB Database\database\lor_output_v7_scene.db
+```
+
+This proves the permanent task account can access the current LOR source,
+durable state, review tree, and SQLite output without an interactive Windows
+login. The temporary probe task and files are not production components and
+must be removed after evidence capture.
+
+Launcher V1.6.0 now implements two explicit deployment profiles:
+
+| Profile | Host model | Task model | Default listener |
+|---|---|---|---|
+| `OfficeInteractive` | Temporary recovery | At user logon / Interactive / Limited | `192.168.5.55:8791` |
+| `PrintServerUnattended` | Approved permanent target | At startup after one minute / Password / Highest | `192.168.5.56:8791` |
+
+The unattended profile refuses installation or startup unless the computer is
+`PRINT-SERVER` and the current identity is
+`PRINT-SERVER\Print Service`. The password is requested through a Windows
+credential prompt and is supplied only to Task Scheduler; it is not stored in
+the repository, command line, runner state, or service log.
 
 The PRINT-SERVER host/runtime prerequisites and dual-workload isolation gates
 are controlled by the
@@ -188,7 +230,7 @@ A healthy result must show:
 - protected runner token `AVAILABLE`;
 - protected PostgreSQL ingest credential `AVAILABLE`;
 - runner health `ok`; and
-- runner version `V1.5.1` or the later version documented by the deployed
+- runner version `V1.6.0` or the later version documented by the deployed
   release.
 
 The displayed credential fingerprint is not a secret. It is safe to use when
@@ -279,29 +321,28 @@ The generic replacement procedure below describes the existing
 logged-in-user runner design. It must **not** be executed unchanged for the
 approved PRINT-SERVER transfer.
 
-Before deploying to `PRINT-SERVER`:
+Transfer requirements and current status:
 
-1. Verify a stable read/write path to the approved preview folders,
+1. **PASSED 2026-08-25:** Verify a stable read/write path to the approved preview folders,
    `runner-state.json`, compatibility manifests, review records, and SQLite
    output from the `PRINT-SERVER\Print Service` noninteractive task context.
    A `G:` mapping visible only in an interactive desktop session is not
    sufficient.
-2. Establish a separate LOR runner working directory and Python environment.
+2. **DEPLOYMENT STEP:** Establish a separate LOR runner working directory and Python environment.
    Do not install into `C:\MSB_LabelService`, alter its Python dependencies, or
    reuse its logs or configuration.
-3. Update and test `run_lor_runner.ps1` so `Install` can create the approved
-   at-startup, run-whether-logged-on-or-not task under the permanent Print
-   Service account. The current launcher intentionally creates an at-logon
-   interactive task and therefore does not yet meet this production target.
-4. Use the reserved PRINT-SERVER address `192.168.5.56` for the listener and
+3. **IMPLEMENTED IN V1.6.0:** The reviewed `PrintServerUnattended` profile
+   creates an at-startup, Password-logon, Highest task under the permanent
+   Print Service account and retains the Office interactive rollback profile.
+4. **DEPLOYMENT STEP:** Use the reserved PRINT-SERVER address `192.168.5.56` for the listener and
    restrict inbound TCP 8791 to `192.168.5.9`.
-5. Create new DPAPI-protected runner and PostgreSQL credentials under the
+5. **DEPLOYMENT STEP:** Create new DPAPI-protected runner and PostgreSQL credentials under the
    permanent task account. Existing Office Desktop DPAPI files are not
    portable.
-6. Back up the Linux pairing environment, then re-pair it to
+6. **CUTOVER STEP:** Back up the Linux pairing environment, then re-pair it to
    `http://192.168.5.56:8791` only when the new runner is ready for controlled
    cutover.
-7. Require local health, Linux API-to-runner health, dashboard availability,
+7. **ACCEPTANCE STEP:** Require local health, Linux API-to-runner health, dashboard availability,
    controlled parser validation, dual-task reboot recovery, and an unaffected
    physical Label Print Service test before disabling the Office Desktop
    runner.
@@ -309,6 +350,99 @@ Before deploying to `PRINT-SERVER`:
 The PRINT-SERVER host facts and workload-isolation requirements are maintained
 in the
 [Print Server Runtime Runbook](https://github.com/Gregovate/MSB_LabelPrintService/blob/main/docs/Print_Server_Runtime_Runbook.md).
+
+### PRINT-SERVER controlled installation
+
+Run these commands locally on `PRINT-SERVER` while signed in as
+`PRINT-SERVER\Print Service`. Use a separate elevated PowerShell window only
+for the firewall rule.
+
+1. Create the isolated working tree and virtual environment:
+
+   ```powershell
+   Set-Location C:\
+   git clone `
+       https://github.com/Gregovate/MSB-Production-Database-Project.git `
+       C:\MSB_LORRunner
+
+   Set-Location C:\MSB_LORRunner
+   git switch main
+   git pull --ff-only
+
+   & "C:\Program Files\Python\python.exe" -m venv .venv
+   .\.venv\Scripts\python.exe -m pip install --upgrade pip
+   .\.venv\Scripts\python.exe -m pip install psycopg2-binary==2.9.10
+   ```
+
+2. Validate the reviewed release before creating credentials or tasks:
+
+   ```powershell
+   [scriptblock]::Create((Get-Content .\run_lor_runner.ps1 -Raw)) |
+       Out-Null
+
+   .\.venv\Scripts\python.exe -m unittest discover `
+       -s .\Docs\01_LOR_System\02_Data_Extraction\Parser `
+       -p "test_*.py"
+   ```
+
+   All tests must pass. Do not install the task from an uncommitted or dirty
+   working tree.
+
+3. In an elevated PowerShell window, create the isolated inbound firewall
+   rule:
+
+   ```powershell
+   New-NetFirewallRule `
+       -DisplayName "MSB LOR Runner 8791" `
+       -Direction Inbound `
+       -Action Allow `
+       -Profile Private `
+       -Protocol TCP `
+       -LocalAddress 192.168.5.56 `
+       -LocalPort 8791 `
+       -RemoteAddress 192.168.5.9 `
+       -Program "C:\MSB_LORRunner\.venv\Scripts\python.exe"
+   ```
+
+   Do not modify the Label Service task, firewall behavior, Python runtime, or
+   `C:\MSB_LabelService`.
+
+4. Back in the normal Print Service PowerShell window, install and verify the
+   new runner:
+
+   ```powershell
+   Set-Location C:\MSB_LORRunner
+
+   .\run_lor_runner.ps1 `
+       -Action Install `
+       -DeploymentProfile PrintServerUnattended
+
+   .\run_lor_runner.ps1 `
+       -Action Status `
+       -DeploymentProfile PrintServerUnattended
+   ```
+
+   `Install` prompts separately for the PostgreSQL `msbadmin` ingest password
+   and the Windows `PRINT-SERVER\Print Service` task password. Do not confuse
+   those credentials. Do not pair Linux until local status shows task
+   `Running`, both DPAPI-protected credentials `AVAILABLE`, health `ok`, and
+   runner `V1.6.0`.
+
+5. Confirm the installed task contract:
+
+   ```powershell
+   (Get-ScheduledTask -TaskName "MSB LOR Operator Runner").Principal |
+       Format-List UserId,LogonType,RunLevel
+
+   (Get-ScheduledTask -TaskName "MSB LOR Operator Runner").Triggers |
+       Format-List *
+   ```
+
+   Require `Print Service`, `Password`, `Highest`, an at-startup trigger, and a
+   one-minute delay.
+
+This completes installation only. Linux re-pairing is the controlled cutover
+and is performed only after the old Office listener is confirmed stopped.
 
 ### Transfer procedure
 

--- a/LOR2DB/Application/README.md
+++ b/LOR2DB/Application/README.md
@@ -9,6 +9,7 @@
 
 | Date | Change |
 |---|---|
+| 2026-08-25 | Added runner V1.6.0 dual deployment profiles after the PRINT-SERVER Password-logon Session-0 task proved headless access to every required Shared Drive path. Production cutover remains separately controlled. |
 | 2026-08-16 | Changed the successful final production-application boundary from failure-red styling to an amber notice with standard blue confirmation controls. Cancellation and actual failures remain red. |
 | 2026-08-16 | Added ingest V0.4.1 / runner V1.5.1 recovery for a Windows console encoding failure after PostgreSQL commit. The exact completed SQLite digest is reused without creating a duplicate import run, and post-commit failures can no longer claim rollback. |
 | 2026-08-16 | Kept `Run parser` permanently available after successful runs and made `Review parser output` an additional action instead of a replacement. Corrected the Windows installer message so an unchanged protected token does not instruct the operator to pair the server again. |
@@ -157,15 +158,24 @@ Production already has an approved 6.6.10 state and must retain it. Never run
 
 Use only the repository-root launcher. `Install` generates one random token,
 protects it with Windows DPAPI, and registers the **MSB LOR Operator Runner**
-task at Greg's logon. It never starts the parser. `PairServer` transfers the
-same token over SSH to a mode-0600 pending file without displaying or placing
-the secret in command history.
+task using the selected deployment profile. It never starts the parser.
+`PairServer` transfers the same token over SSH to a mode-0600 pending file
+without displaying or placing the secret in command history.
 
 ```powershell
 .\run_lor_runner.ps1 -Action Install
 .\run_lor_runner.ps1 -Action PairServer
 .\run_lor_runner.ps1 -Action Stop
 .\run_lor_runner.ps1 -Action Status
+```
+
+The temporary Office deployment defaults to `OfficeInteractive`. The approved
+PRINT-SERVER command is explicit:
+
+```powershell
+.\run_lor_runner.ps1 `
+    -Action Install `
+    -DeploymentProfile PrintServerUnattended
 ```
 
 `Install` safely replaces an existing managed runner, including an orphaned
@@ -195,12 +205,13 @@ runner offline, while the existing SQLite snapshot, PostgreSQL, and any
 already-started reconciliation remain unaffected.
 
 The approved permanent host is `PRINT-SERVER` (`192.168.5.56`) using a
-separate at-startup, run-whether-logged-on-or-not Scheduled Task under
-`PRINT-SERVER\Print Service`. That transfer is planned but not yet deployed.
-The current launcher creates an interactive at-logon task and must be updated
-and tested before it can install the approved PRINT-SERVER production model.
-Headless access to the approved preview/state/output paths is a mandatory
-cutover gate; a user-session-only `G:` mapping is not sufficient.
+separate at-startup, Password-logon Scheduled Task under
+`PRINT-SERVER\Print Service`. A Session-0 task passed headless access to the
+approved preview/state/output paths on 2026-08-25. Runner V1.6.0 now implements
+that `PrintServerUnattended` profile and retains the existing
+`OfficeInteractive` profile for rollback. The transfer is implementation-ready
+but not production-complete until installation, Linux re-pairing, dashboard,
+parser, reboot, and Label Service isolation acceptance all pass.
 
 Installation, restart, credential recovery, network requirements, and transfer
 to a replacement host are controlled by the

--- a/run_lor_runner.ps1
+++ b/run_lor_runner.ps1
@@ -18,7 +18,10 @@ param(
     [ValidateSet('Install', 'ConfigureIngest', 'PairServer', 'Start', 'Stop', 'Status')]
     [string]$Action = 'Status',
 
-    [string]$RunnerHost = '192.168.5.55',
+    [ValidateSet('OfficeInteractive', 'PrintServerUnattended')]
+    [string]$DeploymentProfile,
+
+    [string]$RunnerHost,
     [ValidateRange(1, 65535)]
     [int]$Port = 8791,
 
@@ -30,6 +33,22 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
+if (-not $DeploymentProfile) {
+    if ($env:COMPUTERNAME -ieq 'PRINT-SERVER') {
+        $DeploymentProfile = 'PrintServerUnattended'
+    }
+    else {
+        $DeploymentProfile = 'OfficeInteractive'
+    }
+}
+if (-not $RunnerHost) {
+    if ($DeploymentProfile -eq 'PrintServerUnattended') {
+        $RunnerHost = '192.168.5.56'
+    }
+    else {
+        $RunnerHost = '192.168.5.55'
+    }
+}
 $TaskName = 'MSB LOR Operator Runner'
 $RepoRoot = $PSScriptRoot
 $RunnerPath = Join-Path $RepoRoot `
@@ -231,21 +250,37 @@ function Test-AuthenticatedHealth {
     }
 }
 
+function Assert-DeploymentIdentity {
+    if ($DeploymentProfile -ne 'PrintServerUnattended') {
+        return
+    }
+
+    if ($env:COMPUTERNAME -ine 'PRINT-SERVER') {
+        throw (
+            'PrintServerUnattended may be installed or started only on ' +
+            'PRINT-SERVER.'
+        )
+    }
+    $identity = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+    if ($identity -ine 'PRINT-SERVER\Print Service') {
+        throw (
+            'PrintServerUnattended must run as ' +
+            "PRINT-SERVER\Print Service; current identity is $identity."
+        )
+    }
+}
+
 function Install-ScheduledRunner {
     $account = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
     $arguments = "-NoProfile -WindowStyle Hidden " +
         "-ExecutionPolicy Bypass -File `"$PSCommandPath`" " +
-        "-Action Start -RunnerHost $RunnerHost -Port $Port " +
+        "-Action Start -DeploymentProfile $DeploymentProfile " +
+        "-RunnerHost $RunnerHost -Port $Port " +
         "-StateFile `"$StateFile`""
     $taskAction = New-ScheduledTaskAction `
         -Execute 'powershell.exe' `
         -Argument $arguments `
         -WorkingDirectory $RepoRoot
-    $trigger = New-ScheduledTaskTrigger -AtLogOn -User $account
-    $principal = New-ScheduledTaskPrincipal `
-        -UserId $account `
-        -LogonType Interactive `
-        -RunLevel Limited
     $settings = New-ScheduledTaskSettingsSet `
         -StartWhenAvailable `
         -AllowStartIfOnBatteries `
@@ -254,14 +289,52 @@ function Install-ScheduledRunner {
         -RestartInterval (New-TimeSpan -Minutes 1) `
         -ExecutionTimeLimit ([TimeSpan]::Zero) `
         -MultipleInstances IgnoreNew
-    Register-ScheduledTask `
-        -TaskName $TaskName `
-        -Action $taskAction `
-        -Trigger $trigger `
-        -Principal $principal `
-        -Settings $settings `
-        -Description 'Restricted LOR2DB parser/ingest/version-check runner; requires Greg logon and G: drive.' `
-        -Force | Out-Null
+
+    if ($DeploymentProfile -eq 'PrintServerUnattended') {
+        $trigger = New-ScheduledTaskTrigger -AtStartup
+        $trigger.Delay = 'PT1M'
+        $taskCredential = Get-Credential `
+            -UserName $account `
+            -Message 'Enter the PRINT-SERVER Print Service Windows password'
+        if (-not $taskCredential) {
+            throw 'Windows task credential entry was cancelled.'
+        }
+        $taskPassword = $taskCredential.GetNetworkCredential().Password
+        if ([string]::IsNullOrWhiteSpace($taskPassword)) {
+            throw 'Windows task password cannot be blank.'
+        }
+        try {
+            Register-ScheduledTask `
+                -TaskName $TaskName `
+                -Action $taskAction `
+                -Trigger $trigger `
+                -User $account `
+                -Password $taskPassword `
+                -RunLevel Highest `
+                -Settings $settings `
+                -Description 'Restricted unattended LOR2DB runner on PRINT-SERVER; isolated from MSB Label Service.' `
+                -Force | Out-Null
+        }
+        finally {
+            Remove-Variable taskPassword -ErrorAction SilentlyContinue
+            Remove-Variable taskCredential -ErrorAction SilentlyContinue
+        }
+    }
+    else {
+        $trigger = New-ScheduledTaskTrigger -AtLogOn -User $account
+        $principal = New-ScheduledTaskPrincipal `
+            -UserId $account `
+            -LogonType Interactive `
+            -RunLevel Limited
+        Register-ScheduledTask `
+            -TaskName $TaskName `
+            -Action $taskAction `
+            -Trigger $trigger `
+            -Principal $principal `
+            -Settings $settings `
+            -Description 'Restricted LOR2DB runner; requires the Office user logon and G: drive.' `
+            -Force | Out-Null
+    }
 }
 
 function Stop-InstalledRunner {
@@ -353,6 +426,7 @@ function Start-InstalledRunner {
 
 switch ($Action) {
     'Install' {
+        Assert-DeploymentIdentity
         Assert-RunnerPrerequisites | Out-Null
         Stop-InstalledRunner
         $pairingRequired = $false
@@ -380,7 +454,9 @@ switch ($Action) {
             Remove-Variable secureIngestCredential -ErrorAction SilentlyContinue
         }
         Install-ScheduledRunner
-        Write-Host "[OK] Scheduled Task installed for logged-in account: $TaskName"
+        Write-Host "[OK] Scheduled Task installed: $TaskName"
+        Write-Host "[OK] Deployment profile: $DeploymentProfile"
+        Write-Host "[OK] Task account: $([System.Security.Principal.WindowsIdentity]::GetCurrent().Name)"
         Write-Host "[OK] Credential fingerprint: $(Get-TokenFingerprint -Token $token)"
         Start-InstalledRunner -Token $token
         if ($pairingRequired) {
@@ -393,6 +469,7 @@ switch ($Action) {
     }
 
     'ConfigureIngest' {
+        Assert-DeploymentIdentity
         Assert-RunnerPrerequisites | Out-Null
         $secureIngestCredential = Read-Host `
             'Enter the PostgreSQL msbadmin password for web ingest' `
@@ -421,13 +498,17 @@ switch ($Action) {
         Write-Host '[OK] Pairing token transferred to a mode-0600 pending file.'
         Write-Host "[OK] Credential fingerprint: $(Get-TokenFingerprint -Token $token)"
         Write-Host '[NEXT] From the repository root on msb-prod-db, run:'
-        Write-Host 'sudo python3 LOR2DB/Application/install_lor_runner_pairing.py'
+        Write-Host (
+            'sudo python3 LOR2DB/Application/install_lor_runner_pairing.py ' +
+            "--runner-url http://${RunnerHost}:$Port"
+        )
         Remove-Variable token -ErrorAction SilentlyContinue
     }
 
     'Start' {
         Write-ServiceLog "Start requested for ${RunnerHost}:$Port."
         try {
+            Assert-DeploymentIdentity
             $state = Assert-RunnerPrerequisites
             Write-ServiceLog (
                 "Prerequisites passed for approved LOR " +
@@ -454,7 +535,8 @@ switch ($Action) {
             $env:LOR_INGEST_PATH = $IngestPath
             $env:PYTHONUNBUFFERED = '1'
             Write-ServiceLog (
-                "Starting runner V1.5.1; credential fingerprint=" +
+                "Starting runner V1.6.0; profile=$DeploymentProfile; " +
+                "credential fingerprint=" +
                 "$(Get-TokenFingerprint -Token $token)."
             )
             # BaseHTTPRequestHandler writes normal HTTP access records to
@@ -499,9 +581,14 @@ switch ($Action) {
 
     'Status' {
         Write-Host "Task: $TaskName"
+        Write-Host "Deployment profile: $DeploymentProfile"
+        Write-Host "Runner endpoint: http://${RunnerHost}:$Port"
         $task = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
         if ($task) {
             Write-Host "Scheduled Task state: $($task.State)"
+            Write-Host "Scheduled Task user: $($task.Principal.UserId)"
+            Write-Host "Scheduled Task logon type: $($task.Principal.LogonType)"
+            Write-Host "Scheduled Task run level: $($task.Principal.RunLevel)"
         }
         else {
             Write-Host 'Scheduled Task state: NOT INSTALLED'


### PR DESCRIPTION
## Summary

- add runner V1.6.0 with explicit `OfficeInteractive` and `PrintServerUnattended` deployment profiles
- preserve the existing Office task model for rollback
- enforce `PRINT-SERVER` and `PRINT-SERVER\Print Service` for unattended installation/startup
- register an at-startup Password-logon task at Highest privilege with a one-minute delay
- default the permanent listener to `192.168.5.56:8791`
- retain separate DPAPI secrets, repository, virtual environment, logs, and task from `MSB Label Service`
- print the exact Linux pairing command with the selected runner URL
- record the passing Session-0 headless G-drive evidence and controlled install/cutover procedure

## Validation

- parser/runner tests: 40 passed
- Linux application tests with isolated requirements: 60 passed
- Python compileall: passed
- `git diff --check`: passed
- branch is based directly on current `main`

## Production boundary

This PR makes the PRINT-SERVER implementation ready. It does not itself install the Windows task, alter the Label Service, modify Linux pairing, start parser/ingest, or start reconciliation.