### PR TITLE
Close out Zebra Android scanner field acceptance

### DIFF
--- a/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/Scanner_Android_Field_Acceptance_2026-08-27.md
+++ b/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/Scanner_Android_Field_Acceptance_2026-08-27.md
@@ -1,0 +1,100 @@
+# Scanner Android Field Acceptance — 2026-08-27
+
+| Document control | Value |
+|---|---|
+| Status | ACCEPTANCE / FIELD TEST RECORD |
+| Date | 2026-08-27 |
+| Subsystem | Labeling and Scanning |
+| Hardware | Zebra DS3678-HD + HOTWAV R9 Ultra Android tablet |
+
+## Purpose
+
+Record the actual Android/Bluetooth and warehouse-range findings from the 2026-08-27 scanner test so future work does not have to reconstruct them from chat history.
+
+## Android Pairing Result
+
+The Zebra scanner was successfully paired to the HOTWAV R9 Ultra Android tablet and operated as Bluetooth HID keyboard input in the browser.
+
+However, pairing was **not accomplished using Android Bluetooth settings alone**.
+
+An Android application from the Google Play Store was required to complete the scanner/tablet pairing process.
+
+After pairing was established, ordinary MSB browser scanning used standard Bluetooth HID keyboard behavior. No custom MSB Android scanning application or database driver was required for normal barcode/QR input.
+
+The exact Play Store application name was not preserved in the controlled repository evidence available during this reconciliation and must not be guessed. When the exact application identity is recovered, add it here as a controlled setup dependency.
+
+## Code 128 Range Result
+
+A large Code 128 test barcode approximately six inches wide was tested with the DS3678-HD.
+
+Observed practical range was approximately four feet.
+
+This was insufficient for the intended warehouse/forklift operating distance.
+
+Result:
+
+```text
+DS3678-HD Bluetooth HID / browser input       PASS
+Large Code 128 decode at about four feet      PASS
+Warehouse/forklift working-distance use       FAIL
+```
+
+The DS3678-HD is therefore not accepted as the workshop forklift scanner. The ordered DS3678-ER is the next extended-range acceptance candidate.
+
+## QR Full-URL HID Delay Finding
+
+Existing Display and Container labels already encode full scan URLs.
+
+Examples:
+
+```text
+https://db.sheboyganlights.org/scan/DISP/323
+https://db.sheboyganlights.org/scan/CONT/216
+```
+
+The Zebra decoded the QR values correctly, but Bluetooth HID transmitted the full URL to Android as keyboard characters over several seconds.
+
+This is functionally correct but too slow for repetitive warehouse scanning.
+
+The finding is an input-performance issue, not a failed decode and not an asset-identity problem.
+
+Already-printed Display and Container labels remain supported and are not to be reprinted merely to shorten the encoded payload.
+
+Compact canonical forms such as:
+
+```text
+DISP:323
+CONT:216
+```
+
+remain relevant for future payload/profile work and/or accepted scanner-side formatting, but no production QR payload was changed by this field test.
+
+## Storage Location Status
+
+Storage Location labels have not been printed.
+
+A future compact Location payload may therefore use the canonical form:
+
+```text
+LOC:<location_code>
+```
+
+subject to the intended `/scan/LOC/:key` workflow being implemented and accepted before production Location labels are printed.
+
+## What This Test Did Not Change
+
+The 2026-08-27 scanner work did not:
+
+- change PostgreSQL schema;
+- change Scan resolver behavior;
+- change production QR payloads;
+- reprint existing Display or Container labels;
+- print Storage Location labels;
+- implement the missing Location server route;
+- change the LabelPrintService.
+
+## Related Documents
+
+- [Scanner Hardware and Tablet Integration](Scanner_Hardware_and_Tablet_Integration.md)
+- [Asset Identity and Scan Payload Standard](Asset_Identity_and_Scan_Payload_Standard.md)
+- [Labeling and Scanning](README.md)

--- a/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/Scanner_Hardware_and_Tablet_Integration.md
+++ b/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/Scanner_Hardware_and_Tablet_Integration.md
@@ -2,8 +2,8 @@
 
 | Document control | Value |
 |---|---|
-| Status | CURRENT HARDWARE BASELINE / FIELD ACCEPTANCE PENDING |
-| Current revision | 2026-08-22 |
+| Status | CURRENT HARDWARE BASELINE / PARTIAL FIELD ACCEPTANCE COMPLETE |
+| Current revision | 2026-08-27 |
 | Primary upcoming use | Setup/Deployment scanning |
 
 ## Purpose
@@ -16,7 +16,16 @@ The scanner is an input device. It does not own Production Database identity or 
 
 MSB has procured rugged tablets intended to serve as mobile browser workstations.
 
-MSB has also purchased one industrial cordless scanner kit:
+The current tested Android host is:
+
+```text
+HOTWAV R9 Ultra rugged tablet
+Android 15
+Bluetooth HID scanner input tested
+Primary current role: mobile MSB browser workstation / scanner host
+```
+
+MSB purchased one industrial cordless scanner kit:
 
 ```text
 Zebra DS3678-HD
@@ -26,21 +35,31 @@ Decode type: 1-D / 2-D imager
 Variant: High Density (HD)
 Connection kit: USB cradle/cable/power kit
 Feedback: vibration motor included
-Primary intended deployment: workshop forklift / shop storage workflows
+Original intended deployment: workshop forklift / shop storage workflows
 Secondary candidate deployment: close-range park unloading / trailer receiving
 ```
 
+Direct Bluetooth HID keyboard pairing from the DS3678-HD to the HOTWAV Android tablet has now been proven operational.
+
+The DS3678-HD failed the practical forklift working-distance acceptance test described below. It remains a valid close-range scanner candidate.
+
+A Zebra DS3678-ER has been ordered for extended-range forklift evaluation. It is not yet accepted; it must be tested with the actual HOTWAV tablet, actual MSB labels, and real forklift/rack distances.
+
 The Zebra is not currently intended to be the primary general-purpose park scanner. Park workflows are expected to rely more heavily on rugged tablets/phones, camera scanning where useful, and GPS/location context.
 
-However, the DS3678-HD may be a good fit for a **park unloading checkpoint** where an operator is standing beside a trailer or load and can scan Containers/Displays at close range as they are unloaded. That role does not require across-aisle or long-distance scanning and should be evaluated separately from forklift-seat range acceptance.
+However, the DS3678-HD may still be a good fit for a **park unloading checkpoint** where an operator is standing beside a trailer or load and can scan Containers/Displays at close range as they are unloaded. That role does not require across-aisle or long-distance scanning and remains separate from forklift-seat range acceptance.
 
-This purchased device is the first real industrial-scanner acceptance platform. Future hardware recommendations should use its measured shop and unloading results rather than remain purely conceptual.
+The DS3678-HD is the first real industrial-scanner acceptance platform. Future hardware recommendations must use measured shop and unloading results rather than remain purely conceptual.
 
 ## Scanner Capability
 
 The DS3678-HD supports the symbologies required by the current MSB identity direction, including Code 128 and QR-class 2-D codes.
 
-Zebra documents USB HID Keyboard as the default USB host mode for the DS3678 family. This aligns with the MSB browser architecture: a successful scan can arrive at the focused browser control as keyboard input without a custom database/scanner driver.
+Zebra documents USB HID Keyboard as a supported USB host mode for the DS3678 family. The scanner also supports direct Bluetooth HID keyboard operation.
+
+On 2026-08-27, direct Bluetooth HID from the DS3678-HD to the HOTWAV R9 Ultra Android tablet was verified operational. The scanner successfully behaved as a keyboard input device in the Android browser and populated the focused MSB Scan input field.
+
+This confirms that the MSB browser architecture does not require a custom Zebra Android application or scanner-specific database driver for ordinary barcode capture.
 
 Other Zebra interface modes exist, but do not introduce a more complex scanner protocol unless the real workflow proves HID insufficient.
 
@@ -59,16 +78,38 @@ Data Matrix, 10 mil -> 1.0 to 9.0 in.
 
 Actual range depends on barcode size/density, print quality, contrast, angle, ambient light, and label material.
 
-That range may be entirely adequate for controlled workshop/forklift use where the operator can bring the scanner close to the Container or rack-location label. It is also compatible with a park unloading role where the scanner operator is standing immediately beside the material being unloaded. It should not be documented as an across-aisle or extended-range scanner.
+That range is appropriate for controlled close-range use where the operator can bring the scanner close to the Container or label. It is also compatible with a park unloading role where the scanner operator is standing immediately beside the material being unloaded. It must not be documented as an across-aisle or extended-range scanner.
 
-## Workshop Forklift Acceptance Requirement
+## Workshop Forklift Acceptance Result — DS3678-HD
 
-Before accepting the DS3678-HD as the workshop forklift standard, test it from the actual operating position with the actual MSB labels.
+The DS3678-HD was field-tested on 2026-08-27 with the HOTWAV R9 Ultra Android tablet using direct Bluetooth HID keyboard input.
+
+Observed result:
+
+```text
+Bluetooth HID connection to HOTWAV Android tablet -> PASS
+Browser input to MSB Scan page                    -> PASS
+Approximate range on ~6-inch Code 128 test code   -> about 4 feet
+Forklift working-distance acceptance              -> FAIL
+```
+
+The approximately four-foot result was achieved with a large Code 128 test barcode and is still inadequate for the intended forklift/rack workflow.
+
+The DS3678-HD is therefore **not accepted as the workshop forklift scanner**.
+
+Do not spend further engineering effort trying to make the HD optical variant serve an extended-range forklift role. Retain it only where its close-range performance is operationally appropriate.
+
+The ordered DS3678-ER is the next forklift acceptance candidate.
+
+## Workshop Forklift Acceptance Requirement — DS3678-ER
+
+Before accepting the DS3678-ER as the workshop forklift standard, test it from the actual operating position with the actual MSB labels.
 
 Acceptance should include:
 
-- current Container barcode/QR labels;
-- existing rack-location labels;
+- current Container labels;
+- current Display labels where relevant to the workflow;
+- future rack/location labels only after their final payload/layout is approved;
 - laminated labels if used in production;
 - actual mounting/holding position from the forklift seat;
 - realistic rack/container distances and angles;
@@ -77,11 +118,11 @@ Acceptance should include:
 - vibration/noise conditions;
 - repeated rapid scans rather than one successful demonstration.
 
-If some future workshop task genuinely requires multi-foot or across-aisle scanning, evaluate an ER/XR-class device for that task rather than distorting the browser workflow or encouraging unsafe operator reach.
+If some future workshop task genuinely requires greater range than the ER provides, evaluate a different ER/XR-class device for that task rather than distorting the browser workflow or encouraging unsafe operator reach.
 
 ## Park Unloading Acceptance Requirement
 
-The DS3678-HD should also be tested as a separate **close-range unloading scanner** for Setup/Deployment.
+The DS3678-HD should still be tested as a separate **close-range unloading scanner** for Setup/Deployment.
 
 That workflow may look like:
 
@@ -95,8 +136,8 @@ trailer / truck arrives
 
 Acceptance should verify:
 
-- the scanner can be connected to the actual park tablet/workstation without awkward cabling;
-- the cradle/power arrangement is practical for temporary park use;
+- direct Bluetooth HID remains reliable in the actual park environment;
+- the cradle/power arrangement is practical if used for charging or temporary storage;
 - the operator can scan actual Container/Display labels without slowing unloading;
 - vibration/feedback is clear enough in outdoor/noisy conditions;
 - the workflow can auto-submit or advance without repeated screen touches;
@@ -108,19 +149,124 @@ This close-range role is distinct from GPS/site placement. The scanner confirms 
 
 MSB scan applications must support industrial scanners independently of camera scanning.
 
-The preferred shop baseline is USB/HID keyboard input:
+The verified Android path is:
 
 ```text
-scanner
-    -> cordless link to cradle
-        -> USB HID keyboard input to workstation/tablet host
+Zebra scanner
+    -> direct Bluetooth HID keyboard input
+        -> HOTWAV R9 Ultra Android tablet
             -> focused browser scan field
-                -> scan parser/router
+                -> MSB scan parser/router
 ```
+
+USB HID through the cradle remains a possible host arrangement where practical, but it is not required for the verified HOTWAV Bluetooth workflow.
 
 The browser workflow must not require camera APIs for normal industrial-scanner operation.
 
 Camera scanning remains a separate input mechanism on phones/tablets. Camera and HID scans must resolve to the same canonical payload and use the same business logic.
+
+## Existing Printed Display and Container Labels
+
+Display and Container labels are already physically printed.
+
+The deployed printed labels currently encode full MSB scan URLs, for example:
+
+```text
+https://db.sheboyganlights.org/scan/DISP/7
+https://db.sheboyganlights.org/scan/CONT/216
+```
+
+These existing labels are a physical compatibility constraint. Scanner/application engineering must continue to support them; replacing or reprinting the existing Display and Container label population is not the remediation path for scanner UX problems.
+
+This deployed fact is distinct from the canonical `TYPE:KEY` identity contract. The current MSB Scan page already accepts both the deployed full URLs and compact canonical values such as:
+
+```text
+DISP:7
+CONT:216
+```
+
+## Bluetooth HID Full-URL Performance Finding
+
+During Android Bluetooth HID testing on 2026-08-27, full URL payloads from the existing printed Display and Container labels were visibly transmitted to the Android browser as keyboard input over several seconds.
+
+This is functionally correct but **not acceptable for repetitive high-volume scanning**.
+
+The delay is an input/UX problem rather than an identity-resolution failure. The scanner decoded the labels correctly and the browser received the correct value.
+
+Candidate remediation is scanner-side data formatting so that an existing printed full URL such as:
+
+```text
+https://db.sheboyganlights.org/scan/CONT/216
+```
+
+is transmitted over HID as the shorter equivalent:
+
+```text
+CONT:216
+```
+
+and similarly:
+
+```text
+https://db.sheboyganlights.org/scan/DISP/7
+```
+
+can be transmitted as:
+
+```text
+DISP:7
+```
+
+Zebra Advanced Data Formatting / 123Scan is the current candidate mechanism. This is **not yet an accepted scanner configuration** and must be tested before it becomes the controlled MSB scanner setup.
+
+The application identity contract should not be changed merely to compensate for HID keystroke timing.
+
+## Storage Location Label Status
+
+Storage Location labels have **not** yet been printed.
+
+Unlike the already-deployed Display and Container labels, there is therefore no existing Location-label URL compatibility constraint.
+
+Current approved identity direction for discrete workshop/rack locations remains the compact canonical payload:
+
+```text
+LOC:<location_code>
+```
+
+Example used during scanner testing:
+
+```text
+LOC:RB07-B-01
+```
+
+Future Storage Location label design should be validated with the DS3678-ER and the actual rack operating distance before production printing.
+
+Do not infer from the existing Display and Container labels that future Storage Location labels must encode a full scan URL.
+
+## Storage Location Scan Route Finding
+
+During 2026-08-27 testing, entering/scanning:
+
+```text
+LOC:RB07-B-01
+```
+
+on the current MSB Scan page caused the browser to navigate to:
+
+```text
+/scan/LOC/RB07-B-01
+```
+
+The deployed Directus scan extension returned `ROUTE_NOT_FOUND` because a `/scan/LOC/:key` route is not currently implemented.
+
+This establishes a separate application gap from the scanner hardware work:
+
+```text
+LOC payload recognition / client routing -> present
+LOC server route                         -> missing
+```
+
+Do not print production Storage Location labels until the intended Location scan behavior is implemented and accepted. The missing route must be resolved in the Scan/Setup workflow rather than hidden by scanner-specific behavior.
 
 ## Shop Versus Park Input Boundary
 
@@ -128,29 +274,29 @@ The expected deployment model is deliberately different by environment, while st
 
 ### Workshop / storage
 
-Primary interaction:
+Primary interaction direction:
 
 ```text
-Zebra DS3678-HD
+extended-range Zebra scanner
     -> Container barcode/QR
     -> rack/storage Location barcode/QR
     -> browser workflow
 ```
 
-This environment uses discrete, already-designed rack/storage locations and favors fast repeated HID scans.
+The DS3678-ER is the current ordered candidate for this role. This environment uses discrete, already-designed rack/storage locations and favors fast repeated HID scans.
 
 ### Park unloading / receiving
 
 Candidate interaction:
 
 ```text
-Zebra DS3678-HD
+Zebra DS3678-HD or accepted equivalent
     -> Container / Display barcode or QR at close range
     -> browser load/unload workflow
     -> expected destination / Setup context
 ```
 
-This is a strong candidate use because the scanner operator can stand beside the trailer/load. It does not depend on long-range aiming from a vehicle seat.
+This remains a strong candidate use for the HD because the scanner operator can stand beside the trailer/load. It does not depend on long-range aiming from a vehicle seat.
 
 ### Park placement / field navigation
 
@@ -167,30 +313,37 @@ Park placement should not be forced into a rack-label scanning model merely for 
 
 ## Terminator / Auto-Submit Requirement
 
-During hardware acceptance, determine and deliberately standardize the scanner suffix used by MSB—normally an Enter/Carriage Return style terminator if that fits the application.
+The controlled scanner suffix/terminator is still pending acceptance.
 
-Do not assume the scanner's current suffix configuration.
+The eventual shop and unloading Setup scan screens should allow repetitive operation without requiring the operator to touch the screen after every scan. An Enter/Carriage Return style terminator remains the likely direction if it produces the intended browser behavior.
 
-The eventual shop and unloading Setup scan screens should allow repetitive operation without requiring the operator to touch the screen after every scan. The exact behavior must be tested with the DS3678-HD and then documented as the controlled scanner configuration.
+The exact suffix and any Zebra ADF rules must be tested together and then documented as one controlled scanner configuration.
 
 ## Tablet / Host Integration
 
-The USB cradle must connect to a host that supports the selected USB mode.
+Direct Bluetooth HID between the Zebra DS3678-HD and HOTWAV R9 Ultra Android tablet is now verified.
 
-Before workshop forklift deployment, verify the actual rugged tablet or mounted workstation provides the required USB host connection, power arrangement, and secure cabling for the cradle.
+This removes the previous assumption that the USB cradle must be the communications host for the Android deployment. The cradle may still be used for charging, storage, pairing/configuration, or another accepted operational purpose.
 
-Before park unloading deployment, verify whether the same cradle/USB arrangement can be moved safely and quickly to the park host or whether another approved host/interface arrangement is needed. Do not assume a different scanner protocol is necessary until the actual tablet/host connection is tested.
+For forklift deployment, verify:
 
-The scanner should not connect directly to PostgreSQL. The browser application interprets the decoded asset payload and communicates with the approved backend over the network.
+- reliable Bluetooth reconnect behavior after scanner/tablet sleep or power cycling;
+- practical charging behavior for both scanner and tablet;
+- secure tablet mounting;
+- secure scanner/cradle placement;
+- vehicle-safe power where charging is provided on the forklift;
+- no cabling or mounting that obstructs controls or visibility.
+
+The scanner must not connect directly to PostgreSQL. The browser application interprets the decoded asset payload and communicates with the approved backend over the network.
 
 ## Physical Installation
 
 Workshop forklift installation should provide:
 
-- secure cradle mounting or protected placement;
-- secure tablet/workstation mounting;
-- vehicle-safe power for the tablet and scanner cradle;
-- cable strain relief;
+- secure scanner cradle mounting or protected placement;
+- secure tablet mounting;
+- vehicle-safe power for the tablet and scanner cradle when used;
+- cable strain relief for any installed charging cables;
 - access without obstructing controls or visibility;
 - a scanner location that does not encourage use while the forklift is moving;
 - practical return-to-cradle/charging behavior.
@@ -207,11 +360,11 @@ The field workstation/tablet requires application connectivity throughout the in
 - park unloading/receiving points;
 - park Setup/Deployment scan points where online validation is required.
 
-Scanner-to-cradle communication does not replace application network connectivity.
+Bluetooth scanner connectivity does not replace application network connectivity.
 
 ## Label Compatibility
 
-Current identity direction remains:
+Canonical identity direction remains:
 
 ```text
 DISP:<display_id>
@@ -219,11 +372,13 @@ CONT:<container_id>
 LOC:<location_code>
 ```
 
+Existing printed Display and Container labels use full scan URLs and remain supported deployed artifacts.
+
 `LOC:` is most directly applicable to discrete Production Database location identities such as workshop/rack locations. Park geospatial destinations may use a durable site-location identity resolved through GIS rather than requiring a physical `LOC:` barcode at every destination.
 
 The scanner/application must read the payload as data and route it through the scan platform. Physical labels must not encode annual setup state, load number, destination application, or other transient workflow information.
 
-Label size/density should be chosen from actual DS3678-HD shop and unloading testing rather than theoretical minimum barcode sizes.
+Future Storage Location label size/density should be chosen from actual DS3678-ER forklift testing rather than theoretical minimum barcode sizes.
 
 ## Setup/Deployment Implication
 
@@ -241,28 +396,32 @@ GPS is context/measurement, not asset identity.
 
 ## Known Open Work
 
-- receive and inspect the purchased DS3678-HD kit;
-- verify USB HID operation with the actual workshop forklift tablet/workstation;
-- determine the controlled scanner suffix/terminator;
-- test current Container labels;
-- test existing rack-location labels;
-- measure practical scan range from the actual workshop forklift position;
-- test the scanner as a close-range park unloading/receiving device;
-- verify the practical host/power connection for temporary park unloading use;
-- document scanner configuration once accepted;
-- determine mounting, cradle power, and cable protection;
+- receive and inspect the ordered DS3678-ER;
+- perform actual forklift/rack range acceptance testing with the DS3678-ER;
+- test existing printed Container and Display labels at real forklift distances;
+- determine and test the controlled scanner suffix/terminator;
+- test Zebra ADF / 123Scan shortening of existing full Display and Container scan URLs for Bluetooth HID use;
+- verify Bluetooth reconnect behavior after scanner/tablet sleep and power cycling;
+- implement and accept the intended `/scan/LOC/:key` application behavior before printing production Location labels;
+- design and range-test the future Storage Location labels with the accepted forklift scanner;
+- test the DS3678-HD as a close-range park unloading/receiving device;
+- determine mounting, cradle power, charging, and cable protection;
 - include industrial-scanner input in Setup/Deployment application acceptance tests;
 - separately engineer park GPS/site-location behavior with Site Infrastructure/GIS rather than assuming the Zebra scanner replaces field location logic.
 
 ## Resume Development
 
-For workshop hardware work, begin with the purchased Zebra DS3678-HD, existing rack labels, actual Container labels, and the real forklift operating position.
+For workshop hardware work, begin with the ordered DS3678-ER when received, the HOTWAV R9 Ultra, the already-printed Display and Container labels, and the real forklift operating position.
 
-For park unloading hardware work, test the same scanner beside the trailer/load with the actual park tablet/workstation and normal unloading pace.
+Do not repeat Bluetooth HID feasibility reconnaissance; direct Zebra-to-HOTWAV Android Bluetooth HID is already proven.
+
+For scanner configuration work, evaluate Zebra 123Scan/ADF against the existing full-URL Display and Container labels and verify that shortening the HID output does not break the canonical MSB scan behavior.
+
+For Storage Location work, continue from the established fact that Location labels are not yet printed and that the current `/scan/LOC/:key` server route is missing. Implement and accept the intended Location workflow before production Location-label printing.
+
+For park unloading hardware work, retain the DS3678-HD as a close-range candidate and test it beside the trailer/load with the actual park tablet/workstation and normal unloading pace.
 
 For application work, preserve HID keyboard input as a first-class scan path while keeping camera/GPS field input additive.
-
-For the broader workflow, continue from [Setup and Deployment](../12_Setup_and_Deployment/README.md) after the current FieldWiring Scan Integration is closed.
 
 ## Related Documents
 


### PR DESCRIPTION
## Scope

Closeout of completed 2026-08-27 scanner/tablet field testing only.

This PR promotes the scanner findings to `main` independently of unrelated Controller Inventory work and independently of later QR/profile architecture work.

## Findings recorded

- Zebra DS3678-HD paired to HOTWAV R9 Ultra Android tablet and worked as Bluetooth HID keyboard input in the browser.
- Pairing required an Android Play Store pairing application; Android Bluetooth settings alone were not sufficient in the actual test.
- After pairing, normal browser scanning used standard HID input; no custom MSB Android scan application/database driver was required for ordinary capture.
- Large ~6-inch Code 128 test barcode decoded at roughly four feet, but that range failed the intended warehouse/forklift working-distance requirement.
- Existing full-URL Display/Container QR labels decode correctly, but Bluetooth HID typing of the long URL takes several seconds and is too slow for repetitive warehouse work.
- Existing Display/Container labels remain supported and are not to be relabeled merely to shorten the payload.
- Storage Location labels remain unprinted; `/scan/LOC/:key` end-to-end behavior remains unfinished.
- DS3678-ER remains the next forklift-range acceptance candidate.

## Branch recovery

The main scanner document is ported from the scanner-only evidence commit `ff948db76ded0d95718cf3dd19415e968458ca04` without merging the surrounding `docs/controller-inventory-v1-review` branch.

A dated acceptance record was added to capture the pairing-app requirement explicitly because that detail was not preserved in the earlier scanner document.

## Non-changes

No PostgreSQL schema, Scan route, QR payload, LabelPrintService code, printer configuration, or physical label population is changed by this PR.