### PR TITLE
Make routine LOR parser and ingest durable and evidence-bound

### DIFF
--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/lor_operator_runner.py
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/lor_operator_runner.py
@@ -2,7 +2,7 @@
 
 Initial release: 2026-08-13 V1.0.0
 
-Current version: 2026-08-25 V1.6.0
+Current version: 2026-08-27 V1.7.0
 
 V1.5.0 adds the fixed, digest-locked PostgreSQL ingest operation and bounded
 read-only ingest console. Parser execution remains repeatable and never starts
@@ -43,7 +43,7 @@ from urllib.parse import urlparse
 from lor_version_checker import build_manifest, compare_manifests, manifest_source_signature, write_json
 
 
-RUNNER_VERSION = "V1.6.0"
+RUNNER_VERSION = "V1.7.0"
 MAX_BROWSER_CONSOLE_CHARACTERS = 500_000
 
 AUTHORITATIVE_OUTPUT_TABLES = (
@@ -475,7 +475,12 @@ class Runner:
         self.store.update(operation)
 
     def _start_parser_activity(
-        self, target: str, version: str, folder: Path, actor: str
+        self,
+        target: str,
+        version: str,
+        folder: Path,
+        actor: str,
+        request_id: str | None = None,
     ) -> tuple[dict[str, Any], Path]:
         """Record one recoverable browser-visible parser attempt."""
         stamp = datetime.now().strftime("%Y%m%d-%H%M%S-%f")
@@ -493,6 +498,7 @@ class Runner:
             "started_at": utc_now(),
             "completed_at": None,
             "run_by": actor,
+            "request_id": request_id,
             "console_log_path": str(log_path),
             "error": None,
             "result": None,
@@ -550,7 +556,11 @@ class Runner:
         return public
 
     def _start_ingest_activity(
-        self, digest: str, actor: str
+        self,
+        digest: str,
+        actor: str,
+        parser_activity_id: str | None = None,
+        request_id: str | None = None,
     ) -> tuple[dict[str, Any], Path]:
         """Record one recoverable browser-visible PostgreSQL ingest attempt."""
         state = self.store.read()
@@ -569,6 +579,8 @@ class Runner:
             "started_at": utc_now(),
             "completed_at": None,
             "run_by": actor,
+            "parser_activity_id": parser_activity_id,
+            "request_id": request_id,
             "console_log_path": str(log_path),
             "error": None,
             "result": None,
@@ -629,13 +641,242 @@ class Runner:
         public["console_truncated"] = truncated
         return public
 
-    def run_ingest(self, expected_digest: str, actor: str) -> dict[str, Any]:
-        """Run the one fixed, parser-authorized SQLite-to-PostgreSQL ingest."""
+    @staticmethod
+    def _normalize_request_id(request_id: str) -> str:
+        """Validate one browser-generated idempotency key."""
+        value = str(request_id or "").strip()
+        if not re.fullmatch(r"[A-Za-z0-9._:-]{8,128}", value):
+            raise ValueError(
+                "Request ID must contain 8-128 safe identifier characters"
+            )
+        return value
+
+    def _background_parser(
+        self,
+        target: str,
+        actor: str,
+        activity: dict[str, Any],
+        console_log: Path,
+    ) -> None:
+        """Complete one already-recorded parser activity."""
+        try:
+            self.run_parser(
+                target,
+                actor,
+                activity_context=(activity, console_log),
+            )
+        except Exception as error:
+            latest = self.store.read().get("parser_activity") or {}
+            if (
+                latest.get("activity_id") == activity["activity_id"]
+                and latest.get("status") == "RUNNING"
+            ):
+                detail = f"[FATAL] Parser operation failed: {error}"
+                self._finish_parser_activity(
+                    activity,
+                    "FAILED",
+                    console_log,
+                    detail,
+                    error=str(error),
+                )
+        finally:
+            self.operation_lock.release()
+
+    def start_parser(
+        self,
+        target: str,
+        actor: str,
+        request_id: str,
+    ) -> dict[str, Any]:
+        """
+        Record one production parser activity, return immediately, and
+        complete the work on the managed runner thread.
+        """
+        if target != "current":
+            raise ValueError(
+                "Durable parser start is valid only for "
+                "the current production parser"
+            )
+
+        request_id = self._normalize_request_id(request_id)
+
+        latest = self.store.read().get("parser_activity") or {}
+        if latest.get("request_id") == request_id:
+            return self.public_parser_activity() or {}
+
+        if not self.operation_lock.acquire(blocking=False):
+            latest = self.store.read().get("parser_activity") or {}
+
+            if latest.get("request_id") == request_id:
+                return self.public_parser_activity() or {}
+
+            raise RuntimeError(
+                "Another parser, ingest, or version-check operation "
+                "is already running"
+            )
+
+        try:
+            state = self.store.read()
+            version = state["current_lor_version"]
+            folder = Path(state["current_preview_folder"])
+
+            activity, console_log = self._start_parser_activity(
+                target,
+                version,
+                folder,
+                actor,
+                request_id=request_id,
+            )
+
+            worker = threading.Thread(
+                target=self._background_parser,
+                args=(target, actor, activity, console_log),
+                name=f"lor-parser-{activity['activity_id']}",
+                daemon=True,
+            )
+            worker.start()
+
+            return self.public_parser_activity() or {}
+        except Exception:
+            self.operation_lock.release()
+            raise
+
+    def _background_ingest(
+        self,
+        digest: str,
+        parser_activity_id: str,
+        actor: str,
+        activity: dict[str, Any],
+        console_log: Path,
+    ) -> None:
+        """Complete one already-recorded PostgreSQL ingest activity."""
+        try:
+            self.run_ingest(
+                digest,
+                actor,
+                expected_parser_activity_id=parser_activity_id,
+                activity_context=(activity, console_log),
+            )
+        except Exception as error:
+            latest = self.store.read().get("ingest_activity") or {}
+
+            if (
+                latest.get("activity_id") == activity["activity_id"]
+                and latest.get("status") == "RUNNING"
+            ):
+                detail = f"[FATAL] PostgreSQL ingest failed: {error}"
+                self._finish_ingest_activity(
+                    activity,
+                    "FAILED",
+                    console_log,
+                    detail,
+                    error=str(error),
+                )
+        finally:
+            self.operation_lock.release()
+
+    def start_ingest(
+        self,
+        expected_digest: str,
+        parser_activity_id: str,
+        actor: str,
+        request_id: str,
+    ) -> dict[str, Any]:
+        """
+        Record one digest/activity-locked ingest, return immediately,
+        and complete it on the managed runner thread.
+        """
+        digest = str(expected_digest or "").strip().lower()
+
+        if not re.fullmatch(r"[0-9a-f]{64}", digest):
+            raise ValueError(
+                "Expected SQLite SHA-256 must contain "
+                "64 hexadecimal characters"
+            )
+
+        parser_activity_id = str(parser_activity_id or "").strip()
+        if not parser_activity_id:
+            raise ValueError(
+                "Expected parser activity ID is required for ingest"
+            )
+
+        request_id = self._normalize_request_id(request_id)
+
+        latest = self.store.read().get("ingest_activity") or {}
+        if latest.get("request_id") == request_id:
+            return self.public_ingest_activity() or {}
+
+        if not self.operation_lock.acquire(blocking=False):
+            latest = self.store.read().get("ingest_activity") or {}
+
+            if latest.get("request_id") == request_id:
+                return self.public_ingest_activity() or {}
+
+            raise RuntimeError(
+                "Another parser, ingest, or version-check operation "
+                "is already running"
+            )
+
+        try:
+            activity, console_log = self._start_ingest_activity(
+                digest,
+                actor,
+                parser_activity_id=parser_activity_id,
+                request_id=request_id,
+            )
+
+            worker = threading.Thread(
+                target=self._background_ingest,
+                args=(
+                    digest,
+                    parser_activity_id,
+                    actor,
+                    activity,
+                    console_log,
+                ),
+                name=f"lor-ingest-{activity['activity_id']}",
+                daemon=True,
+            )
+            worker.start()
+
+            return self.public_ingest_activity() or {}
+        except Exception:
+            self.operation_lock.release()
+            raise
+
+    def run_ingest(
+        self,
+        expected_digest: str,
+        actor: str,
+        expected_parser_activity_id: str | None = None,
+        *,
+        activity_context: tuple[dict[str, Any], Path] | None = None,
+    ) -> dict[str, Any]:
+        """Run the fixed parser-authorized SQLite-to-PostgreSQL ingest."""
         digest = expected_digest.strip().lower()
         if not re.fullmatch(r"[0-9a-f]{64}", digest):
             raise ValueError("Expected SQLite SHA-256 must contain 64 hexadecimal characters")
         state = self.store.read()
         parser_run = state.get("production_parser_run") or {}
+        parser_activity = state.get("parser_activity") or {}
+
+        if expected_parser_activity_id:
+            activity_result = parser_activity.get("result") or {}
+
+            if (
+                parser_activity.get("activity_id")
+                != expected_parser_activity_id
+                or parser_activity.get("target") != "current"
+                or parser_activity.get("status") != "PASSED"
+                or str(
+                    activity_result.get("sqlite_sha256") or ""
+                ).lower() != digest
+            ):
+                raise ValueError(
+                    "The requested ingest is not bound to "
+                    "the current passed parser activity"
+                )
+
         if (
             parser_run.get("status") != "COMPLETE"
             or parser_run.get("validation_status") != "PASSED"
@@ -662,7 +903,21 @@ class Runner:
 
         password = required_environment("LOR_INGEST_PG_PASSWORD")
         version = state["current_lor_version"]
-        activity, console_log = self._start_ingest_activity(digest, actor)
+
+        parser_evidence_id = (
+            expected_parser_activity_id
+            or parser_activity.get("activity_id")
+        )
+
+        if activity_context is None:
+            activity, console_log = self._start_ingest_activity(
+                digest,
+                actor,
+                parser_activity_id=parser_evidence_id,
+            )
+        else:
+            activity, console_log = activity_context
+
         command = [
             sys.executable,
             str(self.ingest_path),
@@ -720,6 +975,7 @@ class Runner:
             "import_run_id": int(match.group(1)),
             "completed_at": utc_now(),
             "run_by": actor,
+            "parser_activity_id": parser_evidence_id,
         }
         self._finish_ingest_activity(
             activity, "PASSED", console_log, console_output, result=result
@@ -828,7 +1084,13 @@ class Runner:
         self.store.update(operation)
         return record
 
-    def run_parser(self, target: str, actor: str) -> dict[str, Any]:
+    def run_parser(
+        self,
+        target: str,
+        actor: str,
+        *,
+        activity_context: tuple[dict[str, Any], Path] | None = None,
+    ) -> dict[str, Any]:
         state = self.store.read()
         if target in {"current", "baseline"}:
             version = state["current_lor_version"]
@@ -913,7 +1175,28 @@ class Runner:
             "--result-json", str(result_json),
             "--non-interactive",
         ]
-        activity, console_log = self._start_parser_activity(target, version, folder, actor)
+        if activity_context is None:
+            activity, console_log = self._start_parser_activity(
+                target,
+                version,
+                folder,
+                actor,
+            )
+        else:
+            activity, console_log = activity_context
+
+            if (
+                activity.get("target") != target
+                or activity.get("source_lor_version") != version
+                or Path(
+                    str(activity.get("source_preview_folder") or "")
+                ) != folder
+            ):
+                raise RuntimeError(
+                    "Pre-recorded parser activity does not match "
+                    "the requested source"
+                )
+
         try:
             completed = subprocess.run(
                 command, capture_output=True, text=True, timeout=900,
@@ -1169,6 +1452,33 @@ class RequestHandler(BaseHTTPRequestHandler):
         payload = self.body()
         actor = str(payload.get("actor") or "unknown-operator")
         if self.command == "POST":
+            if path == "/parser/start":
+                return HTTPStatus.ACCEPTED, {
+                    "activity": self.runner.start_parser(
+                        str(payload.get("target") or ""),
+                        actor,
+                        str(payload.get("request_id") or ""),
+                    )
+                }
+
+            if path == "/ingest/start":
+                return HTTPStatus.ACCEPTED, {
+                    "activity": self.runner.start_ingest(
+                        str(
+                            payload.get(
+                                "expected_sqlite_sha256"
+                            ) or ""
+                        ),
+                        str(
+                            payload.get(
+                                "parser_activity_id"
+                            ) or ""
+                        ),
+                        actor,
+                        str(payload.get("request_id") or ""),
+                    )
+                }
+
             # Only one state-changing/check/parser/ingest operation may run at a time.
             # This prevents concurrent website clicks from targeting the same
             # candidate database or changing the version record mid-run. A

--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/lor_operator_runner.py
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/lor_operator_runner.py
@@ -507,6 +507,14 @@ class Runner:
         def operation(current: dict[str, Any]) -> None:
             current["parser_activity"] = activity
 
+            if request_id:
+                history = list(
+                    current.get("operation_request_ids") or []
+                )
+                if request_id not in history:
+                    history.append(request_id)
+                current["operation_request_ids"] = history
+
         self.store.update(operation)
         return activity, log_path
 
@@ -546,13 +554,15 @@ class Runner:
         log_path = Path(str(public.pop("console_log_path", "")))
         console_output = ""
         truncated = False
-        if log_path.is_file():
+        console_available = log_path.is_file()
+        if console_available:
             console_output = log_path.read_text(encoding="utf-8", errors="replace")
             if len(console_output) > MAX_BROWSER_CONSOLE_CHARACTERS:
                 console_output = console_output[-MAX_BROWSER_CONSOLE_CHARACTERS:]
                 truncated = True
         public["console_output"] = console_output
         public["console_truncated"] = truncated
+        public["console_available"] = console_available
         return public
 
     def _start_ingest_activity(
@@ -588,6 +598,14 @@ class Runner:
 
         def operation(current: dict[str, Any]) -> None:
             current["ingest_activity"] = activity
+
+            if request_id:
+                history = list(
+                    current.get("operation_request_ids") or []
+                )
+                if request_id not in history:
+                    history.append(request_id)
+                current["operation_request_ids"] = history
 
         self.store.update(operation)
         return activity, log_path
@@ -630,7 +648,8 @@ class Runner:
         log_path = Path(str(public.pop("console_log_path", "")))
         console_output = ""
         truncated = False
-        if log_path.is_file():
+        console_available = log_path.is_file()
+        if console_available:
             console_output = log_path.read_text(
                 encoding="utf-8", errors="replace"
             )
@@ -639,6 +658,7 @@ class Runner:
                 truncated = True
         public["console_output"] = console_output
         public["console_truncated"] = truncated
+        public["console_available"] = console_available
         return public
 
     @staticmethod
@@ -700,9 +720,19 @@ class Runner:
 
         request_id = self._normalize_request_id(request_id)
 
-        latest = self.store.read().get("parser_activity") or {}
+        state = self.store.read()
+        latest = state.get("parser_activity") or {}
+
         if latest.get("request_id") == request_id:
             return self.public_parser_activity() or {}
+
+        if request_id in (
+            state.get("operation_request_ids") or []
+        ):
+            raise ValueError(
+                "Request ID was already accepted; "
+                "no duplicate parser operation was started"
+            )
 
         if not self.operation_lock.acquire(blocking=False):
             latest = self.store.read().get("parser_activity") or {}
@@ -802,9 +832,19 @@ class Runner:
 
         request_id = self._normalize_request_id(request_id)
 
-        latest = self.store.read().get("ingest_activity") or {}
+        state = self.store.read()
+        latest = state.get("ingest_activity") or {}
+
         if latest.get("request_id") == request_id:
             return self.public_ingest_activity() or {}
+
+        if request_id in (
+            state.get("operation_request_ids") or []
+        ):
+            raise ValueError(
+                "Request ID was already accepted; "
+                "no duplicate ingest operation was started"
+            )
 
         if not self.operation_lock.acquire(blocking=False):
             latest = self.store.read().get("ingest_activity") or {}
@@ -860,24 +900,28 @@ class Runner:
         parser_run = state.get("production_parser_run") or {}
         parser_activity = state.get("parser_activity") or {}
 
-        if expected_parser_activity_id:
-            activity_result = parser_activity.get("result") or {}
+        parser_evidence_id = (
+            expected_parser_activity_id
+            or str(parser_activity.get("activity_id") or "")
+        )
+        activity_result = parser_activity.get("result") or {}
 
-            if (
-                parser_activity.get("activity_id")
-                != expected_parser_activity_id
-                or parser_run.get("parser_activity_id")
-                != expected_parser_activity_id
-                or parser_activity.get("target") != "current"
-                or parser_activity.get("status") != "PASSED"
-                or str(
-                    activity_result.get("sqlite_sha256") or ""
-                ).lower() != digest
-            ):
-                raise ValueError(
-                    "The requested ingest is not bound to "
-                    "the current passed parser activity"
-                )
+        if (
+            not parser_evidence_id
+            or parser_activity.get("activity_id")
+                != parser_evidence_id
+            or parser_run.get("parser_activity_id")
+                != parser_evidence_id
+            or parser_activity.get("target") != "current"
+            or parser_activity.get("status") != "PASSED"
+            or str(
+                activity_result.get("sqlite_sha256") or ""
+            ).lower() != digest
+        ):
+            raise ValueError(
+                "The requested ingest is not bound to "
+                "the current passed parser activity"
+            )
 
         if (
             parser_run.get("status") != "COMPLETE"
@@ -905,11 +949,6 @@ class Runner:
 
         password = required_environment("LOR_INGEST_PG_PASSWORD")
         version = state["current_lor_version"]
-
-        parser_evidence_id = (
-            expected_parser_activity_id
-            or parser_activity.get("activity_id")
-        )
 
         if activity_context is None:
             activity, console_log = self._start_ingest_activity(

--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/lor_operator_runner.py
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/lor_operator_runner.py
@@ -866,6 +866,8 @@ class Runner:
             if (
                 parser_activity.get("activity_id")
                 != expected_parser_activity_id
+                or parser_run.get("parser_activity_id")
+                != expected_parser_activity_id
                 or parser_activity.get("target") != "current"
                 or parser_activity.get("status") != "PASSED"
                 or str(
@@ -976,6 +978,7 @@ class Runner:
             "completed_at": utc_now(),
             "run_by": actor,
             "parser_activity_id": parser_evidence_id,
+            "ingest_activity_id": activity["activity_id"],
         }
         self._finish_ingest_activity(
             activity, "PASSED", console_log, console_output, result=result
@@ -1232,6 +1235,7 @@ class Runner:
             "run_by": actor,
             "completed_at": utc_now(),
             "result_json": str(result_json),
+            "parser_activity_id": activity["activity_id"],
         }
 
         def operation(current: dict[str, Any]) -> None:
@@ -1244,10 +1248,8 @@ class Runner:
                 raise RuntimeError("LOR version changed while the parser was running; result was not recorded")
             if target == "current":
                 key = "production_parser_run"
-                previous_ingest = current.get("production_ingest_run") or {}
-                if previous_ingest.get("sqlite_sha256") != record.get("sqlite_sha256"):
-                    current["production_ingest_run"] = None
-                    current["ingest_activity"] = None
+                current["production_ingest_run"] = None
+                current["ingest_activity"] = None
             elif target == "baseline":
                 key = "baseline_parser_run"
                 current["candidate_output_comparison"] = None

--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/test_lor_operator_runner.py
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/test_lor_operator_runner.py
@@ -88,6 +88,11 @@ class OperatorRunnerTests(unittest.TestCase):
         self.assertIn("PRINT-SERVER\\Print Service", source)
         self.assertIn("192.168.5.56", source)
         self.assertIn("192.168.5.55", source)
+        self.assertIn("function Wait-RunnerPrerequisites", source)
+        self.assertIn("Readiness attempt", source)
+        self.assertIn("READINESS TIMEOUT", source)
+        self.assertIn("$state = Wait-RunnerPrerequisites", source)
+        self.assertIn("$ProductionSqlitePath", source)
 
     def test_http_access_log_uses_stdout_not_stderr(self) -> None:
         """A successful request must not become a PowerShell native error."""

--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/test_lor_operator_runner.py
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/test_lor_operator_runner.py
@@ -33,15 +33,15 @@ class OperatorRunnerTests(unittest.TestCase):
         self.addCleanup(self.temporary.cleanup)
         self.root = Path(self.temporary.name)
         self.previews = self.root / "previews"
-        self.current = self.previews / "Database Previews V6.6.4"
-        self.candidate = self.previews / "Database Previews V6.6.10"
+        self.current = self.previews / "Database Previews V6.6.10"
+        self.candidate = self.previews / "Database Previews V6.6.11"
         for folder in (self.current, self.candidate):
             folder.mkdir(parents=True)
             (folder / "test.lorprev").write_text(PREVIEW_XML, encoding="utf-8")
         self.state_file = self.root / "state" / "lor-runner-state.json"
         runner_module.initialize(argparse.Namespace(
             current_preview_folder=self.current,
-            current_lor_version="6.6.4",
+            current_lor_version="6.6.10",
             deep_preview="test.lorprev",
             state_file=self.state_file,
         ))
@@ -156,7 +156,7 @@ class OperatorRunnerTests(unittest.TestCase):
                 json.dumps({
                     "status": "COMPLETE",
                     "validation_status": "PASSED",
-                    "source_lor_version": "6.6.4",
+                    "source_lor_version": "6.6.10",
                     "sqlite_sha256": "a" * 64,
                 }),
                 encoding="utf-8",
@@ -233,7 +233,7 @@ class OperatorRunnerTests(unittest.TestCase):
             state["production_parser_run"] = {
                 "status": "COMPLETE",
                 "validation_status": "PASSED",
-                "source_lor_version": "6.6.4",
+                "source_lor_version": "6.6.10",
                 "sqlite_path": str(database),
                 "sqlite_sha256": digest,
             }
@@ -352,7 +352,7 @@ class OperatorRunnerTests(unittest.TestCase):
             state["production_parser_run"] = {
                 "status": "COMPLETE",
                 "validation_status": "PASSED",
-                "source_lor_version": "6.6.4",
+                "source_lor_version": "6.6.10",
                 "sqlite_path": str(database),
                 "sqlite_sha256": digest,
             }
@@ -378,15 +378,15 @@ class OperatorRunnerTests(unittest.TestCase):
             )
 
     def test_candidate_is_resolved_only_from_versioned_preview_root(self) -> None:
-        state = self.runner.select_candidate("6.6.10", "operator@example.com")
-        self.assertEqual(state["new_lor_version"], "6.6.10")
+        state = self.runner.select_candidate("6.6.11", "operator@example.com")
+        self.assertEqual(state["new_lor_version"], "6.6.11")
         self.assertEqual(Path(state["new_preview_folder"]), self.candidate.resolve())
         with self.assertRaisesRegex(ValueError, "numeric and dot-separated"):
             self.runner.select_candidate("..\\outside", "operator@example.com")
 
     def test_approval_preserves_manifest_and_appends_history(self) -> None:
-        self.runner.select_candidate("6.6.10", "operator@example.com")
-        candidate_manifest = build_manifest(self.candidate, "6.6.10", "test.lorprev")
+        self.runner.select_candidate("6.6.11", "operator@example.com")
+        candidate_manifest = build_manifest(self.candidate, "6.6.11", "test.lorprev")
         candidate_manifest_path = self.root / "reports" / "candidate-manifest.json"
         write_json(candidate_manifest_path, candidate_manifest)
 
@@ -400,13 +400,13 @@ class OperatorRunnerTests(unittest.TestCase):
                 "status": "COMPLETE",
                 "validation_status": "PASSED",
                 "parser_version": "V7.0.10",
-                "source_lor_version": "6.6.10",
+                "source_lor_version": "6.6.11",
                 "sqlite_sha256": "a" * 64,
             }
             state["baseline_parser_run"] = {
                 "status": "COMPLETE",
                 "validation_status": "PASSED",
-                "source_lor_version": "6.6.4",
+                "source_lor_version": "6.6.10",
                 "sqlite_sha256": "b" * 64,
             }
             state["candidate_output_comparison"] = {
@@ -415,9 +415,9 @@ class OperatorRunnerTests(unittest.TestCase):
             }
 
         self.store.update(prepare)
-        state = self.runner.approve_candidate("6.6.10", "operator@example.com")
+        state = self.runner.approve_candidate("6.6.11", "operator@example.com")
         approved_manifest = self.state_file.with_name("current-lor-manifest.json")
-        self.assertEqual(state["current_lor_version"], "6.6.10")
+        self.assertEqual(state["current_lor_version"], "6.6.11")
         self.assertEqual(state["current_manifest_path"], str(approved_manifest))
         self.assertEqual(
             json.loads(approved_manifest.read_text(encoding="utf-8"))["manifest_sha256"],
@@ -426,10 +426,10 @@ class OperatorRunnerTests(unittest.TestCase):
         self.assertEqual(len(state["approval_history"]), 1)
         self.assertEqual(state["last_approval"]["parser_version"], "V7.0.10")
         self.assertEqual(state["last_approval"]["baseline_sqlite_sha256"], "b" * 64)
-        self.assertEqual(state["baseline_parser_run"]["source_lor_version"], "6.6.10")
+        self.assertEqual(state["baseline_parser_run"]["source_lor_version"], "6.6.11")
 
     def test_approval_requires_output_comparison(self) -> None:
-        self.runner.select_candidate("6.6.10", "operator@example.com")
+        self.runner.select_candidate("6.6.11", "operator@example.com")
 
         def prepare(state):
             state["candidate_check"] = {"status": "PASSED"}
@@ -444,11 +444,11 @@ class OperatorRunnerTests(unittest.TestCase):
 
         self.store.update(prepare)
         with self.assertRaisesRegex(ValueError, "output differences"):
-            self.runner.approve_candidate("6.6.10", "operator@example.com")
+            self.runner.approve_candidate("6.6.11", "operator@example.com")
 
     def test_changed_candidate_folder_invalidates_checked_manifest(self) -> None:
-        self.runner.select_candidate("6.6.10", "operator@example.com")
-        manifest = build_manifest(self.candidate, "6.6.10", "test.lorprev")
+        self.runner.select_candidate("6.6.11", "operator@example.com")
+        manifest = build_manifest(self.candidate, "6.6.11", "test.lorprev")
         manifest_path = self.root / "reports" / "candidate-manifest.json"
         write_json(manifest_path, manifest)
 
@@ -480,7 +480,7 @@ class OperatorRunnerTests(unittest.TestCase):
             result_path.write_text(json.dumps({
                 "status": "COMPLETE",
                 "validation_status": "PASSED",
-                "source_lor_version": "6.6.4",
+                "source_lor_version": "6.6.10",
                 "sqlite_sha256": "a" * 64,
             }), encoding="utf-8")
             return argparse.Namespace(
@@ -541,7 +541,7 @@ class OperatorRunnerTests(unittest.TestCase):
             state["production_parser_run"] = {
                 "status": "COMPLETE",
                 "validation_status": "PASSED",
-                "source_lor_version": "6.6.4",
+                "source_lor_version": "6.6.10",
                 "sqlite_path": str(database),
                 "sqlite_sha256": digest,
             }
@@ -579,7 +579,7 @@ class OperatorRunnerTests(unittest.TestCase):
             state["production_parser_run"] = {
                 "status": "COMPLETE",
                 "validation_status": "PASSED",
-                "source_lor_version": "6.6.4",
+                "source_lor_version": "6.6.10",
                 "sqlite_path": str(database),
                 "sqlite_sha256": digest,
             }
@@ -618,8 +618,8 @@ class ParserOutputComparisonTests(unittest.TestCase):
         self.root = Path(self.temporary.name)
         self.baseline = self.root / "baseline.db"
         self.candidate = self.root / "candidate.db"
-        self._create_database(self.baseline, revision="1", name="Master 6.6.4", source="old.lorprev")
-        self._create_database(self.candidate, revision="2", name="Master 6.6.10", source="new.lorprev")
+        self._create_database(self.baseline, revision="1", name="Master 6.6.10", source="old.lorprev")
+        self._create_database(self.candidate, revision="2", name="Master 6.6.11", source="new.lorprev")
 
     def _create_database(self, path: Path, revision: str, name: str, source: str) -> None:
         # sqlite3.Connection.__exit__ commits/rolls back but does not close.
@@ -659,8 +659,8 @@ class ParserOutputComparisonTests(unittest.TestCase):
         return runner_module.compare_parser_outputs(
             self.baseline,
             self.candidate,
-            "6.6.4",
             "6.6.10",
+            "6.6.11",
             self.root / "comparison.json",
             self.root / "comparison.md",
         )

--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/test_lor_operator_runner.py
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/test_lor_operator_runner.py
@@ -95,6 +95,7 @@ class OperatorRunnerTests(unittest.TestCase):
         self.assertIn("READINESS TIMEOUT", source)
         self.assertIn("$state = Wait-RunnerPrerequisites", source)
         self.assertIn("$ProductionSqlitePath", source)
+        self.assertIn("Starting runner V1.7.0", source)
 
     def test_http_access_log_uses_stdout_not_stderr(self) -> None:
         """A successful request must not become a PowerShell native error."""
@@ -171,6 +172,30 @@ class OperatorRunnerTests(unittest.TestCase):
         run.side_effect = complete
         request_id = "parser-request-12345678"
 
+        def seed_previous_ingest(state):
+            state["production_ingest_run"] = {
+                "status": "COMPLETE",
+                "sqlite_sha256": "a" * 64,
+                "parser_activity_id": "current-old-parser",
+                "ingest_activity_id": "ingest-old",
+                "import_run_id": 46,
+            }
+            state["ingest_activity"] = {
+                "activity_id": "ingest-old",
+                "status": "PASSED",
+                "sqlite_sha256": "a" * 64,
+                "parser_activity_id": "current-old-parser",
+                "result": {
+                    "status": "COMPLETE",
+                    "sqlite_sha256": "a" * 64,
+                    "parser_activity_id": "current-old-parser",
+                    "ingest_activity_id": "ingest-old",
+                    "import_run_id": 46,
+                },
+            }
+
+        self.store.update(seed_previous_ingest)
+
         first = self.runner.start_parser(
             "current",
             "operator@example.com",
@@ -214,6 +239,14 @@ class OperatorRunnerTests(unittest.TestCase):
             activity["result"]["sqlite_sha256"],
             "a" * 64,
         )
+
+        state = self.store.read()
+        self.assertEqual(
+            state["production_parser_run"]["parser_activity_id"],
+            activity["activity_id"],
+        )
+        self.assertIsNone(state["production_ingest_run"])
+        self.assertIsNone(state["ingest_activity"])
         self.assertEqual(run.call_count, 1)
 
     @patch("lor_operator_runner.subprocess.run")
@@ -236,6 +269,7 @@ class OperatorRunnerTests(unittest.TestCase):
                 "source_lor_version": "6.6.10",
                 "sqlite_path": str(database),
                 "sqlite_sha256": digest,
+                "parser_activity_id": parser_activity_id,
             }
             state["parser_activity"] = {
                 "activity_id": parser_activity_id,
@@ -335,6 +369,10 @@ class OperatorRunnerTests(unittest.TestCase):
         self.assertEqual(
             production["parser_activity_id"],
             parser_activity_id,
+        )
+        self.assertEqual(
+            production["ingest_activity_id"],
+            activity["activity_id"],
         )
         self.assertEqual(run.call_count, 1)
 

--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/test_lor_operator_runner.py
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/test_lor_operator_runner.py
@@ -247,6 +247,10 @@ class OperatorRunnerTests(unittest.TestCase):
         )
         self.assertIsNone(state["production_ingest_run"])
         self.assertIsNone(state["ingest_activity"])
+        self.assertIn(
+            request_id,
+            state["operation_request_ids"],
+        )
         self.assertEqual(run.call_count, 1)
 
     @patch("lor_operator_runner.subprocess.run")
@@ -374,6 +378,11 @@ class OperatorRunnerTests(unittest.TestCase):
             production["ingest_activity_id"],
             activity["activity_id"],
         )
+        self.assertIn(
+            request_id,
+            self.store.read()["operation_request_ids"],
+        )
+        self.assertTrue(activity["console_available"])
         self.assertEqual(run.call_count, 1)
 
     def test_ingest_rejects_wrong_parser_activity_binding(
@@ -414,6 +423,53 @@ class OperatorRunnerTests(unittest.TestCase):
                 "operator@example.com",
                 expected_parser_activity_id="current-wrong",
             )
+
+    @patch("lor_operator_runner.subprocess.run")
+    def test_used_parser_request_id_cannot_start_duplicate(
+        self, run
+    ) -> None:
+        request_id = "parser-replay-12345678"
+
+        def prepare(state):
+            state["operation_request_ids"] = [request_id]
+
+        self.store.update(prepare)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "already accepted",
+        ):
+            self.runner.start_parser(
+                "current",
+                "operator@example.com",
+                request_id,
+            )
+
+        run.assert_not_called()
+
+    @patch("lor_operator_runner.subprocess.run")
+    def test_used_ingest_request_id_cannot_start_duplicate(
+        self, run
+    ) -> None:
+        request_id = "ingest-replay-12345678"
+
+        def prepare(state):
+            state["operation_request_ids"] = [request_id]
+
+        self.store.update(prepare)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "already accepted",
+        ):
+            self.runner.start_ingest(
+                "a" * 64,
+                "current-parser-evidence",
+                "operator@example.com",
+                request_id,
+            )
+
+        run.assert_not_called()
 
     def test_candidate_is_resolved_only_from_versioned_preview_root(self) -> None:
         state = self.runner.select_candidate("6.6.11", "operator@example.com")
@@ -533,6 +589,7 @@ class OperatorRunnerTests(unittest.TestCase):
         activity = self.runner.public_parser_activity()
         self.assertEqual(activity["status"], "PASSED")
         self.assertEqual(activity["target"], "current")
+        self.assertTrue(activity["console_available"])
         self.assertIn("[OK] parser complete", activity["console_output"])
         self.assertNotIn("console_log_path", self.runner.public_state()["parser_activity"])
 
@@ -567,6 +624,7 @@ class OperatorRunnerTests(unittest.TestCase):
         runner_module.Runner(self.store)
         activity = self.runner.public_parser_activity()
         self.assertEqual(activity["status"], "INTERRUPTED")
+        self.assertFalse(activity["console_available"])
         self.assertIn("restarted", activity["error"])
 
     @patch("lor_operator_runner.subprocess.run")
@@ -575,6 +633,8 @@ class OperatorRunnerTests(unittest.TestCase):
         database.write_bytes(b"reviewed sqlite")
         digest = runner_module.hashlib.sha256(database.read_bytes()).hexdigest()
 
+        parser_activity_id = "current-web-ingest"
+
         def prepare(state):
             state["production_parser_run"] = {
                 "status": "COMPLETE",
@@ -582,6 +642,15 @@ class OperatorRunnerTests(unittest.TestCase):
                 "source_lor_version": "6.6.10",
                 "sqlite_path": str(database),
                 "sqlite_sha256": digest,
+                "parser_activity_id": parser_activity_id,
+            }
+            state["parser_activity"] = {
+                "activity_id": parser_activity_id,
+                "target": "current",
+                "status": "PASSED",
+                "result": {
+                    "sqlite_sha256": digest,
+                },
             }
 
         self.store.update(prepare)
@@ -608,10 +677,12 @@ class OperatorRunnerTests(unittest.TestCase):
                 self.runner.run_ingest(digest, "operator@example.com")
         self.assertEqual(run.call_count, 1)
 
-    def test_web_ingest_rejects_digest_not_approved_by_parser(self) -> None:
+    def test_web_ingest_rejects_digest_not_bound_to_parser_activity(self) -> None:
         database = self.root / "lor_output_v7_scene.db"
         database.write_bytes(b"reviewed sqlite")
         digest = runner_module.hashlib.sha256(database.read_bytes()).hexdigest()
+
+        parser_activity_id = "current-digest-guard"
 
         def prepare(state):
             state["production_parser_run"] = {
@@ -620,10 +691,19 @@ class OperatorRunnerTests(unittest.TestCase):
                 "source_lor_version": "6.6.10",
                 "sqlite_path": str(database),
                 "sqlite_sha256": digest,
+                "parser_activity_id": parser_activity_id,
+            }
+            state["parser_activity"] = {
+                "activity_id": parser_activity_id,
+                "target": "current",
+                "status": "PASSED",
+                "result": {
+                    "sqlite_sha256": digest,
+                },
             }
 
         self.store.update(prepare)
-        with self.assertRaisesRegex(ValueError, "not the latest validated"):
+        with self.assertRaisesRegex(ValueError, "not bound to the current passed parser activity"):
             self.runner.run_ingest("0" * 64, "operator@example.com")
 
     def test_runner_restart_marks_incomplete_ingest_activity_interrupted(self) -> None:
@@ -638,6 +718,7 @@ class OperatorRunnerTests(unittest.TestCase):
         restarted = runner_module.Runner(self.store)
         activity = restarted.public_ingest_activity()
         self.assertEqual(activity["status"], "INTERRUPTED")
+        self.assertFalse(activity["console_available"])
         self.assertIn("restarted", activity["error"])
 
     def test_current_parser_blocks_new_xml_contract(self) -> None:

--- a/Docs/01_LOR_System/02_Data_Extraction/Parser/test_lor_operator_runner.py
+++ b/Docs/01_LOR_System/02_Data_Extraction/Parser/test_lor_operator_runner.py
@@ -9,6 +9,8 @@ import json
 import os
 import sqlite3
 import tempfile
+import threading
+import time
 import unittest
 from http import HTTPStatus
 from pathlib import Path
@@ -129,6 +131,251 @@ class OperatorRunnerTests(unittest.TestCase):
 
         self.assertEqual(status, HTTPStatus.CONFLICT)
         self.assertIn("already running", payload["error"])
+
+    @patch("lor_operator_runner.subprocess.run")
+    def test_async_current_parser_start_is_durable_and_idempotent(
+        self, run
+    ) -> None:
+        entered = threading.Event()
+        release = threading.Event()
+
+        def complete(command, **_kwargs):
+            entered.set()
+
+            if not release.wait(2):
+                raise RuntimeError("test parser release timed out")
+
+            result_path = Path(
+                command[command.index("--result-json") + 1]
+            )
+            result_path.parent.mkdir(
+                parents=True,
+                exist_ok=True,
+            )
+            result_path.write_text(
+                json.dumps({
+                    "status": "COMPLETE",
+                    "validation_status": "PASSED",
+                    "source_lor_version": "6.6.4",
+                    "sqlite_sha256": "a" * 64,
+                }),
+                encoding="utf-8",
+            )
+
+            return argparse.Namespace(
+                returncode=0,
+                stdout="[OK] async parser complete\n",
+                stderr="",
+            )
+
+        run.side_effect = complete
+        request_id = "parser-request-12345678"
+
+        first = self.runner.start_parser(
+            "current",
+            "operator@example.com",
+            request_id,
+        )
+
+        self.assertEqual(first["status"], "RUNNING")
+        self.assertEqual(first["request_id"], request_id)
+        self.assertTrue(
+            first["activity_id"].startswith("current-")
+        )
+        self.assertTrue(entered.wait(2))
+
+        second = self.runner.start_parser(
+            "current",
+            "operator@example.com",
+            request_id,
+        )
+
+        self.assertEqual(
+            second["activity_id"],
+            first["activity_id"],
+        )
+        self.assertEqual(run.call_count, 1)
+
+        release.set()
+
+        for _ in range(200):
+            activity = self.runner.public_parser_activity()
+
+            if activity["status"] != "RUNNING":
+                break
+
+            time.sleep(0.01)
+
+        activity = self.runner.public_parser_activity()
+
+        self.assertEqual(activity["status"], "PASSED")
+        self.assertEqual(activity["request_id"], request_id)
+        self.assertEqual(
+            activity["result"]["sqlite_sha256"],
+            "a" * 64,
+        )
+        self.assertEqual(run.call_count, 1)
+
+    @patch("lor_operator_runner.subprocess.run")
+    def test_async_ingest_is_bound_to_parser_activity_and_idempotent(
+        self, run
+    ) -> None:
+        database = self.root / "lor_output_v7_scene.db"
+        database.write_bytes(b"reviewed sqlite")
+
+        digest = runner_module.hashlib.sha256(
+            database.read_bytes()
+        ).hexdigest()
+
+        parser_activity_id = "current-parser-evidence"
+
+        def prepare(state):
+            state["production_parser_run"] = {
+                "status": "COMPLETE",
+                "validation_status": "PASSED",
+                "source_lor_version": "6.6.4",
+                "sqlite_path": str(database),
+                "sqlite_sha256": digest,
+            }
+            state["parser_activity"] = {
+                "activity_id": parser_activity_id,
+                "target": "current",
+                "status": "PASSED",
+                "result": {
+                    "sqlite_sha256": digest,
+                },
+            }
+
+        self.store.update(prepare)
+
+        entered = threading.Event()
+        release = threading.Event()
+
+        def complete(_command, **_kwargs):
+            entered.set()
+
+            if not release.wait(2):
+                raise RuntimeError("test ingest release timed out")
+
+            return argparse.Namespace(
+                returncode=0,
+                stdout=(
+                    "[DONE] Snapshot ingest complete. "
+                    "import_run_id=47\n"
+                ),
+                stderr="",
+            )
+
+        run.side_effect = complete
+        request_id = "ingest-request-12345678"
+
+        with patch.dict(
+            os.environ,
+            {"LOR_INGEST_PG_PASSWORD": "secret"},
+        ):
+            first = self.runner.start_ingest(
+                digest,
+                parser_activity_id,
+                "operator@example.com",
+                request_id,
+            )
+
+            self.assertEqual(first["status"], "RUNNING")
+            self.assertEqual(
+                first["request_id"],
+                request_id,
+            )
+            self.assertEqual(
+                first["parser_activity_id"],
+                parser_activity_id,
+            )
+            self.assertTrue(entered.wait(2))
+
+            second = self.runner.start_ingest(
+                digest,
+                parser_activity_id,
+                "operator@example.com",
+                request_id,
+            )
+
+            self.assertEqual(
+                second["activity_id"],
+                first["activity_id"],
+            )
+            self.assertEqual(run.call_count, 1)
+
+            release.set()
+
+            for _ in range(200):
+                activity = (
+                    self.runner.public_ingest_activity()
+                )
+
+                if activity["status"] != "RUNNING":
+                    break
+
+                time.sleep(0.01)
+
+        activity = self.runner.public_ingest_activity()
+
+        self.assertEqual(activity["status"], "PASSED")
+        self.assertEqual(
+            activity["parser_activity_id"],
+            parser_activity_id,
+        )
+
+        production = (
+            self.store.read()["production_ingest_run"]
+        )
+
+        self.assertEqual(
+            production["import_run_id"],
+            47,
+        )
+        self.assertEqual(
+            production["parser_activity_id"],
+            parser_activity_id,
+        )
+        self.assertEqual(run.call_count, 1)
+
+    def test_ingest_rejects_wrong_parser_activity_binding(
+        self,
+    ) -> None:
+        database = self.root / "lor_output_v7_scene.db"
+        database.write_bytes(b"reviewed sqlite")
+
+        digest = runner_module.hashlib.sha256(
+            database.read_bytes()
+        ).hexdigest()
+
+        def prepare(state):
+            state["production_parser_run"] = {
+                "status": "COMPLETE",
+                "validation_status": "PASSED",
+                "source_lor_version": "6.6.4",
+                "sqlite_path": str(database),
+                "sqlite_sha256": digest,
+            }
+            state["parser_activity"] = {
+                "activity_id": "current-correct",
+                "target": "current",
+                "status": "PASSED",
+                "result": {
+                    "sqlite_sha256": digest,
+                },
+            }
+
+        self.store.update(prepare)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "not bound to the current passed parser activity",
+        ):
+            self.runner.run_ingest(
+                digest,
+                "operator@example.com",
+                expected_parser_activity_id="current-wrong",
+            )
 
     def test_candidate_is_resolved_only_from_versioned_preview_root(self) -> None:
         state = self.runner.select_candidate("6.6.10", "operator@example.com")

--- a/LOR2DB/Application/backend.py
+++ b/LOR2DB/Application/backend.py
@@ -3,7 +3,7 @@ MSB Database - LOR reconciliation preflight API
 backend.py
 
 Initial Release : 2026-08-05  V0.1.0
-Current Version : 2026-08-15  V0.6.1
+Current Version : 2026-08-27  V0.6.2
 Author          : GAL / OpenAI
 
 Purpose:
@@ -80,7 +80,7 @@ from flask import Flask, Response, jsonify, request
 from psycopg2.extras import RealDictCursor
 
 
-APP_VERSION = "V0.6.1"
+APP_VERSION = "V0.6.2"
 FALLBACK_ACTIONS = {"DEFER", "CORRECT_SOURCE_REQUIRED", "RESTORE_TO_LOR_REQUIRED"}
 STAGE_AUTHORITY_ACTIONS = {
     "APPROVE_STAGE_CHANGE", "ADD_NEW_STAGE",
@@ -427,6 +427,20 @@ def json_body() -> dict[str, Any]:
     return payload
 
 
+def require_operation_id(
+    payload: dict[str, Any],
+    key: str,
+    label: str,
+) -> str:
+    """Accept only opaque runner/browser operation identifiers."""
+    value = str(payload.get(key) or "").strip()
+    if not re.fullmatch(r"[A-Za-z0-9._:-]{8,128}", value):
+        raise ApiError(
+            f"{label} must contain 8-128 safe identifier characters"
+        )
+    return value
+
+
 def optional_decision_reason(payload: dict[str, Any], action: str) -> str:
     """Keep a nonblank audit reason without requiring an operator comment."""
     reason = str(payload.get("reason") or "").strip()
@@ -537,6 +551,36 @@ def get_ingest_activity() -> Response:
     return jsonify(runner_request("ingest/activity"))
 
 
+@app.post("/parser/start")
+def start_lor_parser() -> tuple[Response, int]:
+    """Start one durable routine production parser activity."""
+    operator = operator_email()
+    payload = json_body()
+    target = str(payload.get("target") or "").strip().lower()
+
+    if target != "current":
+        raise ApiError(
+            "Durable parser start is only available for "
+            "the current production parser"
+        )
+
+    request_id = require_operation_id(
+        payload,
+        "request_id",
+        "Request ID",
+    )
+
+    result = runner_request(
+        "parser/start",
+        {
+            "target": target,
+            "request_id": request_id,
+            "actor": operator,
+        },
+    )
+    return jsonify(result), 202
+
+
 @app.post("/parser/check")
 def run_parser_compatibility_check() -> Response:
     operator = operator_email()
@@ -554,6 +598,45 @@ def run_lor_parser() -> Response:
     return jsonify(runner_request(
         "parser/run", {"target": target, "actor": operator}, timeout=920
     ))
+
+
+@app.post("/ingest/start")
+def start_postgresql_ingest() -> tuple[Response, int]:
+    """Start one durable parser-activity-locked PostgreSQL ingest."""
+    operator = operator_email()
+    payload = json_body()
+
+    digest = str(
+        payload.get("expected_sqlite_sha256") or ""
+    ).strip().lower()
+
+    if not re.fullmatch(r"[0-9a-f]{64}", digest):
+        raise ApiError(
+            "Expected SQLite SHA-256 must contain "
+            "64 hexadecimal characters"
+        )
+
+    parser_activity_id = require_operation_id(
+        payload,
+        "parser_activity_id",
+        "Parser activity ID",
+    )
+    request_id = require_operation_id(
+        payload,
+        "request_id",
+        "Request ID",
+    )
+
+    result = runner_request(
+        "ingest/start",
+        {
+            "expected_sqlite_sha256": digest,
+            "parser_activity_id": parser_activity_id,
+            "request_id": request_id,
+            "actor": operator,
+        },
+    )
+    return jsonify(result), 202
 
 
 @app.post("/ingest/run")

--- a/LOR2DB/Application/backend.py
+++ b/LOR2DB/Application/backend.py
@@ -593,8 +593,12 @@ def run_parser_compatibility_check() -> Response:
 def run_lor_parser() -> Response:
     operator = operator_email()
     target = str(json_body().get("target") or "").strip().lower()
-    if target not in {"current", "baseline", "candidate"}:
-        raise ApiError("Parser target must be current, baseline, or candidate")
+    if target not in {"baseline", "candidate"}:
+        raise ApiError(
+            "Synchronous parser runs are reserved for "
+            "baseline/candidate version checks; "
+            "use /parser/start for production"
+        )
     return jsonify(runner_request(
         "parser/run", {"target": target, "actor": operator}, timeout=920
     ))
@@ -641,18 +645,12 @@ def start_postgresql_ingest() -> tuple[Response, int]:
 
 @app.post("/ingest/run")
 def run_postgresql_ingest() -> Response:
-    """Run only the latest validated SQLite digest through the fixed runner."""
-    operator = operator_email()
-    digest = str(
-        json_body().get("expected_sqlite_sha256") or ""
-    ).strip().lower()
-    if not re.fullmatch(r"[0-9a-f]{64}", digest):
-        raise ApiError("Expected SQLite SHA-256 must contain 64 hexadecimal characters")
-    return jsonify(runner_request(
-        "ingest/run",
-        {"expected_sqlite_sha256": digest, "actor": operator},
-        timeout=920,
-    ))
+    """Reject the retired synchronous browser ingest path."""
+    operator_email()
+    raise ApiError(
+        "Synchronous ingest is disabled; use /ingest/start",
+        409,
+    )
 
 
 @app.post("/parser/approve")

--- a/LOR2DB/Application/landing/index.html
+++ b/LOR2DB/Application/landing/index.html
@@ -33,6 +33,6 @@
     </form>
   </dialog>
 
-  <script src="lor2db.js?v=0.6.1" defer></script>
+  <script src="lor2db.js?v=0.6.2" defer></script>
 </body>
 </html>

--- a/LOR2DB/Application/landing/lor2db.js
+++ b/LOR2DB/Application/landing/lor2db.js
@@ -35,15 +35,35 @@
     const run = document?.parser_runner?.production_parser_run;
     const activity = document?.parser_runner?.parser_activity;
     const digest = String(run?.sqlite_sha256 || "").toLowerCase();
-    if (run?.validation_status !== "PASSED" || !/^[0-9a-f]{64}$/.test(digest)) return null;
+    const activityId = String(activity?.activity_id || "");
+
+    if (
+      run?.status !== "COMPLETE"
+      || run?.validation_status !== "PASSED"
+      || !/^[0-9a-f]{64}$/.test(digest)
+      || !activityId
+      || String(run?.parser_activity_id || "") !== activityId
+    ) return null;
+
     if (
       activity?.target !== "current"
       || activity?.status !== "PASSED"
-      || String(activity?.result?.sqlite_sha256 || "").toLowerCase() !== digest
+      || String(activity?.result?.sqlite_sha256 || "").toLowerCase()
+        !== digest
     ) return null;
+
     const ingested = document?.parser_runner?.production_ingest_run;
-    if (ingested?.status === "COMPLETE" && ingested.sqlite_sha256 === digest) return null;
-    return { sqlite_sha256: digest };
+
+    if (
+      ingested?.status === "COMPLETE"
+      && ingested.sqlite_sha256 === digest
+      && ingested.parser_activity_id === activityId
+    ) return null;
+
+    return {
+      sqlite_sha256: digest,
+      parser_activity_id: activityId
+    };
   }
 
   function parserWorkflowCard(runner, runnerError) {

--- a/LOR2DB/Application/landing/lor2db.js
+++ b/LOR2DB/Application/landing/lor2db.js
@@ -1,4 +1,4 @@
-/* MSB LOR landing page - 2026-08-16 V0.6.1 */
+/* MSB LOR landing page - 2026-08-27 V0.6.2 */
 (function () {
   "use strict";
 

--- a/LOR2DB/Application/landing/parser/index.html
+++ b/LOR2DB/Application/landing/parser/index.html
@@ -19,6 +19,6 @@
       <section class="card"><p>Loading parser status...</p></section>
     </div>
   </main>
-  <script src="parser.js?v=0.6.1" defer></script>
+  <script src="parser.js?v=0.6.2" defer></script>
 </body>
 </html>

--- a/LOR2DB/Application/landing/parser/parser.js
+++ b/LOR2DB/Application/landing/parser/parser.js
@@ -1,4 +1,4 @@
-/* MSB parser and ingest workflow - 2026-08-16 V0.6.1 */
+/* MSB parser and ingest workflow - 2026-08-27 V0.6.2 */
 (function () {
   "use strict";
 
@@ -8,6 +8,8 @@
   let ingestActivity;
   let pollTimer;
   let reviewedDigest;
+  let reviewedParserActivityId;
+  const pendingRequestIds = {};
 
   const esc = (value) => String(value ?? "").replace(/[&<>"']/g, (char) => ({
     "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;"
@@ -31,6 +33,56 @@
     return payload;
   }
 
+  function operationRequestId(kind) {
+    const key = `lor2db-${kind}-request-id`;
+
+    if (pendingRequestIds[kind]) {
+      return pendingRequestIds[kind];
+    }
+
+    try {
+      const stored = sessionStorage.getItem(key);
+      if (stored) {
+        pendingRequestIds[kind] = stored;
+        return stored;
+      }
+    } catch (_error) {
+      // In-memory idempotency still protects repeated clicks in this page.
+    }
+
+    const suffix = globalThis.crypto?.randomUUID
+      ? globalThis.crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(16).slice(2)}-${Math.random().toString(16).slice(2)}`;
+
+    const value = `${kind}:${suffix}`;
+    pendingRequestIds[kind] = value;
+
+    try {
+      sessionStorage.setItem(key, value);
+    } catch (_error) {
+      // In-memory fallback is sufficient for the current page lifetime.
+    }
+
+    return value;
+  }
+
+  function clearOperationRequestId(kind, acceptedRequestId) {
+    if (!acceptedRequestId) return;
+
+    if (pendingRequestIds[kind] === acceptedRequestId) {
+      delete pendingRequestIds[kind];
+    }
+
+    try {
+      const key = `lor2db-${kind}-request-id`;
+      if (sessionStorage.getItem(key) === acceptedRequestId) {
+        sessionStorage.removeItem(key);
+      }
+    } catch (_error) {
+      // Nothing else is required if browser storage is unavailable.
+    }
+  }
+
   function counts(result) {
     const values = result?.counts;
     if (!values) return "";
@@ -44,27 +96,50 @@
     </div>`;
   }
 
-  function validatedDigest(runner) {
+  function validatedParserEvidence(runner, consoleActivity) {
     const run = runner?.production_parser_run;
     const activity = runner?.parser_activity;
     const digest = String(run?.sqlite_sha256 || "").toLowerCase();
-    if (run?.validation_status !== "PASSED" || !/^[0-9a-f]{64}$/.test(digest)) return null;
+    const activityId = String(activity?.activity_id || "");
+
+    if (
+      run?.validation_status !== "PASSED"
+      || !/^[0-9a-f]{64}$/.test(digest)
+      || !activityId
+    ) return null;
+
     if (
       activity?.target !== "current"
       || activity?.status !== "PASSED"
       || String(activity?.result?.sqlite_sha256 || "").toLowerCase() !== digest
     ) return null;
-    return digest;
+
+    if (
+      consoleActivity?.activity_id !== activityId
+      || consoleActivity?.status !== "PASSED"
+      || String(consoleActivity?.result?.sqlite_sha256 || "").toLowerCase() !== digest
+    ) return null;
+
+    return {
+      digest,
+      activityId
+    };
   }
 
-  function ingestWorkflow(runner, digest, workflow) {
-    if (!digest) return "";
+  function ingestWorkflow(runner, evidence, workflow) {
+    const digest = evidence?.digest;
+    const parserActivityId = evidence?.activityId;
+
+    if (!digest || !parserActivityId) return "";
+
     const ingest = ingestActivity?.activity;
     const ingested = runner.production_ingest_run;
     const sameDigestComplete = ingested?.status === "COMPLETE" && ingested.sqlite_sha256 === digest;
     const running = ingest?.status === "RUNNING";
     const failed = ingest?.status === "FAILED" || ingest?.status === "INTERRUPTED";
-    const reviewed = reviewedDigest === digest;
+    const reviewed =
+      reviewedDigest === digest
+      && reviewedParserActivityId === parserActivityId;
     let status = reviewed ? "READY FOR INGEST" : "REVIEW REQUIRED";
     let detail = reviewed
       ? "You marked this exact parser output as correct. Ingest is now available for this SQLite SHA-256 only."
@@ -103,6 +178,7 @@
       <div class="card-title"><div><p class="eyebrow">2. Operator approval and ingest</p><h2>PostgreSQL snapshot ingest</h2></div><span class="pill">${esc(status)}</span></div>
       <p>${detail}</p>
       <dl class="facts">
+        <div><dt>Parser activity ID</dt><dd class="digest">${esc(parserActivityId)}</dd></div>
         <div><dt>Validated SQLite SHA-256</dt><dd class="digest">${esc(digest)}</dd></div>
         <div><dt>PostgreSQL import run</dt><dd>${esc(ingested?.import_run_id || "Not yet created")}</dd></div>
       </dl>
@@ -126,14 +202,41 @@
     </section>`;
   }
 
-  function consoleCard(id, title, activity, emptyMessage) {
+  function consoleCard(
+    id,
+    title,
+    activity,
+    emptyMessage,
+    expectedActivityId
+  ) {
     const record = activity?.activity;
-    const status = record?.status || "NOT RUN";
-    const output = record?.console_output || (status === "RUNNING" ? "Operation is running..." : emptyMessage);
+
+    const mismatched = Boolean(
+      expectedActivityId
+      && record?.activity_id
+      && record.activity_id !== expectedActivityId
+    );
+
+    const status = mismatched
+      ? "REFRESHING"
+      : (record?.status || "NOT RUN");
+
+    const output = mismatched
+      ? "Current console evidence is still refreshing. Approval is blocked until the activity ID matches."
+      : (
+          record?.console_output
+          || (
+            status === "RUNNING"
+              ? "Operation is running..."
+              : emptyMessage
+          )
+        );
+
     return `<section id="${esc(id)}" class="card">
       <div class="card-title"><h2>${esc(title)}</h2><span class="pill state-${esc(status.toLowerCase())}">${esc(status)}</span></div>
-      ${record?.console_truncated ? '<p class="warning">Only the most recent 500,000 characters are displayed. The complete log remains on the Office PC.</p>' : ""}
-      ${record?.error ? `<p class="error">${esc(record.error)}</p>` : ""}
+      ${record?.activity_id ? `<dl class="facts"><div><dt>Activity ID</dt><dd class="digest">${esc(record.activity_id)}</dd></div>${record?.parser_activity_id ? `<div><dt>Parser activity ID</dt><dd class="digest">${esc(record.parser_activity_id)}</dd></div>` : ""}</dl>` : ""}
+      ${record?.console_truncated && !mismatched ? '<p class="warning">Only the most recent 500,000 characters are displayed. The complete log remains on the runner host.</p>' : ""}
+      ${record?.error && !mismatched ? `<p class="error">${esc(record.error)}</p>` : ""}
       <pre class="console">${esc(output)}</pre>
     </section>`;
   }
@@ -149,8 +252,32 @@
     const ingestRunning = ingestActivity?.activity?.status === "RUNNING";
     const run = latest?.result || runner.production_parser_run;
     const status = latest?.status || "NOT RUN FROM THIS PAGE";
-    const digest = validatedDigest(runner);
-    if (reviewedDigest && reviewedDigest !== digest) reviewedDigest = undefined;
+
+    if (latest?.request_id) {
+      clearOperationRequestId("parser", latest.request_id);
+    }
+
+    if (ingestActivity?.activity?.request_id) {
+      clearOperationRequestId(
+        "ingest",
+        ingestActivity.activity.request_id
+      );
+    }
+
+    const evidence = validatedParserEvidence(runner, latest);
+    const digest = evidence?.digest;
+    const parserActivityId = evidence?.activityId;
+
+    if (
+      reviewedDigest
+      && (
+        reviewedDigest !== digest
+        || reviewedParserActivityId !== parserActivityId
+      )
+    ) {
+      reviewedDigest = undefined;
+      reviewedParserActivityId = undefined;
+    }
     const targetNote = latest && latest.target !== "current"
       ? `<p class="warning">The latest parser activity belongs to the ${esc(latest.target)} version-check workflow, not the production parser.</p>`
       : "";
@@ -161,6 +288,7 @@
       <dl class="facts">
         <div><dt>Approved LOR version</dt><dd>${esc(runner.current_lor_version)}</dd></div>
         <div><dt>Parser status</dt><dd>${esc(status)}</dd></div>
+        <div><dt>Parser activity ID</dt><dd class="digest">${esc(latest?.activity_id || "Not recorded")}</dd></div>
         <div><dt>Preview source folder</dt><dd class="path-value">${esc(runner.current_preview_folder)}</dd></div>
         <div><dt>Started</dt><dd>${esc(displayDate(latest?.started_at))}</dd></div>
         <div><dt>Production SQLite</dt><dd class="path-value">${esc(run?.sqlite_path || "Not recorded")}</dd></div>
@@ -178,15 +306,28 @@
         <a class="secondary" href="../">Return to dashboard</a>
       </div>
     </section>
-    ${consoleCard("parser-console", "Parser console output", parserActivity, "No parser console output has been recorded yet.")}
-    ${ingestWorkflow(runner, digest, model.workflow)}
-    ${consoleCard("ingest-console", "PostgreSQL ingest console output", ingestActivity, "No PostgreSQL ingest has been run for this parser output.")}
+    ${consoleCard(
+      "parser-console",
+      "Parser console output",
+      parserActivity,
+      "No parser console output has been recorded yet.",
+      runner.parser_activity?.activity_id
+    )}
+    ${ingestWorkflow(runner, evidence, model.workflow)}
+    ${consoleCard(
+      "ingest-console",
+      "PostgreSQL ingest console output",
+      ingestActivity,
+      "No PostgreSQL ingest has been run for this parser output.",
+      runner.ingest_activity?.activity_id
+    )}
     ${reconciliationWorkflow(runner, digest, model.workflow)}`;
 
     document.querySelector("#run-parser")?.addEventListener("click", runParser);
     document.querySelector("#rerun-parser")?.addEventListener("click", runParser);
     document.querySelector("#mark-ready-ingest")?.addEventListener("click", () => {
       reviewedDigest = digest;
+      reviewedParserActivityId = parserActivityId;
       render();
       document.querySelector("#ingest-step")?.scrollIntoView({ behavior: "smooth", block: "start" });
     });
@@ -213,40 +354,89 @@
   }
 
   async function runParser(event) {
-    if (!window.confirm("Run the parser now? You can inspect the output and run it again before ingest.")) return;
     reviewedDigest = undefined;
+    reviewedParserActivityId = undefined;
+
+    const requestId = operationRequestId("parser");
+
     event.currentTarget.disabled = true;
     event.currentTarget.textContent = "Starting parser...";
-    if (!pollTimer) pollTimer = window.setInterval(refresh, 2000);
+
+    if (!pollTimer) {
+      pollTimer = window.setInterval(refresh, 2000);
+    }
+
     try {
-      await request("parser/run", { method: "POST", body: JSON.stringify({ target: "current" }) });
+      parserActivity = await request(
+        "parser/start",
+        {
+          method: "POST",
+          body: JSON.stringify({
+            target: "current",
+            request_id: requestId
+          })
+        }
+      );
+
+      clearOperationRequestId("parser", requestId);
+      render();
     } catch (error) {
       window.alert(error.message);
-    } finally {
-      await refresh();
     }
+
+    await refresh();
   }
 
   async function runIngest(event) {
-    const digest = validatedDigest(model?.parser_runner);
-    if (!digest || reviewedDigest !== digest) {
-      window.alert("Review and approve this exact parser output before ingest.");
+    const evidence = validatedParserEvidence(
+      model?.parser_runner,
+      parserActivity?.activity
+    );
+
+    const digest = evidence?.digest;
+    const parserActivityId = evidence?.activityId;
+
+    if (
+      !digest
+      || !parserActivityId
+      || reviewedDigest !== digest
+      || reviewedParserActivityId !== parserActivityId
+    ) {
+      window.alert(
+        "Review and approve this exact parser activity and SQLite output before ingest."
+      );
       return;
     }
-    if (!window.confirm("Ingest this reviewed SQLite snapshot into PostgreSQL now? Reconciliation will not start automatically.")) return;
+
+    const requestId = operationRequestId("ingest");
+
     event.currentTarget.disabled = true;
     event.currentTarget.textContent = "Starting ingest...";
-    if (!pollTimer) pollTimer = window.setInterval(refresh, 2000);
+
+    if (!pollTimer) {
+      pollTimer = window.setInterval(refresh, 2000);
+    }
+
     try {
-      await request("ingest/run", {
-        method: "POST",
-        body: JSON.stringify({ expected_sqlite_sha256: digest })
-      });
+      ingestActivity = await request(
+        "ingest/start",
+        {
+          method: "POST",
+          body: JSON.stringify({
+            expected_sqlite_sha256: digest,
+            parser_activity_id: parserActivityId,
+            request_id: requestId
+          })
+        }
+      );
+
+      clearOperationRequestId("ingest", requestId);
+      render();
     } catch (error) {
       window.alert(error.message);
-    } finally {
-      await refresh();
     }
+
+    await refresh();
   }
 
   async function startReconciliation(event) {

--- a/LOR2DB/Application/landing/parser/parser.js
+++ b/LOR2DB/Application/landing/parser/parser.js
@@ -119,6 +119,7 @@
     if (
       consoleActivity?.activity_id !== activityId
       || consoleActivity?.status !== "PASSED"
+      || consoleActivity?.console_available !== true
       || String(consoleActivity?.result?.sqlite_sha256 || "").toLowerCase() !== digest
     ) return null;
 
@@ -166,6 +167,7 @@
     if (
       consoleActivity?.activity_id !== ingestActivityId
       || consoleActivity?.status !== "PASSED"
+      || consoleActivity?.console_available !== true
       || consoleActivity?.parser_activity_id !== parserActivityId
       || consoleActivity?.result?.ingest_activity_id
         !== ingestActivityId
@@ -280,13 +282,21 @@
       && record.activity_id !== expectedActivityId
     );
 
+    const evidenceUnavailable = Boolean(
+      !mismatched
+      && record?.status === "PASSED"
+      && record?.console_available !== true
+    );
+
     const status = mismatched
       ? "REFRESHING"
       : (record?.status || "NOT RUN");
 
     const output = mismatched
       ? "Current console evidence is still refreshing. Approval is blocked until the activity ID matches."
-      : (
+      : evidenceUnavailable
+        ? "Current console evidence is unavailable. Approval and reconciliation are blocked."
+        : (
           record?.console_output
           || (
             status === "RUNNING"
@@ -298,6 +308,7 @@
     return `<section id="${esc(id)}" class="card">
       <div class="card-title"><h2>${esc(title)}</h2><span class="pill state-${esc(status.toLowerCase())}">${esc(status)}</span></div>
       ${record?.activity_id ? `<dl class="facts"><div><dt>Activity ID</dt><dd class="digest">${esc(record.activity_id)}</dd></div>${record?.parser_activity_id ? `<div><dt>Parser activity ID</dt><dd class="digest">${esc(record.parser_activity_id)}</dd></div>` : ""}</dl>` : ""}
+      ${evidenceUnavailable ? '<p class="error">Current console evidence is unavailable. Approval and reconciliation are blocked.</p>' : ""}
       ${record?.console_truncated && !mismatched ? '<p class="warning">Only the most recent 500,000 characters are displayed. The complete log remains on the runner host.</p>' : ""}
       ${record?.error && !mismatched ? `<p class="error">${esc(record.error)}</p>` : ""}
       <pre class="console">${esc(output)}</pre>

--- a/LOR2DB/Application/landing/parser/parser.js
+++ b/LOR2DB/Application/landing/parser/parser.js
@@ -101,12 +101,18 @@
     const activity = runner?.parser_activity;
     const digest = String(run?.sqlite_sha256 || "").toLowerCase();
     const activityId = String(activity?.activity_id || "");
+    const parserVersion = String(run?.parser_version || "");
+    const sourceManifestSha256 = String(
+      run?.source_manifest_sha256 || ""
+    ).toLowerCase();
 
     if (
       run?.status !== "COMPLETE"
       || run?.validation_status !== "PASSED"
       || !/^[0-9a-f]{64}$/.test(digest)
       || !activityId
+      || !parserVersion
+      || !/^[0-9a-f]{64}$/.test(sourceManifestSha256)
       || String(run?.parser_activity_id || "") !== activityId
     ) return null;
 
@@ -114,6 +120,10 @@
       activity?.target !== "current"
       || activity?.status !== "PASSED"
       || String(activity?.result?.sqlite_sha256 || "").toLowerCase() !== digest
+      || String(activity?.result?.parser_version || "") !== parserVersion
+      || String(
+        activity?.result?.source_manifest_sha256 || ""
+      ).toLowerCase() !== sourceManifestSha256
     ) return null;
 
     if (
@@ -121,11 +131,17 @@
       || consoleActivity?.status !== "PASSED"
       || consoleActivity?.console_available !== true
       || String(consoleActivity?.result?.sqlite_sha256 || "").toLowerCase() !== digest
+      || String(consoleActivity?.result?.parser_version || "") !== parserVersion
+      || String(
+        consoleActivity?.result?.source_manifest_sha256 || ""
+      ).toLowerCase() !== sourceManifestSha256
     ) return null;
 
     return {
       digest,
-      activityId
+      activityId,
+      parserVersion,
+      sourceManifestSha256
     };
   }
 
@@ -187,8 +203,15 @@
   function ingestWorkflow(runner, evidence, workflow) {
     const digest = evidence?.digest;
     const parserActivityId = evidence?.activityId;
+    const parserVersion = evidence?.parserVersion;
+    const sourceManifestSha256 = evidence?.sourceManifestSha256;
 
-    if (!digest || !parserActivityId) return "";
+    if (
+      !digest
+      || !parserActivityId
+      || !parserVersion
+      || !sourceManifestSha256
+    ) return "";
 
     const ingest = ingestActivity?.activity;
     const ingested = runner.production_ingest_run;
@@ -242,6 +265,8 @@
       <p>${detail}</p>
       <dl class="facts">
         <div><dt>Parser activity ID</dt><dd class="digest">${esc(parserActivityId)}</dd></div>
+        <div><dt>Parser version</dt><dd>${esc(parserVersion)}</dd></div>
+        <div><dt>Source manifest SHA-256</dt><dd class="digest">${esc(sourceManifestSha256)}</dd></div>
         <div><dt>Validated SQLite SHA-256</dt><dd class="digest">${esc(digest)}</dd></div>
         <div><dt>PostgreSQL import run</dt><dd>${esc(ingested?.import_run_id || "Not yet created")}</dd></div>
       </dl>
@@ -324,7 +349,9 @@
     const latest = parserActivity?.activity;
     const parserRunning = latest?.status === "RUNNING";
     const ingestRunning = ingestActivity?.activity?.status === "RUNNING";
-    const run = latest?.result || runner.production_parser_run;
+    const run = latest?.target === "current"
+      ? latest?.result
+      : runner.production_parser_run;
     const status = latest?.status || "NOT RUN FROM THIS PAGE";
 
     if (latest?.request_id) {
@@ -363,6 +390,8 @@
         <div><dt>Approved LOR version</dt><dd>${esc(runner.current_lor_version)}</dd></div>
         <div><dt>Parser status</dt><dd>${esc(status)}</dd></div>
         <div><dt>Parser activity ID</dt><dd class="digest">${esc(latest?.activity_id || "Not recorded")}</dd></div>
+        <div><dt>Parser version</dt><dd>${esc(run?.parser_version || "Not recorded")}</dd></div>
+        <div><dt>Source manifest SHA-256</dt><dd class="digest">${esc(run?.source_manifest_sha256 || "Not recorded")}</dd></div>
         <div><dt>Preview source folder</dt><dd class="path-value">${esc(runner.current_preview_folder)}</dd></div>
         <div><dt>Started</dt><dd>${esc(displayDate(latest?.started_at))}</dd></div>
         <div><dt>Production SQLite</dt><dd class="path-value">${esc(run?.sqlite_path || "Not recorded")}</dd></div>

--- a/LOR2DB/Application/landing/parser/parser.js
+++ b/LOR2DB/Application/landing/parser/parser.js
@@ -103,9 +103,11 @@
     const activityId = String(activity?.activity_id || "");
 
     if (
-      run?.validation_status !== "PASSED"
+      run?.status !== "COMPLETE"
+      || run?.validation_status !== "PASSED"
       || !/^[0-9a-f]{64}$/.test(digest)
       || !activityId
+      || String(run?.parser_activity_id || "") !== activityId
     ) return null;
 
     if (
@@ -126,6 +128,60 @@
     };
   }
 
+  function validatedIngestEvidence(
+    runner,
+    parserEvidence,
+    consoleActivity
+  ) {
+    const digest = parserEvidence?.digest;
+    const parserActivityId = parserEvidence?.activityId;
+    const ingested = runner?.production_ingest_run;
+    const stateActivity = runner?.ingest_activity;
+    const ingestActivityId = String(
+      ingested?.ingest_activity_id || ""
+    );
+
+    if (
+      !digest
+      || !parserActivityId
+      || ingested?.status !== "COMPLETE"
+      || String(ingested?.sqlite_sha256 || "").toLowerCase()
+        !== digest
+      || ingested?.parser_activity_id !== parserActivityId
+      || !ingestActivityId
+    ) return null;
+
+    if (
+      stateActivity?.activity_id !== ingestActivityId
+      || stateActivity?.status !== "PASSED"
+      || stateActivity?.parser_activity_id !== parserActivityId
+      || stateActivity?.result?.ingest_activity_id
+        !== ingestActivityId
+      || stateActivity?.result?.parser_activity_id
+        !== parserActivityId
+      || stateActivity?.result?.import_run_id
+        !== ingested?.import_run_id
+    ) return null;
+
+    if (
+      consoleActivity?.activity_id !== ingestActivityId
+      || consoleActivity?.status !== "PASSED"
+      || consoleActivity?.parser_activity_id !== parserActivityId
+      || consoleActivity?.result?.ingest_activity_id
+        !== ingestActivityId
+      || consoleActivity?.result?.parser_activity_id
+        !== parserActivityId
+      || consoleActivity?.result?.import_run_id
+        !== ingested?.import_run_id
+    ) return null;
+
+    return {
+      ...parserEvidence,
+      ingestActivityId,
+      importRunId: ingested.import_run_id
+    };
+  }
+
   function ingestWorkflow(runner, evidence, workflow) {
     const digest = evidence?.digest;
     const parserActivityId = evidence?.activityId;
@@ -134,7 +190,12 @@
 
     const ingest = ingestActivity?.activity;
     const ingested = runner.production_ingest_run;
-    const sameDigestComplete = ingested?.status === "COMPLETE" && ingested.sqlite_sha256 === digest;
+    const completeEvidence = validatedIngestEvidence(
+      runner,
+      evidence,
+      ingest
+    );
+    const sameDigestComplete = Boolean(completeEvidence);
     const running = ingest?.status === "RUNNING";
     const failed = ingest?.status === "FAILED" || ingest?.status === "INTERRUPTED";
     const reviewed =
@@ -186,12 +247,14 @@
     </section>`;
   }
 
-  function reconciliationWorkflow(runner, digest, workflow) {
+  function reconciliationWorkflow(runner, evidence, workflow) {
     const ingested = runner?.production_ingest_run;
-    const sameDigestComplete = digest
-      && ingested?.status === "COMPLETE"
-      && ingested.sqlite_sha256 === digest;
-    if (!sameDigestComplete) return "";
+    const completeEvidence = validatedIngestEvidence(
+      runner,
+      evidence,
+      ingestActivity?.activity
+    );
+    if (!completeEvidence) return "";
     const controls = workflow?.can_start
       ? '<button id="start-reconciliation" class="primary" type="button">Start reconciliation</button>'
       : '<button id="refresh-reconciliation" type="button">Refresh reconciliation status</button>';
@@ -321,7 +384,7 @@
       "No PostgreSQL ingest has been run for this parser output.",
       runner.ingest_activity?.activity_id
     )}
-    ${reconciliationWorkflow(runner, digest, model.workflow)}`;
+    ${reconciliationWorkflow(runner, evidence, model.workflow)}`;
 
     document.querySelector("#run-parser")?.addEventListener("click", runParser);
     document.querySelector("#rerun-parser")?.addEventListener("click", runParser);
@@ -346,10 +409,63 @@
     }
   }
 
-  async function refresh() {
-    [model, parserActivity, ingestActivity] = await Promise.all([
-      request("dashboard"), request("parser/activity"), request("ingest/activity")
+  async function loadCurrentState() {
+    return Promise.all([
+      request("dashboard"),
+      request("parser/activity"),
+      request("ingest/activity")
     ]);
+  }
+
+  function requiresSettlementRefresh() {
+    const runner = model?.parser_runner;
+    const parser = parserActivity?.activity;
+    const ingest = ingestActivity?.activity;
+
+    const parserNeedsSettlement = Boolean(
+      parser
+      && parser.status !== "RUNNING"
+      && (
+        runner?.parser_activity?.activity_id
+          !== parser.activity_id
+        || runner?.parser_activity?.status
+          !== parser.status
+        || (
+          parser.status === "PASSED"
+          && runner?.production_parser_run?.parser_activity_id
+            !== parser.activity_id
+        )
+      )
+    );
+
+    const ingestNeedsSettlement = Boolean(
+      ingest
+      && ingest.status !== "RUNNING"
+      && (
+        runner?.ingest_activity?.activity_id
+          !== ingest.activity_id
+        || runner?.ingest_activity?.status
+          !== ingest.status
+        || (
+          ingest.status === "PASSED"
+          && runner?.production_ingest_run?.ingest_activity_id
+            !== ingest.activity_id
+        )
+      )
+    );
+
+    return parserNeedsSettlement || ingestNeedsSettlement;
+  }
+
+  async function refresh() {
+    [model, parserActivity, ingestActivity] =
+      await loadCurrentState();
+
+    if (requiresSettlementRefresh()) {
+      [model, parserActivity, ingestActivity] =
+        await loadCurrentState();
+    }
+
     render();
   }
 

--- a/LOR2DB/Application/test_backend.py
+++ b/LOR2DB/Application/test_backend.py
@@ -362,6 +362,22 @@ class BackendSafetyTests(unittest.TestCase):
         self.assertEqual(response.status_code, 400)
         runner.assert_not_called()
 
+    def test_parser_run_rejects_current_production_target(
+        self,
+    ) -> None:
+        with patch.object(backend, "runner_request") as runner:
+            response = backend.app.test_client().post(
+                "/parser/run",
+                json={"target": "current"},
+                headers={
+                    "Cf-Access-Authenticated-User-Email":
+                        "greg@sheboyganlights.org"
+                },
+            )
+
+        self.assertEqual(response.status_code, 400)
+        runner.assert_not_called()
+
     def test_parser_run_rejects_arbitrary_target(self) -> None:
         response = backend.app.test_client().post(
             "/parser/run",
@@ -452,36 +468,31 @@ class BackendSafetyTests(unittest.TestCase):
             },
         )
 
-    def test_ingest_forwards_only_validated_digest_and_authenticated_actor(self) -> None:
-        digest = "a" * 64
-        with patch.object(backend, "runner_request", return_value={"status": "COMPLETE"}) as runner:
+    def test_legacy_synchronous_ingest_is_disabled(self) -> None:
+        with patch.object(backend, "runner_request") as runner:
             response = backend.app.test_client().post(
                 "/ingest/run",
-                json={
-                    "expected_sqlite_sha256": digest,
-                    "sqlite_path": "C:\\unsafe.db",
-                    "command": "arbitrary",
-                },
+                json={"expected_sqlite_sha256": "a" * 64},
                 headers={
                     "Cf-Access-Authenticated-User-Email":
                         "greg@sheboyganlights.org"
                 },
             )
-        self.assertEqual(response.status_code, 200)
-        runner.assert_called_once_with(
-            "ingest/run",
-            {
-                "expected_sqlite_sha256": digest,
-                "actor": "greg@sheboyganlights.org",
-            },
-            timeout=920,
-        )
 
-    def test_ingest_rejects_invalid_digest_before_runner_use(self) -> None:
+        self.assertEqual(response.status_code, 409)
+        runner.assert_not_called()
+
+    def test_ingest_start_rejects_invalid_digest_before_runner_use(self) -> None:
         with patch.object(backend, "runner_request") as runner:
             response = backend.app.test_client().post(
-                "/ingest/run",
-                json={"expected_sqlite_sha256": "not-a-digest"},
+                "/ingest/start",
+                json={
+                    "expected_sqlite_sha256": "not-a-digest",
+                    "parser_activity_id":
+                        "current-20260827-152821-123456",
+                    "request_id":
+                        "ingest:12345678-1234-1234-1234-123456789abc",
+                },
                 headers={
                     "Cf-Access-Authenticated-User-Email":
                         "greg@sheboyganlights.org"
@@ -493,6 +504,9 @@ class BackendSafetyTests(unittest.TestCase):
     def test_landing_page_separates_parser_and_version_workflows(self) -> None:
         landing = Path(__file__).with_name("landing")
         source = (landing / "lor2db.js").read_text(encoding="utf-8")
+        landing_page = (
+            landing / "index.html"
+        ).read_text(encoding="utf-8")
         version_source = (
             landing / "version-check" / "version-check.js"
         ).read_text(encoding="utf-8")
@@ -523,6 +537,7 @@ class BackendSafetyTests(unittest.TestCase):
         self.assertIn("Parser activity ID", parser_source)
         self.assertIn("validatedParserEvidence", parser_source)
         self.assertIn("validatedIngestEvidence", parser_source)
+        self.assertIn("console_available", parser_source)
         self.assertIn("requiresSettlementRefresh", parser_source)
         self.assertIn("ingest_activity_id", parser_source)
         self.assertIn("operationRequestId", parser_source)
@@ -542,6 +557,10 @@ class BackendSafetyTests(unittest.TestCase):
         self.assertIn(
             'parser.js?v=0.6.2',
             parser_page,
+        )
+        self.assertIn(
+            'lor2db.js?v=0.6.2',
+            landing_page,
         )
         self.assertIn("Start reconciliation", parser_source)
         self.assertIn('request("runs/start"', parser_source)

--- a/LOR2DB/Application/test_backend.py
+++ b/LOR2DB/Application/test_backend.py
@@ -522,7 +522,11 @@ class BackendSafetyTests(unittest.TestCase):
         self.assertIn("parser_activity_id", parser_source)
         self.assertIn("Parser activity ID", parser_source)
         self.assertIn("validatedParserEvidence", parser_source)
+        self.assertIn("validatedIngestEvidence", parser_source)
+        self.assertIn("requiresSettlementRefresh", parser_source)
+        self.assertIn("ingest_activity_id", parser_source)
         self.assertIn("operationRequestId", parser_source)
+        self.assertIn("run?.parser_activity_id", source)
         self.assertNotIn(
             'window.confirm("Run the parser now?',
             parser_source,

--- a/LOR2DB/Application/test_backend.py
+++ b/LOR2DB/Application/test_backend.py
@@ -306,6 +306,62 @@ class BackendSafetyTests(unittest.TestCase):
             },
         )
 
+    def test_parser_start_forwards_durable_current_operation(
+        self,
+    ) -> None:
+        request_id = "parser:12345678-1234-1234-1234-123456789abc"
+
+        with patch.object(
+            backend,
+            "runner_request",
+            return_value={
+                "activity": {
+                    "activity_id": "current-20260827-123456",
+                    "status": "RUNNING",
+                    "request_id": request_id,
+                }
+            },
+        ) as runner:
+            response = backend.app.test_client().post(
+                "/parser/start",
+                json={
+                    "target": "current",
+                    "request_id": request_id,
+                },
+                headers={
+                    "Cf-Access-Authenticated-User-Email":
+                        "greg@sheboyganlights.org"
+                },
+            )
+
+        self.assertEqual(response.status_code, 202)
+        runner.assert_called_once_with(
+            "parser/start",
+            {
+                "target": "current",
+                "request_id": request_id,
+                "actor": "greg@sheboyganlights.org",
+            },
+        )
+
+    def test_parser_start_rejects_nonproduction_target(self) -> None:
+        with patch.object(backend, "runner_request") as runner:
+            response = backend.app.test_client().post(
+                "/parser/start",
+                json={
+                    "target": "baseline",
+                    "request_id":
+                        "parser:12345678-1234-1234-1234-123456789abc",
+                },
+                headers={
+                    "Cf-Access-Authenticated-User-Email":
+                        "greg@sheboyganlights.org"
+                },
+            )
+
+        self.assertEqual(response.status_code, 400)
+        runner.assert_not_called()
+
     def test_parser_run_rejects_arbitrary_target(self) -> None:
         response = backend.app.test_client().post(
             "/parser/run",
@@ -350,6 +406,51 @@ class BackendSafetyTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json, expected)
         runner.assert_called_once_with("parser/activity")
+
+    def test_ingest_start_binds_digest_parser_activity_and_request(
+        self,
+    ) -> None:
+        digest = "a" * 64
+        parser_activity_id = "current-20260827-152821-123456"
+        request_id = "ingest:12345678-1234-1234-1234-123456789abc"
+
+        with patch.object(
+            backend,
+            "runner_request",
+            return_value={
+                "activity": {
+                    "activity_id": "ingest-20260827-153000-123456",
+                    "status": "RUNNING",
+                    "request_id": request_id,
+                    "parser_activity_id": parser_activity_id,
+                }
+            },
+        ) as runner:
+            response = backend.app.test_client().post(
+                "/ingest/start",
+                json={
+                    "expected_sqlite_sha256": digest,
+                    "parser_activity_id": parser_activity_id,
+                    "request_id": request_id,
+                    "sqlite_path": "C:\\unsafe.db",
+                    "command": "arbitrary",
+                },
+                headers={
+                    "Cf-Access-Authenticated-User-Email":
+                        "greg@sheboyganlights.org"
+                },
+            )
+
+        self.assertEqual(response.status_code, 202)
+        runner.assert_called_once_with(
+            "ingest/start",
+            {
+                "expected_sqlite_sha256": digest,
+                "parser_activity_id": parser_activity_id,
+                "request_id": request_id,
+                "actor": "greg@sheboyganlights.org",
+            },
+        )
 
     def test_ingest_forwards_only_validated_digest_and_authenticated_actor(self) -> None:
         digest = "a" * 64

--- a/LOR2DB/Application/test_backend.py
+++ b/LOR2DB/Application/test_backend.py
@@ -535,6 +535,14 @@ class BackendSafetyTests(unittest.TestCase):
         self.assertIn('"ingest/start"', parser_source)
         self.assertIn("parser_activity_id", parser_source)
         self.assertIn("Parser activity ID", parser_source)
+        self.assertIn("Parser version", parser_source)
+        self.assertIn("Source manifest SHA-256", parser_source)
+        self.assertIn("source_manifest_sha256", parser_source)
+        self.assertIn("parser_version", parser_source)
+        self.assertNotIn(
+            "latest?.result || runner.production_parser_run",
+            parser_source,
+        )
         self.assertIn("validatedParserEvidence", parser_source)
         self.assertIn("validatedIngestEvidence", parser_source)
         self.assertIn("console_available", parser_source)

--- a/LOR2DB/Application/test_backend.py
+++ b/LOR2DB/Application/test_backend.py
@@ -499,6 +499,9 @@ class BackendSafetyTests(unittest.TestCase):
         parser_source = (
             landing / "parser" / "parser.js"
         ).read_text(encoding="utf-8")
+        parser_page = (
+            landing / "parser" / "index.html"
+        ).read_text(encoding="utf-8")
 
         self.assertIn('href="parser/"', source)
         self.assertIn('href="version-check/"', source)
@@ -514,7 +517,28 @@ class BackendSafetyTests(unittest.TestCase):
         self.assertIn("Each run rebuilds and replaces the SQLite output", parser_source)
         self.assertIn("Parser output looks correct — ready for ingest", parser_source)
         self.assertIn("Ingest to PostgreSQL", parser_source)
-        self.assertIn('request("ingest/run"', parser_source)
+        self.assertIn('"parser/start"', parser_source)
+        self.assertIn('"ingest/start"', parser_source)
+        self.assertIn("parser_activity_id", parser_source)
+        self.assertIn("Parser activity ID", parser_source)
+        self.assertIn("validatedParserEvidence", parser_source)
+        self.assertIn("operationRequestId", parser_source)
+        self.assertNotIn(
+            'window.confirm("Run the parser now?',
+            parser_source,
+        )
+        self.assertNotIn(
+            'window.confirm("Ingest this reviewed SQLite',
+            parser_source,
+        )
+        self.assertNotIn(
+            'request("ingest/run"',
+            parser_source,
+        )
+        self.assertIn(
+            'parser.js?v=0.6.2',
+            parser_page,
+        )
         self.assertIn("Start reconciliation", parser_source)
         self.assertIn('request("runs/start"', parser_source)
         self.assertIn("Review parser output", source)

--- a/run_lor_runner.ps1
+++ b/run_lor_runner.ps1
@@ -65,6 +65,11 @@ $SecretPath = Join-Path $SecretRoot 'runner-token.dpapi'
 $IngestSecretPath = Join-Path $SecretRoot 'postgres-ingest-password.dpapi'
 $ServiceLogPath = Join-Path $SecretRoot 'runner-service.log'
 $PendingRemotePath = '~/.msb-lor-runner-token.pending'
+$ProductionSqlitePath =
+    'G:\Shared drives\MSB Database\database\lor_output_v7_scene.db'
+$ReadinessTimeoutSeconds = 600
+$ReadinessInitialDelaySeconds = 2
+$ReadinessMaxDelaySeconds = 30
 
 function Write-ServiceLog {
     param([Parameter(Mandatory = $true)][string]$Message)
@@ -221,6 +226,87 @@ function Assert-RunnerPrerequisites {
     }
     return $state
 }
+
+function Wait-RunnerPrerequisites {
+    <#
+    PRINT-SERVER depends on Google Drive for Desktop mounting G: after the
+    interactive Print Service Autologon session begins. The Scheduled Task
+    must not fail permanently merely because it starts before DriveFS has
+    finished mounting the approved LOR paths.
+
+    Local deployment files are checked once and fail immediately. G:-backed
+    runtime prerequisites are retried with bounded exponential backoff.
+    #>
+
+    foreach ($requiredLocalPath in @(
+        $RunnerPath,
+        $ParserPath,
+        $CheckerPath,
+        $IngestPath,
+        $PythonPath
+    )) {
+        if (-not (Test-Path -LiteralPath $requiredLocalPath -PathType Leaf)) {
+            throw "Required local runner file was not found: $requiredLocalPath"
+        }
+    }
+
+    if ($DeploymentProfile -ne 'PrintServerUnattended') {
+        return (Assert-RunnerPrerequisites)
+    }
+
+    $deadline = [DateTime]::UtcNow.AddSeconds($ReadinessTimeoutSeconds)
+    $delaySeconds = $ReadinessInitialDelaySeconds
+    $attempt = 0
+    $lastFailure = $null
+
+    while ([DateTime]::UtcNow -lt $deadline) {
+        $attempt++
+        try {
+            $state = Assert-RunnerPrerequisites
+
+            $sqliteDirectory = Split-Path -Parent $ProductionSqlitePath
+            if (-not (
+                Test-Path -LiteralPath $sqliteDirectory -PathType Container
+            )) {
+                throw (
+                    'Production SQLite destination is unavailable: ' +
+                    $sqliteDirectory
+                )
+            }
+
+            if ($attempt -gt 1) {
+                Write-ServiceLog (
+                    "Readiness passed on attempt $attempt after waiting for " +
+                    'Google Drive/runtime prerequisites.'
+                )
+            }
+
+            return $state
+        }
+        catch {
+            $lastFailure = $_.Exception.Message
+            Write-ServiceLog (
+                "Readiness attempt $attempt waiting ${delaySeconds}s: " +
+                $lastFailure
+            )
+
+            Start-Sleep -Seconds $delaySeconds
+            $delaySeconds = [Math]::Min(
+                $delaySeconds * 2,
+                $ReadinessMaxDelaySeconds
+            )
+        }
+    }
+
+    $message = (
+        'Runner prerequisites were not ready within ' +
+        "${ReadinessTimeoutSeconds}s. Last failure: $lastFailure"
+    )
+
+    Write-ServiceLog "READINESS TIMEOUT: $message"
+    throw $message
+}
+
 
 function Test-AuthenticatedHealth {
     param([Parameter(Mandatory = $true)][string]$Token)
@@ -509,7 +595,7 @@ switch ($Action) {
         Write-ServiceLog "Start requested for ${RunnerHost}:$Port."
         try {
             Assert-DeploymentIdentity
-            $state = Assert-RunnerPrerequisites
+            $state = Wait-RunnerPrerequisites
             Write-ServiceLog (
                 "Prerequisites passed for approved LOR " +
                 "$($state.current_lor_version)."
@@ -526,8 +612,7 @@ switch ($Action) {
             $env:LOR_RUNNER_TOKEN = $token
             $env:LOR_INGEST_PG_PASSWORD = $ingestCredential
             $env:LOR_PREVIEW_PARENT = 'G:\Shared drives\MSB Database'
-            $env:LOR_SQLITE_OUTPUT =
-                'G:\Shared drives\MSB Database\database\lor_output_v7_scene.db'
+            $env:LOR_SQLITE_OUTPUT = $ProductionSqlitePath
             $env:LOR_RUNNER_REPORTS_ROOT =
                 'G:\Shared drives\MSB Database\LOR Version Reviews'
             $env:LOR_PARSER_PATH = $ParserPath

--- a/run_lor_runner.ps1
+++ b/run_lor_runner.ps1
@@ -620,7 +620,7 @@ switch ($Action) {
             $env:LOR_INGEST_PATH = $IngestPath
             $env:PYTHONUNBUFFERED = '1'
             Write-ServiceLog (
-                "Starting runner V1.6.0; profile=$DeploymentProfile; " +
+                "Starting runner V1.7.0; profile=$DeploymentProfile; " +
                 "credential fingerprint=" +
                 "$(Get-TokenFingerprint -Token $token)."
             )


### PR DESCRIPTION
## Summary

This PR repairs the routine LOR parser/ingest workflow after the 2026-08-27 production recovery.

It:
- makes routine parser and ingest actions single-submit and durable;
- records and reuses request IDs to prevent duplicate operations on retry;
- binds parser approval to the exact parser activity ID, parser version, source manifest SHA-256, SQLite SHA-256, and current console evidence;
- binds ingest completion to the exact parser activity, ingest activity, import run, and source digest;
- blocks approval/reconciliation when current console evidence is unavailable or stale;
- prevents stale prior parser results from appearing under a newer current parser activity;
- retires synchronous production browser parser/ingest mutation paths while retaining baseline/candidate version-check behavior;
- adds bounded PRINT-SERVER Google Drive readiness retry so a late G: mount can recover without a manual task restart;
- keeps the Label Service operationally isolated.

## Validation

Local validation after final branch sync:
- `Docs/01_LOR_System/02_Data_Extraction/Parser/test_lor_operator_runner.py`: 23/23 PASS
- `LOR2DB/Application/test_backend.py`: 34/34 PASS
- `git diff --check origin/main...HEAD`: PASS

Node is not installed on the Office development workstation, so the optional `node --check` was not available; browser contract coverage is provided by the backend/static tests.

## Related issues

Addresses the implementation work for:
- #77 — exact activity/digest console evidence binding
- #78 — single-submit durable parser/ingest operations
- #80 — PRINT-SERVER Google Drive readiness retry

Production acceptance is still required before those issues are closed, including a real parser run, ingest run, refresh/retry behavior, cold-boot late-G: recovery, and Label Service verification.