### PR TITLE
Make parser approval start ingest in one click

### DIFF
--- a/LOR2DB/Application/landing/parser/index.html
+++ b/LOR2DB/Application/landing/parser/index.html
@@ -19,6 +19,6 @@
       <section class="card"><p>Loading parser status...</p></section>
     </div>
   </main>
-  <script src="parser.js?v=0.6.2" defer></script>
+  <script src="parser.js?v=0.6.2.1" defer></script>
 </body>
 </html>

--- a/LOR2DB/Application/landing/parser/parser.js
+++ b/LOR2DB/Application/landing/parser/parser.js
@@ -1,4 +1,4 @@
-/* MSB parser and ingest workflow - 2026-08-27 V0.6.2 */
+/* MSB parser and ingest workflow - 2026-08-27 V0.6.2.1 */
 (function () {
   "use strict";
 
@@ -236,7 +236,7 @@
           <button id="rerun-parser" type="button">Make corrections and run parser again</button>
         </div>`
       : `<div class="page-actions">
-          <button id="mark-ready-ingest" class="primary" type="button">Parser output looks correct — ready for ingest</button>
+          <button id="run-ingest" class="primary" type="button">Parser output looks correct — ready for ingest</button>
           <button id="rerun-parser" type="button">Make corrections and run parser again</button>
         </div>`;
 
@@ -257,7 +257,7 @@
       detail = "Review the ingest console error below. Reconciliation has not started. Correct the problem and retry this same validated snapshot.";
       controls = reviewed
         ? '<div class="page-actions"><button id="run-ingest" class="primary" type="button">Retry PostgreSQL ingest</button><button id="rerun-parser" type="button">Make corrections and run parser again</button></div>'
-        : '<div class="page-actions"><button id="mark-ready-ingest" class="primary" type="button">Parser output still looks correct — retry ingest</button><button id="rerun-parser" type="button">Make corrections and run parser again</button></div>';
+        : '<div class="page-actions"><button id="run-ingest" class="primary" type="button">Parser output still looks correct — retry ingest</button><button id="rerun-parser" type="button">Make corrections and run parser again</button></div>';
     }
 
     return `<section id="ingest-step" class="card next-step-card">
@@ -428,12 +428,6 @@
 
     document.querySelector("#run-parser")?.addEventListener("click", runParser);
     document.querySelector("#rerun-parser")?.addEventListener("click", runParser);
-    document.querySelector("#mark-ready-ingest")?.addEventListener("click", () => {
-      reviewedDigest = digest;
-      reviewedParserActivityId = parserActivityId;
-      render();
-      document.querySelector("#ingest-step")?.scrollIntoView({ behavior: "smooth", block: "start" });
-    });
     document.querySelector("#run-ingest")?.addEventListener("click", runIngest);
     document.querySelector("#start-reconciliation")?.addEventListener("click", startReconciliation);
     document.querySelector("#refresh-output")?.addEventListener("click", refresh);
@@ -552,17 +546,17 @@
     const digest = evidence?.digest;
     const parserActivityId = evidence?.activityId;
 
-    if (
-      !digest
-      || !parserActivityId
-      || reviewedDigest !== digest
-      || reviewedParserActivityId !== parserActivityId
-    ) {
+    if (!digest || !parserActivityId) {
       window.alert(
-        "Review and approve this exact parser activity and SQLite output before ingest."
+        "Current parser evidence is not available for ingest. Refresh and review the exact parser activity before trying again."
       );
       return;
     }
+
+    // This one deliberate click is both the operator approval of the exact
+    // parser activity/digest and the idempotent request to start ingest.
+    reviewedDigest = digest;
+    reviewedParserActivityId = parserActivityId;
 
     const requestId = operationRequestId("ingest");
 

--- a/LOR2DB/Application/test_parser_ingest_single_submit.py
+++ b/LOR2DB/Application/test_parser_ingest_single_submit.py
@@ -11,6 +11,9 @@ class ParserIngestSingleSubmitTests(unittest.TestCase):
         parser_dir = Path(__file__).parent / "landing" / "parser"
         source = (parser_dir / "parser.js").read_text(encoding="utf-8")
         page = (parser_dir / "index.html").read_text(encoding="utf-8")
+        run_start = source.index("  async function runIngest(event) {")
+        run_end = source.index("  async function startReconciliation(event) {")
+        run_ingest = source[run_start:run_end]
 
         self.assertIn(
             '<button id="run-ingest" class="primary" type="button">Parser output looks correct — ready for ingest</button>',
@@ -22,14 +25,18 @@ class ParserIngestSingleSubmitTests(unittest.TestCase):
             'document.querySelector("#run-ingest")?.addEventListener("click", runIngest);',
             source,
         )
-        self.assertIn("reviewedDigest = digest;", source)
-        self.assertIn("reviewedParserActivityId = parserActivityId;", source)
-        self.assertNotIn("|| reviewedDigest !== digest", source)
-        self.assertNotIn("|| reviewedParserActivityId !== parserActivityId", source)
-        self.assertIn('"ingest/start"', source)
-        self.assertIn("request_id: requestId", source)
-        self.assertIn("parser_activity_id: parserActivityId", source)
-        self.assertIn("expected_sqlite_sha256: digest", source)
+        self.assertIn("reviewedDigest = digest;", run_ingest)
+        self.assertIn("reviewedParserActivityId = parserActivityId;", run_ingest)
+        self.assertNotIn("reviewedDigest !== digest", run_ingest)
+        self.assertNotIn("reviewedParserActivityId !== parserActivityId", run_ingest)
+        self.assertIn('"ingest/start"', run_ingest)
+        self.assertIn("request_id: requestId", run_ingest)
+        self.assertIn("parser_activity_id: parserActivityId", run_ingest)
+        self.assertIn("expected_sqlite_sha256: digest", run_ingest)
+        self.assertLess(
+            run_ingest.index("reviewedDigest = digest;"),
+            run_ingest.index('"ingest/start"'),
+        )
         self.assertIn('parser.js?v=0.6.2.1', page)
 
 

--- a/LOR2DB/Application/test_parser_ingest_single_submit.py
+++ b/LOR2DB/Application/test_parser_ingest_single_submit.py
@@ -1,0 +1,37 @@
+"""Regression contract for the parser page's single-submit ingest approval."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+class ParserIngestSingleSubmitTests(unittest.TestCase):
+    def test_approval_click_is_the_ingest_submit(self) -> None:
+        parser_dir = Path(__file__).parent / "landing" / "parser"
+        source = (parser_dir / "parser.js").read_text(encoding="utf-8")
+        page = (parser_dir / "index.html").read_text(encoding="utf-8")
+
+        self.assertIn(
+            '<button id="run-ingest" class="primary" type="button">Parser output looks correct — ready for ingest</button>',
+            source,
+        )
+        self.assertNotIn('id="mark-ready-ingest"', source)
+        self.assertNotIn('querySelector("#mark-ready-ingest")', source)
+        self.assertIn(
+            'document.querySelector("#run-ingest")?.addEventListener("click", runIngest);',
+            source,
+        )
+        self.assertIn("reviewedDigest = digest;", source)
+        self.assertIn("reviewedParserActivityId = parserActivityId;", source)
+        self.assertNotIn("|| reviewedDigest !== digest", source)
+        self.assertNotIn("|| reviewedParserActivityId !== parserActivityId", source)
+        self.assertIn('"ingest/start"', source)
+        self.assertIn("request_id: requestId", source)
+        self.assertIn("parser_activity_id: parserActivityId", source)
+        self.assertIn("expected_sqlite_sha256: digest", source)
+        self.assertIn('parser.js?v=0.6.2.1', page)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fix the remaining production acceptance defect in #78 without touching the runner, backend, PostgreSQL ingest code, or reconciliation workflow.

The parser page previously split one operator intent into two clicks:

1. `Parser output looks correct — ready for ingest` only set browser-local review state.
2. A second `Ingest to PostgreSQL` click actually submitted `/ingest/start`.

This change makes the first deliberate approval click submit the existing durable/idempotent ingest request immediately for the exact validated parser activity ID and SQLite SHA-256.

## Scope

- Reuse the existing `runIngest()` path and request-id idempotency.
- The approval button is now wired directly to `runIngest()`.
- `runIngest()` treats that click as approval of the exact currently validated parser activity/digest and immediately POSTs `/ingest/start`.
- Retry after a failed ingest is also one click, including after page refresh.
- Cache-bust only the parser page JavaScript (`0.6.2.1`).
- Add a focused static regression contract.

## Explicitly unchanged

- PRINT-SERVER runner V1.7.0
- Linux backend V0.6.2
- parser execution
- PostgreSQL ingest implementation
- activity IDs / request IDs / locking
- exact parser/SQLite evidence validation
- reconciliation start behavior
- live console streaming (#85 remains separate)

## Production acceptance

The current validated parser result is intentionally preserved and has not been ingested. After merge/deploy, the operator should be able to continue from that same parser result without rerunning the parser: one click on `Parser output looks correct — ready for ingest` must disable immediately and start exactly one durable ingest activity.

Fixes the ingest-click portion of #78.