### PR TITLE
FieldWiring: distinguish multiple Preview contexts within one Stage

### DIFF
--- a/FieldWiring/Application/fieldwiring.js
+++ b/FieldWiring/Application/fieldwiring.js
@@ -125,9 +125,10 @@ function showResolved(c) {
   if (c.display_name) rows.push(['Display', c.display_name]);
   rows.push(
     ['Stage / Area', `${c.stage_key ? c.stage_key + ' · ' : ''}${c.stage_name || 'Unresolved'}`],
-    ['Scene / Area', isScene ? c.scene_name : wholeScope],
-    ['Wiring', c.context_type || 'Unknown']
+    ['Scene / Area', isScene ? c.scene_name : wholeScope]
   );
+  if (c.preview_name) rows.push(['Preview', c.preview_name]);
+  rows.push(['Wiring', c.context_type || 'Unknown']);
   resolvedGrid.innerHTML = rows.map(([label,value]) => `
     <div class="resolved-row"><span>${esc(label)}</span><strong>${esc(value)}</strong></div>
   `).join('');
@@ -172,16 +173,20 @@ function flattenBrowseNodes(stageList) {
 function browseContextChoices(node) {
   const choices = [];
   const ownerLabel = node.scope_type === 'SUBSTAGE' ? 'Whole Sub-stage' : 'Whole Stage';
+  const wholeContexts = node.contexts || [];
+  const multipleWholePreviews = wholeContexts.length > 1;
 
-  (node.contexts || []).forEach(context => {
+  wholeContexts.forEach(context => {
     choices.push({
       context: {
         ...context,
         scope_kind: 'Stage / Preview',
         scene_name: null
       },
-      label: ownerLabel,
-      badge: node.scope_type === 'SUBSTAGE' ? 'Sub-stage' : 'Stage'
+      label: multipleWholePreviews && context.preview_name ? context.preview_name : ownerLabel,
+      badge: multipleWholePreviews
+        ? 'Preview'
+        : (node.scope_type === 'SUBSTAGE' ? 'Sub-stage' : 'Stage')
     });
   });
 

--- a/FieldWiring/Application/fieldwiring.js
+++ b/FieldWiring/Application/fieldwiring.js
@@ -174,17 +174,41 @@ function browseContextChoices(node) {
   const choices = [];
   const ownerLabel = node.scope_type === 'SUBSTAGE' ? 'Whole Sub-stage' : 'Whole Stage';
   const wholeContexts = node.contexts || [];
-  const multipleWholePreviews = wholeContexts.length > 1;
 
-  wholeContexts.forEach(context => {
+  // A physical Stage can have several separate LOR Previews even when some
+  // of those Previews expose only formal Scene contexts in the shared
+  // hierarchy.  For browse presentation, collect Preview identity from both
+  // whole-scope contexts and Scene contexts.  Only synthesize these additional
+  // Preview choices when more than one distinct Preview exists; ordinary
+  // single-Preview Stage/Scene presentation therefore remains unchanged.
+  const allPreviewContexts = [...wholeContexts];
+  (node.scenes || []).forEach(scene => {
+    allPreviewContexts.push(...(scene.contexts || []));
+  });
+
+  const previewContextsById = new Map();
+  allPreviewContexts.forEach(context => {
+    const previewIdentity = context.preview_uuid || context.preview_name;
+    if (!previewIdentity || previewContextsById.has(previewIdentity)) return;
+    previewContextsById.set(previewIdentity, context);
+  });
+
+  const previewContexts = [...previewContextsById.values()];
+  const multiplePreviews = previewContexts.length > 1;
+  const browsePreviews = multiplePreviews ? previewContexts : wholeContexts;
+
+  browsePreviews.forEach(context => {
     choices.push({
       context: {
         ...context,
         scope_kind: 'Stage / Preview',
-        scene_name: null
+        scene_uuid: null,
+        scene_name: null,
+        scene_stage_key: null,
+        scene_background_file: null
       },
-      label: multipleWholePreviews && context.preview_name ? context.preview_name : ownerLabel,
-      badge: multipleWholePreviews
+      label: multiplePreviews && context.preview_name ? context.preview_name : ownerLabel,
+      badge: multiplePreviews
         ? 'Preview'
         : (node.scope_type === 'SUBSTAGE' ? 'Sub-stage' : 'Stage')
     });

--- a/FieldWiring/Application/fieldwiring.js
+++ b/FieldWiring/Application/fieldwiring.js
@@ -174,41 +174,21 @@ function browseContextChoices(node) {
   const choices = [];
   const ownerLabel = node.scope_type === 'SUBSTAGE' ? 'Whole Sub-stage' : 'Whole Stage';
   const wholeContexts = node.contexts || [];
+  const multipleWholePreviews = wholeContexts.length > 1;
 
-  // A physical Stage can have several separate LOR Previews even when some
-  // of those Previews expose only formal Scene contexts in the shared
-  // hierarchy.  For browse presentation, collect Preview identity from both
-  // whole-scope contexts and Scene contexts.  Only synthesize these additional
-  // Preview choices when more than one distinct Preview exists; ordinary
-  // single-Preview Stage/Scene presentation therefore remains unchanged.
-  const allPreviewContexts = [...wholeContexts];
-  (node.scenes || []).forEach(scene => {
-    allPreviewContexts.push(...(scene.contexts || []));
-  });
-
-  const previewContextsById = new Map();
-  allPreviewContexts.forEach(context => {
-    const previewIdentity = context.preview_uuid || context.preview_name;
-    if (!previewIdentity || previewContextsById.has(previewIdentity)) return;
-    previewContextsById.set(previewIdentity, context);
-  });
-
-  const previewContexts = [...previewContextsById.values()];
-  const multiplePreviews = previewContexts.length > 1;
-  const browsePreviews = multiplePreviews ? previewContexts : wholeContexts;
-
-  browsePreviews.forEach(context => {
+  // Only whole-scope contexts become Preview choices.  Formal Scene contexts
+  // stay Scene choices even when they originate from a distinct LOR Preview;
+  // duplicating those same contexts as both Preview and Scene choices is
+  // operationally confusing and does not represent a different field scope.
+  wholeContexts.forEach(context => {
     choices.push({
       context: {
         ...context,
         scope_kind: 'Stage / Preview',
-        scene_uuid: null,
-        scene_name: null,
-        scene_stage_key: null,
-        scene_background_file: null
+        scene_name: null
       },
-      label: multiplePreviews && context.preview_name ? context.preview_name : ownerLabel,
-      badge: multiplePreviews
+      label: multipleWholePreviews && context.preview_name ? context.preview_name : ownerLabel,
+      badge: multipleWholePreviews
         ? 'Preview'
         : (node.scope_type === 'SUBSTAGE' ? 'Sub-stage' : 'Stage')
     });

--- a/FieldWiring/Application/test_multi_preview_browse.py
+++ b/FieldWiring/Application/test_multi_preview_browse.py
@@ -74,7 +74,7 @@ def test_one_physical_stage_retains_multiple_preview_contexts():
     assert all(item["scope_kind"] == "Stage / Preview" for item in stage["contexts"])
 
 
-def test_stage01_shape_can_split_preview_identity_between_whole_and_scene_contexts():
+def test_stage01_shape_keeps_whole_preview_and_formal_scene_scopes_distinct():
     outside_preview = "preview-outside"
     contexts = [
         _context(
@@ -124,29 +124,29 @@ def test_stage01_shape_can_split_preview_identity_between_whole_and_scene_contex
         "01-Open-Close Sign",
     ]
 
-    preview_ids = {item["preview_uuid"] for item in stage["contexts"]}
-    for scene in stage["scenes"]:
-        preview_ids.update(item["preview_uuid"] for item in scene["contexts"])
-
-    assert preview_ids == {
-        "preview-goal",
+    # The MSB Sign and Open-Close Preview identities remain available as
+    # provenance inside their formal Scene contexts, but they must not be
+    # duplicated as separate whole-Preview field choices.
+    scene_preview_ids = {
+        item["preview_uuid"]
+        for scene in stage["scenes"]
+        for item in scene["contexts"]
+    }
+    assert scene_preview_ids == {
         "preview-msb",
         "preview-open",
         outside_preview,
     }
 
 
-def test_browser_contract_exposes_all_preview_identities_for_multi_preview_stage():
+def test_browser_contract_labels_only_multiple_whole_scope_previews():
     source = (Path(__file__).resolve().parent / "fieldwiring.js").read_text(encoding="utf-8")
 
-    assert "const allPreviewContexts = [...wholeContexts];" in source
-    assert "allPreviewContexts.push(...(scene.contexts || []));" in source
-    assert "const previewContextsById = new Map();" in source
-    assert "const multiplePreviews = previewContexts.length > 1;" in source
-    assert "const browsePreviews = multiplePreviews ? previewContexts : wholeContexts;" in source
-    assert "scene_uuid: null" in source
-    assert "multiplePreviews && context.preview_name ? context.preview_name : ownerLabel" in source
-    assert "multiplePreviews\n        ? 'Preview'" in source
+    assert "const multipleWholePreviews = wholeContexts.length > 1;" in source
+    assert "multipleWholePreviews && context.preview_name ? context.preview_name : ownerLabel" in source
+    assert "multipleWholePreviews\n        ? 'Preview'" in source
+    assert "allPreviewContexts" not in source
+    assert "previewContextsById" not in source
     assert "if (c.preview_name) rows.push(['Preview', c.preview_name]);" in source
     assert "params.set('preview_uuid', c.preview_uuid);" in source
 

--- a/FieldWiring/Application/test_multi_preview_browse.py
+++ b/FieldWiring/Application/test_multi_preview_browse.py
@@ -8,7 +8,15 @@ from field_context_hierarchy import build_field_hierarchy
 from wiring_data import load_wiring_data
 
 
-def _context(preview_uuid: str, preview_name: str, stage_key: str = "01"):
+def _context(
+    preview_uuid: str,
+    preview_name: str,
+    stage_key: str = "01",
+    *,
+    scene_name: str = "Root",
+    scene_stage_key: str | None = None,
+    scene_background_file: str | None = None,
+):
     return {
         "preview": {
             "preview_uuid": preview_uuid,
@@ -19,10 +27,10 @@ def _context(preview_uuid: str, preview_name: str, stage_key: str = "01"):
             ),
         },
         "scene": {
-            "scene_uuid": f"scene-{preview_uuid}",
-            "scene_name": "Root",
-            "scene_stage_key": stage_key,
-            "scene_background_file": None,
+            "scene_uuid": f"scene-{preview_uuid}-{scene_name}",
+            "scene_name": scene_name,
+            "scene_stage_key": scene_stage_key,
+            "scene_background_file": scene_background_file,
         },
         "scope_kind": "Scene",
         "context_type": "Background Wiring",
@@ -66,12 +74,79 @@ def test_one_physical_stage_retains_multiple_preview_contexts():
     assert all(item["scope_kind"] == "Stage / Preview" for item in stage["contexts"])
 
 
-def test_browser_contract_exposes_preview_name_only_for_multi_preview_whole_scope():
+def test_stage01_shape_can_split_preview_identity_between_whole_and_scene_contexts():
+    outside_preview = "preview-outside"
+    contexts = [
+        _context(
+            "preview-goal",
+            "Show Background Stage 01 FE Goal Sign",
+            scene_name="Goal Sign",
+        ),
+        _context(
+            "preview-msb",
+            "Show Background Stage 01 FE MSB Sign",
+            scene_name="01-Making Spirits Bright",
+            scene_stage_key="01",
+        ),
+        _context(
+            "preview-open",
+            "Show Background Stage 01 FE Open-Close Sign",
+            scene_name="01-Open-Close Sign",
+            scene_stage_key="01",
+        ),
+        _context(
+            outside_preview,
+            "Show Background Stage 01 FE Outside Gate",
+            scene_name="Root",
+        ),
+        _context(
+            outside_preview,
+            "Show Background Stage 01 FE Outside Gate",
+            scene_name="01-Entrance Arch",
+            scene_stage_key="01",
+            scene_background_file=(
+                r"G:\Shared drives\Display Folders\01-Front Entrance-FE"
+                r"\01-Entrance Arch\PreviewBackground\Entry Arch Visualizer.jpg"
+            ),
+        ),
+    ]
+
+    result = build_field_hierarchy([_stage(contexts)])
+    stage = result["stages"][0]
+
+    assert [item["preview_uuid"] for item in stage["contexts"]] == [
+        "preview-goal",
+        outside_preview,
+    ]
+    assert [scene["label"] for scene in stage["scenes"]] == [
+        "01-Entrance Arch",
+        "01-Making Spirits Bright",
+        "01-Open-Close Sign",
+    ]
+
+    preview_ids = {item["preview_uuid"] for item in stage["contexts"]}
+    for scene in stage["scenes"]:
+        preview_ids.update(item["preview_uuid"] for item in scene["contexts"])
+
+    assert preview_ids == {
+        "preview-goal",
+        "preview-msb",
+        "preview-open",
+        outside_preview,
+    }
+
+
+def test_browser_contract_exposes_all_preview_identities_for_multi_preview_stage():
     source = (Path(__file__).resolve().parent / "fieldwiring.js").read_text(encoding="utf-8")
 
-    assert "const multipleWholePreviews = wholeContexts.length > 1;" in source
-    assert "multipleWholePreviews && context.preview_name ? context.preview_name : ownerLabel" in source
-    assert "multipleWholePreviews\n        ? 'Preview'" in source
+    assert "const allPreviewContexts = [...wholeContexts];" in source
+    assert "allPreviewContexts.push(...(scene.contexts || []));" in source
+    assert "const previewContextsById = new Map();" in source
+    assert "const multiplePreviews = previewContexts.length > 1;" in source
+    assert "const browsePreviews = multiplePreviews ? previewContexts : wholeContexts;" in source
+    assert "scene_uuid: null" in source
+    assert "multiplePreviews && context.preview_name ? context.preview_name : ownerLabel" in source
+    assert "multiplePreviews\n        ? 'Preview'" in source
     assert "if (c.preview_name) rows.push(['Preview', c.preview_name]);" in source
     assert "params.set('preview_uuid', c.preview_uuid);" in source
 

--- a/FieldWiring/Application/test_multi_preview_browse.py
+++ b/FieldWiring/Application/test_multi_preview_browse.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+
+from field_context_hierarchy import build_field_hierarchy
+from wiring_data import load_wiring_data
+
+
+def _context(preview_uuid: str, preview_name: str, stage_key: str = "01"):
+    return {
+        "preview": {
+            "preview_uuid": preview_uuid,
+            "preview_name": preview_name,
+            "preview_background_file": (
+                rf"G:\Shared drives\Display Folders\{stage_key}-Front Entrance-FE"
+                rf"\PreviewBackground\{preview_uuid}.jpg"
+            ),
+        },
+        "scene": {
+            "scene_uuid": f"scene-{preview_uuid}",
+            "scene_name": "Root",
+            "scene_stage_key": stage_key,
+            "scene_background_file": None,
+        },
+        "scope_kind": "Scene",
+        "context_type": "Background Wiring",
+    }
+
+
+def _stage(contexts):
+    return {
+        "stage": {
+            "stage_id": 31,
+            "stage_key": "01",
+            "stage_name": "Show Background Stage 01 Front Entrance",
+            "folder_path": r"G:\Shared drives\Display Folders\01-Front Entrance-FE",
+        },
+        "contexts": list(contexts),
+    }
+
+
+def test_one_physical_stage_retains_multiple_preview_contexts():
+    preview_names = [
+        "Show Background Stage 01 FE Goal Sign",
+        "Show Background Stage 01 FE MSB Sign",
+        "Show Background Stage 01 FE Open-Close Sign",
+        "Show Background Stage 01 FE Outside Gate",
+    ]
+    result = build_field_hierarchy(
+        [_stage([_context(f"preview-{index}", name) for index, name in enumerate(preview_names, 1)])]
+    )
+
+    assert len(result["stages"]) == 1
+    stage = result["stages"][0]
+    assert stage["stage_key"] == "01"
+    assert stage["scenes"] == []
+    assert [item["preview_name"] for item in stage["contexts"]] == preview_names
+    assert [item["preview_uuid"] for item in stage["contexts"]] == [
+        "preview-1",
+        "preview-2",
+        "preview-3",
+        "preview-4",
+    ]
+    assert all(item["scope_kind"] == "Stage / Preview" for item in stage["contexts"])
+
+
+def test_browser_contract_exposes_preview_name_only_for_multi_preview_whole_scope():
+    source = (Path(__file__).resolve().parent / "fieldwiring.js").read_text(encoding="utf-8")
+
+    assert "const multipleWholePreviews = wholeContexts.length > 1;" in source
+    assert "multipleWholePreviews && context.preview_name ? context.preview_name : ownerLabel" in source
+    assert "multipleWholePreviews\n        ? 'Preview'" in source
+    assert "if (c.preview_name) rows.push(['Preview', c.preview_name]);" in source
+    assert "params.set('preview_uuid', c.preview_uuid);" in source
+
+
+class SQLiteSnapshotRepository:
+    def __init__(self, path):
+        self.path = path
+
+    @contextmanager
+    def connect(self):
+        conn = sqlite3.connect(self.path)
+        conn.row_factory = sqlite3.Row
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+
+def test_same_stage_preview_selection_loads_only_selected_preview_wiring(tmp_path):
+    path = tmp_path / "multi_preview.db"
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE lor_snap__v_current_previews (
+            import_run_id INTEGER, id TEXT, name TEXT, revision TEXT,
+            background_file TEXT, source_filename TEXT
+        );
+        CREATE TABLE ref__stage (
+            stage_id INTEGER PRIMARY KEY, stage_key TEXT, stage_name TEXT,
+            folder_path TEXT
+        );
+        CREATE TABLE ref__display (
+            display_id INTEGER PRIMARY KEY, display_name TEXT, stage_id INTEGER,
+            lor_prop_id TEXT, display_status_id INTEGER
+        );
+        CREATE TABLE lor_snap__v_current_props (
+            preview_id TEXT, prop_id TEXT, raw_prop_id TEXT, lor_comment TEXT,
+            string_type TEXT, device_type TEXT
+        );
+        CREATE TABLE lor_snap__preview_wiring_fieldlead_v6 (
+            preview_name TEXT, source TEXT, channel_name TEXT, display_name TEXT,
+            network TEXT, controller TEXT, start_channel INTEGER, end_channel INTEGER,
+            color TEXT, device_type TEXT, lor_tag TEXT, connection_type TEXT,
+            cross_display INTEGER, lead_rank INTEGER
+        );
+        CREATE TABLE lor_snap__v_current_run (
+            import_run_id INTEGER, run_ts TEXT, parser_version TEXT,
+            parser_completed_at TEXT, source_preview_folder TEXT,
+            ingest_script_version TEXT, ingest_completed_at TEXT
+        );
+        CREATE TABLE lor_snap__v_current_scenes (
+            preview_id TEXT, scene_id TEXT, name TEXT, stage_id TEXT,
+            background_file TEXT
+        );
+        CREATE TABLE lor_snap__v_current_scene_lor_props (
+            preview_id TEXT, scene_id TEXT, prop_id TEXT, raw_prop_id TEXT
+        );
+
+        INSERT INTO lor_snap__v_current_previews VALUES
+            (52, 'preview-goal', 'Show Background Stage 01 FE Goal Sign', '1', NULL, 'goal.lorprev'),
+            (52, 'preview-open', 'Show Background Stage 01 FE Open-Close Sign', '1', NULL, 'open.lorprev');
+        INSERT INTO lor_snap__v_current_run
+            VALUES (52, 'x', 'V7.0.11', 'x', 'folder', 'V0.4.2', 'x');
+        INSERT INTO ref__stage
+            VALUES (31, '01', 'Front Entrance', '01-Front Entrance-FE');
+
+        INSERT INTO ref__display VALUES
+            (101, 'FE-GoalSign', 31, 'raw-goal', 1),
+            (102, 'FE-OpenCloseSign', 31, 'raw-open', 1);
+
+        INSERT INTO lor_snap__v_current_props VALUES
+            ('preview-goal', 'p-goal', 'raw-goal', 'FE-GoalSign', 'Traditional', 'LOR'),
+            ('preview-open', 'p-open', 'raw-open', 'FE-OpenCloseSign', 'Traditional', 'LOR');
+
+        INSERT INTO lor_snap__preview_wiring_fieldlead_v6 VALUES
+            ('Show Background Stage 01 FE Goal Sign', 'PROP', 'Goal', 'FE-GoalSign',
+             'Regular', '01', 1, 1, NULL, 'LOR', '', 'FIELD', 0, 1),
+            ('Show Background Stage 01 FE Open-Close Sign', 'PROP', 'Open', 'FE-OpenCloseSign',
+             'Regular', '02', 1, 1, NULL, 'LOR', '', 'FIELD', 0, 1);
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    goal = load_wiring_data(SQLiteSnapshotRepository(path), "preview-goal", None, 31)
+    opened = load_wiring_data(SQLiteSnapshotRepository(path), "preview-open", None, 31)
+
+    assert goal["preview"]["preview_uuid"] == "preview-goal"
+    assert [row["display_name"] for row in goal["rows"]] == ["FE-GoalSign"]
+
+    assert opened["preview"]["preview_uuid"] == "preview-open"
+    assert [row["display_name"] for row in opened["rows"]] == ["FE-OpenCloseSign"]

--- a/FieldWiring/Application/test_multi_preview_browse.py
+++ b/FieldWiring/Application/test_multi_preview_browse.py
@@ -22,8 +22,8 @@ def _context(
             "preview_uuid": preview_uuid,
             "preview_name": preview_name,
             "preview_background_file": (
-                rf"G:\Shared drives\Display Folders\{stage_key}-Front Entrance-FE"
-                rf"\PreviewBackground\{preview_uuid}.jpg"
+                rf"G:\\Shared drives\\Display Folders\\{stage_key}-Front Entrance-FE"
+                rf"\\PreviewBackground\\{preview_uuid}.jpg"
             ),
         },
         "scene": {
@@ -43,7 +43,7 @@ def _stage(contexts):
             "stage_id": 31,
             "stage_key": "01",
             "stage_name": "Show Background Stage 01 Front Entrance",
-            "folder_path": r"G:\Shared drives\Display Folders\01-Front Entrance-FE",
+            "folder_path": r"G:\\Shared drives\\Display Folders\\01-Front Entrance-FE",
         },
         "contexts": list(contexts),
     }
@@ -85,14 +85,12 @@ def test_stage01_shape_keeps_whole_preview_and_formal_scene_scopes_distinct():
         _context(
             "preview-msb",
             "Show Background Stage 01 FE MSB Sign",
-            scene_name="01-Making Spirits Bright",
-            scene_stage_key="01",
+            scene_name="Making Spirits Bright",
         ),
         _context(
             "preview-open",
             "Show Background Stage 01 FE Open-Close Sign",
-            scene_name="01-Open-Close Sign",
-            scene_stage_key="01",
+            scene_name="Open-Close Sign",
         ),
         _context(
             outside_preview,
@@ -105,8 +103,8 @@ def test_stage01_shape_keeps_whole_preview_and_formal_scene_scopes_distinct():
             scene_name="01-Entrance Arch",
             scene_stage_key="01",
             scene_background_file=(
-                r"G:\Shared drives\Display Folders\01-Front Entrance-FE"
-                r"\01-Entrance Arch\PreviewBackground\Entry Arch Visualizer.jpg"
+                r"G:\\Shared drives\\Display Folders\\01-Front Entrance-FE"
+                r"\\01-Entrance Arch\\PreviewBackground\\Entry Arch Visualizer.jpg"
             ),
         ),
     ]
@@ -116,25 +114,23 @@ def test_stage01_shape_keeps_whole_preview_and_formal_scene_scopes_distinct():
 
     assert [item["preview_uuid"] for item in stage["contexts"]] == [
         "preview-goal",
+        "preview-msb",
+        "preview-open",
         outside_preview,
     ]
     assert [scene["label"] for scene in stage["scenes"]] == [
         "01-Entrance Arch",
-        "01-Making Spirits Bright",
-        "01-Open-Close Sign",
     ]
 
-    # The MSB Sign and Open-Close Preview identities remain available as
-    # provenance inside their formal Scene contexts, but they must not be
-    # duplicated as separate whole-Preview field choices.
+    # Stand-alone Preview content intentionally uses unprefixed Scene names, so
+    # Goal Sign, MSB Sign, and Open-Close remain whole-Preview field choices.
+    # Only the prefixed Entrance Arch context is a formal Stage 01 Scene.
     scene_preview_ids = {
         item["preview_uuid"]
         for scene in stage["scenes"]
         for item in scene["contexts"]
     }
     assert scene_preview_ids == {
-        "preview-msb",
-        "preview-open",
         outside_preview,
     }
 


### PR DESCRIPTION
## Purpose

Preserve one permanent physical Stage while allowing FieldWiring operators to distinguish multiple LOR Preview contexts without duplicating true formal Scene choices.

Current acceptance cases:

- Stage 00 HWY-42: two whole-Preview contexts, Rotary Trees and Traffic Signs.
- Stage 01 Front Entrance: Goal Sign, MSB Sign, Open-Close Sign, and Outside Gate are whole-Preview contexts. `01-Entrance Arch` remains the one formal Stage 01 Scene.

The Stage 01 acceptance shape reflects the current LOR naming contract: stand-alone Preview content uses an unprefixed Scene name; a true formal Scene uses the `NN-...` prefix.

## Change

- Keep existing Stage/Sub-stage/Scene hierarchy unchanged.
- When one Stage/Sub-stage has more than one whole-area Preview context, show the Preview name instead of multiple indistinguishable `Whole Stage` choices.
- Do not synthesize duplicate Preview choices from contexts already represented as formal Scenes.
- Mark whole-area multi-Preview choices as `Preview` in the browse UI.
- Show the selected Preview in the resolved wiring card.
- Preserve existing `preview_uuid` deep-link behavior.
- Leave single-Preview Stage/Sub-stage presentation unchanged.

## Tests

Regression coverage proves:

1. one physical Stage can retain multiple whole-Preview contexts;
2. the current Stage 01 naming shape produces four whole-Preview choices and only the true `01-Entrance Arch` formal Scene;
3. browser presentation does not duplicate formal Scene-backed Preview identities as extra Preview choices;
4. two whole-Preview contexts under the same Stage load separate wiring packages when selected by `preview_uuid`.

Final local regression at head `5e3d0a5a60333f84768cc9a3b3bd2cebb64e1ddc`:

- focused PR regression: `4 passed in 0.16s`
- complete FieldWiring suite: `116 passed in 2.82s`

## Browser acceptance

Acceptance used a fresh read-only FieldWiring engineering snapshot exported from current PostgreSQL import run `58`:

- `fieldwiring_snapshot_run_58_20260829T185938Z.db`
- SQLite integrity check: `ok`
- PostgreSQL remained read-only; local FieldWiring used `sqlite-dev` snapshot mode.

Observed Stage 01 browse shape:

- Preview — `Show Background Stage 01 FE Goal Sign`
- Preview — `Show Background Stage 01 FE MSB Sign`
- Preview — `Show Background Stage 01 FE Open-Close Sign`
- Preview — `Show Background Stage 01 FE Outside Gate`
- Scene — `01-Entrance Arch`

All five selections resolved successfully to their wiring/context packages.

**PR 95 browser acceptance: PASS.**

## Scope

FieldWiring presentation only. No shared structured-scope resolver changes, parser changes, LOR2DB changes, PostgreSQL schema/data changes, Controller Inventory schema changes, Stage identity changes, or production deployment changes.

The separately discovered `ref.stage.stage_name` Google Drive source-of-truth defect is explicitly outside this PR.