### PR TITLE
Restore LOR2DB governed-root resolver permission

### DIFF
--- a/LOR2DB/02_Reconciliation/reconciliation/README.md
+++ b/LOR2DB/02_Reconciliation/reconciliation/README.md
@@ -11,8 +11,8 @@ change, or merely reports evidence.
 | Path | Contents | Execution rule |
 |---|---|---|
 | `current_procedures/` | Canonical standalone P1, P2, P3, and P4 definitions matching the latest accepted migration chain | Inspection or explicitly authorized repair only; these files do not call promotion |
-| `migrations/` | Immutable installation history `0011` through `0040` | Run only the specifically authorized next migration; never rerun the folder as a batch |
-| `validation/` | Validation `10` through `35` | Follow each file's header; several are transaction-wrapped rollback tests |
+| `migrations/` | Immutable installation history `0011` through `0041` | Run only the specifically authorized next migration; never rerun the folder as a batch |
+| `validation/` | Validation `10` through `36` | Follow each file's header; several are transaction-wrapped rollback tests |
 | `operator_queries/preflight/` | Read-only latest-ingest reports `01` through `09` | Run individually; no operator-supplied `import_run_id` |
 | `incidents/` | Production incident report and its incident-specific forensic SQL | Historical evidence; not part of routine reconciliation |
 
@@ -20,11 +20,11 @@ The root Markdown files are this index and the current design specification.
 
 ## Current Stage Root Authority
 
-For current P1 Stage/Sub-stage name and path behavior, use:
+For current P1 Stage/Sub-stage name, path, and LOR2DB application-access behavior, use:
 
 [Stage Root Authority and Path Synchronization](Stage_Root_Authority_and_Path_Synchronization.md)
 
-That document is the current authority for the migrations 0039/0040 Stage-root contract. Where older design text describes earlier P1 naming or `folder_path` behavior, the focused Stage-root contract controls.
+That document is the current authority for the migrations 0039/0040 Stage-root contract and migration 0041 least-privilege application grant. Where older design text describes earlier P1 naming, `folder_path`, or application-role behavior, the focused Stage-root contract controls.
 
 Key current rules are:
 
@@ -32,7 +32,9 @@ Key current rules are:
 - governed Stage/Sub-stage `stage_name` and `folder_name` are the exact Google Drive root basename, including Stage/Sub-stage key and terminal short code;
 - current `folder_path` may be synchronized from the reconciliation run's frozen LOR path evidence only when exactly one governed root matches the permanent Stage identity;
 - Stage path synchronization does not enumerate or search Google Drive;
-- held/special rows `12,39,40,90-94` remain outside the automatic governed-root repair.
+- held/special rows `12,39,40,90-94` remain outside the automatic governed-root repair;
+- `lor_preflight_app` has explicit execute permission on `ops.f_lor_governed_stage_roots(bigint,text)` while `PUBLIC` remains revoked;
+- browser-facing database changes must be acceptance-tested under the real least-privilege application role, not only as `msbadmin`.
 
 ## Current promotion procedures
 
@@ -59,7 +61,7 @@ is authoritative for the named object only.
 | Database object | Originally installed | Current definition | Validation |
 |---|---|---|---|
 | `ops.f_build_lor_reconciliation_stage_candidates(bigint)` | `migrations/0015_create_reconciliation_safe_p1_stage_promotion.sql` | `migrations/0023_use_preview_manifest_for_stage_bindings.sql` | `validation/19_preview_manifest_stage_binding_validation.sql` |
-| `ops.f_lor_governed_stage_roots(bigint,text)` | `migrations/0039_repair_stage_folder_authority.sql` | `migrations/0039_repair_stage_folder_authority.sql` | `validation/34_stage_folder_authority_validation.sql`, `validation/35_stage_folder_path_sync_validation.sql` |
+| `ops.f_lor_governed_stage_roots(bigint,text)` | `migrations/0039_repair_stage_folder_authority.sql` | `migrations/0039_repair_stage_folder_authority.sql` + explicit `lor_preflight_app` grant in `0041` | `validation/34_stage_folder_authority_validation.sql`, `validation/35_stage_folder_path_sync_validation.sql`, `validation/36_lor_preflight_governed_root_grant_validation.sql` |
 | `lor_snap.v_display_reconciliation_source` | `migrations/0011_create_lor_display_reconciliation_preflight_v7.sql` | `migrations/0038_allow_spare_to_display_activation.sql` | `validation/33_spare_to_display_activation_validation.sql` |
 | `ops.v_lor_display_reconciliation` | `migrations/0011_create_lor_display_reconciliation_preflight_v7.sql` | `migrations/0038_allow_spare_to_display_activation.sql` | `validation/33_spare_to_display_activation_validation.sql` |
 | `ops.f_start_lor_display_reconciliation(text)` | `migrations/0014_create_lor_reconciliation_decision_layer.sql` | `migrations/0038_allow_spare_to_display_activation.sql` | `validation/33_spare_to_display_activation_validation.sql` |
@@ -87,7 +89,7 @@ is retained only as incident evidence. It is not step 8A of the normal workflow.
 
 ## Migration and validation status
 
-The current installed migration chain is `0011` through `0040`.
+The current installed migration chain is `0011` through `0041`.
 
 Migration `0029` must be revision
 `2026-08-05-true-noop-reconciliation-writes-v4`; its corresponding validation
@@ -132,10 +134,15 @@ Migration `0040` synchronizes an existing governed Stage/Sub-stage
 `folder_path` only from exactly one frozen governed LOR root that matches the
 permanent Stage name/folder identity. It performs no Google Drive search and is
 paired with `validation/35_stage_folder_path_sync_validation.sql`.
+Migration `0041` restores the missing least-privilege LOR2DB application grant
+for the governed-root resolver. It grants `EXECUTE` only to `lor_preflight_app`,
+keeps `PUBLIC` revoked, and is paired with
+`validation/36_lor_preflight_governed_root_grant_validation.sql`, which exercises
+the actual Stage-review view under `SET LOCAL ROLE lor_preflight_app`.
 
-Both 0039 and 0040 were production deployed and validated on 2026-08-30. See
+Migrations 0039 through 0041 were production deployed and validated on 2026-08-30. See
 [Stage Root Authority and Path Synchronization](Stage_Root_Authority_and_Path_Synchronization.md)
-for the acceptance record and rollback artifacts.
+for the acceptance record, Run 18 recovery, and rollback artifacts.
 
 Do not infer that a numbered validation is harmless from its filename alone.
 Read its header. In particular,
@@ -154,6 +161,7 @@ not an installation script.
 - Governed Stage/Sub-stage names come from exact frozen root path evidence, not descriptive LOR Preview/Scene names.
 - Existing governed `folder_path` is synchronized only when exactly one frozen governed root matches the permanent `stage_name` and `folder_name` identity.
 - P1 does not enumerate or recursively search Google Drive to discover a moved Stage/Sub-stage.
+- Browser-facing database objects must be validated under the real least-privilege application role before production approval.
 - Captured `lor_snap` rows and frozen reconciliation candidates are never
   rewritten to repair a production-reference defect.
 - A new permanent stage is inserted only by P1 after an explicit, evidence-

--- a/LOR2DB/02_Reconciliation/reconciliation/Stage_Root_Authority_and_Path_Synchronization.md
+++ b/LOR2DB/02_Reconciliation/reconciliation/Stage_Root_Authority_and_Path_Synchronization.md
@@ -4,17 +4,17 @@
 |---|---|
 | Document Type | Database engineering contract |
 | System | LOR2DB Reconciliation / Google Drive Stage context |
-| Status | CURRENT — migrations 0039 and 0040 production deployed and validated |
+| Status | CURRENT — migrations 0039 through 0041 production deployed and validated |
 | Owner | MSB Database Administrator |
 | Last Reviewed | 2026-08-30 |
-| Issues | #96, #101 |
-| Migrations | `0039_repair_stage_folder_authority.sql`, `0040_sync_existing_stage_folder_path.sql` |
+| Issues | #96, #101, #104 |
+| Migrations | `0039_repair_stage_folder_authority.sql`, `0040_sync_existing_stage_folder_path.sql`, `0041_grant_lor_preflight_governed_root.sql` |
 
 ## Purpose
 
 This document is the current authority for how LOR2DB stores and maintains permanent Stage/Sub-stage naming and the current Google Drive `folder_path` locator in `ref.stage`.
 
-It records the production behavior established by migrations 0039 and 0040. Where older reconciliation design documents describe earlier P1 Stage naming or path behavior, this contract controls for Stage root naming and `folder_path` synchronization.
+It records the production behavior established by migrations 0039, 0040, and the least-privilege application grant repaired by migration 0041. Where older reconciliation design documents describe earlier P1 Stage naming, path behavior, or application access, this contract controls for Stage root naming and `folder_path` synchronization.
 
 ## Existing Google Drive Naming Contract — Unchanged
 
@@ -138,6 +138,39 @@ When those conditions are satisfied:
 
 If governed root evidence is absent, multiple, or inconsistent with the permanent Stage identity, P1 does not synthesize or guess a path.
 
+## Migration 0041 — LOR2DB Least-Privilege Resolver Access
+
+Migration 0039 correctly revoked `PUBLIC` execute on `ops.f_lor_governed_stage_roots(bigint,text)`, but the first production installation omitted the explicit grant required by the least-privilege LOR2DB login `lor_preflight_app`.
+
+That omission blocked browser Stage review on reconciliation Run 18 / import 60 with:
+
+```text
+permission denied for function f_lor_governed_stage_roots
+```
+
+Migration 0041 repairs only that privilege boundary:
+
+```text
+GRANT EXECUTE ON FUNCTION
+    ops.f_lor_governed_stage_roots(bigint,text)
+TO lor_preflight_app;
+```
+
+`PUBLIC` remains revoked. No production Stage data, snapshot data, reconciliation actions, parser data, Google Drive content, or application code is changed by 0041.
+
+### Required application-role acceptance rule
+
+A database change used by the LOR2DB browser is not production-accepted merely because it works as `msbadmin`.
+
+When a new function, view, or procedure enters a browser-facing query path, acceptance must exercise that exact path under the real least-privilege application role. For the governed-root resolver this means validating with:
+
+```text
+SET LOCAL ROLE lor_preflight_app
+    -> SELECT from ops.v_lor_reconciliation_operator_stage_review
+```
+
+This application-role check is required in addition to object-definition and administrator-role validation.
+
 ## Held / Special Stage Identities
 
 The current held set remains outside automatic root-name/path repair:
@@ -189,6 +222,29 @@ SHA-256:
 4b243a01583c18571349727cfeaa0e9b213536fcd8bf158580542c3099d9eaa0
 ```
 
+### Migration 0041 / Run 18 recovery
+
+Production evidence identified `lor_preflight_app` as the only LOR2DB login missing resolver execute permission. Before repair:
+
+```text
+can_record_stage_authority = true
+can_read_governed_root     = false
+Run 18 / import 60         = AWAITING_DECISIONS
+Run 18 actions             = 0
+```
+
+The production repair first tested the exact Stage-review query inside a temporary transaction after granting execute and using `SET LOCAL ROLE lor_preflight_app`; the query returned the unresolved `03a-Mega Cube-MC` Stage candidate. That proof transaction was rolled back and the privilege returned to false, proving no hidden state change.
+
+Migration 0041 then granted execute permanently to `lor_preflight_app`. Validation 36 proved:
+
+- `lor_preflight_app` can execute the governed-root resolver;
+- `PUBLIC` remains revoked;
+- the actual browser-facing Stage review succeeds under `SET LOCAL ROLE lor_preflight_app`;
+- Run 18 remained open and unchanged with zero actions;
+- PostgreSQL remained healthy.
+
+Run 18 therefore resumes in place. No new parser, ingest, or reconciliation run is required.
+
 ## Operator Consequence During Folder Cleanup
 
 When a governed Stage/Sub-stage folder is renamed or moved during Display Folders cleanup:
@@ -215,6 +271,8 @@ Migrations 0039 and 0040 did not modify:
 - Scene classification; or
 - the established Stage/Sub-stage/Scene/Display naming grammar.
 
+Migration 0041 changes only the explicit database privilege needed by the existing LOR2DB Stage-review path.
+
 FieldWiring and Procedures continue to consume current Production Database/LOR path context under their existing resolver contracts. Keeping `ref.stage.folder_path` synchronized reduces stale-anchor recovery and gives those applications a current persisted Stage/Sub-stage locator.
 
 ## Authoritative Implementation
@@ -224,6 +282,8 @@ FieldWiring and Procedures continue to consume current Production Database/LOR p
 - [`validation/34_stage_folder_authority_validation.sql`](validation/34_stage_folder_authority_validation.sql) — migration 0039 validation
 - [`migrations/0040_sync_existing_stage_folder_path.sql`](migrations/0040_sync_existing_stage_folder_path.sql) — existing Stage/Sub-stage path synchronization
 - [`validation/35_stage_folder_path_sync_validation.sql`](validation/35_stage_folder_path_sync_validation.sql) — migration 0040 validation
+- [`migrations/0041_grant_lor_preflight_governed_root.sql`](migrations/0041_grant_lor_preflight_governed_root.sql) — least-privilege LOR2DB resolver grant
+- [`validation/36_lor_preflight_governed_root_grant_validation.sql`](validation/36_lor_preflight_governed_root_grant_validation.sql) — application-role grant validation
 
 ## Related Documents
 

--- a/LOR2DB/02_Reconciliation/reconciliation/migrations/0041_grant_lor_preflight_governed_root.sql
+++ b/LOR2DB/02_Reconciliation/reconciliation/migrations/0041_grant_lor_preflight_governed_root.sql
@@ -1,0 +1,52 @@
+/* ============================================================================
+Migration: 0041_grant_lor_preflight_governed_root.sql
+Issue:     #104 Grant LOR2DB least-privilege access to governed Stage root resolver
+
+Purpose:
+  Restore the least-privilege LOR2DB application role's ability to load Stage
+  review after migrations 0039/0040 introduced the governed-root resolver.
+
+Regression:
+  Migration 0039 correctly revoked PUBLIC execute on
+  ops.f_lor_governed_stage_roots(bigint,text), but did not explicitly grant
+  the function to lor_preflight_app. The LOR2DB Stage review view calls this
+  resolver directly, so the browser could create/resume a reconciliation but
+  then fail while loading Stage review with "permission denied for function
+  f_lor_governed_stage_roots".
+
+Safety:
+  - Grants EXECUTE only to the existing least-privilege LOR2DB login role.
+  - Does not grant EXECUTE to PUBLIC.
+  - Does not modify reconciliation rows, LOR snapshots, ref.stage, or any
+    production business data.
+  - Does not change the function definition or SECURITY DEFINER boundary.
+============================================================================ */
+
+BEGIN;
+
+DO $migration$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_roles
+        WHERE rolname = 'lor_preflight_app'
+          AND rolcanlogin
+    ) THEN
+        RAISE EXCEPTION
+            'Required least-privilege LOR2DB login role lor_preflight_app does not exist';
+    END IF;
+END
+$migration$;
+
+GRANT EXECUTE ON FUNCTION
+    ops.f_lor_governed_stage_roots(bigint, text)
+TO lor_preflight_app;
+
+COMMIT;
+
+SELECT
+    has_function_privilege(
+        'lor_preflight_app',
+        'ops.f_lor_governed_stage_roots(bigint,text)',
+        'EXECUTE'
+    ) AS lor_preflight_can_execute_governed_root;

--- a/LOR2DB/02_Reconciliation/reconciliation/validation/36_lor_preflight_governed_root_grant_validation.sql
+++ b/LOR2DB/02_Reconciliation/reconciliation/validation/36_lor_preflight_governed_root_grant_validation.sql
@@ -1,0 +1,81 @@
+/* ============================================================================
+Validation: 36_lor_preflight_governed_root_grant_validation.sql
+Migration:  0041_grant_lor_preflight_governed_root.sql
+Issue:      #104
+
+Purpose:
+  Prove the least-privilege LOR2DB application role can execute the governed
+  Stage-root resolver and load the Stage review view, while PUBLIC remains
+  denied.
+
+Execution:
+  Read-only validation. Run as msbadmin after migration 0041.
+============================================================================ */
+
+BEGIN READ ONLY;
+
+SELECT
+    has_function_privilege(
+        'lor_preflight_app',
+        'ops.f_lor_governed_stage_roots(bigint,text)',
+        'EXECUTE'
+    ) AS lor_preflight_can_execute_governed_root,
+    NOT EXISTS (
+        SELECT 1
+        FROM pg_proc AS p
+        CROSS JOIN LATERAL aclexplode(
+            coalesce(p.proacl, acldefault('f', p.proowner))
+        ) AS a
+        WHERE p.oid =
+              'ops.f_lor_governed_stage_roots(bigint,text)'::regprocedure
+          AND a.grantee = 0
+          AND a.privilege_type = 'EXECUTE'
+    ) AS public_execute_remains_revoked;
+
+DO $validation$
+BEGIN
+    IF NOT has_function_privilege(
+        'lor_preflight_app',
+        'ops.f_lor_governed_stage_roots(bigint,text)',
+        'EXECUTE'
+    ) THEN
+        RAISE EXCEPTION
+            'lor_preflight_app cannot execute ops.f_lor_governed_stage_roots(bigint,text)';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM pg_proc AS p
+        CROSS JOIN LATERAL aclexplode(
+            coalesce(p.proacl, acldefault('f', p.proowner))
+        ) AS a
+        WHERE p.oid =
+              'ops.f_lor_governed_stage_roots(bigint,text)'::regprocedure
+          AND a.grantee = 0
+          AND a.privilege_type = 'EXECUTE'
+    ) THEN
+        RAISE EXCEPTION
+            'PUBLIC unexpectedly has EXECUTE on governed-root resolver';
+    END IF;
+END
+$validation$;
+
+/* Exercise the exact browser read boundary under the actual application role. */
+SET LOCAL ROLE lor_preflight_app;
+
+SELECT
+    lor_reconciliation_run_id,
+    import_run_id,
+    lor_reconciliation_group_id,
+    source_stage_key,
+    proposed_stage_name,
+    proposed_folder_name
+FROM ops.v_lor_reconciliation_operator_stage_review
+ORDER BY lor_reconciliation_run_id DESC,
+         lor_reconciliation_group_id,
+         lor_reconciliation_stage_candidate_id
+LIMIT 10;
+
+RESET ROLE;
+
+ROLLBACK;

--- a/LOR2DB/Application/test_lor_preflight_governed_root_grant_migration.py
+++ b/LOR2DB/Application/test_lor_preflight_governed_root_grant_migration.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MIGRATION = (
+    ROOT
+    / "02_Reconciliation"
+    / "reconciliation"
+    / "migrations"
+    / "0041_grant_lor_preflight_governed_root.sql"
+)
+VALIDATION = (
+    ROOT
+    / "02_Reconciliation"
+    / "reconciliation"
+    / "validation"
+    / "36_lor_preflight_governed_root_grant_validation.sql"
+)
+
+
+def text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_migration_grants_only_lor_preflight_role():
+    sql = text(MIGRATION)
+    assert "GRANT EXECUTE ON FUNCTION" in sql
+    assert "ops.f_lor_governed_stage_roots(bigint, text)" in sql
+    assert "TO lor_preflight_app" in sql
+    assert "TO PUBLIC" not in sql
+
+
+def test_migration_requires_existing_login_role():
+    sql = text(MIGRATION)
+    assert "rolname = 'lor_preflight_app'" in sql
+    assert "rolcanlogin" in sql
+
+
+def test_validation_checks_application_execute_privilege():
+    sql = text(VALIDATION)
+    assert "has_function_privilege" in sql
+    assert "'lor_preflight_app'" in sql
+    assert "'ops.f_lor_governed_stage_roots(bigint,text)'" in sql
+
+
+def test_validation_proves_public_execute_remains_revoked():
+    sql = text(VALIDATION)
+    assert "aclexplode" in sql
+    assert "a.grantee = 0" in sql
+    assert "a.privilege_type = 'EXECUTE'" in sql
+
+
+def test_validation_exercises_exact_browser_stage_review_boundary():
+    sql = text(VALIDATION)
+    assert "SET LOCAL ROLE lor_preflight_app" in sql
+    assert "FROM ops.v_lor_reconciliation_operator_stage_review" in sql


### PR DESCRIPTION
## Summary

Emergency regression repair for Issue #104.

Migrations 0039/0040 introduced `ops.f_lor_governed_stage_roots(bigint,text)` and correctly revoked `PUBLIC` execute, but the least-privilege LOR2DB login `lor_preflight_app` was never granted execute. The browser therefore created reconciliation Run 18 / import 60 and then failed loading Stage review with `permission denied for function f_lor_governed_stage_roots`.

## Production evidence before repair

- `lor_preflight_app` had `ops` schema usage;
- it could execute the Stage authority decision function;
- it could **not** execute the governed-root resolver;
- the resolver ACL granted only `msbadmin` and `directus_app`;
- Run 18 was `AWAITING_DECISIONS` with one unresolved group;
- Run 18 had zero actions, so no decision was accidentally persisted.

## Repair

- migration `0041_grant_lor_preflight_governed_root.sql` grants only `lor_preflight_app` execute on the resolver;
- `PUBLIC` remains revoked;
- validation `36_lor_preflight_governed_root_grant_validation.sql` checks the privilege and uses `SET LOCAL ROLE lor_preflight_app` to read the exact Stage-review view used by the browser;
- regression test preserves the least-privilege grant contract;
- Stage-root authority documentation and the reconciliation engineering index are updated through migration 0041 / validation 36.

No parser, LOR snapshot, reconciliation business row, Stage data, Google Drive, FieldWiring, Procedures, or application code change.

## Production repair acceptance — PASSED 2026-08-30

Candidate originally tested/applied:

```text
f157eb3c9e3fef8943f0ee0aa2db5cc6c413f580
```

The production repair used a two-stage proof:

1. inside a transaction, grant execute temporarily, `SET LOCAL ROLE lor_preflight_app`, and query `ops.v_lor_reconciliation_operator_stage_review` for Run 18;
2. rollback and prove the privilege returned to false;
3. apply migration 0041 permanently;
4. run validation 36 under the actual application role.

Results:

- application-role proof returned the unresolved `03a-Mega Cube-MC` Stage candidate for Run 18;
- proof transaction rolled back successfully;
- migration 0041 applied successfully;
- `lor_preflight_app` can execute the resolver after migration;
- `PUBLIC` remains revoked;
- validation 36 successfully read the Stage-review view under `SET LOCAL ROLE lor_preflight_app`;
- Run 18 remained open and unchanged;
- Run 18 actions remained `0` before and after repair;
- PostgreSQL remained healthy and accepting connections.

Run 18 can therefore resume in place. No new parser, ingest, or reconciliation is required.

## Acceptance rule added

This incident exposed a production-approval gap: administrator-role database validation is insufficient for browser-facing database changes.

For any new or changed function/view/procedure used by LOR2DB, production acceptance must also exercise the actual browser-facing query path under the real least-privilege login role, normally with `SET LOCAL ROLE lor_preflight_app`.

## Final PR scope

Exactly five files differ from the base:

```text
LOR2DB/02_Reconciliation/reconciliation/migrations/0041_grant_lor_preflight_governed_root.sql
LOR2DB/02_Reconciliation/reconciliation/validation/36_lor_preflight_governed_root_grant_validation.sql
LOR2DB/Application/test_lor_preflight_governed_root_grant_migration.py
LOR2DB/02_Reconciliation/reconciliation/Stage_Root_Authority_and_Path_Synchronization.md
LOR2DB/02_Reconciliation/reconciliation/README.md
```

Issue: #104