### PR TITLE
Restore parser-page resume of existing reconciliation

### DIFF
--- a/LOR2DB/Application/landing/parser/README.md
+++ b/LOR2DB/Application/landing/parser/README.md
@@ -1,0 +1,88 @@
+# LOR2DB Parser Page Reconciliation Handoff
+
+| Document control | Value |
+|---|---|
+| Status | CURRENT |
+| System | LOR2DB parser / ingest page |
+| Owner | MSB Database Administrator |
+| Last reviewed | 2026-08-30 |
+| Issue | #106 |
+
+## Purpose
+
+This document owns the parser page's handoff from a completed PostgreSQL ingest to the persistent LOR reconciliation workflow.
+
+The parser page does not own reconciliation state. PostgreSQL and the LOR2DB backend remain authoritative for whether the current snapshot can start a reconciliation, already belongs to an unfinished reconciliation, or has been consumed by a terminal run.
+
+## Backend Workflow Contract
+
+The parser page reads the same authenticated dashboard endpoint used by the LOR2DB landing page:
+
+```text
+../preflight/api/dashboard
+```
+
+The returned `workflow` object controls the valid next action.
+
+### New snapshot ready to start
+
+```text
+workflow.state     = READY_TO_START
+workflow.can_start = true
+workflow.action.kind = start
+```
+
+The parser page may show **Start reconciliation**. The actual Start request remains guarded by the backend/database one-run-per-snapshot contract.
+
+### Existing reconciliation is open
+
+```text
+workflow.state       = IN_PROGRESS
+workflow.can_start   = false
+workflow.action.kind = review
+workflow.action.url  = preflight/?run=<run_id>
+```
+
+The parser page must show a direct **Continue previous reconciliation** / **Continue reconciliation** action to that persisted run.
+
+A browser refresh must not strand the operator at the ingest page, create another reconciliation, rerun the parser, or rerun ingest.
+
+### Snapshot has no valid action
+
+If `workflow.can_start` is false and there is no valid `review` action, the parser page must not manufacture a Start or Continue action. The dashboard remains the authoritative place to inspect the current state.
+
+## Refresh / Recovery Rule
+
+Browser storage is not reconciliation authority.
+
+After a refresh, tab close/reopen, frontend error, or corrected backend/database permission problem:
+
+```text
+reload parser page
+    -> read authenticated dashboard state
+    -> if a persisted review action exists, route to that exact run
+    -> otherwise expose only the action authorized by current backend state
+```
+
+The parser-page resume bridge accepts only the fixed relative review URL form:
+
+```text
+preflight/?run=<numeric run_id>
+```
+
+It performs read-only dashboard access and cannot call `runs/start` or any reconciliation write endpoint.
+
+## Production Regression — Run 18 / Import 60
+
+On 2026-08-30 import 60 successfully created reconciliation Run 18. A separate missing least-privilege database grant (#104) initially prevented the browser from reading Stage review. After migration 0041 repaired that permission, refreshing `/lor2db/parser/` still rendered only **Refresh reconciliation status** because the existing parser JavaScript ignored the backend `workflow.action` review URL.
+
+Issue #106 corrects that frontend recovery gap. Run 18 / import 60 is the production acceptance case: refreshing the parser page must provide a direct route back to existing Run 18 without creating new parser, ingest, or reconciliation state.
+
+## Implementation
+
+- `parser.js` — primary parser/ingest workflow rendering and Start action.
+- `parser-reconciliation-resume.js` — read-only recovery bridge that converts the legacy refresh-status control into the backend-authorized persisted review action when one exists.
+- `index.html` — loads the resume bridge after `parser.js`.
+- `test_parser_reconciliation_resume.py` — regression contract for script ordering, review action handling, URL restriction, and no-write behavior.
+
+The resume bridge is deliberately narrow. It does not alter parser evidence, ingest evidence, reconciliation database logic, or the one-reconciliation-per-snapshot contract.

--- a/LOR2DB/Application/landing/parser/index.html
+++ b/LOR2DB/Application/landing/parser/index.html
@@ -20,5 +20,6 @@
     </div>
   </main>
   <script src="parser.js?v=0.6.2.1" defer></script>
+  <script src="parser-reconciliation-resume.js?v=0.6.2.2" defer></script>
 </body>
 </html>

--- a/LOR2DB/Application/landing/parser/parser-reconciliation-resume.js
+++ b/LOR2DB/Application/landing/parser/parser-reconciliation-resume.js
@@ -1,0 +1,79 @@
+/* MSB parser reconciliation resume bridge - 2026-08-30 V0.6.2.2 */
+(function () {
+  "use strict";
+
+  const app = document.querySelector("#app");
+  const REVIEW_URL = /^preflight\/\?run=\d+$/;
+  let requestInFlight = false;
+
+  if (!app) return;
+
+  async function loadWorkflow() {
+    const response = await fetch("../preflight/api/dashboard", {
+      credentials: "same-origin",
+      headers: { "Content-Type": "application/json" }
+    });
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      throw new Error(payload.error || `Request failed (${response.status})`);
+    }
+    return payload.workflow;
+  }
+
+  function applyReviewAction(refreshButton, workflow) {
+    const action = workflow?.action;
+    const reviewUrl = String(action?.url || "");
+
+    if (action?.kind !== "review" || !REVIEW_URL.test(reviewUrl)) {
+      return false;
+    }
+
+    const link = document.createElement("a");
+    link.id = "continue-reconciliation";
+    link.className = "primary";
+    link.href = `../${reviewUrl}`;
+    link.textContent = action.label || "Continue reconciliation";
+    refreshButton.replaceWith(link);
+
+    const section = link.closest("section");
+    if (section) {
+      const heading = section.querySelector("h2");
+      if (heading) heading.textContent = "Continue reconciliation";
+
+      const pill = section.querySelector(".pill");
+      if (pill) pill.textContent = "RECONCILIATION IN PROGRESS";
+
+      const detail = section.querySelector(".card-title + p");
+      if (detail) {
+        detail.textContent = workflow?.message
+          || "A reconciliation already exists for this snapshot. Continue that persisted run.";
+      }
+    }
+
+    return true;
+  }
+
+  async function reconcileControl() {
+    const refreshButton = document.querySelector("#refresh-reconciliation");
+    if (!refreshButton || requestInFlight) return;
+
+    requestInFlight = true;
+    try {
+      const workflow = await loadWorkflow();
+      applyReviewAction(refreshButton, workflow);
+    } catch (error) {
+      // Leave the existing refresh control intact. The parser page remains
+      // usable and a later render/refresh will retry this read-only lookup.
+      console.error("Unable to load persisted reconciliation action", error);
+    } finally {
+      requestInFlight = false;
+    }
+  }
+
+  const observer = new MutationObserver(() => {
+    void reconcileControl();
+  });
+
+  observer.observe(app, { childList: true, subtree: true });
+  void reconcileControl();
+}());

--- a/LOR2DB/Application/test_parser_reconciliation_resume.py
+++ b/LOR2DB/Application/test_parser_reconciliation_resume.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+PARSER_DIR = ROOT / "landing" / "parser"
+INDEX = PARSER_DIR / "index.html"
+RESUME = PARSER_DIR / "parser-reconciliation-resume.js"
+
+
+def test_parser_page_loads_resume_bridge_after_main_parser_script():
+    html = INDEX.read_text(encoding="utf-8")
+
+    main_script = 'parser.js?v=0.6.2.1'
+    resume_script = 'parser-reconciliation-resume.js?v=0.6.2.2'
+
+    assert main_script in html
+    assert resume_script in html
+    assert html.index(main_script) < html.index(resume_script)
+
+
+def test_resume_bridge_consumes_backend_review_action_and_persisted_run_url():
+    source = RESUME.read_text(encoding="utf-8")
+
+    assert '../preflight/api/dashboard' in source
+    assert 'action?.kind !== "review"' in source
+    assert 'REVIEW_URL.test(reviewUrl)' in source
+    assert 'link.href = `../${reviewUrl}`' in source
+    assert 'action.label || "Continue reconciliation"' in source
+    assert 'refreshButton.replaceWith(link)' in source
+
+
+def test_resume_bridge_does_not_start_or_mutate_reconciliation():
+    source = RESUME.read_text(encoding="utf-8")
+
+    assert 'runs/start' not in source
+    assert 'method: "POST"' not in source
+    assert 'method: "PUT"' not in source
+    assert 'method: "DELETE"' not in source
+
+
+def test_resume_bridge_rejects_arbitrary_review_urls():
+    source = RESUME.read_text(encoding="utf-8")
+
+    assert 'const REVIEW_URL = /^preflight\\/\\?run=\\d+$/' in source
+
+
+def test_non_review_or_no_action_state_leaves_existing_control_unchanged():
+    source = RESUME.read_text(encoding="utf-8")
+
+    assert 'return false;' in source
+    assert 'Leave the existing refresh control intact' in source


### PR DESCRIPTION
## Summary

Fixes Issue #106: after a successful ingest has already started reconciliation, refreshing `/lor2db/parser/` must resume that persisted reconciliation instead of leaving the operator at a dead **Refresh reconciliation status** control.

## Root cause

The backend already returns the correct persistent workflow action:

```text
workflow.state = IN_PROGRESS
workflow.action.kind = review
workflow.action.url = preflight/?run=<run_id>
```

but the parser page only checks `workflow.can_start`. Every non-startable state therefore renders the same refresh-status button and ignores the existing review URL.

## Repair

This narrow frontend recovery bridge:

- reads the existing authenticated dashboard workflow state;
- activates only when the parser page has rendered the legacy `#refresh-reconciliation` control;
- accepts only `action.kind=review` with fixed relative URL `preflight/?run=<numeric run_id>`;
- replaces that control with the backend-provided **Continue previous reconciliation** action;
- updates the card to show reconciliation is already in progress;
- performs no POST/PUT/DELETE and cannot call `runs/start`;
- leaves non-review/no-action states unchanged.

The bridge is loaded after the existing parser script so it preserves the current parser/ingest implementation and persistent backend authority.

## Scope

Exactly four files:

```text
LOR2DB/Application/landing/parser/index.html
LOR2DB/Application/landing/parser/parser-reconciliation-resume.js
LOR2DB/Application/test_parser_reconciliation_resume.py
LOR2DB/Application/landing/parser/README.md
```

No PostgreSQL schema, parser, ingest, reconciliation database logic, Google Drive, FieldWiring, or Procedures changes.

## Regression coverage

Static regression coverage verifies:

- resume script loads after primary parser script;
- authenticated dashboard workflow is consumed;
- only `review` actions with the fixed run URL shape are accepted;
- the persisted run URL becomes the Continue action;
- the bridge contains no reconciliation start/write endpoint.

The new script also passes JavaScript syntax checking.

## Production deployment and live acceptance — PASSED 2026-08-30

Accepted candidate:

```text
f29ef038fd40be474b0ebd73c3ce909a2db44a1c
```

Production frontend is served from Synology Web Station under:

```text
/volume1/web/my/lor2db/parser/
```

The first attempted deployment via `scp` failed because the Synology SSH service does not provide the expected SFTP/SCP subsystem. No files were changed by that failed attempt. Deployment was then completed through the working SSH shell by base64-decoding the exact candidate bytes into the two runtime files.

Deployed SHA-256 values:

```text
index.html
63968d204f010e0f4f08eedb1abc7411b1caa287f05fa8e48232e913fba8ecad

parser-reconciliation-resume.js
3296c662f214420f96d603857c65a23ec748885f83b6598054e29af1874504b1
```

Live browser acceptance:

- hard refresh of `/lor2db/parser/` succeeded;
- the dead **Refresh reconciliation status** state was replaced by the persisted Continue action;
- the operator successfully resumed existing reconciliation **Run 18 / import 60**;
- no new parser, ingest, or reconciliation was required.

This is the required production acceptance for Issue #106.

Issue: #106