### PR TITLE
Update Scan operator entry for protected home shortcut

### DIFF
--- a/Docs/02_Production_Database/02_Operational_SOPs/Scanning/README.md
+++ b/Docs/02_Production_Database/02_Operational_SOPs/Scanning/README.md
@@ -8,7 +8,7 @@
 | Audience | MSB volunteers, operators, and managers |
 | Status | DRAFT — operator review and screenshots required |
 | Owner | MSB Database Administrator |
-| Last Reviewed | 2026-08-24 |
+| Last Reviewed | 2026-09-03 |
 | Keywords | scan, scanning, QR code, display, container, phone, tablet, camera, manual entry, field wiring, procedures |
 
 ## What Is MSB Scan?
@@ -23,9 +23,17 @@ You do **not** need to understand database IDs, application routes, or the repos
 
 ## Open Scan
 
-Open:
+The normal operator entry is the protected MSB Internal home page:
 
-**https://db.sheboyganlights.org/scan/**
+**https://my.sheboyganlights.org/**
+
+Use the green **Open Scan** button in the top Work Order / Scan / Database section.
+
+You may also open Scan directly at:
+
+**https://my.sheboyganlights.org/scan/**
+
+`/scan/` is the canonical operator application entry. Existing printed labels and older scan links that use `https://db.sheboyganlights.org/scan/...` remain supported for compatibility and do not need to be replaced merely because the operator launch point is now under `my.sheboyganlights.org`.
 
 The Scan page provides two normal ways to start:
 
@@ -39,7 +47,7 @@ The Scan page provides two normal ways to start:
 | Enter a code instead of using the camera | [Use Scan Manually](Use_Scan_Manually.md) |
 | Understand what `DISP`, `CONT`, `LOC`, and `CTRL` mean | [QR Code Types and Meanings](QR_Code_Types_and_Meanings.md) |
 | Set up a phone or tablet to scan labels | [Set Up a Phone or Tablet for Scanning](Set_Up_Phone_or_Tablet_for_Scanning.md) |
-| Know which button to choose after I scan something | [What To Do After You Scan](What_To_Do_After_You_Scan.md) |
+| Know which button to choose after I scan something | [What To_Do_After_You_Scan](What_To_Do_After_You_Scan.md) |
 
 ## Current Production Boundary
 

--- a/Docs/02_Production_Database/02_Operational_SOPs/Scanning/README.md
+++ b/Docs/02_Production_Database/02_Operational_SOPs/Scanning/README.md
@@ -47,7 +47,7 @@ The Scan page provides two normal ways to start:
 | Enter a code instead of using the camera | [Use Scan Manually](Use_Scan_Manually.md) |
 | Understand what `DISP`, `CONT`, `LOC`, and `CTRL` mean | [QR Code Types and Meanings](QR_Code_Types_and_Meanings.md) |
 | Set up a phone or tablet to scan labels | [Set Up a Phone or Tablet for Scanning](Set_Up_Phone_or_Tablet_for_Scanning.md) |
-| Know which button to choose after I scan something | [What To_Do_After_You_Scan](What_To_Do_After_You_Scan.md) |
+| Know which button to choose after I scan something | [What To Do After You Scan](What_To_Do_After_You_Scan.md) |
 
 ## Current Production Boundary
 


### PR DESCRIPTION
## Purpose

Update the Scan operator portal after the protected MSB Internal home page gained a prominent Scan shortcut.

## Change

- makes `https://my.sheboyganlights.org/` the normal operator starting point;
- directs operators to the green **Open Scan** button in the top Work Order / Scan / Database section;
- documents `https://my.sheboyganlights.org/scan/` as the canonical direct application entry;
- preserves compatibility guidance for existing printed labels and older `https://db.sheboyganlights.org/scan/...` links;
- updates the document review date to 2026-09-03.

## Scope

Documentation only. No Scan runtime, routing, label payloads, Cloudflare Access behavior, or `db.` compatibility behavior is changed.