### PR TITLE
Add CTRL Scan route to Controller Inventory

### DIFF
--- a/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/Asset_Identity_and_Scan_Payload_Standard.md
+++ b/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/Asset_Identity_and_Scan_Payload_Standard.md
@@ -23,13 +23,13 @@ Current approved prefixes include:
 | Container | `CONT` | `CONT:587` |
 | Storage Location | `LOC` | `LOC:RA-01-A-03` |
 | Display | `DISP` | `DISP:251` |
-| Controller | `CTRL` | `CTRL:CL-042` |
+| Controller | `CTRL` | `CTRL:1014` |
 
 Rules:
 
 - use the stable internal Production Database identifier for Displays and Containers;
 - use the operational location code for labeled discrete Storage Locations;
-- controller identity must use the permanent Controller Inventory identity once that subsystem is implemented;
+- controller identity uses permanent `ref.controller.controller_id` from the deployed Controller Inventory;
 - do not use LOR UUIDs as Production asset identity;
 - do not use raw GPS coordinates as a permanent location identity;
 - do not use single-letter prefixes for new machine-readable identifiers.
@@ -81,6 +81,28 @@ Migration rules:
 
 This is a staged physical-payload migration only. The durable Container identity remains the same Production Database `container_id`.
 
+## Controller QR Wrapper and Compact HID Input
+
+The canonical Controller identifier is:
+
+```text
+CTRL:<controller_id>
+```
+
+The accepted new Controller QR payload wraps that permanent identity in the stable Scan route so a phone/tablet camera can open it directly:
+
+```text
+https://db.sheboyganlights.org/scan/CTRL/<controller_id>
+```
+
+The Zebra ADF emits the compact value `CTRL:<controller_id>` instead of typing the full URL. Manual entry may use the compact value or the supported full Scan URL. Both forms must converge on `/scan/CTRL/<controller_id>` and then hand the identity to the existing Controller Inventory:
+
+```text
+https://my.sheboyganlights.org/fieldwiring/controllers?controller_id=<controller_id>
+```
+
+The URL is a replaceable Scan wrapper, not a second identity. Controller Inventory owns Controller details/actions; Scan does not duplicate that application. The route remains subject to production deployment and real-label acceptance before Controller labels are printed in volume.
+
 ## Storage Location Versus Park GIS Location
 
 `LOC:<location_code>` is the approved machine-readable pattern for **discrete labeled operational locations**, especially workshop/rack/storage locations.
@@ -115,6 +137,7 @@ For Displays, that design is a verified deployed capability. The current product
 ```text
 /scan/
 /scan/DISP/:key
+/scan/CONT/:key
 /scan/DISP/:key/test
 /scan/DISP/:key/container
 /scan/DISP/:key/work-orders
@@ -122,7 +145,7 @@ For Displays, that design is a verified deployed capability. The current product
 
 `/scan/DISP/:key` resolves permanent `ref.display.display_id` and then presents task destinations. New Display field applications such as FieldWiring must extend that existing resolved-identity hub rather than creating another Display QR payload or lookup engine.
 
-The broader `/scan/<TYPE>/<KEY>` concept remains partly a design direction for workflows not yet verified as deployed. Do not infer that all Container, Location, Controller, or Setup behaviors exist merely because Display scanning does.
+The Container route is also deployed and opens the authoritative Directus Container record, where assigned Displays are available. The `CTRL` route and Controller Inventory search handoff are implemented in the current Git source candidate but are not production behavior until deployed and physically accepted. `LOC` and broader Setup movement behavior remain future work; do not infer that they exist merely because Display and Container scanning work.
 
 See [Deployed Display Scan Runtime Boundary](Deployed_Display_Scan_Runtime_Boundary.md) for the verified Display implementation boundary.
 
@@ -213,6 +236,8 @@ new compact CONT:587
 ```
 
 must resolve to the same Container identity and workflow.
+
+For Controllers, the full Scan URL in the camera-readable QR and compact `CTRL:<controller_id>` from Zebra HID/manual entry must likewise resolve to the same permanent Controller Inventory identity and result.
 
 GPS is additional location context. It is not a different Container identity path.
 

--- a/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/Deployed_Display_Scan_Runtime_Boundary.md
+++ b/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/Deployed_Display_Scan_Runtime_Boundary.md
@@ -2,8 +2,8 @@
 
 | Document control | Value |
 |---|---|
-| Status | CURRENT PRODUCTION DEPENDENCY — Procedure source candidate ready; production deployment pending |
-| Current revision | 2026-08-23 |
+| Status | CURRENT PRODUCTION DEPENDENCY — CTRL source candidate ready; production deployment pending |
+| Current revision | 2026-09-03 |
 | Owner | MSB Database Administrator |
 | Production host | `msb-prod-db` |
 | Production runtime path | `/opt/directus/extensions/directus-extension-scan/` |
@@ -32,13 +32,13 @@ Directus executes:
 dist/index.js
 ```
 
-The current accepted production SHA-256 after FieldWiring integration and the Directus public-origin correction is:
+The current Server Management runbook records this accepted production SHA-256, including the FieldWiring and Procedures Display-hub actions:
 
 ```text
-b4f6c27f4880a8eaf8a90d8d55c7939c5bd190645dca9329344a86c3175cb20f
+fb2a98088e363430fb0a303e4c895bae8202f4f253ac22a1481a406eb5b7443a
 ```
 
-That hash remains the accepted **live production baseline** until the Procedure-enabled candidate is actually deployed and accepted through the Server Management safety gate.
+That hash remains the accepted **live production baseline** until the CTRL-enabled candidate is deployed and accepted through the Server Management safety gate.
 
 The accepted application/business source is version-controlled under:
 
@@ -47,6 +47,7 @@ Scan/directus-extension-scan/
     package.json
     src/index.js
     dist/index.js
+    test/controller-route.test.mjs
 ```
 
 The live deployment does not need to contain the development `src/` tree. Application source belongs in the Production Database repository; live deployment/recovery belongs in Server Management.
@@ -74,7 +75,7 @@ Verified production routes include:
 /scan/DISP/:key/work-orders
 ```
 
-The Procedure source candidate does **not** add or replace a Scan route. It adds a Display-hub link to the already-deployed protected Procedure application.
+The Git-controlled CTRL candidate adds `/scan/CTRL/:key`; that route is not included in the production inventory above until deployment acceptance is complete.
 
 The scan landing page supports camera scanning, QR codes, 1-D barcodes, manual entry, and URL handling.
 
@@ -98,9 +99,8 @@ The currently accepted production hub independently presents or resolves:
 - the current Display Testing record/status when applicable;
 - the assigned Container;
 - active Work Orders; and
-- the accepted Field Wiring action.
-
-The Procedure-enabled source candidate adds one independent **Procedures** action without changing those existing actions.
+- the accepted Field Wiring action; and
+- the accepted Procedures action.
 
 Testing, Container, Work Order, FieldWiring, and Procedure remain separate downstream actions. A failure in one downstream application must not make the basic Display hub or unrelated actions unavailable.
 
@@ -159,7 +159,7 @@ FieldWiring remains a downstream consumer. A FieldWiring outage must not disable
 
 See [FieldWiring Scan Integration Engineering Handoff — 2026-08-22](FieldWiring_Scan_Integration_Engineering_Handoff_2026-08-22.md) for the accepted implementation and production evidence.
 
-## Procedure Display Scan Integration — Source Candidate Ready
+## Procedure Display Scan Integration — Accepted Production
 
 The standalone Procedure application is production-operational at:
 
@@ -167,7 +167,7 @@ The standalone Procedure application is production-operational at:
 https://my.sheboyganlights.org/procedures/
 ```
 
-Procedure already accepts permanent Display identity as an application entry input and already owns its Setup/Takedown/Inspection task-selection UI.
+Procedure accepts permanent Display identity as an application entry input and owns its Setup/Takedown/Inspection task-selection UI.
 
 The agreed Display Scan UX is one additive **Procedures** button:
 
@@ -184,26 +184,7 @@ Existing Display QR
 
 The Scan hub passes only the permanent `display_id`. It does not duplicate Setup/Takedown/Inspection buttons and does not call the Procedure API merely to determine whether the button should render.
 
-Git-controlled candidate source is on:
-
-```text
-branch: agent/procedure-scan-action
-implementation commit: 333f7c20a26e8ed2a0460ddbf309c167bffa2992
-```
-
-Both candidate files intentionally use the same Git blob:
-
-```text
-Scan/directus-extension-scan/src/index.js
-Scan/directus-extension-scan/dist/index.js
-Git blob: b3fd0e992b22407784e9da0dbc21d371c0d4a483
-```
-
-Compared with the current `main` baseline, each file has exactly one added line: the Procedures link. No existing Scan route or database query is changed.
-
-This is **not yet production acceptance**. The current live artifact remains the accepted hash `b4f6c27f4880a8eaf8a90d8d55c7939c5bd190645dca9329344a86c3175cb20f` until the Server Management deployment gate verifies the live baseline, creates a new rollback, stages and syntax-checks the candidate, restarts Directus, and completes regression acceptance.
-
-The Procedure follow-on preserves the architectural rules proven by FieldWiring:
+The accepted Procedure integration preserves the architectural rules proven by FieldWiring:
 
 - no physical QR change;
 - no second Display resolver;
@@ -211,6 +192,18 @@ The Procedure follow-on preserves the architectural rules proven by FieldWiring:
 - no Procedure schema or generic document registry merely for scan integration;
 - no Procedure health/API call required just to render the Display hub; and
 - existing Display, Testing, Container, Work Order, and FieldWiring actions remain independently usable if Procedure is unavailable.
+
+## Controller Scan Integration — Source Candidate Ready
+
+Controller Inventory V0.4.0 is merged to `main` and production-operational. It already supports exact detail entry through:
+
+```text
+https://my.sheboyganlights.org/fieldwiring/controllers?controller_id=<controller_id>
+```
+
+The bounded Scan candidate adds `/scan/CTRL/:key`, validates that the key is a positive integer permanent Controller ID, and redirects to that existing Controller Inventory entry point. The Controller browser initializes its Search control from `controller_id`, filters the list, and opens the exact detail panel.
+
+The candidate does not query Controller tables or duplicate Controller details/actions inside Scan. Camera-readable full URLs and compact Zebra HID/manual values converge on the same route and identity. Production deployment, regression checks, and physical label/device acceptance are still required.
 
 ## Future Setup/Deployment Scan Platform Boundary
 
@@ -222,6 +215,7 @@ Durable labels should remain asset/location identifiers such as:
 DISP:<display_id>
 CONT:<container_id>
 LOC:<location_code>
+CTRL:<controller_id>
 ```
 
 Annual setup dates, load numbers, transient movement state, application-specific routes, and other workflow state must not become physical label identity.
@@ -234,7 +228,7 @@ The broader Setup/Deployment workflow remains separate from Procedure document l
 
 Owns:
 
-- permanent Display/Container/Location identity and relationships;
+- permanent Display/Container/Location/Controller identity and relationships;
 - scan payload/business contracts;
 - Git-controlled scan application source under `Scan/directus-extension-scan/`;
 - Testing, Work Order, Container, FieldWiring, Procedure, and Setup/Deployment integration behavior;
@@ -257,17 +251,17 @@ A server path does not transfer business-rule authority to the Server Management
 
 ## Current Stop Point
 
-As of 2026-08-23:
+As of 2026-09-03:
 
 - current scan application source is recovered in Git;
 - FieldWiring Scan Integration is accepted production work;
-- current accepted live scan artifact hash is `b4f6c27f4880a8eaf8a90d8d55c7939c5bd190645dca9329344a86c3175cb20f`;
+- current accepted live scan artifact hash is `fb2a98088e363430fb0a303e4c895bae8202f4f253ac22a1481a406eb5b7443a`;
 - the Directus public-origin correction is accepted production behavior;
 - the `/scan/` Synology route is production-operational;
-- standalone Procedure field access is production-operational;
-- the Procedure Display Scan UX is now settled as one **Procedures** button that passes only permanent `display_id` and leaves Setup/Takedown/Inspection selection inside the existing Procedure application;
-- the Git-controlled Procedure-enabled Scan source candidate is implemented on `agent/procedure-scan-action`, with implementation commit `333f7c20a26e8ed2a0460ddbf309c167bffa2992`;
-- production deployment and regression acceptance of that candidate are still pending through the current Server Management runbook;
+- standalone Procedure field access and its Display-hub action are production-operational;
+- Controller Inventory V0.4.0 is merged and production-operational;
+- the Git-controlled CTRL route candidate hands permanent `controller_id` to the existing Controller Inventory Search/detail experience;
+- production deployment and device acceptance of the CTRL candidate are pending through the current Server Management runbook;
 - the broader Container/Location Setup/Deployment workflow remains separate engineering scope; and
 - no schema or physical QR change is part of this bounded integration.
 
@@ -281,5 +275,5 @@ Before deploying the candidate, read the current Server Management [Display Scan
 - [Field Context Resolution Contract](Field_Context_Resolution_Contract.md)
 - [Wiring System](../09_Wiring_System/README.md)
 - [Setup and Deployment](../12_Setup_and_Deployment/README.md)
-- [Procedure Application](../../../../../Procedures/Application/README.md)
+- [Procedure Application](../../../../Procedures/Application/README.md)
 - [MSB Server Management — Display Scan Extension Deployment and Recovery](https://github.com/Gregovate/MSB-Server-Management/blob/main/docs/directus/Display_Scan_Extension_Deployment_and_Recovery.md)

--- a/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/README.md
+++ b/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/README.md
@@ -27,7 +27,7 @@ Read [Labeling and Scanning — Subsystem and Repository Boundary](Subsystem_and
 
 ## Current State
 
-Display and container label printing is an implemented production capability used to connect physical assets to Production Database records.
+Display and Container label-printing infrastructure exists, but the current operator request surfaces are not equivalent: there is no usable interface to select Displays and request their labels. Controller Inventory has a Print Label request button, while the separate LabelPrintService does not yet consume Controller requests. Those request/polling gaps are separate from Scan identity routing.
 
 **Display QR lookup is also an implemented production capability.** The current Display scan route is deployed as a Directus endpoint extension on `msb-prod-db` under `/opt/directus/extensions/directus-extension-scan/`. It resolves the permanent Production Database `display_id` and presents the existing Display scan hub.
 
@@ -38,6 +38,7 @@ Scan/directus-extension-scan/
     package.json
     src/index.js
     dist/index.js
+    test/controller-route.test.mjs
 ```
 
 The source is stored in the Production Database repository because it operates directly against Production Database identities/data. Its label/payload/scan behavior still implements the Labeling and Scanning subsystem contract.
@@ -52,7 +53,7 @@ The detailed deployed runtime hash, rollback artifacts, restart/recovery sequenc
 
 The scan hub remains independent of FieldWiring for Display Record, Testing, Container, Work Order, and other existing actions. FieldWiring does not have to be healthy merely for the Display hub to render.
 
-**Procedure is also production-operational independently at `https://my.sheboyganlights.org/procedures/`.** The Procedure Display Scan source candidate is implemented on branch `agent/procedure-scan-action` from current `main`. The agreed Scan UX is one additive **Procedures** button on the Display hub:
+**Procedure and its Display Scan action are accepted production behavior.** The Display hub includes one additive **Procedures** button:
 
 ```text
 /procedures/?display_id=<permanent display_id>
@@ -60,15 +61,16 @@ The scan hub remains independent of FieldWiring for Display Record, Testing, Con
 
 The Scan hub passes only the permanent `display_id`. Setup, Takedown, and Inspection selection remains inside the existing Procedure application, which already presents those three operator task choices. This avoids duplicating Procedure task-selection UI in Scan and does not add a Procedure API/health dependency merely to render the Display hub.
 
-Application-source implementation commit:
+No physical QR redesign, second resolver, Procedure schema, alternate Google hierarchy, or duplicate document registry is part of this integration.
+
+**Controller Inventory V0.4.0 is deployed production behavior.** A bounded `CTRL` Scan source candidate now reuses its exact-controller entry contract:
 
 ```text
-333f7c20a26e8ed2a0460ddbf309c167bffa2992
+/scan/CTRL/<controller_id>
+    -> /fieldwiring/controllers?controller_id=<controller_id>
 ```
 
-This source candidate is **not yet a production-runtime acceptance record**. Until the documented Server Management deployment gate is executed and accepted, the current live Scan runtime remains the previously accepted FieldWiring-enabled artifact and hash.
-
-No physical QR redesign, second resolver, Procedure schema, alternate Google hierarchy, or duplicate document registry is part of this integration.
+The Controller page uses that parameter to populate/filter Search and open the exact detail panel. The `CTRL` route is not production behavior until the Scan candidate passes the Server Management deployment gate and physical Zebra/camera acceptance.
 
 The broader Setup/Deployment scan workflow remains separate engineering scope. High-volume Container and Storage Location scanning is expected during setup season, but the real pull/stage/load/delivery process must be reconstructed before broader scan-platform refactoring or transaction semantics are approved.
 
@@ -78,7 +80,7 @@ Label printing crosses a repository and service boundary:
 
 - **Labeling and Scanning** owns the cross-system label/payload/scan contract;
 - the **Production Database** owns the authoritative asset records and database-backed request/batch state;
-- **Directus** provides the current operator interface for selecting records and enabling `Print Label`;
+- the **Production Database operator applications** provide asset-specific request surfaces where implemented;
 - the separate **MSB_LabelPrintService** consumes the approved database contract and performs physical printing on the dedicated print server.
 
 The LabelPrintService is an external supporting subsystem. If it is unavailable, printing stops, but the Production Database remains authoritative and usable.
@@ -88,7 +90,7 @@ The LabelPrintService is an external supporting subsystem. If it is unavailable,
 - [Subsystem and Repository Boundary](Subsystem_and_Repository_Boundary.md) — controlling separation among Labeling and Scanning, the Production Database, and LabelPrintService/PRINT-SERVER.
 - [Label Payload and Profile Architecture](Label_Payload_and_Profile_Architecture.md) — current QR-generation/profile reconnaissance and implementation gates.
 - [FieldWiring Scan Integration Engineering Handoff — 2026-08-22](FieldWiring_Scan_Integration_Engineering_Handoff_2026-08-22.md) — accepted production Scan/FieldWiring baseline, permanent `display_id` handoff, source-control boundary, failure boundary, acceptance matrix, and deferred regression cases.
-- [Deployed Display Scan Runtime Boundary](Deployed_Display_Scan_Runtime_Boundary.md) — current Directus scan endpoint, application/runtime ownership boundary, Procedure source-candidate state, and current scan-extension resume point.
+- [Deployed Display Scan Runtime Boundary](Deployed_Display_Scan_Runtime_Boundary.md) — current Directus scan endpoint, application/runtime ownership boundary, accepted production baseline, and current scan-extension candidate.
 - [Asset Identity and Scan Payload Standard](Asset_Identity_and_Scan_Payload_Standard.md) — durable asset/payload rules.
 - [Field Context Resolution Contract](Field_Context_Resolution_Contract.md) — shared scan-to-Display/hierarchy contract used by Work Orders, FieldWiring, Procedures, Testing, and future field functions.
 - [Field Document Publication and Currentness Contract](Field_Document_Publication_and_Currentness_Contract.md) — shared browser/PDF/offline/currentness rules for field documents reached through the scan/task workflow.
@@ -231,37 +233,29 @@ The former loose `H_Asset_ID_Labeling_and_Scanning_Plan.md` has been reconciled 
 - [Setup and Deployment](../12_Setup_and_Deployment/README.md)
 - [Site Infrastructure / GIS](../11_Site_Infrastructure_GIS/README.md)
 - [Operational Label Printing SOPs](../../02_Operational_SOPs/Label_Printing/README.md)
-- [Operational SOPs](../../02_Production_Database/02_Operational_SOPs/README.md)
+- [Operational SOPs](../../02_Operational_SOPs/README.md)
 - [MSB Label Print Service](https://github.com/Gregovate/MSB_LabelPrintService)
 - [MSB-Server-Management](https://github.com/Gregovate/MSB-Server-Management)
 
 ## Resume Development
 
-### Procedure Display Scan Integration — source candidate ready; deployment/acceptance pending
+### Controller Scan Integration — source candidate ready; deployment/acceptance pending
 
-Standalone Procedure field access and FieldWiring Scan Integration are accepted production baselines. Procedure Display Scan Integration now has an application-source candidate on branch `agent/procedure-scan-action`.
+Current production Controller Inventory already owns Controller search, detail, assignments, planning, maintenance, and label-request actions. The bounded Scan candidate adds no competing Controller screen or database query.
 
-Agreed operator behavior:
-
-```text
-Display scan hub
-    -> Procedures
-        -> /procedures/?display_id=<permanent display_id>
-            -> existing Procedure page
-                -> operator chooses Setup, Takedown, or Inspection
-```
-
-The source candidate adds exactly one Display-hub link in both Git-controlled `src/index.js` and `dist/index.js`. It does not call Procedure to decide whether to render the button and does not change any existing Scan route.
-
-Application-source commit:
+Accepted handoff:
 
 ```text
-333f7c20a26e8ed2a0460ddbf309c167bffa2992
+camera QR: https://db.sheboyganlights.org/scan/CTRL/<controller_id>
+Zebra/manual: CTRL:<controller_id>
+    -> /scan/CTRL/<controller_id>
+    -> /fieldwiring/controllers?controller_id=<controller_id>
+    -> Search filtered and exact Controller detail opened
 ```
 
-Next step is deployment/acceptance through the current `MSB-Server-Management` Display Scan Extension Deployment and Recovery runbook. Before live replacement, verify the live artifact still matches the documented accepted baseline, create a new timestamped rollback, stage/syntax-check the candidate, and regression-test Display Record, Testing, Container, Work Orders, Field Wiring, manual/camera Scan behavior as applicable, plus the new Procedures action.
+The Git-controlled `src/index.js` and deployable `dist/index.js` remain identical. The Controller browser initializes its existing Search control from the same `controller_id` parameter already used by FieldWiring cross-links and exact-detail loading.
 
-Preserve the current physical Display identity/payload contract. Do not add a second resolver, Procedure schema, alternate Google hierarchy, direct Procedure-document URL in the QR, or a Procedure health/API dependency merely to render the Display scan hub.
+Next step is deployment/acceptance through the current `MSB-Server-Management` Display Scan Extension Deployment and Recovery runbook. Verify the live artifact hash, create a timestamped rollback, stage/syntax-check the candidate, restart Directus, and regress existing Display/Container/manual/camera behavior plus compact/full-URL `CTRL` inputs and the Controller Inventory result. Update the Server Management runbook only after that production acceptance.
 
 ### Setup/Deployment operational scanning — separate project
 

--- a/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/Setup_Season_Scan_Integration_Handoff_2026-09-02.md
+++ b/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/Setup_Season_Scan_Integration_Handoff_2026-09-02.md
@@ -6,7 +6,7 @@
 | System | Labeling and Scanning / Scan / Setup and Deployment |
 | Status | CURRENT WORKING HANDOFF |
 | Owner | MSB Technical Team |
-| Date | 2026-09-02 |
+| Date | 2026-09-03 |
 
 ## Purpose
 
@@ -55,22 +55,67 @@ LOC:<location_code>
 CTRL:<controller_id>
 ```
 
-Zebra scanners have been configured to report compact canonical values for deployed Display/Container/Location scanning instead of typing the full scan URL.
+The Zebra ADF correction was physically checked on 2026-09-03: the scanner types the expected compact canonical value into Google Docs. That proves the HID/ADF input format, not end-to-end Scan application behavior for every identity type.
 
 This is an input-method normalization convenience. The Scan application must not require Zebra-specific behavior. Manual entry, camera decode, Zebra HID input, and supported legacy/full URLs must converge on the same identity resolution where compatibility is required.
 
 ## Current Known Scan Problems
 
-As of this handoff:
+As of the 2026-09-03 reconnaissance:
 
-- reaching the Scan application is cumbersome and needs one obvious supported operator entry point;
+- the MSB Internal home page at `https://my.sheboyganlights.org/` now provides the obvious supported **Open Scan** entry point; the former discovery/navigation problem is resolved;
 - `DISP` is the most developed route;
-- `CONT` exists but has limited result/actions;
+- `CONT` is accepted for its current purpose: it opens the Directus Container record, where the original design exposes assigned Displays;
 - `LOC` does not yet have complete route/resolution behavior; focused implementation is #88;
-- `CTRL` needs a Scan route/result now that permanent Controller Inventory IDs exist;
+- production Controller Inventory is deployed at `/fieldwiring/controllers` and accepts `?controller_id=<id>` for exact detail selection;
+- the Git-controlled `CTRL` Scan source candidate routes the permanent Controller identity to that existing Controller Inventory instead of building a duplicate result page; deployment and physical acceptance remain pending;
 - iPhone behavior is not accepted merely because a camera preview opens; actual barcode/QR decode and correct routing must be physically verified;
 - camera-permission failure/recovery remains #112;
 - operator documentation in #67 must follow corrected deployed behavior rather than freezing current defects into SOPs.
+
+## Current-State Matrix
+
+`Source-supported` means the current code path accepts the input. `Input-only verified` means the Zebra emitted the expected value in Google Docs; it is not an end-to-end route acceptance result.
+
+| Type | Manual | Zebra HID | Android camera | iPhone camera | Route exists | Result/actions |
+|---|---|---|---|---|---|---|
+| `DISP` | Source-supported | Input-only verified in current test pass | Physical decode/routing acceptance not recorded in this pass | Camera may open; real-label decode/routing not accepted | Yes — production | Existing Display hub: Directus record, Testing, Container, Work Orders, Field Wiring, and Procedures |
+| `CONT` | Source-supported | End-to-end Container scan reported working; compact ADF output independently verified | Physical decode/routing acceptance not recorded in this pass | Camera may open; real-label decode/routing not accepted | Yes — production | Opens the Directus Container record and its Display assignments; preserve this accepted behavior |
+| `LOC` | Landing-page normalization exists, but destination fails because no route exists | Compact ADF output verified only | Not accepted | Not accepted | No | #88 must supply Location resolution and the minimum Setup-owned operator workflow |
+| `CTRL` | Compact/full-URL normalization is source-supported by the candidate | Compact `CTRL:<id>` input contract; end-to-end production acceptance pending | Full-URL QR decode/routing acceptance pending | Full-URL QR decode/routing acceptance pending | Source candidate only | Redirects to production Controller Inventory with `controller_id=<id>`, which filters Search and opens exact detail |
+
+The Controller capture contract is:
+
+```text
+phone/tablet camera QR
+    -> https://db.sheboyganlights.org/scan/CTRL/<controller_id>
+
+Zebra HID or manual compact entry
+    -> CTRL:<controller_id>
+
+both
+    -> /scan/CTRL/<controller_id>
+    -> https://my.sheboyganlights.org/fieldwiring/controllers?controller_id=<controller_id>
+```
+
+Controller Inventory remains the owner of Controller details and actions. Scan only resolves and hands off permanent identity.
+
+## Label-Request Interface Findings
+
+- Controller Inventory has a **Print Label** request button, but external print-service polling does not yet consume that request; that is separate LabelPrintService work.
+- No usable operator interface currently exists to select Displays and request their labels. That is a database/label-request UI gap, not part of the bounded `CTRL` Scan route.
+- Do not volume-print Controller labels until the Scan route, operator destination, Zebra/camera behavior, and real-world scan distance pass the physical-label gate below.
+
+## Smallest Ordered Repair Plan
+
+1. Review and merge the bounded `CTRL` source candidate without changing existing `DISP` or `CONT` behavior.
+2. Deploy it through the current Server Management Scan runbook, then accept compact Zebra/manual and full-URL phone/tablet inputs against a real Controller label and the Controller Inventory result.
+3. Complete `LOC` resolution and the minimum Setup-owned operator action under #88; do not infer movement from scan order.
+4. Complete real-label Android/iPhone decode and camera permission/recovery acceptance under #112.
+5. Update the operator SOP and discovery guidance under #67 only after the deployed routes and camera behavior are correct.
+6. Add broader Setup movement/staging/load semantics only where the reconstructed operational process proves they are needed.
+
+Keep #113 as the umbrella and keep #88, #112, and #67 focused; do not create a new issue for each small finding.
 
 ## Setup-Season Direction
 
@@ -108,7 +153,7 @@ A new Scan engineering thread should begin by:
 2. refreshing current remote `main` before editing;
 3. inventorying current `Scan/directus-extension-scan/` source and current deployed Scan baseline/runbook;
 4. documenting the current route matrix for `DISP`, `CONT`, `LOC`, and `CTRL` before changing code;
-5. resolving the operator entry/navigation problem;
+5. preserving the now-deployed MSB Internal **Open Scan** entry point;
 6. verifying capture methods independently: manual, Zebra HID, Android camera, iPhone camera;
 7. implementing/accepting focused route gaps without redesigning LabelPrintService;
 8. continuing #88 for Setup-critical Location and movement semantics;

--- a/Docs/02_Production_Database/01_System_Architecture/08_Controller_Inventory/README.md
+++ b/Docs/02_Production_Database/01_System_Architecture/08_Controller_Inventory/README.md
@@ -4,7 +4,7 @@
 |---|---|
 | Status | PRODUCTION V0.4.0 DEPLOYED — CORE PLANNING / MAINTENANCE ACCEPTED |
 | Issue | #110 |
-| Draft PR | #111 |
+| Merged PR | #111 |
 | Permanent identity | `ref.controller.controller_id` |
 | Permanent database | Installed on `msb-prod-db` |
 | Current production checkout | `63be47f40be78f608416935ed0583287da9d90e6` |
@@ -200,6 +200,15 @@ Current limitation: the external LabelPrintService does not yet have accepted Co
 
 The accidental pending CTRL 1001 request must be cleared under a bounded production mutation procedure before Controller physical print routing becomes active.
 
+The accepted Scan destination reuses this production browser rather than creating a separate Controller result screen:
+
+```text
+/scan/CTRL/<controller_id>
+    -> /fieldwiring/controllers?controller_id=<controller_id>
+```
+
+The `controller_id` parameter populates/filters the existing Search control and opens the exact Controller detail. The matching Scan extension change is currently a Git-controlled source candidate and still requires deployment plus physical full-URL QR and compact Zebra HID acceptance before Controller labels are printed in volume.
+
 ## Directus Experiment — Closed
 
 Do not resume the Directus Controller relationship workspace experiment. It caused item-detail failures around the legitimate composite relationship key.
@@ -218,9 +227,9 @@ The core Controller planning/maintenance system is deployed. Remaining work is n
 3. clear the accidental CTRL 1001 pending label request before physical Controller printing is enabled;
 4. complete Production Crew and Read Only browser capability acceptance;
 5. write and accept plain-English operator procedures against the deployed V0.4.0 screens;
-6. reconcile final documentation and prepare draft PR #111 for review/merge.
+6. add final operator procedures after the remaining Production Crew and Read Only capability checks.
 
-PR #111 remains draft. Production deployment does **not** authorize merging `main`.
+PR #111 is merged to `main`, and Controller Inventory V0.4.0 is production-operational. Future Scan deployment remains a separate controlled change.
 
 ## Operator Procedures
 

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/README.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/README.md
@@ -12,7 +12,7 @@ The operational database/application workflow for scheduling, pick lists, load o
 
 **FieldWiring, Display Scan, and the standalone Procedure application are accepted production baselines.** Procedure is production-operational at `https://my.sheboyganlights.org/procedures/` and uses the shared Field Context resolver plus the existing read-only Google `Display Folders` mount. Do not rediscover or redesign those accepted systems merely to continue Setup/Deployment work.
 
-The bounded **Procedure Display Scan Integration** UX is now settled and its application-source candidate is implemented on `agent/procedure-scan-action`: the existing Display scan hub gets one **Procedures** button that passes only permanent `display_id` to `/procedures/?display_id=<display_id>`. Setup/Takedown/Inspection selection remains inside the existing Procedure page. Production deployment/regression acceptance of that Scan candidate is still pending through the current Server Management runbook. Human Procedure-document authoring/alignment and the broader scheduling/pick/load/forklift workflow remain separate work streams.
+The bounded **Procedure Display Scan Integration** is accepted production behavior: the Display scan hub passes permanent `display_id` to `/procedures/?display_id=<display_id>`, and Setup/Takedown/Inspection selection remains inside Procedure. Controller Inventory V0.4.0 is also merged and production-operational. Human Procedure-document authoring/alignment and the broader scheduling/pick/load/forklift workflow remain separate work streams.
 
 MSB has purchased a **Zebra DS3678-HD cordless ultra-rugged 1-D/2-D scanner kit** for the workshop forklift. It uses the Zebra 3600-series USB cradle and supports USB HID keyboard input. Because this is the **HD (High Density)** variant rather than an ER/XR extended-range model, its actual suitability from the forklift seat must be tested with real MSB Container and Storage Location labels before it is accepted as the final forklift-distance standard. See [Scanner Hardware and Tablet Integration](../07_Labeling_and_Scanning/Scanner_Hardware_and_Tablet_Integration.md).
 
@@ -158,7 +158,7 @@ Display scan hub
                 -> operator chooses Setup, Takedown, or Inspection
 ```
 
-The Scan hub passes only `display_id`, does not duplicate the three Procedure task buttons, and does not call Procedure merely to decide whether the link should render. The source candidate is implemented on `agent/procedure-scan-action` with implementation commit `333f7c20a26e8ed2a0460ddbf309c167bffa2992`; production deployment/acceptance is still pending. Do not invent a second resolver, encode Stage/Scene/Google paths in the QR, or make the Display hub depend on Procedure health merely to render the Procedures action.
+The Scan hub passes only `display_id`, does not duplicate the three Procedure task buttons, and does not call Procedure merely to decide whether the link should render. This is accepted production behavior. Do not invent a second resolver, encode Stage/Scene/Google paths in the QR, or make the Display hub depend on Procedure health merely to render the Procedures action.
 
 Setup is also expected to become a high-volume scan workflow for deployment operations rather than only document lookup.
 
@@ -168,6 +168,7 @@ Durable physical identities remain the starting point:
 DISP:<permanent display_id>
 CONT:<permanent container_id>
 LOC:<operational storage/location code>
+CTRL:<permanent controller_id>
 ```
 
 Annual setup dates, load numbers, staging status, and other transient workflow state must not be encoded into the permanent labels.
@@ -180,6 +181,8 @@ phone/tablet camera -> camera decoder
 ```
 
 The purchased Zebra DS3678-HD gives the project a real industrial hardware acceptance target. Its USB HID behavior fits the browser-first design, but the hardware must be tested against actual label size/density and actual forklift position before deciding whether HD range is adequate or an ER/XR scanner is required for some tasks.
+
+The 2026-09-03 ADF correction is input-method evidence only: the Zebra emitted compact canonical identifiers correctly in Google Docs. The current Container route is accepted because it opens the Directus Container record and assigned Displays. `LOC` still has no complete route and remains #88. The Git-controlled `CTRL` candidate hands permanent Controller identity to the existing production Controller Inventory Search/detail page; it adds no Setup movement meaning.
 
 Likely setup interactions may include both scan orders:
 
@@ -245,11 +248,15 @@ Already production-operational:
 
 - current Setup/Takedown/Inspection document lookup by Display/Stage/Scene;
 - field-friendly Procedure presentation through `my.sheboyganlights.org/procedures/`;
-- shared Field Context resolution and read-only Google `Display Folders` consumption.
+- shared Field Context resolution and read-only Google `Display Folders` consumption;
+- the one-button Procedures action on the Display scan hub;
+- Controller Inventory V0.4.0 and its exact-controller deep-link input.
 
-Current bounded follow-on:
+Current bounded Scan follow-on:
 
-- deploy and accept the implemented one-button Procedure action from the existing permanent-identity Display scan hub.
+- deploy and accept `/scan/CTRL/<controller_id>` handing off to `/fieldwiring/controllers?controller_id=<controller_id>`;
+- continue #88 for Location identity resolution and the minimum Setup-owned workflow;
+- physically accept relevant Zebra and phone/tablet label behavior before volume printing new Location or Controller labels.
 
 Separate planned operational work includes:
 
@@ -291,7 +298,7 @@ The standalone Procedure field-access application is accepted production work. D
 
 Current Procedure-related open work is separated into these scopes:
 
-- **Procedure Display Scan Integration** — source candidate is implemented as one Display-hub **Procedures** action using permanent `display_id`; remaining work is Directus Scan deployment and regression acceptance through the Server Management safety gate;
+- **Procedure Display Scan Integration** — accepted production behavior; preserve the permanent `display_id` handoff and downstream ownership boundary;
 - **Procedure document authoring/alignment** — continue the legacy Setup-document review, alignment, archive, and publication work in the existing Stage/Scene `Display Folders` hierarchy;
 - **Contributor/operator documentation** — finalize the Stage Setup Instruction contributor workflow and the editable-source versus published-PDF relationship where Google Docs remain in use;
 - **additional field acceptance as needed** — complete any broader PC/phone/tablet, print, or offline validation required for the 2026 field workflow; and
@@ -308,38 +315,35 @@ Begin from current `main` and the current responsible runbooks. Do not rediscove
 Read first:
 
 1. [Procedure Application README](../../../../Procedures/Application/README.md) — current standalone Procedure application contract, production status, and Scan entry contract;
-2. [Labeling and Scanning](../07_Labeling_and_Scanning/README.md) — current scan platform handoff and Procedure scan candidate state;
-3. [Deployed Display Scan Runtime Boundary](../07_Labeling_and_Scanning/Deployed_Display_Scan_Runtime_Boundary.md) — current Git/runtime boundary, accepted live Scan baseline, and Procedure source candidate;
+2. [Labeling and Scanning](../07_Labeling_and_Scanning/README.md) — current scan platform handoff and CTRL candidate state;
+3. [Deployed Display Scan Runtime Boundary](../07_Labeling_and_Scanning/Deployed_Display_Scan_Runtime_Boundary.md) — current Git/runtime boundary, accepted live Scan baseline, and CTRL source candidate;
 4. [FieldWiring Scan Integration Engineering Handoff](../07_Labeling_and_Scanning/FieldWiring_Scan_Integration_Engineering_Handoff_2026-08-22.md) — accepted additive scan integration pattern and failure boundary;
 5. [Procedure System Field Context Handoff — 2026-08-22](00_Procedure_System_Field_Context_Handoff_2026-08-22.md) — architecture precedence for Procedure/Field Context;
 6. [Field Context Resolution Contract](../07_Labeling_and_Scanning/Field_Context_Resolution_Contract.md);
 7. [Stage Setup Documentation Standard](../../../../System_Documentation/Project_Rules/Stage_Setup_Documentation_Standard.md); and
 8. [MSB-Server-Management Display Scan Extension Deployment and Recovery](https://github.com/Gregovate/MSB-Server-Management/blob/main/docs/directus/Display_Scan_Extension_Deployment_and_Recovery.md) before any scan deployment.
 
-### Procedure Display Scan Integration — deployment/acceptance is the current bounded task
+### Controller Scan Integration — deployment/acceptance is the current bounded Scan task
 
 The accepted identity and UX handoff is:
 
 ```text
-existing physical Display QR
-    -> DISP:<permanent display_id>
-    -> existing /scan/DISP/:key Display hub
-    -> Procedures
-    -> /procedures/?display_id=<permanent display_id>
-    -> existing Procedure application receives permanent display_id
-    -> operator chooses Setup, Takedown, or Inspection
+camera QR: https://db.sheboyganlights.org/scan/CTRL/<controller_id>
+Zebra/manual: CTRL:<controller_id>
+    -> /scan/CTRL/<controller_id>
+    -> /fieldwiring/controllers?controller_id=<controller_id>
+    -> existing Controller Inventory filters Search and opens exact detail
 ```
 
-The source candidate is already implemented on `agent/procedure-scan-action`; implementation commit `333f7c20a26e8ed2a0460ddbf309c167bffa2992`. The next step is not additional architecture reconnaissance: it is the documented Server Management deployment gate and regression acceptance.
+The candidate reuses permanent `ref.controller.controller_id` and the deployed Controller browser. It must pass the documented Server Management deployment gate and real-label Zebra/phone/tablet acceptance before volume Controller label printing.
 
 This work must not create:
 
-- a new physical QR format;
-- a second Display/Stage/Scene resolver;
-- a Procedure-only Google hierarchy or mount;
-- a generic Procedure document registry;
-- a new Procedure database schema merely for scan integration; or
-- a Procedure health/API dependency that makes unrelated Scan actions unavailable.
+- a second Controller result application;
+- a second Controller identity;
+- Controller database or movement mutations merely from scanning;
+- annual Setup state in the permanent Controller label; or
+- a dependency on Zebra-specific formatting.
 
 Follow the existing Server Management scan-extension runbook for live hash verification, rollback capture, staging, syntax validation, restart, and regression testing. Operational discoveries made during this work must be written into the responsible runbook before later steps depend on them.
 

--- a/FieldWiring/Application/controllers.html
+++ b/FieldWiring/Application/controllers.html
@@ -68,7 +68,7 @@
   </section>
 </main>
 
-<script src="controllers.js"></script>
+<script src="controllers.js?v=2026-09-03.1"></script>
 <script src="static/controllers_search_context.js"></script>
 <script src="static/controllers_detail_extras.js?v=2026-09-02.3"></script>
 <script src="static/controllers_management.js?v=2026-09-02.2"></script>

--- a/FieldWiring/Application/controllers.js
+++ b/FieldWiring/Application/controllers.js
@@ -302,5 +302,10 @@ assignmentFilter.addEventListener('change', loadControllers);
 document.getElementById('refresh-button').addEventListener('click', loadControllers);
 document.getElementById('clear-filters-button').addEventListener('click', clearFilters);
 
+const requestedControllerId = new URLSearchParams(window.location.search).get('controller_id');
+if (requestedControllerId && /^\d+$/.test(requestedControllerId)) {
+  searchInput.value = requestedControllerId;
+}
+
 configureTheme();
 loadControllers();

--- a/FieldWiring/Application/test_controller_fieldwiring_crosslinks.py
+++ b/FieldWiring/Application/test_controller_fieldwiring_crosslinks.py
@@ -106,9 +106,13 @@ def test_fieldwiring_loads_controller_crosslink_assets() -> None:
 
 def test_controller_inventory_supports_exact_controller_deep_link_and_exposes_print_label() -> None:
     html = (BASE_DIR / "controllers.html").read_text(encoding="utf-8")
+    base_script = (BASE_DIR / "controllers.js").read_text(encoding="utf-8")
     script = (BASE_DIR / "static" / "controllers_detail_extras.js").read_text(encoding="utf-8")
 
+    assert "controllers.js?v=2026-09-03.1" in html
     assert "controllers_detail_extras.js" in html
+    assert "get('controller_id')" in base_script
+    assert "searchInput.value = requestedControllerId" in base_script
     assert "get('controller_id')" in script
     assert "loadControllerDetail(controllerId)" in script
     assert "Print Label" in script

--- a/Scan/directus-extension-scan/dist/index.js
+++ b/Scan/directus-extension-scan/dist/index.js
@@ -15,6 +15,9 @@
      /scan/CONT/:key
        → Container scan landing page
 
+     /scan/CTRL/:key
+       → Controller Inventory exact-controller search/detail
+
      /scan/DISP/:key/test
        → Opens display test record in Directus
 
@@ -187,7 +190,7 @@ export default {
             <button id="scanBtn" type="button" class="btn secondary">Scan with Camera</button>
             <button id="stopBtn" type="button" class="btn secondary" style="display:none;">Stop Camera</button>
 
-            <div class="hint">Examples: DISP:141, CONT:238, LOC:RA-01-A-03, or a full scan URL</div>
+            <div class="hint">Examples: DISP:141, CONT:238, LOC:RA-01-A-03, CTRL:1014, or a full scan URL</div>
 
             <div id="reader"></div>
             <div id="scanStatus"></div>
@@ -615,6 +618,29 @@ export default {
         </body>
         </html>
       `);
+    });
+
+    // ============================================================
+    // CONTROLLER INVENTORY HANDOFF
+    // /scan/CTRL/:key
+    // Opens the production Controller Inventory with the permanent
+    // controller_id selected in both Search and the detail panel.
+    // ============================================================
+    router.get('/CTRL/:key', async (req, res) => {
+      const key = String(req.params.key ?? '').trim();
+      const controllerId = Number(key);
+
+      if (!/^\d+$/.test(key) || !Number.isSafeInteger(controllerId) || controllerId <= 0) {
+        res.status(400).send(`
+          <h1>Invalid Controller</h1>
+          <p>Expected CTRL:&lt;controller_id&gt;; received CTRL:${escapeHtml(key)}</p>
+        `);
+        return;
+      }
+
+      res.redirect(
+        `https://my.sheboyganlights.org/fieldwiring/controllers?controller_id=${encodeURIComponent(controllerId)}`
+      );
     });
 
     // ============================================================

--- a/Scan/directus-extension-scan/package.json
+++ b/Scan/directus-extension-scan/package.json
@@ -1,6 +1,9 @@
 {
   "name": "directus-extension-scan",
   "version": "1.0.0",
+  "scripts": {
+    "test": "node --test test/*.test.mjs"
+  },
   "type": "module",
   "directus:extension": {
     "type": "endpoint",

--- a/Scan/directus-extension-scan/src/index.js
+++ b/Scan/directus-extension-scan/src/index.js
@@ -15,6 +15,9 @@
      /scan/CONT/:key
        → Container scan landing page
 
+     /scan/CTRL/:key
+       → Controller Inventory exact-controller search/detail
+
      /scan/DISP/:key/test
        → Opens display test record in Directus
 
@@ -187,7 +190,7 @@ export default {
             <button id="scanBtn" type="button" class="btn secondary">Scan with Camera</button>
             <button id="stopBtn" type="button" class="btn secondary" style="display:none;">Stop Camera</button>
 
-            <div class="hint">Examples: DISP:141, CONT:238, LOC:RA-01-A-03, or a full scan URL</div>
+            <div class="hint">Examples: DISP:141, CONT:238, LOC:RA-01-A-03, CTRL:1014, or a full scan URL</div>
 
             <div id="reader"></div>
             <div id="scanStatus"></div>
@@ -615,6 +618,29 @@ export default {
         </body>
         </html>
       `);
+    });
+
+    // ============================================================
+    // CONTROLLER INVENTORY HANDOFF
+    // /scan/CTRL/:key
+    // Opens the production Controller Inventory with the permanent
+    // controller_id selected in both Search and the detail panel.
+    // ============================================================
+    router.get('/CTRL/:key', async (req, res) => {
+      const key = String(req.params.key ?? '').trim();
+      const controllerId = Number(key);
+
+      if (!/^\d+$/.test(key) || !Number.isSafeInteger(controllerId) || controllerId <= 0) {
+        res.status(400).send(`
+          <h1>Invalid Controller</h1>
+          <p>Expected CTRL:&lt;controller_id&gt;; received CTRL:${escapeHtml(key)}</p>
+        `);
+        return;
+      }
+
+      res.redirect(
+        `https://my.sheboyganlights.org/fieldwiring/controllers?controller_id=${encodeURIComponent(controllerId)}`
+      );
     });
 
     // ============================================================

--- a/Scan/directus-extension-scan/test/controller-route.test.mjs
+++ b/Scan/directus-extension-scan/test/controller-route.test.mjs
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import scanExtension from '../src/index.js';
+
+function registeredRoutes() {
+  const routes = new Map();
+  const router = {
+    get(path, handler) {
+      routes.set(path, handler);
+    },
+  };
+
+  scanExtension.handler(router, { database: () => undefined });
+  return routes;
+}
+
+function responseRecorder() {
+  return {
+    statusCode: 200,
+    body: null,
+    redirectTarget: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    send(body) {
+      this.body = body;
+      return this;
+    },
+    redirect(target) {
+      this.redirectTarget = target;
+      return this;
+    },
+  };
+}
+
+test('CTRL route hands permanent identity to Controller Inventory', async () => {
+  const handler = registeredRoutes().get('/CTRL/:key');
+  const response = responseRecorder();
+
+  assert.equal(typeof handler, 'function');
+  await handler({ params: { key: '1014' } }, response);
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(
+    response.redirectTarget,
+    'https://my.sheboyganlights.org/fieldwiring/controllers?controller_id=1014',
+  );
+});
+
+test('CTRL route rejects a nonnumeric Controller identity', async () => {
+  const handler = registeredRoutes().get('/CTRL/:key');
+  const response = responseRecorder();
+
+  await handler({ params: { key: 'not-a-controller' } }, response);
+
+  assert.equal(response.statusCode, 400);
+  assert.match(response.body, /Expected CTRL:/);
+  assert.equal(response.redirectTarget, null);
+});


### PR DESCRIPTION
## Summary

- add `/scan/CTRL/:key` with positive-integer Controller ID validation
- redirect resolved Controller identity to the production Controller Inventory at `/fieldwiring/controllers?controller_id=<id>`
- initialize the existing Controller Search box from `controller_id`, filter the list, and retain exact-detail loading
- preserve existing `DISP` and `CONT` routes
- add focused route tests and keep Scan `src/index.js` and deployable `dist/index.js` identical
- update the controlled Scan, payload, Controller Inventory, and Setup documentation, including the current-state matrix and smallest ordered repair plan

## Input contract

```text
camera QR: https://db.sheboyganlights.org/scan/CTRL/<controller_id>
Zebra/manual: CTRL:<controller_id>
    -> /scan/CTRL/<controller_id>
    -> https://my.sheboyganlights.org/fieldwiring/controllers?controller_id=<controller_id>
```

Scan resolves permanent identity only. Controller Inventory owns details/actions, and Setup/Deployment owns movement meaning.

## Verification

- `node --test Scan/directus-extension-scan/test/controller-route.test.mjs` — 2 passed
- JavaScript syntax checks passed for Scan `src`, Scan `dist`, and Controller Inventory
- Scan `src/index.js` and `dist/index.js` are byte-identical
- modified documentation relative links passed validation
- `git diff --check` passed
- full Python `pytest` was unavailable in this workspace because `pytest` and `psycopg2` are not installed; the exact Controller deep-link source contract was checked directly and passed

## Deployment boundary

This PR does not deploy Scan, change production configuration, modify PostgreSQL schema, or implement LabelPrintService polling. Production deployment and physical Zebra/phone/tablet acceptance must follow the current Server Management Scan deployment/recovery runbook.

Umbrella: #113

Focused follow-ons remain #88 (LOC), #112 (camera permission/recovery), and #67 (operator documentation).