### PR TITLE
Add Controller label execution batch schema

### DIFF
--- a/Controllers/Database/025_create_controller_label_print_batches.sql
+++ b/Controllers/Database/025_create_controller_label_print_batches.sql
@@ -1,0 +1,208 @@
+/* ============================================================================
+Controller label printing — execution batch contract
+Issue: Gregovate/MSB_LabelPrintService#14
+Revision: 2026-09-03 V0.1.0
+
+Purpose:
+  Add the Production Database objects required for LabelPrintService V4 to
+  consume ref.controller.print_label safely.
+
+Safety contract:
+  - The browser continues to request labels only through
+    ref.request_controller_label(text, bigint).
+  - LabelPrintService snapshots the exact pending Controller IDs before print.
+  - Only Controllers present in a successfully completed snapshot are cleared.
+  - A failed preflight creates no batch.
+  - A failed physical batch remains visible and leaves print_label set.
+============================================================================ */
+
+BEGIN;
+
+DO $preflight$
+DECLARE
+    v_template_count integer;
+BEGIN
+    IF to_regclass('ref.controller') IS NULL THEN
+        RAISE EXCEPTION 'ref.controller is required';
+    END IF;
+    IF to_regclass('ref.label_template') IS NULL THEN
+        RAISE EXCEPTION 'ref.label_template is required';
+    END IF;
+    IF to_regclass('ref.person') IS NULL THEN
+        RAISE EXCEPTION 'ref.person is required';
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'printservice') THEN
+        RAISE EXCEPTION 'Required role printservice does not exist';
+    END IF;
+
+    SELECT count(*)
+      INTO v_template_count
+    FROM ref.label_template
+    WHERE label_template_code = 'QR_24MM_HORIZONTAL';
+
+    IF v_template_count <> 1 THEN
+        RAISE EXCEPTION
+            'Expected exactly one QR_24MM_HORIZONTAL label template; found %',
+            v_template_count;
+    END IF;
+END
+$preflight$;
+
+-- Controller permanent-ID labels all use the governed 24 mm QR family.
+-- This is a controlled configuration backfill, not a user edit. Temporarily
+-- suppress the row-touch trigger so the 177 existing Controller audit records
+-- are not falsely rewritten as though an operator changed each Controller.
+ALTER TABLE ref.controller DISABLE TRIGGER trg_controller_actor_update;
+
+UPDATE ref.controller AS c
+SET label_template_id = lt.label_template_id
+FROM ref.label_template AS lt
+WHERE lt.label_template_code = 'QR_24MM_HORIZONTAL'
+  AND c.label_template_id IS NULL;
+
+ALTER TABLE ref.controller ENABLE TRIGGER trg_controller_actor_update;
+
+DO $template_assignment$
+DECLARE
+    v_invalid_count integer;
+BEGIN
+    SELECT count(*)
+      INTO v_invalid_count
+    FROM ref.controller AS c
+    LEFT JOIN ref.label_template AS lt
+      ON lt.label_template_id = c.label_template_id
+    WHERE lt.label_template_code IS DISTINCT FROM 'QR_24MM_HORIZONTAL';
+
+    IF v_invalid_count <> 0 THEN
+        RAISE EXCEPTION
+            'Every Controller must resolve to QR_24MM_HORIZONTAL; invalid rows=%',
+            v_invalid_count;
+    END IF;
+END
+$template_assignment$;
+
+-- New Controller rows are created without an explicit label_template_id.
+-- Resolve the accepted catalog row now and install its stable ID as the default.
+DO $default_template$
+DECLARE
+    v_label_template_id integer;
+BEGIN
+    SELECT label_template_id
+      INTO STRICT v_label_template_id
+    FROM ref.label_template
+    WHERE label_template_code = 'QR_24MM_HORIZONTAL';
+
+    EXECUTE format(
+        'ALTER TABLE ref.controller ALTER COLUMN label_template_id SET DEFAULT %s',
+        v_label_template_id
+    );
+END
+$default_template$;
+
+CREATE TABLE ops.controller_label_batch (
+    controller_label_batch_id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    batch_started_at timestamptz NOT NULL DEFAULT now(),
+    batch_completed_at timestamptz,
+    started_by_person_id integer,
+    started_by_text text,
+    label_template_id integer NOT NULL,
+    status text NOT NULL DEFAULT 'PENDING',
+    notes text,
+
+    CONSTRAINT fk_controller_label_batch_person
+        FOREIGN KEY (started_by_person_id)
+        REFERENCES ref.person(person_id)
+        ON UPDATE CASCADE
+        ON DELETE SET NULL,
+    CONSTRAINT fk_controller_label_batch_template
+        FOREIGN KEY (label_template_id)
+        REFERENCES ref.label_template(label_template_id),
+    CONSTRAINT ck_controller_label_batch_status
+        CHECK (status IN ('PENDING', 'PRINTING', 'COMPLETED', 'FAILED'))
+);
+
+CREATE INDEX idx_controller_label_batch_status
+    ON ops.controller_label_batch(status);
+
+CREATE TABLE ops.controller_label_batch_item (
+    controller_label_batch_item_id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    controller_label_batch_id bigint NOT NULL,
+    controller_id bigint NOT NULL,
+    qr_url text NOT NULL,
+    line1 text NOT NULL,
+    printed_flag boolean NOT NULL DEFAULT false,
+    printed_at timestamptz,
+
+    CONSTRAINT fk_controller_label_batch_item_batch
+        FOREIGN KEY (controller_label_batch_id)
+        REFERENCES ops.controller_label_batch(controller_label_batch_id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_controller_label_batch_item_controller
+        FOREIGN KEY (controller_id)
+        REFERENCES ref.controller(controller_id)
+        ON UPDATE CASCADE
+        ON DELETE RESTRICT,
+    CONSTRAINT uq_controller_label_batch_item_batch_controller
+        UNIQUE (controller_label_batch_id, controller_id),
+    CONSTRAINT ck_controller_label_batch_item_qr_url
+        CHECK (qr_url ~ '^https://db[.]sheboyganlights[.]org/scan/CTRL/[0-9]+$'),
+    CONSTRAINT ck_controller_label_batch_item_line1
+        CHECK (line1 ~ '^CTRL:[0-9]+$')
+);
+
+CREATE INDEX idx_controller_label_batch_item_batch
+    ON ops.controller_label_batch_item(controller_label_batch_id);
+
+COMMENT ON TABLE ops.controller_label_batch IS
+    'Immutable execution-batch header for permanent Controller ID labels.';
+COMMENT ON TABLE ops.controller_label_batch_item IS
+    'Frozen Controller label render intent. LabelPrintService clears only Controllers in a successfully completed batch.';
+COMMENT ON COLUMN ops.controller_label_batch_item.qr_url IS
+    'Full phone-compatible QR payload: https://db.sheboyganlights.org/scan/CTRL/<controller_id>.';
+COMMENT ON COLUMN ops.controller_label_batch_item.line1 IS
+    'Visible permanent Controller identity: CTRL:<controller_id>.';
+
+GRANT SELECT ON ref.controller TO printservice;
+GRANT UPDATE (
+    print_label,
+    label_print_count_cached,
+    label_print_last_at_cached,
+    label_print_last_by_cached_id
+) ON ref.controller TO printservice;
+GRANT SELECT ON ref.label_template TO printservice;
+
+GRANT SELECT, INSERT, UPDATE, DELETE
+    ON ops.controller_label_batch TO printservice;
+GRANT SELECT, INSERT, UPDATE, DELETE
+    ON ops.controller_label_batch_item TO printservice;
+GRANT SELECT, USAGE
+    ON SEQUENCE ops.controller_label_batch_controller_label_batch_id_seq
+    TO printservice;
+GRANT SELECT, USAGE
+    ON SEQUENCE ops.controller_label_batch_item_controller_label_batch_item_id_seq
+    TO printservice;
+
+COMMIT;
+
+SELECT
+    count(*) FILTER (WHERE c.label_template_id IS NULL)
+        AS controllers_without_template,
+    count(*) FILTER (
+        WHERE lt.label_template_code = 'QR_24MM_HORIZONTAL'
+    ) AS controllers_with_24mm_template,
+    count(*) FILTER (WHERE c.print_label) AS pending_controller_requests
+FROM ref.controller AS c
+LEFT JOIN ref.label_template AS lt
+  ON lt.label_template_id = c.label_template_id;
+
+SELECT
+    to_regclass('ops.controller_label_batch') AS controller_batch_table,
+    to_regclass('ops.controller_label_batch_item') AS controller_batch_item_table,
+    has_table_privilege('printservice', 'ref.controller', 'SELECT')
+        AS printservice_can_read_controller,
+    has_column_privilege('printservice', 'ref.controller', 'print_label', 'UPDATE')
+        AS printservice_can_clear_request,
+    has_table_privilege('printservice', 'ops.controller_label_batch', 'INSERT')
+        AS printservice_can_create_batch,
+    has_table_privilege('printservice', 'ops.controller_label_batch_item', 'INSERT')
+        AS printservice_can_create_items;

--- a/Controllers/README.md
+++ b/Controllers/README.md
@@ -10,6 +10,7 @@ Current operational authority is:
 - `Docs/02_Production_Database/01_System_Architecture/08_Controller_Inventory/Controller_Management_Application_Boundary_2026-08-31.md`
 - `Docs/02_Production_Database/01_System_Architecture/08_Controller_Inventory/Controller_Inventory_Operational_Implementation_Roadmap_2026-08-31.md`
 - `Docs/02_Production_Database/01_System_Architecture/08_Controller_Inventory/Controller_Current_Programmed_Configuration_Contract_2026-08-31.md`
+- `Docs/02_Production_Database/01_System_Architecture/08_Controller_Inventory/Controller_Label_Print_Service_Integration_2026-09-03.md`
 
 This `Controllers/` area preserves the bootstrap source, reconciliation evidence, database scripts, diagnostics, migrations, and acceptance artifacts used to create the permanent Controller Inventory. It is no longer the current operational handoff.
 
@@ -175,6 +176,8 @@ label_template_id
 No new `label_id`, `label_type_id`, or Controller-specific template table is authorized.
 
 Current Manager label-request behavior belongs in the browser-native Controller Management workflow. Actual printer handoff remains governed by the existing labeling subsystem.
+
+`Database/025_create_controller_label_print_batches.sql` is the controlled candidate that assigns the accepted 24 mm family/default, adds `ops.controller_label_batch*`, and grants the external print service its bounded execution/finalization access. It must be installed and validated before LabelPrintService Controller polling is enabled.
 
 ## Current Operational Direction
 

--- a/Docs/02_Production_Database/01_System_Architecture/08_Controller_Inventory/Controller_Label_Print_Service_Integration_2026-09-03.md
+++ b/Docs/02_Production_Database/01_System_Architecture/08_Controller_Inventory/Controller_Label_Print_Service_Integration_2026-09-03.md
@@ -1,0 +1,117 @@
+# Controller Label Print-Service Integration
+
+| Document Control | Value |
+|---|---|
+| Document Type | Engineering integration contract |
+| System | Controller Inventory / LabelPrintService |
+| Status | DRAFT — database batch migration and V4 consumer require deployment acceptance |
+| Owner | Production Database administrator / LabelPrintService maintainer |
+| Last Reviewed | 2026-09-03 |
+| Production Request Command | `ref.request_controller_label(text, bigint)` |
+| Candidate Database Migration | `Controllers/Database/025_create_controller_label_print_batches.sql` |
+| Downstream Issue | `Gregovate/MSB_LabelPrintService#14` |
+
+## Purpose
+
+This document defines the database half of permanent Controller label printing.
+The Controller browser already creates an authorized request. The missing work
+is the durable execution-batch contract and the LabelPrintService V4 consumer.
+
+## Current Production Request
+
+The deployed browser calls:
+
+```sql
+ref.request_controller_label(p_email, p_controller_id)
+```
+
+That command authorizes the current user and sets:
+
+```text
+ref.controller.print_label = true
+```
+
+Repeated requests are idempotent while the flag is already true. The browser
+does not print and does not receive physical printer feedback.
+
+## Permanent Identity and Payload
+
+```text
+Visible label text: CTRL:<controller_id>
+Printed QR payload: https://db.sheboyganlights.org/scan/CTRL/<controller_id>
+Physical family:    QR_24MM_HORIZONTAL
+Printer/media:      PT-P950NW / 24 mm laminated tape
+```
+
+The full URL and compact `CTRL:` form both resolve to Controller Inventory.
+Mutable Controller programming, Display assignments, firmware, and location are
+not part of permanent label identity.
+
+## Candidate Execution-Batch Schema
+
+Migration `Controllers/Database/025_create_controller_label_print_batches.sql`
+adds:
+
+```text
+ops.controller_label_batch
+ops.controller_label_batch_item
+```
+
+The migration also:
+
+- assigns existing Controllers to the governed `QR_24MM_HORIZONTAL` catalog row
+  when `label_template_id` is null;
+- sets that catalog ID as the default for newly created Controllers;
+- grants `printservice` only the Controller read/finalization access needed by
+  the polling service plus batch-table/sequence access;
+- constrains frozen `line1` and `qr_url` values to the accepted Controller
+  identity formats.
+
+The batch item is the immutable physical render snapshot. It contains the exact
+Controller ID, full QR URL, visible `CTRL:` text, and physical completion state.
+
+## Required Transaction Boundary
+
+The downstream service must follow this sequence:
+
+1. read pending `ref.controller.print_label` rows;
+2. validate every row resolves to `QR_24MM_HORIZONTAL`;
+3. complete printer, media, template, runtime-path, and queue preflight;
+4. lock the exact pending Controller rows and verify the workload did not change;
+5. create and commit the batch header/items;
+6. print the frozen rows;
+7. after confirmed success, clear only Controller requests present in that batch
+   and update their cached print summary;
+8. mark a failed physical batch `FAILED` without clearing its requests.
+
+A failed preflight creates no execution batch. A request that arrives after the
+snapshot remains pending for a later batch.
+
+## Activation Gate
+
+Controller polling must remain disabled in LabelPrintService until all of the
+following are true:
+
+- migration `025` has been reviewed and installed;
+- migration validation reports zero Controllers without an assigned template;
+- `printservice` permission checks pass;
+- the previously documented pending Controller `1001` request is inspected and
+  deliberately cleared or selected as the controlled physical test;
+- the V4 consumer is installed with its feature flag still off;
+- 24 mm laminated tape is intentionally loaded for the controlled test.
+
+Do not enable the consumer merely because the code exists in a draft branch.
+
+## Ownership Boundary
+
+The Production Database owns Controller identity, request state, label-family
+assignment, execution-batch history, and targeted finalization. LabelPrintService
+owns polling, local LBX selection, Brother preflight, b-PAC rendering, Windows
+spooler observation, physical execution logs, and restart/no-double-print
+behavior.
+
+## Related Documents
+
+- [Controller Inventory](README.md)
+- [Label Payload and Profile Architecture](../07_Labeling_and_Scanning/Label_Payload_and_Profile_Architecture.md)
+- [Controller Management Authentication / Authorization Contract](Controller_Management_Authentication_Authorization_Contract_2026-08-31.md)

--- a/Docs/02_Production_Database/01_System_Architecture/08_Controller_Inventory/README.md
+++ b/Docs/02_Production_Database/01_System_Architecture/08_Controller_Inventory/README.md
@@ -17,6 +17,7 @@
 | Management boundary | [Controller Management Application Boundary — 2026-08-31](Controller_Management_Application_Boundary_2026-08-31.md) |
 | Programmed configuration | [Controller Current Programmed Configuration Contract — 2026-08-31](Controller_Current_Programmed_Configuration_Contract_2026-08-31.md) |
 | Operational roadmap | [Controller Inventory Operational Implementation Roadmap — 2026-08-31](Controller_Inventory_Operational_Implementation_Roadmap_2026-08-31.md) |
+| Label printing integration | [Controller Label Print-Service Integration — 2026-09-03](Controller_Label_Print_Service_Integration_2026-09-03.md) |
 
 Controller Inventory owns permanent physical Controller identity, current Controller-to-Display relationships, physical Controller facts, and the physical Controller's recorded current programmed configuration. LOR/V7 remains authoritative for current show wiring topology and what the show currently requires.
 
@@ -197,7 +198,7 @@ CTRL:<controller_id>
 
 The browser Print Label command sets the governed `ref.controller.print_label` request flag. The physical polling/print service remains a separate subsystem.
 
-Current limitation: the external LabelPrintService does not yet have accepted Controller template/profile/routing support. Physical Controller label printing is therefore not considered complete simply because the browser request flag exists.
+Current limitation: the external LabelPrintService does not yet poll `ref.controller.print_label` in production. The 24 mm template/profile and deployed scan route are accepted, but the Controller execution-batch schema and V4 consumer remain deployment candidates. Physical Controller label printing is therefore not complete simply because the browser request flag exists.
 
 The accidental pending CTRL 1001 request must be cleared under a bounded production mutation procedure before Controller physical print routing becomes active.
 


### PR DESCRIPTION
## Purpose

Add the Production Database execution-batch contract required for LabelPrintService to consume `ref.controller.print_label` safely.

## Changes

- add migration `Controllers/Database/025_create_controller_label_print_batches.sql`;
- assign existing/new Controllers to the accepted `QR_24MM_HORIZONTAL` family;
- add `ops.controller_label_batch` and `ops.controller_label_batch_item`;
- constrain frozen `CTRL:<id>` text and full `/scan/CTRL/<id>` URLs;
- grant bounded `printservice` access;
- document the Controller Inventory / LabelPrintService ownership and activation boundary.

## Current production boundary

The Controller request command and CTRL scan route are already deployed. Production LabelPrintService V4 still does not poll or print Controller requests.

Merging this PR does not apply migration 025 to PostgreSQL, enable Controller polling, clear Controller 1001, or print a label.

## Activation gate

After merge, use the Production Database deployment runbook to back up, apply, and validate migration 025. Controller polling must remain disabled until table/permission checks pass and the pending Controller 1001 request is deliberately resolved or selected for the controlled physical test.

## Validation

- rebased onto current Production Database `main` at `ae32451`;
- one documentation conflict resolved in favor of the newer PR #117 scan-acceptance wording;
- branch contains four scoped files;
- `git diff --check origin/main...HEAD` passed.

Downstream: Gregovate/MSB_LabelPrintService#18 and draft PR #22.