### PR TITLE
Fix Scan input focus for Zebra HID

### DIFF
--- a/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/Asset_Identity_and_Scan_Payload_Standard.md
+++ b/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/Asset_Identity_and_Scan_Payload_Standard.md
@@ -101,7 +101,7 @@ The Zebra ADF emits the compact value `CTRL:<controller_id>` instead of typing t
 https://my.sheboyganlights.org/fieldwiring/controllers?controller_id=<controller_id>
 ```
 
-The URL is a replaceable Scan wrapper, not a second identity. Controller Inventory owns Controller details/actions; Scan does not duplicate that application. The route is deployed, and manual compact/full-URL production entry passed on 2026-09-03. Real printed-label, Zebra, camera, and useful-distance acceptance remain required before Controller labels are printed in volume.
+The URL is a replaceable Scan wrapper, not a second identity. Controller Inventory owns Controller details/actions; Scan does not duplicate that application. The route is deployed, manual compact/full-URL entry passed, and a printed Controller `1031` label passed phone-camera and Zebra DS3678-ER routing on 2026-09-03. The tablet required the entry field to be selected before Zebra input; Scan input-focus repair and documented useful-distance/OS-specific device acceptance remain required.
 
 ## Storage Location Versus Park GIS Location
 
@@ -146,7 +146,7 @@ For Displays, that design is a verified deployed capability. The current product
 
 `/scan/DISP/:key` resolves permanent `ref.display.display_id` and then presents task destinations. New Display field applications such as FieldWiring must extend that existing resolved-identity hub rather than creating another Display QR payload or lookup engine.
 
-The Container route is also deployed and opens the authoritative Directus Container record, where assigned Displays are available. The `CTRL` route is deployed and hands the permanent Controller identity to the existing Controller Inventory Search/detail result. Manual compact/full-URL input is accepted; physical Controller-label/device acceptance remains pending. `LOC` and broader Setup movement behavior remain future work; do not infer that they exist merely because Display, Container, and Controller routing work.
+The Container route is also deployed and opens the authoritative Directus Container record, where assigned Displays are available. The `CTRL` route is deployed and hands the permanent Controller identity to the existing Controller Inventory Search/detail result. Manual compact/full-URL input and a physical Controller label through phone-camera and Zebra paths are accepted; the tablet initial-focus defect remains open. `LOC` and broader Setup movement behavior remain future work; do not infer that they exist merely because Display, Container, and Controller routing work.
 
 See [Deployed Display Scan Runtime Boundary](Deployed_Display_Scan_Runtime_Boundary.md) for the verified Display implementation boundary.
 

--- a/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/Controller_Scan_Production_Deployment_Acceptance_2026-09-03.md
+++ b/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/Controller_Scan_Production_Deployment_Acceptance_2026-09-03.md
@@ -2,7 +2,7 @@
 
 | Document control | Value |
 |---|---|
-| Status | PRODUCTION DEPLOYED — manual input accepted; physical-label/device acceptance pending |
+| Status | PRODUCTION DEPLOYED — manual and physical Controller scan paths accepted; tablet HID focus repair pending |
 | Issue | #113 |
 | Merged PR | #116 |
 | Production host | `msb-prod-db` / `192.168.5.9` |
@@ -84,29 +84,44 @@ Accepted:
 | Manual compact canonical value | PASS |
 | Exact Controller Inventory Search/detail result | PASS |
 
-## Explicitly pending physical acceptance
+## Physical Controller-label acceptance
 
-No physical Controller label could be printed during this acceptance because Controller polling/printing was not yet available in the separate LabelPrintService workstream.
+A production label for Controller `1031` was printed and tested on 2026-09-03.
 
-Do not report the following as passed yet:
+| Input path | Result |
+|---|---|
+| Phone camera decoded `https://db.sheboyganlights.org/scan/CTRL/1031` | PASS |
+| Full QR URL opened Controller 1031 | PASS |
+| Zebra DS3678-ER decoded the same label as `CTRL:1031` | PASS |
+| Zebra ADF Enter submitted the compact identifier | PASS |
+| Controller Inventory opened Controller 1031 | PASS |
 
-- physical Controller label output;
-- Zebra scan of the printed Controller label through the production Scan application;
-- Android or iPhone camera decode of the printed Controller label;
-- automatic Enter/submission from the final Zebra Controller ADF rule; or
-- useful physical scan distance for the final label design.
+The exact phone operating system and practical scan distance were not recorded in this pass. Do not convert this result into separate Android and iPhone acceptance claims until those devices are identified or independently tested.
 
-The Zebra ADF had independently produced the expected compact value in Google Docs earlier on 2026-09-03. That is valid input-format evidence, but it is not a substitute for the pending printed-label end-to-end test.
+## Tablet HID focus defect
+
+The tablet Scan page did not place the cursor in **Scan code or paste URL** when the page opened. The operator had to tap the field before using the Zebra. After the field was selected, the Zebra compact identifier and Enter submission worked correctly.
+
+This is a Scan landing-page input-focus defect. It is not a Controller label, QR payload, route, Controller Inventory, or Zebra ADF defect.
+
+The focused repair under #113 must:
+
+- actively focus the entry field when Scan opens or becomes active;
+- retain the first HID character even if the mobile browser ignores initial autofocus;
+- restore focus after a cancelled or failed camera attempt;
+- avoid hijacking deliberate input in another editable control; and
+- be physically retested on the production tablet without first tapping the field.
 
 ## Resume point
 
-After LabelPrintService produces the first Controller label:
+After the input-focus repair is deployed:
 
-1. confirm its QR contains `https://db.sheboyganlights.org/scan/CTRL/<controller_id>`;
-2. scan the physical label with Zebra and verify the Scan application receives `CTRL:<controller_id>` and submits it;
-3. scan the same physical label with the relevant phone/tablet cameras;
-4. verify every path opens the exact Controller Inventory result; and
-5. record practical scan distance and complete the physical-label gate before volume printing.
+1. open Scan from the normal protected launcher without tapping the entry field;
+2. scan the physical Controller label with the Zebra and verify the first character, complete `CTRL:<controller_id>` value, and Enter submission are all retained;
+3. verify the exact Controller Inventory result opens;
+4. return to Scan and repeat the test to cover browser page restoration;
+5. confirm the focus behavior does not force an unwanted on-screen keyboard or interfere with camera/manual input; and
+6. record the tested phone/tablet operating systems and practical scan distance.
 
 `LOC` route/resolution and Setup movement semantics remain separate work under #88.
 

--- a/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/Deployed_Display_Scan_Runtime_Boundary.md
+++ b/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/Deployed_Display_Scan_Runtime_Boundary.md
@@ -2,8 +2,8 @@
 
 | Document control | Value |
 |---|---|
-| Status | CURRENT PRODUCTION DEPENDENCY — CTRL route deployed; physical-label acceptance pending |
-| Current revision | 2026-09-03 |
+| Status | CURRENT PRODUCTION DEPENDENCY — CTRL physical scan accepted; tablet HID focus repair pending |
+| Current revision | 2026-09-04 |
 | Owner | MSB Database Administrator |
 | Production host | `msb-prod-db` |
 | Production runtime path | `/opt/directus/extensions/directus-extension-scan/` |
@@ -52,6 +52,7 @@ Scan/directus-extension-scan/
     src/index.js
     dist/index.js
     test/controller-route.test.mjs
+    test/scan-input-focus.test.mjs
 ```
 
 The live deployment does not need to contain the development `src/` tree. Application source belongs in the Production Database repository; live deployment/recovery belongs in Server Management.
@@ -206,7 +207,7 @@ https://my.sheboyganlights.org/fieldwiring/controllers?controller_id=<controller
 
 The deployed Scan route adds `/scan/CTRL/:key`, validates that the key is a positive integer permanent Controller ID, and redirects to that existing Controller Inventory entry point. The Controller browser initializes its Search control from `controller_id`, filters the list, and opens the exact detail panel.
 
-The route does not query Controller tables or duplicate Controller details/actions inside Scan. Production manual entry of both the full Scan URL and compact canonical value passed on 2026-09-03. Physical printed-label, Zebra end-to-end, phone/tablet camera, and useful-distance acceptance remain pending until LabelPrintService can produce the first Controller label.
+The route does not query Controller tables or duplicate Controller details/actions inside Scan. Production manual entry of both the full Scan URL and compact canonical value passed on 2026-09-03. A printed Controller `1031` label then passed phone-camera full-URL routing and Zebra DS3678-ER compact-value/Enter routing. The tablet required the operator to tap the entry field first, exposing a Scan input-focus defect. The exact phone OS and useful scan distance were not recorded.
 
 ## Future Setup/Deployment Scan Platform Boundary
 
@@ -265,7 +266,8 @@ As of 2026-09-03:
 - Controller Inventory V0.4.0 is merged and production-operational;
 - the deployed CTRL route hands permanent `controller_id` to the existing Controller Inventory Search/detail experience;
 - manual full-URL and compact CTRL inputs are production-accepted;
-- physical Controller-label, Zebra end-to-end, camera, and distance acceptance remain pending;
+- physical Controller-label, phone-camera, and Zebra end-to-end routing are accepted for Controller 1031;
+- tablet initial HID focus, OS-specific camera classification, and useful-distance recording remain pending;
 - the broader Container/Location Setup/Deployment workflow remains separate engineering scope; and
 - no schema or physical QR change is part of this bounded integration.
 

--- a/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/README.md
+++ b/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/README.md
@@ -27,7 +27,7 @@ Read [Labeling and Scanning — Subsystem and Repository Boundary](Subsystem_and
 
 ## Current State
 
-Display and Container label-printing infrastructure exists, but the current operator request surfaces are not equivalent: there is no usable interface to select Displays and request their labels. Controller Inventory has a Print Label request button, while the separate LabelPrintService does not yet consume Controller requests. Those request/polling gaps are separate from Scan identity routing.
+Display and Container label-printing infrastructure exists, but the current operator request surfaces are not equivalent: there is no usable interface to select Displays and request their labels. Controller Inventory and the separate LabelPrintService now produce permanent Controller labels. Remaining print-service issues stay separate from Scan identity routing.
 
 **Display QR lookup is also an implemented production capability.** The current Display scan route is deployed as a Directus endpoint extension on `msb-prod-db` under `/opt/directus/extensions/directus-extension-scan/`. It resolves the permanent Production Database `display_id` and presents the existing Display scan hub.
 
@@ -70,7 +70,7 @@ No physical QR redesign, second resolver, Procedure schema, alternate Google hie
     -> /fieldwiring/controllers?controller_id=<controller_id>
 ```
 
-The Controller page uses that parameter to populate/filter Search and open the exact detail panel. Manual production entry of both `CTRL:1014` and the full `https://db.sheboyganlights.org/scan/CTRL/1014` URL passed on 2026-09-03. Physical printed-label, Zebra end-to-end, phone/tablet camera, and useful-distance acceptance remain pending until LabelPrintService can print the first Controller label.
+The Controller page uses that parameter to populate/filter Search and open the exact detail panel. Manual production entry of both `CTRL:1014` and the full `https://db.sheboyganlights.org/scan/CTRL/1014` URL passed on 2026-09-03. A printed Controller `1031` label then passed phone-camera full-URL routing and Zebra DS3678-ER compact `CTRL:1031` plus Enter routing. The tablet exposed a remaining Scan defect: the operator had to tap the entry field before the Zebra input was accepted. The phone operating system and useful scan distance were not recorded in that pass.
 
 The broader Setup/Deployment scan workflow remains separate engineering scope. High-volume Container and Storage Location scanning is expected during setup season, but the real pull/stage/load/delivery process must be reconstructed before broader scan-platform refactoring or transaction semantics are approved.
 
@@ -240,7 +240,7 @@ The former loose `H_Asset_ID_Labeling_and_Scanning_Plan.md` has been reconciled 
 
 ## Resume Development
 
-### Controller Scan Integration — production deployed; physical-label acceptance pending
+### Controller Scan Integration — physical routing accepted; tablet focus repair pending
 
 Current production Controller Inventory owns Controller search, detail, assignments, planning, maintenance, and label-request actions. The deployed Scan handoff adds no competing Controller screen or database query.
 
@@ -256,7 +256,7 @@ Zebra/manual: CTRL:<controller_id>
 
 The Git-controlled `src/index.js` and deployed `dist/index.js` remain identical. The Controller browser initializes its existing Search control from the same `controller_id` parameter already used by FieldWiring cross-links and exact-detail loading.
 
-Production deployment passed at shared checkout `72f5b7164f31753a33e5c2a9d83d9a7a6909a417` with live Scan SHA-256 `3457efa15f461b774ef20462f57807d36cb848cac67bdcffcc2a8284c2dc2f96`. Manual compact and full-URL inputs passed. Complete physical Controller-label, Zebra, camera, and useful-distance acceptance after the separate LabelPrintService can print the first Controller label; do not infer those results from manual entry.
+Production deployment passed at shared checkout `72f5b7164f31753a33e5c2a9d83d9a7a6909a417` with live Scan SHA-256 `3457efa15f461b774ef20462f57807d36cb848cac67bdcffcc2a8284c2dc2f96`. Manual compact/full-URL inputs and a printed Controller `1031` label through phone-camera and Zebra paths passed. The current tablet still requires the operator to select the entry field before Zebra scanning. Repair and physically accept that initial-focus behavior, then record the tested camera operating systems and useful scan distance.
 
 ### Setup/Deployment operational scanning — separate project
 

--- a/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/Scan_Operator_Documentation_and_Backbone_Handoff.md
+++ b/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/Scan_Operator_Documentation_and_Backbone_Handoff.md
@@ -160,11 +160,11 @@ The current Scan application verifies:
 - **Scan with Camera**;
 - current Display Scan landing behavior;
 - current Container Scan landing behavior; and
-- deployed Controller handoff to exact Controller Inventory Search/detail from compact or full-URL manual input.
+- deployed Controller handoff to exact Controller Inventory Search/detail from manual, phone-camera, and Zebra input.
 
 The approved identity standard includes `DISP`, `CONT`, `LOC`, and `CTRL`, but the operator documentation must distinguish approved identity types from workflows actually deployed and accepted.
 
-Do not document a complete `LOC` workflow until it is implemented and verified. The deployed `CTRL` route may be documented for manual use; physical Controller-label, Zebra end-to-end, and phone/tablet camera instructions remain pending device acceptance.
+Do not document a complete `LOC` workflow until it is implemented and verified. The deployed `CTRL` route and physical Controller `1031` phone-camera/Zebra result may be documented. Keep the tablet initial-focus defect visible until the repair is deployed and physically accepted, and do not claim separate Android/iPhone acceptance until the tested operating systems are recorded.
 
 ## Remaining Acceptance Work
 
@@ -173,10 +173,11 @@ Before the Scan operator set becomes CURRENT:
 1. review the wording with an operator/volunteer audience in mind;
 2. capture current screenshots from the real Scan UI;
 3. physically verify phone/tablet camera permission and successful scanning on the device types volunteers use;
-4. add those screenshots under `Scanning/images/` and verify Markdown rendering;
-5. complete the Backbone single-source publication/rendering decision;
-6. create/link the corresponding Backbone implementation work when the source-side package is ready;
-7. verify volunteer search/navigation on deployed `my.sheboyganlights.org`.
+4. physically verify Zebra scanning works immediately after Scan opens without first tapping the entry field;
+5. add those screenshots under `Scanning/images/` and verify Markdown rendering;
+6. complete the Backbone single-source publication/rendering decision;
+7. create/link the corresponding Backbone implementation work when the source-side package is ready;
+8. verify volunteer search/navigation on deployed `my.sheboyganlights.org`.
 
 ## Related Documents
 

--- a/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/Setup_Season_Scan_Integration_Handoff_2026-09-02.md
+++ b/Docs/02_Production_Database/01_System_Architecture/07_Labeling_and_Scanning/Setup_Season_Scan_Integration_Handoff_2026-09-02.md
@@ -6,7 +6,7 @@
 | System | Labeling and Scanning / Scan / Setup and Deployment |
 | Status | CURRENT WORKING HANDOFF |
 | Owner | MSB Technical Team |
-| Date | 2026-09-03 |
+| Date | 2026-09-04 |
 
 ## Purpose
 
@@ -55,7 +55,7 @@ LOC:<location_code>
 CTRL:<controller_id>
 ```
 
-The Zebra ADF correction was physically checked on 2026-09-03: the scanner types the expected compact canonical value into Google Docs. That proves the HID/ADF input format, not end-to-end Scan application behavior for every identity type.
+The Zebra ADF correction was first checked in Google Docs, then a printed Controller `1031` label passed the production end-to-end route on 2026-09-03. The Zebra emitted `CTRL:1031`, submitted Enter, and opened Controller 1031 after the operator manually selected the Scan entry field.
 
 This is an input-method normalization convenience. The Scan application must not require Zebra-specific behavior. Manual entry, camera decode, Zebra HID input, and supported legacy/full URLs must converge on the same identity resolution where compatibility is required.
 
@@ -68,7 +68,9 @@ As of the 2026-09-03 reconnaissance:
 - `CONT` is accepted for its current purpose: it opens the Directus Container record, where the original design exposes assigned Displays;
 - `LOC` does not yet have complete route/resolution behavior; focused implementation is #88;
 - production Controller Inventory is deployed at `/fieldwiring/controllers` and accepts `?controller_id=<id>` for exact detail selection;
-- the deployed `CTRL` Scan route sends permanent Controller identity to the existing Controller Inventory instead of building a duplicate result page; manual compact/full-URL production entry passed, while physical label/device acceptance remains pending;
+- the deployed `CTRL` Scan route sends permanent Controller identity to the existing Controller Inventory instead of building a duplicate result page;
+- a printed Controller `1031` label passed phone-camera and Zebra DS3678-ER end-to-end routing;
+- the tablet does not reliably focus the Scan entry field when the app opens, so the Zebra currently requires an unnecessary operator tap before scanning; this is an input-focus defect under #113;
 - iPhone behavior is not accepted merely because a camera preview opens; actual barcode/QR decode and correct routing must be physically verified;
 - camera-permission failure/recovery remains #112;
 - operator documentation in #67 must follow corrected deployed behavior rather than freezing current defects into SOPs.
@@ -82,7 +84,7 @@ As of the 2026-09-03 reconnaissance:
 | `DISP` | Source-supported | Input-only verified in current test pass | Physical decode/routing acceptance not recorded in this pass | Camera may open; real-label decode/routing not accepted | Yes — production | Existing Display hub: Directus record, Testing, Container, Work Orders, Field Wiring, and Procedures |
 | `CONT` | Source-supported | End-to-end Container scan reported working; compact ADF output independently verified | Physical decode/routing acceptance not recorded in this pass | Camera may open; real-label decode/routing not accepted | Yes — production | Opens the Directus Container record and its Display assignments; preserve this accepted behavior |
 | `LOC` | Landing-page normalization exists, but destination fails because no route exists | Compact ADF output verified only | Not accepted | Not accepted | No | #88 must supply Location resolution and the minimum Setup-owned operator workflow |
-| `CTRL` | PASS — compact and full URL entered manually in production | Input-only ADF proof in Google Docs; printed-label end-to-end test pending | Printed-label decode/routing pending | Printed-label decode/routing pending | Yes — production | Redirects to Controller Inventory with `controller_id=<id>`, filters Search, and opens exact detail |
+| `CTRL` | PASS — compact and full URL entered manually in production | PASS with printed `CTRL:1031`; current tablet requires the entry field to be tapped first | Not classified — a phone-camera decode passed, but its OS was not recorded | Not classified — a phone-camera decode passed, but its OS was not recorded | Yes — production | Redirects to Controller Inventory with `controller_id=<id>`, filters Search, and opens exact detail |
 
 The Controller capture contract is:
 
@@ -102,15 +104,15 @@ Controller Inventory remains the owner of Controller details and actions. Scan o
 
 ## Label-Request Interface Findings
 
-- Controller Inventory has a **Print Label** request button, but external print-service polling does not yet consume that request; that is separate LabelPrintService work.
+- Controller Inventory and the external LabelPrintService now produce Controller labels; remaining print-service issues stay in that separate workstream.
 - No usable operator interface currently exists to select Displays and request their labels. That is a database/label-request UI gap, not part of the bounded `CTRL` Scan route.
 - Do not volume-print Controller labels until the Scan route, operator destination, Zebra/camera behavior, and real-world scan distance pass the physical-label gate below.
 
 ## Smallest Ordered Repair Plan
 
-1. After LabelPrintService can print the first Controller label, complete physical Zebra and phone/tablet acceptance against the deployed route and Controller Inventory result.
+1. Repair Scan landing-page focus under #113 so Zebra HID works immediately without selecting the field, then physically retest initial load and return-to-Scan behavior.
 2. Complete `LOC` resolution and the minimum Setup-owned operator action under #88; do not infer movement from scan order.
-3. Complete real-label Android/iPhone decode and camera permission/recovery acceptance under #112.
+3. Complete OS-specific Android/iPhone decode and camera permission/recovery acceptance under #112.
 4. Finish operator SOP review under #67 against the deployed routes and accepted device behavior.
 5. Add broader Setup movement/staging/load semantics only where the reconstructed operational process proves they are needed.
 
@@ -153,7 +155,7 @@ A new Scan engineering thread should begin by:
 3. inventorying current `Scan/directus-extension-scan/` source and current deployed Scan baseline/runbook;
 4. using the current route matrix above instead of reconstructing `DISP`, `CONT`, `LOC`, and `CTRL` state from chat;
 5. preserving the now-deployed MSB Internal **Open Scan** entry point;
-6. verifying capture methods independently: manual, Zebra HID, Android camera, iPhone camera;
+6. verifying capture methods independently: manual, Zebra HID, Android camera, iPhone camera, including reliable initial input focus for HID;
 7. implementing/accepting focused route gaps without redesigning LabelPrintService;
 8. continuing #88 for Setup-critical Location and movement semantics;
 9. updating #67 operator docs only after actual device/route acceptance.

--- a/Docs/02_Production_Database/02_Operational_SOPs/Scanning/QR_Code_Types_and_Meanings.md
+++ b/Docs/02_Production_Database/02_Operational_SOPs/Scanning/QR_Code_Types_and_Meanings.md
@@ -8,7 +8,7 @@
 | Audience | MSB volunteers and operators |
 | Status | DRAFT — operator review required |
 | Owner | MSB Database Administrator |
-| Last Reviewed | 2026-09-03 |
+| Last Reviewed | 2026-09-04 |
 | Keywords | QR code, scan code, DISP, CONT, LOC, CTRL, display, container, location, controller |
 
 ## Purpose
@@ -30,7 +30,7 @@ You usually do not need to memorize the prefixes. They simply tell you what kind
 | `DISP` | Display | `DISP:251` | Current Display Scan hub is deployed and verified |
 | `CONT` | Container | `CONT:587` | Current Container Scan landing page exists and opens the Container record |
 | `LOC` | Storage Location | `LOC:RA-01-A-03` | Approved identity type; broader operator Scan workflow is not yet documented as fully deployed |
-| `CTRL` | Controller | `CTRL:1014` | Production route opens the exact Controller Inventory record; physical-label testing remains pending |
+| `CTRL` | Controller | `CTRL:1014` | Printed Controller label opens the exact Controller Inventory record by phone camera or Zebra |
 
 ## What The Code Does
 
@@ -89,7 +89,7 @@ CTRL:
 
 The permanent numeric value after `CTRL:` is the Controller ID. Entering a compact value such as `CTRL:1014`, or opening its full Scan URL, routes to Controller Inventory with that Controller selected.
 
-The route and manual-entry behavior are deployed. Physical Controller-label scanning will be accepted after the printing service can produce the first label.
+The route, manual-entry behavior, phone-camera QR path, and Zebra compact-value path are deployed and physically verified. On the tested tablet, select the Scan entry field before using the Zebra until the known initial-focus defect is repaired.
 
 ## Expected Result
 

--- a/Docs/02_Production_Database/02_Operational_SOPs/Scanning/README.md
+++ b/Docs/02_Production_Database/02_Operational_SOPs/Scanning/README.md
@@ -8,7 +8,7 @@
 | Audience | MSB volunteers, operators, and managers |
 | Status | DRAFT — operator review and screenshots required |
 | Owner | MSB Database Administrator |
-| Last Reviewed | 2026-09-03 |
+| Last Reviewed | 2026-09-04 |
 | Keywords | scan, scanning, QR code, display, container, phone, tablet, camera, manual entry, field wiring, procedures |
 
 ## What Is MSB Scan?
@@ -55,7 +55,7 @@ Display scanning is the most complete current Scan workflow.
 
 Container scanning also has a current Scan landing page that opens the Container record.
 
-Controller scanning now opens the exact Controller Inventory record. Manual entry of both `CTRL:<controller_id>` and the full Controller Scan URL is deployed and verified. Physical Controller-label scanning remains pending until the printing service can produce the first label.
+Controller scanning opens the exact Controller Inventory record. Manual entry, a phone-camera scan of the full Controller URL, and a Zebra scan producing `CTRL:<controller_id>` plus Enter are verified. The current production tablet requires the Scan entry field to be selected before Zebra scanning; this is a known defect under #113, not the intended final workflow.
 
 `LOC` remains an approved identity type without a completed production route or Setup movement workflow. The QR Code reference explains that distinction.
 

--- a/Docs/02_Production_Database/02_Operational_SOPs/Scanning/Use_Scan_Manually.md
+++ b/Docs/02_Production_Database/02_Operational_SOPs/Scanning/Use_Scan_Manually.md
@@ -8,7 +8,7 @@
 | Audience | MSB volunteers and operators |
 | Status | DRAFT — operator review and screenshots required |
 | Owner | MSB Database Administrator |
-| Last Reviewed | 2026-09-03 |
+| Last Reviewed | 2026-09-04 |
 | Keywords | manual scan, enter code, paste URL, DISP, CONT, CTRL, scan without camera |
 
 ## Purpose
@@ -37,6 +37,8 @@ You should see:
 ### 1. Click or tap the entry box
 
 Select **Scan code or paste URL**.
+
+The current production tablet also requires this selection before a Zebra scan. That extra tap is a known Scan defect under repair, not the intended final scanner workflow.
 
 ### 2. Enter the code
 

--- a/Docs/02_Production_Database/02_Operational_SOPs/Scanning/What_To_Do_After_You_Scan.md
+++ b/Docs/02_Production_Database/02_Operational_SOPs/Scanning/What_To_Do_After_You_Scan.md
@@ -8,7 +8,7 @@
 | Audience | MSB volunteers and operators |
 | Status | DRAFT — operator review and screenshots required |
 | Owner | MSB Database Administrator |
-| Last Reviewed | 2026-09-03 |
+| Last Reviewed | 2026-09-04 |
 | Keywords | after scan, display record, testing, field wiring, procedures, container, controller, work orders |
 
 ## Purpose
@@ -86,7 +86,7 @@ The Controller route opens Controller Inventory with the exact Controller ID in 
 
 Use the existing Controller Inventory information and actions there. Scan does not provide a second Controller-detail screen.
 
-Physical Controller-label scanning remains pending until the printing service can produce the first label. Manual compact and full-URL Controller entry are deployed.
+Physical Controller-label scanning is verified with a phone camera and Zebra. On the tested tablet, select the Scan entry field before using the Zebra until the known initial-focus defect is repaired.
 
 ## Location Codes
 

--- a/Scan/directus-extension-scan/dist/index.js
+++ b/Scan/directus-extension-scan/dist/index.js
@@ -206,9 +206,32 @@ export default {
 
         let html5QrCode = null;
         let scannerRunning = false;
+        let cameraStarting = false;
 
         function setStatus(message) {
           scanStatus.textContent = message || '';
+        }
+
+        // Mobile browsers do not consistently honor HTML autofocus. Retry the
+        // focus after page activation so a Zebra HID scan can start without an
+        // operator first tapping the field.
+        function focusScanInput() {
+          if (scannerRunning || cameraStarting) return;
+
+          try {
+            input.focus({ preventScroll: true });
+          } catch (err) {
+            input.focus();
+          }
+        }
+
+        function scheduleScanInputFocus() {
+          window.setTimeout(focusScanInput, 0);
+          window.setTimeout(focusScanInput, 250);
+        }
+
+        function isUnfocusedPageSurface(target) {
+          return !target || target === document.body || target === document.documentElement;
         }
 
         // Show any top-level JS errors on screen.
@@ -282,11 +305,13 @@ export default {
 
           if (typeof Html5Qrcode === 'undefined') {
           //  setStatus('Scanner library failed to load.');
+            scheduleScanInputFocus();
             return;
           }
 
           if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
             setStatus('Browser does not support camera access.');
+            scheduleScanInputFocus();
             return;
           }
 
@@ -297,10 +322,10 @@ export default {
 
           reader.style.display = 'block';
           stopBtn.style.display = 'block';
-
-          html5QrCode = new Html5Qrcode('reader');
+          cameraStarting = true;
 
           try {
+            html5QrCode = new Html5Qrcode('reader');
             await html5QrCode.start(
               { facingMode: 'environment' },
               { fps: 10 },
@@ -316,12 +341,15 @@ export default {
             );
 
             scannerRunning = true;
+            cameraStarting = false;
             setStatus('Camera ready');
           } catch (err) {
+            cameraStarting = false;
             console.error('Camera start failed:', err);
             setStatus('Camera start failed: ' + (err && err.message ? err.message : err));
             reader.style.display = 'none';
             stopBtn.style.display = 'none';
+            scheduleScanInputFocus();
           }
         }
 
@@ -333,14 +361,55 @@ export default {
           startCameraScan();
         });
 
-        stopBtn.addEventListener('click', function () {
+        stopBtn.addEventListener('click', async function () {
           // setStatus('Stop button event fired');
-          stopCameraScan();
+          await stopCameraScan();
+          scheduleScanInputFocus();
         });
 
-        // setStatus('Button binding complete');
+        // Restore focus when the browser returns to this page or the page
+        // becomes active again. The delayed retry handles mobile page restore.
+        window.addEventListener('pageshow', scheduleScanInputFocus);
+        window.addEventListener('focus', scheduleScanInputFocus);
+        document.addEventListener('visibilitychange', function () {
+          if (document.visibilityState === 'visible') {
+            scheduleScanInputFocus();
+          }
+        });
 
-        input.focus();
+        // If a mobile browser still refuses initial focus, capture the first
+        // HID character from the otherwise-unfocused page. Once the input has
+        // focus, normal input/form behavior handles the rest of the scan.
+        document.addEventListener('keydown', function (event) {
+          if (
+            scannerRunning ||
+            event.defaultPrevented ||
+            event.isComposing ||
+            event.ctrlKey ||
+            event.metaKey ||
+            event.altKey ||
+            !isUnfocusedPageSurface(event.target)
+          ) {
+            return;
+          }
+
+          if (event.key === 'Enter') {
+            if (input.value.trim()) {
+              event.preventDefault();
+              handleScanValue(input.value);
+            }
+            return;
+          }
+
+          if (event.key && event.key.length === 1) {
+            event.preventDefault();
+            input.value += event.key;
+            focusScanInput();
+          }
+        }, true);
+
+        // setStatus('Button binding complete');
+        scheduleScanInputFocus();
       </script>
         </body>
         </html>

--- a/Scan/directus-extension-scan/src/index.js
+++ b/Scan/directus-extension-scan/src/index.js
@@ -206,9 +206,32 @@ export default {
 
         let html5QrCode = null;
         let scannerRunning = false;
+        let cameraStarting = false;
 
         function setStatus(message) {
           scanStatus.textContent = message || '';
+        }
+
+        // Mobile browsers do not consistently honor HTML autofocus. Retry the
+        // focus after page activation so a Zebra HID scan can start without an
+        // operator first tapping the field.
+        function focusScanInput() {
+          if (scannerRunning || cameraStarting) return;
+
+          try {
+            input.focus({ preventScroll: true });
+          } catch (err) {
+            input.focus();
+          }
+        }
+
+        function scheduleScanInputFocus() {
+          window.setTimeout(focusScanInput, 0);
+          window.setTimeout(focusScanInput, 250);
+        }
+
+        function isUnfocusedPageSurface(target) {
+          return !target || target === document.body || target === document.documentElement;
         }
 
         // Show any top-level JS errors on screen.
@@ -282,11 +305,13 @@ export default {
 
           if (typeof Html5Qrcode === 'undefined') {
           //  setStatus('Scanner library failed to load.');
+            scheduleScanInputFocus();
             return;
           }
 
           if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
             setStatus('Browser does not support camera access.');
+            scheduleScanInputFocus();
             return;
           }
 
@@ -297,10 +322,10 @@ export default {
 
           reader.style.display = 'block';
           stopBtn.style.display = 'block';
-
-          html5QrCode = new Html5Qrcode('reader');
+          cameraStarting = true;
 
           try {
+            html5QrCode = new Html5Qrcode('reader');
             await html5QrCode.start(
               { facingMode: 'environment' },
               { fps: 10 },
@@ -316,12 +341,15 @@ export default {
             );
 
             scannerRunning = true;
+            cameraStarting = false;
             setStatus('Camera ready');
           } catch (err) {
+            cameraStarting = false;
             console.error('Camera start failed:', err);
             setStatus('Camera start failed: ' + (err && err.message ? err.message : err));
             reader.style.display = 'none';
             stopBtn.style.display = 'none';
+            scheduleScanInputFocus();
           }
         }
 
@@ -333,14 +361,55 @@ export default {
           startCameraScan();
         });
 
-        stopBtn.addEventListener('click', function () {
+        stopBtn.addEventListener('click', async function () {
           // setStatus('Stop button event fired');
-          stopCameraScan();
+          await stopCameraScan();
+          scheduleScanInputFocus();
         });
 
-        // setStatus('Button binding complete');
+        // Restore focus when the browser returns to this page or the page
+        // becomes active again. The delayed retry handles mobile page restore.
+        window.addEventListener('pageshow', scheduleScanInputFocus);
+        window.addEventListener('focus', scheduleScanInputFocus);
+        document.addEventListener('visibilitychange', function () {
+          if (document.visibilityState === 'visible') {
+            scheduleScanInputFocus();
+          }
+        });
 
-        input.focus();
+        // If a mobile browser still refuses initial focus, capture the first
+        // HID character from the otherwise-unfocused page. Once the input has
+        // focus, normal input/form behavior handles the rest of the scan.
+        document.addEventListener('keydown', function (event) {
+          if (
+            scannerRunning ||
+            event.defaultPrevented ||
+            event.isComposing ||
+            event.ctrlKey ||
+            event.metaKey ||
+            event.altKey ||
+            !isUnfocusedPageSurface(event.target)
+          ) {
+            return;
+          }
+
+          if (event.key === 'Enter') {
+            if (input.value.trim()) {
+              event.preventDefault();
+              handleScanValue(input.value);
+            }
+            return;
+          }
+
+          if (event.key && event.key.length === 1) {
+            event.preventDefault();
+            input.value += event.key;
+            focusScanInput();
+          }
+        }, true);
+
+        // setStatus('Button binding complete');
+        scheduleScanInputFocus();
       </script>
         </body>
         </html>

--- a/Scan/directus-extension-scan/test/scan-input-focus.test.mjs
+++ b/Scan/directus-extension-scan/test/scan-input-focus.test.mjs
@@ -1,0 +1,174 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import vm from 'node:vm';
+
+import scanExtension from '../src/index.js';
+
+class FakeEventTarget {
+  constructor() {
+    this.listeners = new Map();
+    this.style = {};
+    this.textContent = '';
+    this.value = '';
+  }
+
+  addEventListener(type, handler) {
+    const handlers = this.listeners.get(type) || [];
+    handlers.push(handler);
+    this.listeners.set(type, handlers);
+  }
+
+  async dispatch(type, event = {}) {
+    for (const handler of this.listeners.get(type) || []) {
+      await handler(event);
+    }
+  }
+}
+
+async function renderScanHub() {
+  const routes = new Map();
+  const router = {
+    get(path, handler) {
+      routes.set(path, handler);
+    },
+  };
+  const response = {
+    body: null,
+    setHeader() {},
+    send(body) {
+      this.body = body;
+    },
+  };
+
+  scanExtension.handler(router, { database: () => undefined });
+  await routes.get('/')({}, response);
+  return response.body;
+}
+
+function executeScanClient(html) {
+  const match = html.match(/<script>([\s\S]*?)<\/script>/);
+  assert.ok(match, 'Scan hub inline script should be present');
+
+  const document = new FakeEventTarget();
+  document.body = { tagName: 'BODY' };
+  document.documentElement = { tagName: 'HTML' };
+  document.activeElement = document.body;
+  document.visibilityState = 'visible';
+
+  const elements = new Map([
+    ['scanForm', new FakeEventTarget()],
+    ['scanInput', new FakeEventTarget()],
+    ['scanBtn', new FakeEventTarget()],
+    ['stopBtn', new FakeEventTarget()],
+    ['reader', new FakeEventTarget()],
+    ['scanStatus', new FakeEventTarget()],
+  ]);
+  document.getElementById = (id) => elements.get(id);
+
+  const input = elements.get('scanInput');
+  input.focusCalls = 0;
+  input.focus = () => {
+    input.focusCalls += 1;
+    document.activeElement = input;
+  };
+
+  const window = new FakeEventTarget();
+  window.location = { href: '' };
+  window.setTimeout = (handler) => {
+    handler();
+    return 1;
+  };
+
+  vm.runInNewContext(match[1], {
+    URL,
+    alert() {},
+    console,
+    document,
+    navigator: {},
+    window,
+  });
+
+  return { document, elements, input, window };
+}
+
+test('Scan hub actively focuses the HID entry field at startup', async () => {
+  const html = await renderScanHub();
+  const { document, input } = executeScanClient(html);
+
+  assert.match(html, /id="scanInput"[^>]*autofocus/);
+  assert.ok(input.focusCalls >= 2);
+  assert.equal(document.activeElement, input);
+});
+
+test('first Zebra HID character is retained when the page has no focused control', async () => {
+  const html = await renderScanHub();
+  const { document, input } = executeScanClient(html);
+  document.activeElement = document.body;
+
+  let prevented = false;
+  await document.dispatch('keydown', {
+    altKey: false,
+    ctrlKey: false,
+    defaultPrevented: false,
+    isComposing: false,
+    key: 'C',
+    metaKey: false,
+    preventDefault() {
+      prevented = true;
+    },
+    target: document.body,
+  });
+
+  assert.equal(prevented, true);
+  assert.equal(input.value, 'C');
+  assert.equal(document.activeElement, input);
+});
+
+test('unfocused Zebra Enter submits the captured compact identifier', async () => {
+  const html = await renderScanHub();
+  const { document, input, window } = executeScanClient(html);
+  document.activeElement = document.body;
+  input.value = 'CTRL:1031';
+
+  let prevented = false;
+  await document.dispatch('keydown', {
+    altKey: false,
+    ctrlKey: false,
+    defaultPrevented: false,
+    isComposing: false,
+    key: 'Enter',
+    metaKey: false,
+    preventDefault() {
+      prevented = true;
+    },
+    target: document.body,
+  });
+
+  assert.equal(prevented, true);
+  assert.equal(window.location.href, '/scan/CTRL/1031');
+});
+
+test('page-level HID fallback does not hijack another focused control', async () => {
+  const html = await renderScanHub();
+  const { document, elements, input } = executeScanClient(html);
+  const cameraButton = elements.get('scanBtn');
+  document.activeElement = cameraButton;
+
+  let prevented = false;
+  await document.dispatch('keydown', {
+    altKey: false,
+    ctrlKey: false,
+    defaultPrevented: false,
+    isComposing: false,
+    key: 'C',
+    metaKey: false,
+    preventDefault() {
+      prevented = true;
+    },
+    target: cameraButton,
+  });
+
+  assert.equal(prevented, false);
+  assert.equal(input.value, '');
+  assert.equal(document.activeElement, cameraButton);
+});


### PR DESCRIPTION
## Summary

- records the accepted physical Controller 1031 phone-camera and Zebra scan results
- fixes the Scan landing page so the HID entry field is actively focused on initial load and page restoration
- preserves the first Zebra character through a page-level fallback when a mobile browser ignores autofocus
- submits a completed unfocused HID value on Enter
- restores input focus after a stopped or failed camera attempt
- does not hijack input directed at another focused control
- keeps Scan `src/index.js` and deployable `dist/index.js` identical
- updates the controlled Scan engineering handoff and draft operator documentation

## Field finding

The printed Controller label, full QR URL, Zebra ADF transformation to `CTRL:1031`, Enter submission, and exact Controller Inventory result all passed. The remaining defect was that the production tablet required the operator to tap **Scan code or paste URL** before using the Zebra.

The phone operating system and useful scan distance were not recorded, so this PR does not claim separate Android/iPhone or distance acceptance.

## Verification

- `node --test Scan/directus-extension-scan/test/*.test.mjs` — 6 passed
- JavaScript syntax checks passed for `src/index.js` and `dist/index.js`
- `src/index.js` and `dist/index.js` are byte-identical
- candidate `dist/index.js` SHA-256: `c11e39e99b720f90ecd9a226c0358e3dbc1fa9d51e7a0490f9cc0cd4875474a9`
- `git diff --check` passed

## Deployment boundary

This PR does not change production. After merge, deploy through the current Server Management Scan extension runbook and physically verify Zebra input works immediately after opening and returning to Scan without tapping the field first.

Umbrella: #113

`LOC` remains #88, camera permission/recovery remains #112, and final operator documentation remains #67.