### PR TITLE
Prototype 2025 Setup Session verification UI

### DIFF
--- a/Setup/Application/README.md
+++ b/Setup/Application/README.md
@@ -1,0 +1,113 @@
+# Setup Session Application
+
+Status: **PROTOTYPE — 2025 HISTORICAL VERIFICATION UI; NO DATABASE WRITES**
+
+This folder is the first browser-native Setup Session application prototype.
+
+It exists to validate the Setup task model and field workflow with usable screens and provisional data before PostgreSQL DDL is approved.
+
+## Why this prototype exists
+
+The historical reconstruction spreadsheet is evidence, not a reliable review UI. Sorting changed the visible order and several right-side keys were difficult to interpret. The first validation target is therefore the application experience itself:
+
+```text
+reconstruction evidence
+    -> provisional 2025 task data
+        -> usable browser UI
+            -> manager/team verification and correction
+                -> approved reusable task catalog
+                    -> Admin creates 2026 Setup Session
+```
+
+Do not treat the provisional task rows in this prototype as approved production truth.
+
+## Application direction
+
+The Setup application follows the current MSB browser-native pattern used by FieldWiring / Controller Inventory:
+
+- browser-native HTML/CSS/JavaScript UI;
+- future Flask backend;
+- PostgreSQL remains authoritative;
+- Cloudflare Access identifies the signed-in user;
+- Directus remains role/policy authority where reused;
+- Manager/Admin writes must go through a governed server-side write boundary;
+- no broad writable browser PostgreSQL role.
+
+The prototype is intentionally static so task concepts and movement behavior can be validated before schema or write APIs are locked.
+
+## First prototype scope
+
+The prototype includes:
+
+- `2025 — Historical Verification` season context;
+- reusable task review with plain-English predecessor names;
+- explicit separation between reusable definition and 2025 historical actual;
+- verification states: `UNVERIFIED`, `VERIFIED`, `NEEDS CORRECTION`;
+- provisional Magic Igloo phased work;
+- reusable Arch Trailer unload tasks;
+- Container 34 shared-load simulation across Racing Arches, Polar Bear Playground, Icicle Tunnel, Stars, Candyland, and Food Collection;
+- bulk unload behavior where only Displays still traveling with the Container follow later Container movement;
+- local browser persistence for prototype edits only.
+
+## Shared Container acceptance rule
+
+For Container 34 / Arch Trailer:
+
+```text
+scan/move Container to destination
+    -> all Displays still WITH_CONTAINER inherit that Setup location
+
+execute reusable unload task
+    -> expected Display group is unloaded at that location
+    -> those Displays detach from Container movement
+
+move Container again
+    -> only Displays still WITH_CONTAINER follow it
+```
+
+Completing or correcting a Display/task may later reconcile missed movement evidence, but the system must never invent intermediate movement events that were not observed.
+
+## Prototype-only data
+
+The first screen intentionally uses known representative facts and clearly marks task details as provisional. It is not a replacement for the 2025 historical verification process.
+
+Confirmed Container 34 Display grouping used for the movement acceptance case:
+
+- Racing Arches — 48 Displays
+- Icicle Tunnel — 36 Displays
+- Stars — 24 Displays
+- Food Collection — 8 Displays
+- Polar Bear Playground — 3 Displays
+- Candyland — 2 Displays
+
+Total: 121 Displays.
+
+## Running locally
+
+The prototype has no backend dependency. Serve this directory with any static web server, for example:
+
+```powershell
+cd Setup\Application
+python -m http.server 8780
+```
+
+Then open:
+
+```text
+http://localhost:8780/
+```
+
+## Production boundary
+
+This prototype does not:
+
+- create or alter PostgreSQL tables;
+- create a Setup Session in production;
+- write movement history;
+- replace the current Scan application;
+- establish final authorization behavior;
+- approve reconstructed 2025 task order, dependencies, dates, or actuals.
+
+Production schema and write APIs remain gated on validation through this UI and the authoritative Setup/Deployment documentation under:
+
+`Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment`

--- a/Setup/Application/README.md
+++ b/Setup/Application/README.md
@@ -27,13 +27,13 @@ The Setup application follows the current MSB browser-native pattern used by Fie
 
 - browser-native HTML/CSS/JavaScript UI;
 - Flask backend for controlled read/API work;
-- PostgreSQL remains authoritative;
+- PostgreSQL remains authoritative in production;
 - Cloudflare Access identifies the signed-in user when deployed;
 - Directus remains role/policy authority where reused;
 - Manager/Admin writes must go through a governed server-side write boundary;
 - no broad writable browser PostgreSQL role.
 
-The current prototype backend is read-only.
+The current prototype backend does not write PostgreSQL or Google Drive.
 
 ## First prototype scope
 
@@ -49,49 +49,76 @@ The prototype includes:
 - reusable Arch Trailer unload tasks;
 - Container 34 shared-load simulation across Racing Arches, Polar Bear Playground, Icicle Tunnel, Stars, Candyland, and Food Collection;
 - bulk unload behavior where only Displays still traveling with the Container follow later Container movement;
-- Setup Instruction review state on the task detail page;
-- optional live read-only enumeration of current Setup PDFs, SourceDocs, and Archive files through the existing shared Procedure resolver;
+- Setup Procedure review state on the task detail page;
+- Manager-facing discovery of editable Google Doc sources plus the current published Setup PDF;
 - local browser persistence for prototype task/instruction-review edits only.
 
-## Setup Instruction review / publication boundary
+## Manager Setup Procedure workflow
 
-The current Google Drive / Procedure contract is preserved:
-
-```text
-Procedures\Setup\<current instruction>.pdf
-    = current published field instruction
-
-Procedures\Setup\SourceDocs\
-    = editable working/source material
-
-Procedures\Setup\Archive\
-    = historical / superseded source evidence
-```
-
-For 2025 verification, the intended Manager workflow is:
+The Manager screen and production-crew Procedure screen intentionally have different visibility.
 
 ```text
-historical source in Archive
-    -> review alongside reusable Setup task
-        -> create/use editable working copy in SourceDocs
-            -> revise and approve
-                -> publish approved PDF directly in Procedures\Setup
+Production crew
+    -> current published PDF directly in Procedures\Setup
+
+Authorized Manager
+    -> may see/open the applicable .gdoc source in Archive or SourceDocs
+    -> may correct that Google Doc during verification
+    -> must regenerate/export and replace the published PDF after a source change
 ```
 
-The archived original should not be edited in place merely because it contains useful historical content. Preserve it as evidence and revise a working copy.
+`Archive` remains excluded from normal production-crew navigation. That does **not** make an archived `.gdoc` immutable when an authorized Manager deliberately uses that document as the editable source during the 2025 correction pass.
 
-The prototype records Procedure verification/revision notes locally. When run through `backend.py` with the database and Display Folders configured, it also resolves the current Stage/Sub-stage through the same accepted shared field-context / Procedure stack used by the current Procedure application and shows:
+The Manager task detail page therefore presents the Procedure workflow as actions, not as a folder-governance lesson:
 
-- current published Setup PDF filename(s), with a protected read-only open link;
-- direct files currently in `SourceDocs`;
-- direct files currently in `Archive`;
-- resolver warnings where applicable.
+```text
+Editable procedure
+    <source>.gdoc
+    <full source path>
+    [Open Editable Procedure]
+    [Export Updated PDF]
 
-It still does **not** create a SourceDocs working copy or publish a PDF.
+Published field PDF
+    <current>.pdf
+    [Open Current PDF]
 
-Only after this read-side review is accepted should a separate governed authoring/publication command path be designed.
+If the Google Doc is edited, replace the published PDF before marking the instruction verified.
+```
 
-The existing Procedure application and production Display Folders filesystem are read-only. A future Setup Manager authoring/publication path therefore requires its own governed write boundary. It must not broaden the existing read-only Procedure field application or silently make the shared production mount writable.
+The current prototype can open the Google Doc and request Google's PDF export when the mounted `.gdoc` shortcut exposes a resolvable Google document identity. It does not yet automate replacement of the PDF in Google Drive.
+
+## Procedure resolution modes
+
+### Production direction — shared field-context resolver
+
+When a read-only database source is configured, the Setup prototype reuses the accepted shared Field Context / Procedure resolver. This remains the production direction.
+
+### Local validation fallback — exact Stage key only
+
+For local 2025 review, when no database DSN/snapshot is configured but `SETUP_DRIVE_ROOT` is available, the prototype may resolve the Stage folder directly by exact leading Stage key.
+
+Example:
+
+```text
+stage_key = 04
+    -> exactly one direct folder beginning 04-
+    -> G:\Shared drives\Display Folders\04-Food Collection-FC
+```
+
+For Sub-stages, the prototype may inspect one nested folder level when the exact key is not a direct child.
+
+This fallback:
+
+- is prototype-only;
+- requires exactly one matching folder;
+- does not fuzzy-match Stage names;
+- does not replace the universal resolver in production.
+
+For Food Collection, the intended editable source currently being reviewed is:
+
+```text
+G:\Shared drives\Display Folders\04-Food Collection-FC\Procedures\Setup\Archive\04-Food Collection-FC.gdoc
+```
 
 ## Shared Container acceptance rule
 
@@ -128,60 +155,25 @@ Total: 121 Displays.
 
 The broader non-unload task rows are representative provisional review data derived from current Setup planning evidence. Managers/team leaders must verify task boundaries, order, prerequisites, crew, equipment, timing, material, and Procedure applicability in the UI.
 
-## Running locally — static mode
+## Running locally
 
-Static mode validates the task and movement UI but cannot show real Procedure files:
-
-```powershell
-cd Setup\Application
-python -m http.server 8780
-```
-
-Then open:
-
-```text
-http://localhost:8780/
-```
-
-## Running locally — live read-only Procedure review
-
-Run from the repository root or from `Setup\Application` after configuring a read-only database source and the Display Folders root.
-
-The backend accepts Setup-specific environment variables and also reuses the existing Procedure/FieldWiring variable names when already configured:
-
-```text
-SETUP_DATABASE_DSN
-SETUP_DEV_SNAPSHOT
-SETUP_DRIVE_ROOT
-```
-
-Fallbacks accepted:
-
-```text
-PROCEDURE_DATABASE_DSN
-PROCEDURE_DEV_SNAPSHOT
-PROCEDURE_DRIVE_ROOT
-FIELDWIRING_DATABASE_DSN
-FIELDWIRING_DRIVE_ROOT
-```
-
-Example with a Windows Google Drive root:
+Use the project virtual environment, then run the Flask prototype from the repository root:
 
 ```powershell
+.\.venv\Scripts\Activate.ps1
 $env:SETUP_DRIVE_ROOT = 'G:\Shared drives\Display Folders'
-$env:SETUP_DATABASE_DSN = '<existing read-only PostgreSQL DSN>'
 python .\Setup\Application\backend.py
 ```
 
-Then open:
+Open:
 
 ```text
 http://localhost:8780/
 ```
 
-Do not place credentials in the repository.
+A database DSN is **not required** for the local exact-Stage-key prototype fallback. If `SETUP_DATABASE_DSN`, `PROCEDURE_DATABASE_DSN`, `FIELDWIRING_DATABASE_DSN`, or a configured development snapshot is present, the application uses the shared field-context resolver instead.
 
-After pulling a prototype update, use a hard refresh so the browser reloads the versioned CSS/JavaScript.
+After pulling a prototype update, restart Flask when backend code changed and use a hard browser refresh so the versioned CSS/JavaScript reloads.
 
 ## Production boundary
 
@@ -191,9 +183,7 @@ This prototype does not:
 - create a Setup Session in production;
 - write movement history;
 - modify Google Drive;
-- edit an archived Google Doc;
-- create a SourceDocs working copy;
-- convert/publish a new PDF;
+- automatically replace a published PDF;
 - replace the current Scan or Procedure applications;
 - establish final authorization behavior;
 - approve reconstructed 2025 task order, dependencies, dates, or actuals.

--- a/Setup/Application/README.md
+++ b/Setup/Application/README.md
@@ -80,6 +80,17 @@ The archived original should not be edited in place merely because it contains u
 
 The prototype currently records Procedure verification/revision notes only. It does **not** enumerate the live Archive/SourceDocs/current PDF yet and does not publish a PDF.
 
+The next Procedure-integration step should be read-only first:
+
+```text
+selected Setup task
+    -> resolve its Stage/Sub-stage/Scene context through the shared field-context resolver
+    -> show current published Setup PDF(s)
+    -> Manager-only review list of SourceDocs and Archive candidates
+```
+
+Only after that read-side is accepted should a separate governed authoring/publication command path be designed.
+
 The existing Procedure application and production Display Folders filesystem are read-only. A future Setup Manager authoring/publication path therefore requires its own governed write boundary. It must not broaden the existing read-only Procedure field application or silently make the shared production mount writable.
 
 ## Shared Container acceptance rule

--- a/Setup/Application/README.md
+++ b/Setup/Application/README.md
@@ -26,14 +26,14 @@ Do not treat provisional task rows as approved production truth.
 The Setup application follows the current MSB browser-native pattern used by FieldWiring / Controller Inventory:
 
 - browser-native HTML/CSS/JavaScript UI;
-- future Flask backend;
+- Flask backend for controlled read/API work;
 - PostgreSQL remains authoritative;
-- Cloudflare Access identifies the signed-in user;
+- Cloudflare Access identifies the signed-in user when deployed;
 - Directus remains role/policy authority where reused;
 - Manager/Admin writes must go through a governed server-side write boundary;
 - no broad writable browser PostgreSQL role.
 
-The prototype is intentionally static so task concepts and movement behavior can be validated before schema or write APIs are locked.
+The current prototype backend is read-only.
 
 ## First prototype scope
 
@@ -49,7 +49,8 @@ The prototype includes:
 - Container 34 shared-load simulation across Racing Arches, Polar Bear Playground, Icicle Tunnel, Stars, Candyland, and Food Collection;
 - bulk unload behavior where only Displays still traveling with the Container follow later Container movement;
 - Setup Instruction review state on the task detail page;
-- local browser persistence for prototype edits only.
+- optional live read-only enumeration of current Setup PDFs, SourceDocs, and Archive files through the existing shared Procedure resolver;
+- local browser persistence for prototype task/instruction-review edits only.
 
 ## Setup Instruction review / publication boundary
 
@@ -78,18 +79,16 @@ historical source in Archive
 
 The archived original should not be edited in place merely because it contains useful historical content. Preserve it as evidence and revise a working copy.
 
-The prototype currently records Procedure verification/revision notes only. It does **not** enumerate the live Archive/SourceDocs/current PDF yet and does not publish a PDF.
+The prototype records Procedure verification/revision notes locally. When run through `backend.py` with the database and Display Folders configured, it also resolves the current Stage/Sub-stage through the accepted Procedure stack and shows:
 
-The next Procedure-integration step should be read-only first:
+- current published Setup PDF filename(s), with a protected read-only open link;
+- direct files currently in `SourceDocs`;
+- direct files currently in `Archive`;
+- resolver warnings where applicable.
 
-```text
-selected Setup task
-    -> resolve its Stage/Sub-stage/Scene context through the shared field-context resolver
-    -> show current published Setup PDF(s)
-    -> Manager-only review list of SourceDocs and Archive candidates
-```
+It still does **not** create a SourceDocs working copy or publish a PDF.
 
-Only after that read-side is accepted should a separate governed authoring/publication command path be designed.
+Only after this read-side review is accepted should a separate governed authoring/publication command path be designed.
 
 The existing Procedure application and production Display Folders filesystem are read-only. A future Setup Manager authoring/publication path therefore requires its own governed write boundary. It must not broaden the existing read-only Procedure field application or silently make the shared production mount writable.
 
@@ -128,9 +127,9 @@ Total: 121 Displays.
 
 The broader non-unload task rows are representative provisional review data derived from current Setup planning evidence. Managers/team leaders must verify task boundaries, order, prerequisites, crew, equipment, timing, material, and Procedure applicability in the UI.
 
-## Running locally
+## Running locally — static mode
 
-The prototype has no backend dependency. Serve this directory with any static web server, for example:
+Static mode validates the task and movement UI but cannot show real Procedure files:
 
 ```powershell
 cd Setup\Application
@@ -142,6 +141,44 @@ Then open:
 ```text
 http://localhost:8780/
 ```
+
+## Running locally — live read-only Procedure review
+
+Run from the repository root or from `Setup\Application` after configuring a read-only database source and the Display Folders root.
+
+The backend accepts Setup-specific environment variables and also reuses the existing Procedure/FieldWiring variable names when already configured:
+
+```text
+SETUP_DATABASE_DSN
+SETUP_DEV_SNAPSHOT
+SETUP_DRIVE_ROOT
+```
+
+Fallbacks accepted:
+
+```text
+PROCEDURE_DATABASE_DSN
+PROCEDURE_DEV_SNAPSHOT
+PROCEDURE_DRIVE_ROOT
+FIELDWIRING_DATABASE_DSN
+FIELDWIRING_DRIVE_ROOT
+```
+
+Example with a Windows Google Drive root:
+
+```powershell
+$env:SETUP_DRIVE_ROOT = 'G:\Shared drives\Display Folders'
+$env:SETUP_DATABASE_DSN = '<existing read-only PostgreSQL DSN>'
+python .\Setup\Application\backend.py
+```
+
+Then open:
+
+```text
+http://localhost:8780/
+```
+
+Do not place credentials in the repository.
 
 After pulling a prototype update, use a hard refresh so the browser reloads the versioned CSS/JavaScript.
 
@@ -160,6 +197,6 @@ This prototype does not:
 - establish final authorization behavior;
 - approve reconstructed 2025 task order, dependencies, dates, or actuals.
 
-Production schema, Procedure-review integration, and write APIs remain gated on validation through this UI and the authoritative Setup/Deployment documentation under:
+Production schema, Procedure publication writes, and final authorization remain gated on validation through this UI and the authoritative Setup/Deployment documentation under:
 
 `Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment`

--- a/Setup/Application/README.md
+++ b/Setup/Application/README.md
@@ -44,6 +44,7 @@ The prototype includes:
 - explicit separation between reusable definition and 2025 historical actual;
 - verification states: `UNVERIFIED`, `VERIFIED`, `NEEDS CORRECTION`;
 - a broader provisional Setup task library across representative Stages instead of only Arch Trailer unload tasks;
+- representative general/support work, Mega Cube, Whoville, Elf Choir, Stars, Icicle Tunnel, Candyland, Polar Bear Playground, Racing Arches, Magic Igloo, Food Collection, and Command Center tasks;
 - provisional Magic Igloo phased work and common readiness/power-up tasks;
 - reusable Arch Trailer unload tasks;
 - Container 34 shared-load simulation across Racing Arches, Polar Bear Playground, Icicle Tunnel, Stars, Candyland, and Food Collection;

--- a/Setup/Application/README.md
+++ b/Setup/Application/README.md
@@ -55,6 +55,31 @@ The prototype includes:
 
 ## Manager Setup Procedure workflow
 
+The Setup application uses the existing documented Procedure folder structure. It does not require a separate Setup-specific document layout and does not require the 2025 verification pass to reorganize existing files first.
+
+Documented structure:
+
+```text
+<Stage / Sub-stage / Scene>\Procedures\Setup\
+    <current field PDF>.pdf
+    Archive\
+    images\
+    SourceDocs\
+```
+
+Normal roles remain:
+
+```text
+Procedures\Setup\SourceDocs
+    = normal editable/source area
+
+Procedures\Setup\Archive
+    = legacy / historical / superseded material
+
+Procedures\Setup
+    = current published field PDF(s)
+```
+
 The Manager screen and production-crew Procedure screen intentionally have different visibility.
 
 ```text
@@ -62,12 +87,26 @@ Production crew
     -> current published PDF directly in Procedures\Setup
 
 Authorized Manager
-    -> may see/open the applicable .gdoc source in Archive or SourceDocs
-    -> may correct that Google Doc during verification
-    -> must regenerate/export and replace the published PDF after a source change
+    -> open the applicable editable .gdoc source
+    -> correct it during 2025 verification
+    -> regenerate/export and replace the published PDF after a source change
 ```
 
-`Archive` remains excluded from normal production-crew navigation. That does **not** make an archived `.gdoc` immutable when an authorized Manager deliberately uses that document as the editable source during the 2025 correction pass.
+### 2025 compatibility rule for existing Archive .gdoc files
+
+Some current editable Google Docs were historically placed in `Procedures\Setup\Archive`. Correcting every folder before Setup Session verification would create unnecessary work and is **not** a prerequisite for the Setup system.
+
+For the 2025 verification cycle, editable-source discovery therefore follows this compatibility rule:
+
+```text
+1. Prefer editable .gdoc file(s) in Procedures\Setup\SourceDocs.
+2. If none exist there, use existing editable .gdoc file(s) in Procedures\Setup\Archive in place.
+3. Do not move or rename the file merely to make Setup Session work.
+4. Production crew still sees only the PDF directly in Procedures\Setup.
+5. If the Manager edits the Google Doc, the published PDF must be replaced before the instruction is marked verified/current.
+```
+
+This compatibility rule does not redefine the documented folder meanings. It allows the Setup application to work against the current installed document estate without blocking on Folder Alignment cleanup.
 
 The Manager task detail page therefore presents the Procedure workflow as actions, not as a folder-governance lesson:
 
@@ -114,11 +153,13 @@ This fallback:
 - does not fuzzy-match Stage names;
 - does not replace the universal resolver in production.
 
-For Food Collection, the intended editable source currently being reviewed is:
+For Food Collection, the existing editable source currently being reviewed is:
 
 ```text
 G:\Shared drives\Display Folders\04-Food Collection-FC\Procedures\Setup\Archive\04-Food Collection-FC.gdoc
 ```
+
+The prototype uses that file in place under the 2025 compatibility rule; it does not require moving it to `SourceDocs`.
 
 ## Shared Container acceptance rule
 
@@ -184,6 +225,7 @@ This prototype does not:
 - write movement history;
 - modify Google Drive;
 - automatically replace a published PDF;
+- reorganize Procedure folders;
 - replace the current Scan or Procedure applications;
 - establish final authorization behavior;
 - approve reconstructed 2025 task order, dependencies, dates, or actuals.

--- a/Setup/Application/README.md
+++ b/Setup/Application/README.md
@@ -1,10 +1,10 @@
 # Setup Session Application
 
-Status: **PROTOTYPE — 2025 HISTORICAL VERIFICATION UI; NO DATABASE WRITES**
+Status: **PROTOTYPE — 2025 HISTORICAL VERIFICATION UI; NO DATABASE OR DRIVE WRITES**
 
-This folder is the first browser-native Setup Session application prototype.
+This folder contains the first browser-native Setup Session application prototype.
 
-It exists to validate the Setup task model and field workflow with usable screens and provisional data before PostgreSQL DDL is approved.
+It exists to validate the Setup task model, 2025 historical reconstruction, Procedure knowledge, and field movement workflow with usable screens before PostgreSQL DDL or Google Drive write automation is approved.
 
 ## Why this prototype exists
 
@@ -19,7 +19,7 @@ reconstruction evidence
                     -> Admin creates 2026 Setup Session
 ```
 
-Do not treat the provisional task rows in this prototype as approved production truth.
+Do not treat provisional task rows as approved production truth.
 
 ## Application direction
 
@@ -43,11 +43,44 @@ The prototype includes:
 - reusable task review with plain-English predecessor names;
 - explicit separation between reusable definition and 2025 historical actual;
 - verification states: `UNVERIFIED`, `VERIFIED`, `NEEDS CORRECTION`;
-- provisional Magic Igloo phased work;
+- a broader provisional Setup task library across representative Stages instead of only Arch Trailer unload tasks;
+- provisional Magic Igloo phased work and common readiness/power-up tasks;
 - reusable Arch Trailer unload tasks;
 - Container 34 shared-load simulation across Racing Arches, Polar Bear Playground, Icicle Tunnel, Stars, Candyland, and Food Collection;
 - bulk unload behavior where only Displays still traveling with the Container follow later Container movement;
+- Setup Instruction review state on the task detail page;
 - local browser persistence for prototype edits only.
+
+## Setup Instruction review / publication boundary
+
+The current Google Drive / Procedure contract is preserved:
+
+```text
+Procedures\Setup\<current instruction>.pdf
+    = current published field instruction
+
+Procedures\Setup\SourceDocs\
+    = editable working/source material
+
+Procedures\Setup\Archive\
+    = historical / superseded source evidence
+```
+
+For 2025 verification, the intended Manager workflow is:
+
+```text
+historical source in Archive
+    -> review alongside reusable Setup task
+        -> create/use editable working copy in SourceDocs
+            -> revise and approve
+                -> publish approved PDF directly in Procedures\Setup
+```
+
+The archived original should not be edited in place merely because it contains useful historical content. Preserve it as evidence and revise a working copy.
+
+The prototype currently records Procedure verification/revision notes only. It does **not** enumerate the live Archive/SourceDocs/current PDF yet and does not publish a PDF.
+
+The existing Procedure application and production Display Folders filesystem are read-only. A future Setup Manager authoring/publication path therefore requires its own governed write boundary. It must not broaden the existing read-only Procedure field application or silently make the shared production mount writable.
 
 ## Shared Container acceptance rule
 
@@ -82,6 +115,8 @@ Confirmed Container 34 Display grouping used for the movement acceptance case:
 
 Total: 121 Displays.
 
+The broader non-unload task rows are representative provisional review data derived from current Setup planning evidence. Managers/team leaders must verify task boundaries, order, prerequisites, crew, equipment, timing, material, and Procedure applicability in the UI.
+
 ## Running locally
 
 The prototype has no backend dependency. Serve this directory with any static web server, for example:
@@ -97,6 +132,8 @@ Then open:
 http://localhost:8780/
 ```
 
+After pulling a prototype update, use a hard refresh so the browser reloads the versioned CSS/JavaScript.
+
 ## Production boundary
 
 This prototype does not:
@@ -104,10 +141,14 @@ This prototype does not:
 - create or alter PostgreSQL tables;
 - create a Setup Session in production;
 - write movement history;
-- replace the current Scan application;
+- modify Google Drive;
+- edit an archived Google Doc;
+- create a SourceDocs working copy;
+- convert/publish a new PDF;
+- replace the current Scan or Procedure applications;
 - establish final authorization behavior;
 - approve reconstructed 2025 task order, dependencies, dates, or actuals.
 
-Production schema and write APIs remain gated on validation through this UI and the authoritative Setup/Deployment documentation under:
+Production schema, Procedure-review integration, and write APIs remain gated on validation through this UI and the authoritative Setup/Deployment documentation under:
 
 `Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment`

--- a/Setup/Application/README.md
+++ b/Setup/Application/README.md
@@ -80,7 +80,7 @@ historical source in Archive
 
 The archived original should not be edited in place merely because it contains useful historical content. Preserve it as evidence and revise a working copy.
 
-The prototype records Procedure verification/revision notes locally. When run through `backend.py` with the database and Display Folders configured, it also resolves the current Stage/Sub-stage through the accepted Procedure stack and shows:
+The prototype records Procedure verification/revision notes locally. When run through `backend.py` with the database and Display Folders configured, it also resolves the current Stage/Sub-stage through the same accepted shared field-context / Procedure stack used by the current Procedure application and shows:
 
 - current published Setup PDF filename(s), with a protected read-only open link;
 - direct files currently in `SourceDocs`;

--- a/Setup/Application/backend.py
+++ b/Setup/Application/backend.py
@@ -40,7 +40,7 @@ from Procedures.Application.procedure_context import (  # noqa: E402
     resolve_stage_procedure,
 )
 
-APP_VERSION = "V0.0.4-prototype"
+APP_VERSION = "V0.0.5-prototype"
 app = Flask(__name__)
 
 
@@ -191,7 +191,9 @@ def _google_doc_id_from_url(candidate: str) -> str | None:
     if parsed.scheme != "https" or parsed.netloc.casefold() != "docs.google.com":
         return None
 
-    match = re.match(r"^/document/d/([A-Za-z0-9_-]+)", parsed.path)
+    # Google Docs URLs may be either /document/d/<id> or
+    # /document/u/<session>/d/<id>. Accept both forms.
+    match = re.match(r"^/document(?:/u/\d+)?/d/([A-Za-z0-9_-]+)", parsed.path)
     if match:
         return match.group(1)
 
@@ -214,7 +216,7 @@ def _google_doc_links(path: Path) -> tuple[str | None, str | None, str | None]:
     ids: list[str] = []
 
     try:
-        payload = json.loads(raw)
+        payload = json.loads(raw.lstrip("\ufeff"))
 
         def walk(value: Any, key_name: str = "") -> None:
             if isinstance(value, str):
@@ -337,7 +339,7 @@ def _local_instruction_package(stage_key: str) -> dict[str, Any]:
     current_documents = _published_pdf_payloads(task_root, stage_key)
     editable_sources = [
         item for item in [*source_docs, *archive]
-        if item.get("extension") == ".gdoc" and item.get("editable_google_source")
+        if item.get("extension") == ".gdoc"
     ]
     status = "AVAILABLE" if current_documents else "NO_CURRENT_DOCUMENTS"
     if not task_root.is_dir():
@@ -391,7 +393,7 @@ def _resolved_instruction_package(stage_key: str) -> dict[str, Any]:
     ]
     editable_sources = [
         item for item in [*source_docs, *archive]
-        if item.get("extension") == ".gdoc" and item.get("editable_google_source")
+        if item.get("extension") == ".gdoc"
     ]
 
     return {

--- a/Setup/Application/backend.py
+++ b/Setup/Application/backend.py
@@ -1,0 +1,267 @@
+"""Read-only MSB Setup Session prototype host with Procedure review integration.
+
+This prototype backend intentionally performs no PostgreSQL writes and no Google
+Drive writes.  It reuses the accepted shared field-context / Procedure resolver
+to expose current Setup PDFs plus Manager-review metadata for SourceDocs and
+Archive.
+
+The existing Procedure field application remains unchanged and read-only.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from flask import Flask, Response, jsonify, request, send_file, send_from_directory
+
+BASE_DIR = Path(__file__).resolve().parent
+REPO_ROOT = BASE_DIR.parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from FieldWiring.Application.field_context_repository import (  # noqa: E402
+    ConfigError,
+    FieldContextRepository,
+    PostgresFieldContextRepository,
+    SQLiteFieldContextRepository,
+)
+from Procedures.Application.procedure_context import (  # noqa: E402
+    ProcedureContextError,
+    resolve_stage_procedure,
+)
+
+APP_VERSION = "V0.0.2-prototype"
+app = Flask(__name__)
+
+
+class SetupInstructionError(RuntimeError):
+    """Setup instruction review request could not be safely resolved."""
+
+
+def _env_first(*names: str) -> str:
+    for name in names:
+        value = os.environ.get(name, "").strip()
+        if value:
+            return value
+    return ""
+
+
+def repository() -> FieldContextRepository:
+    snapshot = _env_first("SETUP_DEV_SNAPSHOT", "PROCEDURE_DEV_SNAPSHOT")
+    if snapshot:
+        return SQLiteFieldContextRepository(snapshot)
+
+    dsn = _env_first(
+        "SETUP_DATABASE_DSN",
+        "PROCEDURE_DATABASE_DSN",
+        "FIELDWIRING_DATABASE_DSN",
+    )
+    if dsn:
+        return PostgresFieldContextRepository(dsn)
+
+    raise ConfigError(
+        "Configure SETUP_DATABASE_DSN (or existing PROCEDURE/FIELDWIRING DSN) "
+        "for PostgreSQL, or SETUP_DEV_SNAPSHOT for explicit development snapshot mode."
+    )
+
+
+def drive_root() -> Path:
+    root_text = _env_first(
+        "SETUP_DRIVE_ROOT",
+        "PROCEDURE_DRIVE_ROOT",
+        "FIELDWIRING_DRIVE_ROOT",
+    )
+    if not root_text:
+        raise ConfigError(
+            "Configure SETUP_DRIVE_ROOT (or existing PROCEDURE/FIELDWIRING drive root) "
+            "for the shared Display Folders filesystem."
+        )
+    root = Path(root_text)
+    if not root.is_dir():
+        raise ConfigError(f"Setup Display Folders root is not available: {root_text}")
+    return root
+
+
+def _stage_id_for_key(repo: FieldContextRepository, stage_key: str) -> int:
+    wanted = (stage_key or "").strip().casefold()
+    if not wanted:
+        raise SetupInstructionError("Stage key is required.")
+
+    matches: list[int] = []
+    for item in repo.stages():
+        stage = item.get("stage") or {}
+        current_key = str(stage.get("stage_key") or "").strip().casefold()
+        stage_id = stage.get("stage_id")
+        if current_key == wanted and stage_id is not None:
+            matches.append(int(stage_id))
+
+    unique = sorted(set(matches))
+    if len(unique) != 1:
+        raise SetupInstructionError(
+            f"Stage key {stage_key!r} did not resolve to one unique current Stage/Sub-stage."
+        )
+    return unique[0]
+
+
+def _direct_review_files(folder: Path) -> list[dict[str, Any]]:
+    if not folder.is_dir():
+        return []
+    try:
+        files = [path for path in folder.iterdir() if path.is_file()]
+    except OSError:
+        return []
+
+    result: list[dict[str, Any]] = []
+    for path in sorted(files, key=lambda item: item.name.casefold()):
+        try:
+            size = path.stat().st_size
+        except OSError:
+            size = None
+        result.append(
+            {
+                "name": path.name,
+                "extension": path.suffix.casefold(),
+                "size": size,
+            }
+        )
+    return result
+
+
+def _instruction_package(stage_key: str) -> dict[str, Any]:
+    repo = repository()
+    stage_id = _stage_id_for_key(repo, stage_key)
+    procedure = resolve_stage_procedure(
+        repo,
+        stage_id=stage_id,
+        task="Setup",
+        drive_root=drive_root(),
+        whole_stage=True,
+    )
+
+    task_root_text = str(procedure.get("task_root") or "").strip()
+    task_root = Path(task_root_text) if task_root_text else None
+    source_docs = _direct_review_files(task_root / "SourceDocs") if task_root else []
+    archive = _direct_review_files(task_root / "Archive") if task_root else []
+
+    current_documents = [
+        {
+            "name": item.get("name"),
+            "size": item.get("size"),
+            "url": f"/api/setup-instructions/current?stage_key={stage_key}&name={item.get('name')}",
+        }
+        for item in (procedure.get("documents") or [])
+        if item.get("name")
+    ]
+
+    return {
+        "stage_key": stage_key,
+        "stage_id": stage_id,
+        "status": procedure.get("status"),
+        "scope_type": procedure.get("scope_type"),
+        "current_documents": current_documents,
+        "source_docs": source_docs,
+        "archive": archive,
+        "warnings": procedure.get("operator_warnings") or procedure.get("warnings") or [],
+    }
+
+
+def _current_document_path(stage_key: str, name: str) -> Path:
+    if not name or "\x00" in name or Path(name).name != name:
+        raise SetupInstructionError("Current Setup PDF name is invalid.")
+
+    repo = repository()
+    stage_id = _stage_id_for_key(repo, stage_key)
+    procedure = resolve_stage_procedure(
+        repo,
+        stage_id=stage_id,
+        task="Setup",
+        drive_root=drive_root(),
+        whole_stage=True,
+    )
+    task_root_text = str(procedure.get("task_root") or "").strip()
+    if not task_root_text:
+        raise SetupInstructionError("Current Setup task folder could not be resolved.")
+    task_root = Path(task_root_text)
+
+    matched = next(
+        (item for item in (procedure.get("documents") or []) if item.get("name") == name),
+        None,
+    )
+    if matched is None:
+        raise SetupInstructionError("Requested PDF is not a current published Setup document.")
+
+    candidate = Path(str(matched.get("path") or ""))
+    if not candidate.is_file():
+        raise SetupInstructionError("Requested current Setup PDF is unavailable.")
+
+    try:
+        candidate.resolve(strict=True).relative_to(task_root.resolve(strict=True))
+    except (OSError, ValueError) as exc:
+        raise SetupInstructionError("Requested PDF is outside the resolved Setup folder.") from exc
+
+    if candidate.parent.resolve(strict=True) != task_root.resolve(strict=True):
+        raise SetupInstructionError("Requested PDF is not directly published in Procedures/Setup.")
+
+    return candidate
+
+
+@app.get("/")
+def index() -> Response:
+    return send_from_directory(BASE_DIR, "index.html")
+
+
+@app.get("/<path:name>")
+def static_file(name: str) -> Response:
+    if name.startswith("api/"):
+        raise SetupInstructionError("Unknown Setup API route.")
+    return send_from_directory(BASE_DIR, name)
+
+
+@app.get("/api/health")
+def health() -> Response:
+    mode = "sqlite-dev" if _env_first("SETUP_DEV_SNAPSHOT", "PROCEDURE_DEV_SNAPSHOT") else "postgres"
+    return jsonify(status="ok", version=APP_VERSION, data_mode=mode)
+
+
+@app.get("/api/setup-instructions")
+def setup_instructions() -> Response:
+    stage_key = request.args.get("stage_key", "").strip()
+    return jsonify(instructions=_instruction_package(stage_key))
+
+
+@app.get("/api/setup-instructions/current")
+def setup_current_document() -> Response:
+    stage_key = request.args.get("stage_key", "").strip()
+    name = request.args.get("name", "").strip()
+    path = _current_document_path(stage_key, name)
+    return send_file(
+        path,
+        conditional=True,
+        max_age=60,
+        as_attachment=False,
+        download_name=path.name,
+    )
+
+
+@app.errorhandler(ConfigError)
+def config_error(exc: ConfigError) -> tuple[Response, int]:
+    return jsonify(
+        error="Setup Instruction review is not connected to the current database/document source.",
+        engineering_error=str(exc),
+    ), 503
+
+
+@app.errorhandler(ProcedureContextError)
+def procedure_error(exc: ProcedureContextError) -> tuple[Response, int]:
+    return jsonify(error="Setup Instruction context could not be resolved.", engineering_error=str(exc)), 400
+
+
+@app.errorhandler(SetupInstructionError)
+def setup_instruction_error(exc: SetupInstructionError) -> tuple[Response, int]:
+    return jsonify(error=str(exc), engineering_error=str(exc)), 400
+
+
+if __name__ == "__main__":
+    app.run(host="127.0.0.1", port=int(os.environ.get("PORT", "8780")), debug=False)

--- a/Setup/Application/backend.py
+++ b/Setup/Application/backend.py
@@ -40,7 +40,7 @@ from Procedures.Application.procedure_context import (  # noqa: E402
     resolve_stage_procedure,
 )
 
-APP_VERSION = "V0.0.5-prototype"
+APP_VERSION = "V0.0.6-prototype"
 app = Flask(__name__)
 
 
@@ -418,12 +418,31 @@ def _instruction_package(stage_key: str) -> dict[str, Any]:
     return _local_instruction_package(stage_key)
 
 
+def _resolved_task_root(stage_key: str) -> Path:
+    if not _database_configured():
+        return _local_stage_folder(stage_key) / "Procedures" / "Setup"
+
+    repo = repository()
+    stage_id = _stage_id_for_key(repo, stage_key)
+    procedure = resolve_stage_procedure(
+        repo,
+        stage_id=stage_id,
+        task="Setup",
+        drive_root=drive_root(),
+        whole_stage=True,
+    )
+    task_root_text = str(procedure.get("task_root") or "").strip()
+    if not task_root_text:
+        raise SetupInstructionError("Current Setup task folder could not be resolved.")
+    return Path(task_root_text)
+
+
 def _current_document_path(stage_key: str, name: str) -> Path:
     if not name or "\x00" in name or Path(name).name != name:
         raise SetupInstructionError("Current Setup PDF name is invalid.")
 
     if not _database_configured():
-        task_root = _local_stage_folder(stage_key) / "Procedures" / "Setup"
+        task_root = _resolved_task_root(stage_key)
         candidate = task_root / name
         if candidate.suffix.casefold() != ".pdf" or not candidate.is_file():
             raise SetupInstructionError("Requested PDF is not a current published Setup document.")
@@ -468,6 +487,31 @@ def _current_document_path(stage_key: str, name: str) -> Path:
     return candidate
 
 
+def _editable_document_path(stage_key: str, name: str) -> Path:
+    if not name or "\x00" in name or Path(name).name != name:
+        raise SetupInstructionError("Editable Setup Procedure name is invalid.")
+    if Path(name).suffix.casefold() != ".gdoc":
+        raise SetupInstructionError("Editable Setup Procedure must be a .gdoc file.")
+
+    task_root = _resolved_task_root(stage_key)
+    for folder_name in ("SourceDocs", "Archive"):
+        parent = task_root / folder_name
+        candidate = parent / name
+        if not candidate.is_file():
+            continue
+        try:
+            resolved_parent = parent.resolve(strict=True)
+            resolved_candidate = candidate.resolve(strict=True)
+            resolved_candidate.relative_to(resolved_parent)
+        except (OSError, ValueError) as exc:
+            raise SetupInstructionError("Editable Setup Procedure is outside its allowed folder.") from exc
+        if resolved_candidate.parent != resolved_parent:
+            raise SetupInstructionError("Editable Setup Procedure must be directly in SourceDocs or Archive.")
+        return candidate
+
+    raise SetupInstructionError("Editable Setup Procedure was not found in SourceDocs or Archive.")
+
+
 @app.get("/")
 def index() -> Response:
     return send_from_directory(BASE_DIR, "index.html")
@@ -509,6 +553,26 @@ def setup_current_document() -> Response:
         as_attachment=False,
         download_name=path.name,
     )
+
+
+@app.post("/api/setup-instructions/open-editable")
+def setup_open_editable_document() -> Response:
+    payload = request.get_json(silent=True) or {}
+    stage_key = str(payload.get("stage_key") or "").strip()
+    name = str(payload.get("name") or "").strip()
+    path = _editable_document_path(stage_key, name)
+
+    if os.name != "nt" or not hasattr(os, "startfile"):
+        raise SetupInstructionError(
+            "Opening the local .gdoc through its registered application is only available on the Windows prototype host."
+        )
+
+    try:
+        os.startfile(str(path))  # type: ignore[attr-defined]
+    except OSError as exc:
+        raise SetupInstructionError(f"Windows could not open the editable Setup Procedure: {exc}") from exc
+
+    return jsonify(status="opened", name=path.name, path=str(path))
 
 
 @app.errorhandler(ConfigError)

--- a/Setup/Application/backend.py
+++ b/Setup/Application/backend.py
@@ -1,18 +1,24 @@
-"""Read-only MSB Setup Session prototype host with Procedure review integration.
+"""Read-only MSB Setup Session prototype host with Manager Procedure review.
 
-This prototype backend intentionally performs no PostgreSQL writes and no Google
-Drive writes.  It reuses the accepted shared field-context / Procedure resolver
-to expose current Setup PDFs plus Manager-review metadata for SourceDocs and
-Archive.
+The prototype still performs no PostgreSQL or Google Drive writes.  It reuses
+accepted field-context / Procedure resolution to expose the current Setup PDFs
+plus Manager-only SourceDocs / Archive source metadata.
 
-The existing Procedure field application remains unchanged and read-only.
+Manager review is intentionally different from production-crew presentation:
+Archive/SourceDocs remain hidden from the field Procedure application, while an
+authorized future Manager UI may open an underlying Google Doc for correction.
+If that source is changed, the published PDF in Procedures/Setup must be
+regenerated/replaced before field publication is current again.
 """
 from __future__ import annotations
 
+import json
 import os
+import re
 import sys
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 from flask import Flask, Response, jsonify, request, send_file, send_from_directory
 
@@ -32,7 +38,7 @@ from Procedures.Application.procedure_context import (  # noqa: E402
     resolve_stage_procedure,
 )
 
-APP_VERSION = "V0.0.2-prototype"
+APP_VERSION = "V0.0.3-prototype"
 app = Flask(__name__)
 
 
@@ -105,7 +111,58 @@ def _stage_id_for_key(repo: FieldContextRepository, stage_key: str) -> int:
     return unique[0]
 
 
-def _direct_review_files(folder: Path) -> list[dict[str, Any]]:
+def _google_doc_links(path: Path) -> tuple[str | None, str | None]:
+    """Return (edit_url, pdf_export_url) from a local .gdoc shortcut when safe.
+
+    Google Drive desktop .gdoc files are small shortcut metadata files.  Their
+    exact JSON shape is not treated as authority; we only accept a URL actually
+    present in the file and only when it resolves to docs.google.com/document.
+    """
+    if path.suffix.casefold() != ".gdoc":
+        return None, None
+    try:
+        raw = path.read_text(encoding="utf-8", errors="replace")[:65536]
+    except OSError:
+        return None, None
+
+    candidates: list[str] = []
+    try:
+        payload = json.loads(raw)
+
+        def walk(value: Any) -> None:
+            if isinstance(value, str):
+                if value.startswith("https://"):
+                    candidates.append(value)
+            elif isinstance(value, dict):
+                for item in value.values():
+                    walk(item)
+            elif isinstance(value, list):
+                for item in value:
+                    walk(item)
+
+        walk(payload)
+    except (json.JSONDecodeError, TypeError):
+        candidates.extend(re.findall(r"https://[^\s\"']+", raw))
+
+    for candidate in candidates:
+        try:
+            parsed = urlparse(candidate)
+        except ValueError:
+            continue
+        if parsed.scheme != "https" or parsed.netloc.casefold() != "docs.google.com":
+            continue
+        match = re.match(r"^/document/d/([^/]+)", parsed.path)
+        if not match:
+            continue
+        doc_id = match.group(1)
+        edit_url = f"https://docs.google.com/document/d/{doc_id}/edit"
+        export_url = f"https://docs.google.com/document/d/{doc_id}/export?format=pdf"
+        return edit_url, export_url
+
+    return None, None
+
+
+def _direct_review_files(folder: Path, *, role: str) -> list[dict[str, Any]]:
     if not folder.is_dir():
         return []
     try:
@@ -119,11 +176,16 @@ def _direct_review_files(folder: Path) -> list[dict[str, Any]]:
             size = path.stat().st_size
         except OSError:
             size = None
+        edit_url, export_url = _google_doc_links(path)
         result.append(
             {
                 "name": path.name,
                 "extension": path.suffix.casefold(),
                 "size": size,
+                "role": role,
+                "editable_google_source": bool(edit_url),
+                "edit_url": edit_url,
+                "pdf_export_url": export_url,
             }
         )
     return result
@@ -142,8 +204,10 @@ def _instruction_package(stage_key: str) -> dict[str, Any]:
 
     task_root_text = str(procedure.get("task_root") or "").strip()
     task_root = Path(task_root_text) if task_root_text else None
-    source_docs = _direct_review_files(task_root / "SourceDocs") if task_root else []
-    archive = _direct_review_files(task_root / "Archive") if task_root else []
+    source_docs = (
+        _direct_review_files(task_root / "SourceDocs", role="SOURCEDOC") if task_root else []
+    )
+    archive = _direct_review_files(task_root / "Archive", role="ARCHIVE") if task_root else []
 
     current_documents = [
         {
@@ -155,6 +219,10 @@ def _instruction_package(stage_key: str) -> dict[str, Any]:
         if item.get("name")
     ]
 
+    editable_sources = [
+        item for item in [*source_docs, *archive] if item.get("editable_google_source")
+    ]
+
     return {
         "stage_key": stage_key,
         "stage_id": stage_id,
@@ -163,6 +231,13 @@ def _instruction_package(stage_key: str) -> dict[str, Any]:
         "current_documents": current_documents,
         "source_docs": source_docs,
         "archive": archive,
+        "editable_sources": editable_sources,
+        "manager_rule": (
+            "Authorized Managers may edit the chosen Google Doc source during verification. "
+            "Archive remains excluded from production-crew navigation, but its .gdoc is not "
+            "treated as immutable when the Manager intentionally uses it as the source. "
+            "After any source edit, replace the published PDF in Procedures/Setup."
+        ),
         "warnings": procedure.get("operator_warnings") or procedure.get("warnings") or [],
     }
 

--- a/Setup/Application/backend.py
+++ b/Setup/Application/backend.py
@@ -1,14 +1,16 @@
-"""Read-only MSB Setup Session prototype host with Manager Procedure review.
+"""MSB Setup Session prototype host with Manager Procedure review.
 
-The prototype still performs no PostgreSQL or Google Drive writes.  It reuses
-accepted field-context / Procedure resolution to expose the current Setup PDFs
-plus Manager-only SourceDocs / Archive source metadata.
+The prototype still performs no PostgreSQL or Google Drive writes. When a
+read-only database source is configured it reuses the accepted shared
+field-context / Procedure resolver. For local prototype validation only, when no
+database source is configured, it may resolve one uniquely matching Stage or
+Sub-stage folder beneath SETUP_DRIVE_ROOT by exact Stage key.
 
 Manager review is intentionally different from production-crew presentation:
-Archive/SourceDocs remain hidden from the field Procedure application, while an
-authorized future Manager UI may open an underlying Google Doc for correction.
-If that source is changed, the published PDF in Procedures/Setup must be
-regenerated/replaced before field publication is current again.
+production crew sees only the published PDF, while an authorized Manager may
+open the underlying Google Doc source for correction. If the source is changed,
+the published PDF in Procedures/Setup must be regenerated/replaced before the
+instruction is considered current.
 """
 from __future__ import annotations
 
@@ -18,7 +20,7 @@ import re
 import sys
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlparse
 
 from flask import Flask, Response, jsonify, request, send_file, send_from_directory
 
@@ -38,7 +40,7 @@ from Procedures.Application.procedure_context import (  # noqa: E402
     resolve_stage_procedure,
 )
 
-APP_VERSION = "V0.0.3-prototype"
+APP_VERSION = "V0.0.4-prototype"
 app = Flask(__name__)
 
 
@@ -54,16 +56,28 @@ def _env_first(*names: str) -> str:
     return ""
 
 
-def repository() -> FieldContextRepository:
-    snapshot = _env_first("SETUP_DEV_SNAPSHOT", "PROCEDURE_DEV_SNAPSHOT")
-    if snapshot:
-        return SQLiteFieldContextRepository(snapshot)
+def _snapshot_text() -> str:
+    return _env_first("SETUP_DEV_SNAPSHOT", "PROCEDURE_DEV_SNAPSHOT")
 
-    dsn = _env_first(
+
+def _dsn_text() -> str:
+    return _env_first(
         "SETUP_DATABASE_DSN",
         "PROCEDURE_DATABASE_DSN",
         "FIELDWIRING_DATABASE_DSN",
     )
+
+
+def _database_configured() -> bool:
+    return bool(_snapshot_text() or _dsn_text())
+
+
+def repository() -> FieldContextRepository:
+    snapshot = _snapshot_text()
+    if snapshot:
+        return SQLiteFieldContextRepository(snapshot)
+
+    dsn = _dsn_text()
     if dsn:
         return PostgresFieldContextRepository(dsn)
 
@@ -111,55 +125,166 @@ def _stage_id_for_key(repo: FieldContextRepository, stage_key: str) -> int:
     return unique[0]
 
 
-def _google_doc_links(path: Path) -> tuple[str | None, str | None]:
-    """Return (edit_url, pdf_export_url) from a local .gdoc shortcut when safe.
+def _folder_stage_key(name: str) -> str | None:
+    """Return a leading MSB Stage/Sub-stage key from a folder name."""
+    match = re.match(r"^\s*(\d{2}[A-Za-z]?)\s*[-_]", name)
+    if not match:
+        return None
+    return match.group(1).casefold()
 
-    Google Drive desktop .gdoc files are small shortcut metadata files.  Their
-    exact JSON shape is not treated as authority; we only accept a URL actually
-    present in the file and only when it resolves to docs.google.com/document.
+
+def _local_stage_folder(stage_key: str) -> Path:
+    """Prototype-only exact-key folder resolver when no DB source is configured.
+
+    It checks direct children first, then one child level below them for
+    Sub-stages. It never fuzzy-matches a Stage name and requires exactly one
+    matching directory.
     """
+    wanted = (stage_key or "").strip().casefold()
+    if not wanted:
+        raise SetupInstructionError("Stage key is required.")
+
+    root = drive_root()
+    direct: list[Path] = []
+    try:
+        root_children = [path for path in root.iterdir() if path.is_dir()]
+    except OSError as exc:
+        raise SetupInstructionError("Display Folders root could not be enumerated.") from exc
+
+    for child in root_children:
+        if _folder_stage_key(child.name) == wanted:
+            direct.append(child)
+
+    matches = direct
+    if not matches and re.fullmatch(r"\d{2}[a-z]", wanted):
+        nested: list[Path] = []
+        for parent in root_children:
+            try:
+                children = [path for path in parent.iterdir() if path.is_dir()]
+            except OSError:
+                continue
+            for child in children:
+                if _folder_stage_key(child.name) == wanted:
+                    nested.append(child)
+        matches = nested
+
+    unique: dict[str, Path] = {}
+    for path in matches:
+        try:
+            key = str(path.resolve(strict=True)).casefold()
+        except OSError:
+            key = str(path.absolute()).casefold()
+        unique[key] = path
+
+    if len(unique) != 1:
+        raise SetupInstructionError(
+            f"Prototype Stage key {stage_key!r} resolved to {len(unique)} local folders; expected exactly one."
+        )
+    return next(iter(unique.values()))
+
+
+def _google_doc_id_from_url(candidate: str) -> str | None:
+    try:
+        parsed = urlparse(candidate)
+    except ValueError:
+        return None
+    if parsed.scheme != "https" or parsed.netloc.casefold() != "docs.google.com":
+        return None
+
+    match = re.match(r"^/document/d/([A-Za-z0-9_-]+)", parsed.path)
+    if match:
+        return match.group(1)
+
+    query_id = (parse_qs(parsed.query).get("id") or [None])[0]
+    if query_id and re.fullmatch(r"[A-Za-z0-9_-]{10,}", query_id):
+        return query_id
+    return None
+
+
+def _google_doc_links(path: Path) -> tuple[str | None, str | None, str | None]:
+    """Return (edit_url, pdf_export_url, doc_id) from a local .gdoc shortcut."""
     if path.suffix.casefold() != ".gdoc":
-        return None, None
+        return None, None, None
     try:
         raw = path.read_text(encoding="utf-8", errors="replace")[:65536]
     except OSError:
-        return None, None
+        return None, None, None
 
-    candidates: list[str] = []
+    urls: list[str] = []
+    ids: list[str] = []
+
     try:
         payload = json.loads(raw)
 
-        def walk(value: Any) -> None:
+        def walk(value: Any, key_name: str = "") -> None:
             if isinstance(value, str):
-                if value.startswith("https://"):
-                    candidates.append(value)
+                stripped = value.strip()
+                if stripped.startswith("https://"):
+                    urls.append(stripped)
+                folded_key = key_name.casefold()
+                if folded_key in {"doc_id", "document_id"} and re.fullmatch(
+                    r"[A-Za-z0-9_-]{10,}", stripped
+                ):
+                    ids.append(stripped)
+                if folded_key == "resource_id":
+                    resource_match = re.search(r"(?:document:)?([A-Za-z0-9_-]{10,})$", stripped)
+                    if resource_match:
+                        ids.append(resource_match.group(1))
             elif isinstance(value, dict):
-                for item in value.values():
-                    walk(item)
+                for child_key, child_value in value.items():
+                    walk(child_value, str(child_key))
             elif isinstance(value, list):
-                for item in value:
-                    walk(item)
+                for child_value in value:
+                    walk(child_value, key_name)
 
         walk(payload)
     except (json.JSONDecodeError, TypeError):
-        candidates.extend(re.findall(r"https://[^\s\"']+", raw))
+        urls.extend(re.findall(r"https://[^\s\"']+", raw))
 
-    for candidate in candidates:
+    for candidate in urls:
+        doc_id = _google_doc_id_from_url(candidate)
+        if doc_id:
+            ids.insert(0, doc_id)
+            break
+
+    doc_id = next((item for item in ids if re.fullmatch(r"[A-Za-z0-9_-]{10,}", item)), None)
+    if doc_id:
+        return (
+            f"https://docs.google.com/document/d/{doc_id}/edit",
+            f"https://docs.google.com/document/d/{doc_id}/export?format=pdf",
+            doc_id,
+        )
+
+    # A direct Google Docs URL is still useful to the Manager even if this
+    # shortcut format does not expose an ID we recognize for PDF export.
+    for candidate in urls:
         try:
             parsed = urlparse(candidate)
         except ValueError:
             continue
-        if parsed.scheme != "https" or parsed.netloc.casefold() != "docs.google.com":
-            continue
-        match = re.match(r"^/document/d/([^/]+)", parsed.path)
-        if not match:
-            continue
-        doc_id = match.group(1)
-        edit_url = f"https://docs.google.com/document/d/{doc_id}/edit"
-        export_url = f"https://docs.google.com/document/d/{doc_id}/export?format=pdf"
-        return edit_url, export_url
+        if parsed.scheme == "https" and parsed.netloc.casefold() == "docs.google.com":
+            return candidate, None, None
 
-    return None, None
+    return None, None, None
+
+
+def _review_file_payload(path: Path, *, role: str) -> dict[str, Any]:
+    try:
+        size = path.stat().st_size
+    except OSError:
+        size = None
+    edit_url, export_url, doc_id = _google_doc_links(path)
+    return {
+        "name": path.name,
+        "path": str(path),
+        "extension": path.suffix.casefold(),
+        "size": size,
+        "role": role,
+        "editable_google_source": bool(edit_url),
+        "edit_url": edit_url,
+        "pdf_export_url": export_url,
+        "google_doc_id": doc_id,
+    }
 
 
 def _direct_review_files(folder: Path, *, role: str) -> list[dict[str, Any]]:
@@ -169,29 +294,75 @@ def _direct_review_files(folder: Path, *, role: str) -> list[dict[str, Any]]:
         files = [path for path in folder.iterdir() if path.is_file()]
     except OSError:
         return []
-
-    result: list[dict[str, Any]] = []
-    for path in sorted(files, key=lambda item: item.name.casefold()):
-        try:
-            size = path.stat().st_size
-        except OSError:
-            size = None
-        edit_url, export_url = _google_doc_links(path)
-        result.append(
-            {
-                "name": path.name,
-                "extension": path.suffix.casefold(),
-                "size": size,
-                "role": role,
-                "editable_google_source": bool(edit_url),
-                "edit_url": edit_url,
-                "pdf_export_url": export_url,
-            }
-        )
-    return result
+    return [
+        _review_file_payload(path, role=role)
+        for path in sorted(files, key=lambda item: item.name.casefold())
+    ]
 
 
-def _instruction_package(stage_key: str) -> dict[str, Any]:
+def _published_pdf_payloads(task_root: Path, stage_key: str) -> list[dict[str, Any]]:
+    if not task_root.is_dir():
+        return []
+    try:
+        files = [
+            path for path in task_root.iterdir()
+            if path.is_file() and path.suffix.casefold() == ".pdf"
+        ]
+    except OSError:
+        return []
+    return [
+        {
+            "name": path.name,
+            "path": str(path),
+            "size": path.stat().st_size if path.exists() else None,
+            "url": f"/api/setup-instructions/current?stage_key={stage_key}&name={path.name}",
+        }
+        for path in sorted(files, key=lambda item: item.name.casefold())
+    ]
+
+
+def _manager_rule() -> str:
+    return (
+        "Authorized Managers may open and edit the selected Google Doc source during verification. "
+        "Archive/SourceDocs remain hidden from production-crew navigation. After any Google Doc "
+        "edit, replace the published PDF in Procedures/Setup before marking the instruction verified."
+    )
+
+
+def _local_instruction_package(stage_key: str) -> dict[str, Any]:
+    stage_folder = _local_stage_folder(stage_key)
+    task_root = stage_folder / "Procedures" / "Setup"
+    source_docs = _direct_review_files(task_root / "SourceDocs", role="SOURCEDOC")
+    archive = _direct_review_files(task_root / "Archive", role="ARCHIVE")
+    current_documents = _published_pdf_payloads(task_root, stage_key)
+    editable_sources = [
+        item for item in [*source_docs, *archive]
+        if item.get("extension") == ".gdoc" and item.get("editable_google_source")
+    ]
+    status = "AVAILABLE" if current_documents else "NO_CURRENT_DOCUMENTS"
+    if not task_root.is_dir():
+        status = "TASK_UNAVAILABLE"
+
+    return {
+        "stage_key": stage_key,
+        "stage_id": None,
+        "status": status,
+        "scope_type": "LOCAL_STAGE_PROTOTYPE",
+        "resolution_mode": "local-drive-prototype",
+        "stage_folder": str(stage_folder),
+        "task_root": str(task_root),
+        "current_documents": current_documents,
+        "source_docs": source_docs,
+        "archive": archive,
+        "editable_sources": editable_sources,
+        "manager_rule": _manager_rule(),
+        "warnings": [
+            "Local prototype exact-Stage-key folder fallback is active; production must use the shared field-context resolver."
+        ],
+    }
+
+
+def _resolved_instruction_package(stage_key: str) -> dict[str, Any]:
     repo = repository()
     stage_id = _stage_id_for_key(repo, stage_key)
     procedure = resolve_stage_procedure(
@@ -208,19 +379,19 @@ def _instruction_package(stage_key: str) -> dict[str, Any]:
         _direct_review_files(task_root / "SourceDocs", role="SOURCEDOC") if task_root else []
     )
     archive = _direct_review_files(task_root / "Archive", role="ARCHIVE") if task_root else []
-
     current_documents = [
         {
             "name": item.get("name"),
+            "path": item.get("path"),
             "size": item.get("size"),
             "url": f"/api/setup-instructions/current?stage_key={stage_key}&name={item.get('name')}",
         }
         for item in (procedure.get("documents") or [])
         if item.get("name")
     ]
-
     editable_sources = [
-        item for item in [*source_docs, *archive] if item.get("editable_google_source")
+        item for item in [*source_docs, *archive]
+        if item.get("extension") == ".gdoc" and item.get("editable_google_source")
     ]
 
     return {
@@ -228,23 +399,39 @@ def _instruction_package(stage_key: str) -> dict[str, Any]:
         "stage_id": stage_id,
         "status": procedure.get("status"),
         "scope_type": procedure.get("scope_type"),
+        "resolution_mode": "shared-field-context",
+        "task_root": task_root_text or None,
         "current_documents": current_documents,
         "source_docs": source_docs,
         "archive": archive,
         "editable_sources": editable_sources,
-        "manager_rule": (
-            "Authorized Managers may edit the chosen Google Doc source during verification. "
-            "Archive remains excluded from production-crew navigation, but its .gdoc is not "
-            "treated as immutable when the Manager intentionally uses it as the source. "
-            "After any source edit, replace the published PDF in Procedures/Setup."
-        ),
+        "manager_rule": _manager_rule(),
         "warnings": procedure.get("operator_warnings") or procedure.get("warnings") or [],
     }
+
+
+def _instruction_package(stage_key: str) -> dict[str, Any]:
+    if _database_configured():
+        return _resolved_instruction_package(stage_key)
+    return _local_instruction_package(stage_key)
 
 
 def _current_document_path(stage_key: str, name: str) -> Path:
     if not name or "\x00" in name or Path(name).name != name:
         raise SetupInstructionError("Current Setup PDF name is invalid.")
+
+    if not _database_configured():
+        task_root = _local_stage_folder(stage_key) / "Procedures" / "Setup"
+        candidate = task_root / name
+        if candidate.suffix.casefold() != ".pdf" or not candidate.is_file():
+            raise SetupInstructionError("Requested PDF is not a current published Setup document.")
+        try:
+            candidate.resolve(strict=True).relative_to(task_root.resolve(strict=True))
+        except (OSError, ValueError) as exc:
+            raise SetupInstructionError("Requested PDF is outside the resolved Setup folder.") from exc
+        if candidate.parent.resolve(strict=True) != task_root.resolve(strict=True):
+            raise SetupInstructionError("Requested PDF is not directly published in Procedures/Setup.")
+        return candidate
 
     repo = repository()
     stage_id = _stage_id_for_key(repo, stage_key)
@@ -270,15 +457,12 @@ def _current_document_path(stage_key: str, name: str) -> Path:
     candidate = Path(str(matched.get("path") or ""))
     if not candidate.is_file():
         raise SetupInstructionError("Requested current Setup PDF is unavailable.")
-
     try:
         candidate.resolve(strict=True).relative_to(task_root.resolve(strict=True))
     except (OSError, ValueError) as exc:
         raise SetupInstructionError("Requested PDF is outside the resolved Setup folder.") from exc
-
     if candidate.parent.resolve(strict=True) != task_root.resolve(strict=True):
         raise SetupInstructionError("Requested PDF is not directly published in Procedures/Setup.")
-
     return candidate
 
 
@@ -296,7 +480,12 @@ def static_file(name: str) -> Response:
 
 @app.get("/api/health")
 def health() -> Response:
-    mode = "sqlite-dev" if _env_first("SETUP_DEV_SNAPSHOT", "PROCEDURE_DEV_SNAPSHOT") else "postgres"
+    if _snapshot_text():
+        mode = "sqlite-dev"
+    elif _dsn_text():
+        mode = "postgres"
+    else:
+        mode = "local-drive-prototype"
     return jsonify(status="ok", version=APP_VERSION, data_mode=mode)
 
 
@@ -323,14 +512,14 @@ def setup_current_document() -> Response:
 @app.errorhandler(ConfigError)
 def config_error(exc: ConfigError) -> tuple[Response, int]:
     return jsonify(
-        error="Setup Instruction review is not connected to the current database/document source.",
+        error="Setup Procedure review is not connected to the current document source.",
         engineering_error=str(exc),
     ), 503
 
 
 @app.errorhandler(ProcedureContextError)
 def procedure_error(exc: ProcedureContextError) -> tuple[Response, int]:
-    return jsonify(error="Setup Instruction context could not be resolved.", engineering_error=str(exc)), 400
+    return jsonify(error="Setup Procedure context could not be resolved.", engineering_error=str(exc)), 400
 
 
 @app.errorhandler(SetupInstructionError)

--- a/Setup/Application/index.html
+++ b/Setup/Application/index.html
@@ -177,6 +177,6 @@
 
 <script src="setup.js?v=2026-09-06.1"></script>
 <script src="setup_review_extensions.js?v=2026-09-06.2"></script>
-<script src="setup_instruction_live.js?v=2026-09-06.3"></script>
+<script src="setup_instruction_live.js?v=2026-09-06.4"></script>
 </body>
 </html>

--- a/Setup/Application/index.html
+++ b/Setup/Application/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>MSB Setup Session</title>
   <link rel="stylesheet" href="setup.css">
-  <link rel="stylesheet" href="setup_review_extensions.css?v=2026-09-06.2">
+  <link rel="stylesheet" href="setup_review_extensions.css?v=2026-09-06.3">
 </head>
 <body>
 <header class="site-header">
@@ -177,6 +177,6 @@
 
 <script src="setup.js?v=2026-09-06.1"></script>
 <script src="setup_review_extensions.js?v=2026-09-06.2"></script>
-<script src="setup_instruction_live.js?v=2026-09-06.1"></script>
+<script src="setup_instruction_live.js?v=2026-09-06.3"></script>
 </body>
 </html>

--- a/Setup/Application/index.html
+++ b/Setup/Application/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>MSB Setup Session</title>
   <link rel="stylesheet" href="setup.css">
-  <link rel="stylesheet" href="setup_review_extensions.css?v=2026-09-06.1">
+  <link rel="stylesheet" href="setup_review_extensions.css?v=2026-09-06.2">
 </head>
 <body>
 <header class="site-header">
@@ -176,6 +176,7 @@
 </main>
 
 <script src="setup.js?v=2026-09-06.1"></script>
-<script src="setup_review_extensions.js?v=2026-09-06.1"></script>
+<script src="setup_review_extensions.js?v=2026-09-06.2"></script>
+<script src="setup_instruction_live.js?v=2026-09-06.1"></script>
 </body>
 </html>

--- a/Setup/Application/index.html
+++ b/Setup/Application/index.html
@@ -177,6 +177,6 @@
 
 <script src="setup.js?v=2026-09-06.1"></script>
 <script src="setup_review_extensions.js?v=2026-09-06.2"></script>
-<script src="setup_instruction_live.js?v=2026-09-06.4"></script>
+<script src="setup_instruction_live.js?v=2026-09-06.5"></script>
 </body>
 </html>

--- a/Setup/Application/index.html
+++ b/Setup/Application/index.html
@@ -1,0 +1,179 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>MSB Setup Session</title>
+  <link rel="stylesheet" href="setup.css">
+</head>
+<body>
+<header class="site-header">
+  <div class="brand">
+    <img src="https://webassets.sheboyganlights.org/images/branding/msb-blue-logo-600-plain.svg" alt="Making Spirits Bright">
+    <div class="brand-copy">
+      <h1>Setup Session</h1>
+      <div class="subhead">2025 historical verification prototype</div>
+    </div>
+    <div class="header-actions">
+      <label class="season-label">Season
+        <select id="season-select">
+          <option value="2025" selected>2025 — Historical Verification</option>
+        </select>
+      </label>
+      <button id="reset-prototype" type="button" class="secondary">Reset Prototype</button>
+    </div>
+  </div>
+</header>
+
+<main>
+  <section class="notice">
+    <strong>Prototype only.</strong>
+    Data shown here is provisional unless explicitly marked as confirmed. Use this screen to validate the model and correct the reconstruction before a 2026 Setup Session is created.
+  </section>
+
+  <nav class="tabs" aria-label="Setup Session views">
+    <button class="tab active" data-view="review" type="button">2025 Review</button>
+    <button class="tab" data-view="library" type="button">Reusable Task Library</button>
+    <button class="tab" data-view="movement" type="button">Movement / Unload</button>
+  </nav>
+
+  <section id="summary-grid" class="summary-grid" aria-live="polite"></section>
+
+  <section id="review-view" class="view active-view">
+    <div class="workspace">
+      <div class="card list-card">
+        <div class="section-title">
+          <div>
+            <div class="eyebrow">2025 season</div>
+            <h2>Task Verification</h2>
+          </div>
+          <div class="filters">
+            <label>Status
+              <select id="review-status-filter">
+                <option value="">All</option>
+                <option value="UNVERIFIED">Unverified</option>
+                <option value="NEEDS_CORRECTION">Needs correction</option>
+                <option value="VERIFIED">Verified</option>
+              </select>
+            </label>
+          </div>
+        </div>
+        <div class="hint">Select a task to review the reusable definition separately from the 2025 historical actual.</div>
+        <div id="review-list" class="task-list"></div>
+      </div>
+
+      <div class="card detail-card">
+        <div id="review-empty" class="empty-state">Select a task to review it.</div>
+        <div id="review-detail" hidden>
+          <div class="detail-heading">
+            <div>
+              <div id="detail-stage" class="eyebrow"></div>
+              <h2 id="detail-task-name"></h2>
+              <div id="detail-task-id" class="muted"></div>
+            </div>
+            <span id="detail-verification" class="pill"></span>
+          </div>
+
+          <section class="detail-section split-section">
+            <div>
+              <h3>Reusable Task Definition</h3>
+              <label>Task name<input id="edit-task-name" type="text"></label>
+              <label>Normal crew<input id="edit-crew" type="text"></label>
+              <label>Expected elapsed time<input id="edit-duration" type="text"></label>
+              <label>Captain / leader<input id="edit-captain" type="text"></label>
+              <label>Equipment<input id="edit-equipment" type="text"></label>
+              <label>Completion point<textarea id="edit-completion" rows="3"></textarea></label>
+              <label>Reusable notes<textarea id="edit-notes" rows="3"></textarea></label>
+            </div>
+            <div>
+              <h3>2025 Historical Actual</h3>
+              <label>2025 date(s)<input id="edit-actual-dates" type="text" placeholder="Unknown / to verify"></label>
+              <label>2025 actual crew<input id="edit-actual-crew" type="text" placeholder="Unknown / to verify"></label>
+              <label>2025 actual duration<input id="edit-actual-duration" type="text" placeholder="Unknown / to verify"></label>
+              <label>2025 notes<textarea id="edit-actual-notes" rows="4" placeholder="Historical evidence / corrections"></textarea></label>
+            </div>
+          </section>
+
+          <section class="detail-section">
+            <h3>Prerequisites</h3>
+            <div id="detail-dependencies" class="chip-row"></div>
+          </section>
+
+          <section class="detail-section">
+            <h3>Physical material</h3>
+            <div id="detail-material" class="material-box"></div>
+          </section>
+
+          <div class="action-row">
+            <button id="save-task" type="button">Save Prototype Edit</button>
+            <button id="mark-verified" type="button" class="success">Mark Verified</button>
+            <button id="mark-correction" type="button" class="warning">Needs Correction</button>
+            <button id="mark-unverified" type="button" class="secondary">Back to Unverified</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="library-view" class="view">
+    <div class="card">
+      <div class="section-title">
+        <div>
+          <div class="eyebrow">Reusable knowledge</div>
+          <h2>Task Library</h2>
+        </div>
+        <button id="add-task" type="button">Add Provisional Task</button>
+      </div>
+      <div class="hint">Task order is presentation order only. Dependencies remain separate and are shown by task name, not by reconstruction key.</div>
+      <div id="library-list" class="library-list"></div>
+    </div>
+  </section>
+
+  <section id="movement-view" class="view">
+    <div class="movement-grid">
+      <div class="card">
+        <div class="eyebrow">Shared Container acceptance case</div>
+        <h2>Container 34 — Arch Trailer</h2>
+        <div class="fact-grid">
+          <div><span>Current Setup location</span><strong id="container-location"></strong></div>
+          <div><span>Still onboard</span><strong id="container-onboard"></strong></div>
+          <div><span>Unloaded / detached</span><strong id="container-unloaded"></strong></div>
+        </div>
+        <div class="hint">Moving the trailer updates only Displays still traveling with the Container. Already-unloaded groups do not follow later scans.</div>
+      </div>
+
+      <div class="card">
+        <div class="eyebrow">Selected reusable task</div>
+        <h2>Execute Unload Task</h2>
+        <label>Unload task
+          <select id="movement-task-select"></select>
+        </label>
+        <div id="movement-task-detail" class="movement-task-detail"></div>
+        <div class="action-row">
+          <button id="move-container" type="button">Simulate Container Scan at Destination</button>
+          <button id="confirm-unload" type="button" class="success">Confirm Task Unloaded</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="section-title">
+        <h2>Arch Trailer Load State</h2>
+        <span class="muted">121 confirmed Displays across six Stage groups</span>
+      </div>
+      <div id="arch-groups" class="arch-groups"></div>
+    </div>
+
+    <div class="card">
+      <div class="section-title">
+        <h2>Movement Event Log</h2>
+        <span class="muted">Prototype-local only</span>
+      </div>
+      <div id="movement-log" class="event-log"></div>
+    </div>
+  </section>
+</main>
+
+<script src="setup.js"></script>
+</body>
+</html>

--- a/Setup/Application/index.html
+++ b/Setup/Application/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>MSB Setup Session</title>
   <link rel="stylesheet" href="setup.css">
+  <link rel="stylesheet" href="setup_review_extensions.css?v=2026-09-06.1">
 </head>
 <body>
 <header class="site-header">
@@ -174,6 +175,7 @@
   </section>
 </main>
 
-<script src="setup.js"></script>
+<script src="setup.js?v=2026-09-06.1"></script>
+<script src="setup_review_extensions.js?v=2026-09-06.1"></script>
 </body>
 </html>

--- a/Setup/Application/index.html
+++ b/Setup/Application/index.html
@@ -6,6 +6,7 @@
   <title>MSB Setup Session</title>
   <link rel="stylesheet" href="setup.css">
   <link rel="stylesheet" href="setup_review_extensions.css?v=2026-09-06.3">
+  <link rel="stylesheet" href="setup_review_clarity.css?v=2026-09-06.1">
 </head>
 <body>
 <header class="site-header">

--- a/Setup/Application/index.html
+++ b/Setup/Application/index.html
@@ -178,5 +178,6 @@
 <script src="setup.js?v=2026-09-06.1"></script>
 <script src="setup_review_extensions.js?v=2026-09-06.2"></script>
 <script src="setup_instruction_live.js?v=2026-09-06.5"></script>
+<script src="setup_review_clarity.js?v=2026-09-06.1"></script>
 </body>
 </html>

--- a/Setup/Application/requirements.txt
+++ b/Setup/Application/requirements.txt
@@ -1,0 +1,2 @@
+Flask>=3.1,<4
+psycopg2-binary>=2.9,<3

--- a/Setup/Application/setup.css
+++ b/Setup/Application/setup.css
@@ -1,0 +1,226 @@
+:root {
+  color-scheme: light;
+  --bg: #f4f6f8;
+  --card: #ffffff;
+  --border: #d8dee5;
+  --text: #18212b;
+  --muted: #66717d;
+  --accent: #0f5f8f;
+  --accent-soft: #e9f4fb;
+  --success: #277a43;
+  --success-soft: #eaf6ee;
+  --warning: #9a5a00;
+  --warning-soft: #fff4df;
+  --danger: #a4382d;
+  --danger-soft: #fdeceb;
+  --shadow: 0 1px 3px rgb(23 36 50 / 10%);
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+button, input, select, textarea { font: inherit; }
+button { cursor: pointer; }
+
+.site-header {
+  background: var(--card);
+  border-bottom: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  position: sticky;
+  top: 0;
+  z-index: 20;
+}
+
+.brand {
+  max-width: 1500px;
+  margin: 0 auto;
+  min-height: 78px;
+  padding: 12px 20px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.brand img { width: 86px; height: auto; }
+.brand-copy { flex: 1; }
+.brand-copy h1 { margin: 0; font-size: 1.55rem; }
+.subhead { color: var(--muted); margin-top: 3px; }
+.header-actions { display: flex; align-items: end; gap: 10px; flex-wrap: wrap; justify-content: flex-end; }
+.season-label { min-width: 260px; }
+
+main { max-width: 1500px; margin: 0 auto; padding: 18px 20px 48px; }
+
+.notice {
+  background: #fffbe8;
+  border: 1px solid #eadc92;
+  padding: 12px 14px;
+  border-radius: 8px;
+  margin-bottom: 14px;
+}
+
+.tabs { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 14px; }
+.tab {
+  border: 1px solid var(--border);
+  background: var(--card);
+  padding: 10px 16px;
+  border-radius: 8px;
+  color: var(--text);
+}
+.tab.active { background: var(--accent); color: white; border-color: var(--accent); }
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  margin-bottom: 14px;
+}
+.summary-card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  box-shadow: var(--shadow);
+  padding: 14px 16px;
+}
+.summary-card span { display: block; color: var(--muted); font-size: .88rem; }
+.summary-card strong { display: block; font-size: 1.7rem; margin-top: 3px; }
+
+.card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  box-shadow: var(--shadow);
+  padding: 16px;
+}
+
+.view { display: none; }
+.view.active-view { display: block; }
+.workspace { display: grid; grid-template-columns: minmax(360px, .9fr) minmax(520px, 1.45fr); gap: 14px; align-items: start; }
+.list-card, .detail-card { min-height: 620px; }
+.detail-card { position: sticky; top: 96px; }
+
+.section-title { display: flex; align-items: center; justify-content: space-between; gap: 16px; margin-bottom: 10px; }
+.section-title h2, .section-title h3 { margin: 0; }
+.eyebrow { color: var(--accent); text-transform: uppercase; letter-spacing: .06em; font-weight: 700; font-size: .75rem; }
+.muted { color: var(--muted); }
+.hint { color: var(--muted); font-size: .9rem; margin-bottom: 12px; line-height: 1.4; }
+.empty-state { color: var(--muted); padding: 42px 10px; text-align: center; }
+
+label { display: grid; gap: 5px; font-size: .85rem; color: var(--muted); }
+input, select, textarea {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: white;
+  color: var(--text);
+  padding: 9px 10px;
+}
+textarea { resize: vertical; }
+
+button {
+  border: 1px solid var(--accent);
+  border-radius: 7px;
+  background: var(--accent);
+  color: white;
+  padding: 9px 12px;
+  font-weight: 600;
+}
+button.secondary { background: white; color: var(--text); border-color: var(--border); }
+button.success { background: var(--success); border-color: var(--success); }
+button.warning { background: var(--warning); border-color: var(--warning); }
+button.danger { background: var(--danger); border-color: var(--danger); }
+button.small { font-size: .8rem; padding: 6px 9px; }
+button:disabled { opacity: .45; cursor: not-allowed; }
+
+.task-list { display: grid; gap: 8px; }
+.task-row {
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  padding: 11px 12px;
+  background: white;
+  cursor: pointer;
+}
+.task-row:hover, .task-row.selected { border-color: var(--accent); background: var(--accent-soft); }
+.task-row-top { display: flex; justify-content: space-between; gap: 10px; align-items: start; }
+.task-row h3 { margin: 2px 0 4px; font-size: 1rem; }
+.task-meta { color: var(--muted); font-size: .82rem; line-height: 1.35; }
+.task-dependency { margin-top: 7px; color: #3f4b57; font-size: .82rem; }
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  white-space: nowrap;
+  border-radius: 999px;
+  padding: 5px 9px;
+  font-size: .74rem;
+  font-weight: 800;
+  letter-spacing: .02em;
+  background: #edf0f3;
+  color: #4d5964;
+}
+.pill.verified { background: var(--success-soft); color: var(--success); }
+.pill.correction { background: var(--warning-soft); color: var(--warning); }
+.pill.unverified { background: #edf0f3; color: #4d5964; }
+.pill.onboard { background: var(--accent-soft); color: var(--accent); }
+.pill.unloaded { background: var(--success-soft); color: var(--success); }
+
+.detail-heading { display: flex; justify-content: space-between; align-items: start; gap: 16px; border-bottom: 1px solid var(--border); padding-bottom: 12px; }
+.detail-heading h2 { margin: 3px 0; }
+.detail-section { padding: 14px 0; border-bottom: 1px solid var(--border); }
+.detail-section:last-of-type { border-bottom: 0; }
+.detail-section h3 { margin: 0 0 10px; }
+.split-section { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; }
+.split-section > div { display: grid; gap: 10px; align-content: start; }
+.action-row { display: flex; gap: 8px; flex-wrap: wrap; padding-top: 14px; }
+
+.chip-row { display: flex; gap: 7px; flex-wrap: wrap; }
+.chip { background: #eef2f5; border: 1px solid var(--border); padding: 6px 9px; border-radius: 999px; font-size: .82rem; }
+.material-box { background: #f8fafb; border: 1px solid var(--border); border-radius: 8px; padding: 10px 12px; line-height: 1.5; }
+
+.library-list { display: grid; gap: 12px; }
+.library-stage { border: 1px solid var(--border); border-radius: 9px; overflow: hidden; }
+.library-stage-heading { background: #f2f5f7; padding: 10px 12px; font-weight: 800; border-bottom: 1px solid var(--border); }
+.library-task { display: grid; grid-template-columns: 44px minmax(220px, 1fr) 1fr auto; gap: 10px; align-items: center; padding: 10px 12px; border-bottom: 1px solid var(--border); }
+.library-task:last-child { border-bottom: 0; }
+.library-order { font-weight: 800; color: var(--muted); text-align: center; }
+.library-actions { display: flex; gap: 5px; }
+
+.movement-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; margin-bottom: 14px; }
+.fact-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; margin: 14px 0; }
+.fact-grid > div { border: 1px solid var(--border); border-radius: 8px; padding: 10px; }
+.fact-grid span { display: block; color: var(--muted); font-size: .8rem; }
+.fact-grid strong { display: block; margin-top: 3px; font-size: 1.05rem; }
+.movement-task-detail { margin-top: 12px; background: #f8fafb; border: 1px solid var(--border); border-radius: 8px; padding: 12px; min-height: 120px; line-height: 1.45; }
+.arch-groups { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 10px; }
+.arch-group { border: 1px solid var(--border); border-radius: 9px; padding: 11px; }
+.arch-group h3 { margin: 0 0 5px; font-size: .98rem; }
+.arch-group .group-count { font-size: 1.45rem; font-weight: 800; margin: 8px 0; }
+.event-log { display: grid; gap: 7px; }
+.event-row { border-left: 4px solid var(--accent); background: #f8fafb; border-radius: 6px; padding: 9px 11px; }
+.event-row strong { display: block; margin-bottom: 2px; }
+.event-row span { color: var(--muted); font-size: .82rem; }
+
+@media (max-width: 1050px) {
+  .summary-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .workspace, .movement-grid { grid-template-columns: 1fr; }
+  .detail-card { position: static; min-height: unset; }
+  .split-section { grid-template-columns: 1fr; }
+  .arch-groups { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+
+@media (max-width: 650px) {
+  .brand { align-items: flex-start; flex-wrap: wrap; }
+  .brand img { width: 64px; }
+  .header-actions { width: 100%; justify-content: stretch; }
+  .season-label { min-width: 0; flex: 1; }
+  main { padding: 12px 10px 36px; }
+  .summary-grid, .arch-groups { grid-template-columns: 1fr; }
+  .library-task { grid-template-columns: 34px 1fr; }
+  .library-task > :nth-child(3), .library-actions { grid-column: 2; }
+  .fact-grid { grid-template-columns: 1fr; }
+}

--- a/Setup/Application/setup.js
+++ b/Setup/Application/setup.js
@@ -1,0 +1,457 @@
+const STORAGE_KEY = 'msb.setup.prototype.2025.v1';
+
+const initialTasks = [
+  {
+    id: 'MI-FRAME', stageKey: '26', stageName: 'Magic Igloo', order: 10,
+    name: 'Layout / Erect Frame / Strap Down', verification: 'UNVERIFIED',
+    crew: '8–10 (provisional)', duration: 'About 4 hours (provisional)', captain: 'To verify',
+    equipment: 'SkyTrak; 1 boom lift (provisional)',
+    completion: 'Magic Igloo structure is laid out, erected, secured, and ready for skins.',
+    notes: 'Reusable definition reconstructed from field knowledge; verify wording, crew, equipment, and exact completion point.',
+    dependencies: [], material: 'Physical material relationship still to be reviewed against current Production Database.',
+    actual: { dates: '', crew: '', duration: '', notes: '' }
+  },
+  {
+    id: 'MI-SKINS', stageKey: '26', stageName: 'Magic Igloo', order: 20,
+    name: 'Install Skins and Bungees', verification: 'UNVERIFIED',
+    crew: '4–6 (provisional)', duration: 'About 6 hours (provisional)', captain: 'To verify',
+    equipment: '1 boom lift (provisional)',
+    completion: 'Skins and required bungees are installed and the enclosure is ready for finish work.',
+    notes: 'Warm weather preferred because skins are easier to handle. Verify whether bungees remain in this same practical task.',
+    dependencies: ['MI-FRAME'], material: 'Magic Igloo skin/KIT relationships to be resolved from current Production Database and reviewed supplemental KIT relationships.',
+    actual: { dates: '', crew: '', duration: '', notes: '' }
+  },
+  {
+    id: 'MI-FINISH', stageKey: '26', stageName: 'Magic Igloo', order: 30,
+    name: 'Install Lighting, Cameras, Mats, Signs, and Finish Setup', verification: 'UNVERIFIED',
+    crew: '2–3 (provisional)', duration: 'To verify', captain: 'To verify',
+    equipment: '1 boom lift (provisional)',
+    completion: 'Lighting, security cameras, mats, signs, and other reviewed finish items are installed and the area is operationally ready.',
+    notes: 'May need to split if lighting/cameras and mats/signs prove independently schedulable.',
+    dependencies: ['MI-SKINS'], material: 'Required Displays/KITs to be resolved and reviewed.',
+    actual: { dates: '', crew: '', duration: '', notes: '' }
+  },
+
+  ...[
+    ['RA-UNLOAD', '25', 'Racing Arches', 48],
+    ['PB-UNLOAD', '21', 'Polar Bear Playground', 3],
+    ['IT-UNLOAD', '14', 'Icicle Tunnel', 36],
+    ['ST-UNLOAD', '10', 'Stars', 24],
+    ['CL-UNLOAD', '17', 'Candyland', 2],
+    ['FC-UNLOAD', '04', 'Food Collection', 8]
+  ].map(([id, stageKey, stageName, count], index) => ({
+    id, stageKey, stageName, order: 10,
+    name: `Unload ${stageName}`,
+    verification: 'UNVERIFIED',
+    crew: 'To verify', duration: 'To verify', captain: 'To verify', equipment: 'To verify',
+    completion: `${count} expected ${stageName} Display${count === 1 ? '' : 's'} are unloaded at ${stageName}; all other Display groups remain with Container 34.`,
+    notes: 'Reusable movement task. Operator should choose/execute this practical task without scanning every Display individually.',
+    dependencies: [],
+    material: `Container 34 — Arch Trailer; ${count} expected Displays in this unload group.`,
+    unload: { containerId: 34, count, destination: stageName, groupIndex: index },
+    actual: { dates: '', crew: '', duration: '', notes: '' }
+  }))
+];
+
+const initialGroups = [
+  { taskId: 'RA-UNLOAD', stageKey: '25', name: 'Racing Arches', count: 48, status: 'ONBOARD', location: null },
+  { taskId: 'PB-UNLOAD', stageKey: '21', name: 'Polar Bear Playground', count: 3, status: 'ONBOARD', location: null },
+  { taskId: 'IT-UNLOAD', stageKey: '14', name: 'Icicle Tunnel', count: 36, status: 'ONBOARD', location: null },
+  { taskId: 'ST-UNLOAD', stageKey: '10', name: 'Stars', count: 24, status: 'ONBOARD', location: null },
+  { taskId: 'CL-UNLOAD', stageKey: '17', name: 'Candyland', count: 2, status: 'ONBOARD', location: null },
+  { taskId: 'FC-UNLOAD', stageKey: '04', name: 'Food Collection', count: 8, status: 'ONBOARD', location: null }
+];
+
+function defaultState() {
+  return {
+    tasks: structuredClone(initialTasks),
+    movement: {
+      containerId: 34,
+      location: 'Workshop / storage (prototype start)',
+      groups: structuredClone(initialGroups),
+      events: []
+    }
+  };
+}
+
+function loadState() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return defaultState();
+    const parsed = JSON.parse(raw);
+    if (!parsed?.tasks || !parsed?.movement?.groups) return defaultState();
+    return parsed;
+  } catch (_error) {
+    return defaultState();
+  }
+}
+
+let state = loadState();
+let selectedTaskId = null;
+
+const el = (id) => document.getElementById(id);
+
+function saveState() {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+}
+
+function taskById(id) {
+  return state.tasks.find((task) => task.id === id);
+}
+
+function dependencyNames(task) {
+  return (task.dependencies || []).map((id) => taskById(id)?.name || id);
+}
+
+function verificationClass(status) {
+  if (status === 'VERIFIED') return 'verified';
+  if (status === 'NEEDS_CORRECTION') return 'correction';
+  return 'unverified';
+}
+
+function verificationLabel(status) {
+  if (status === 'VERIFIED') return 'VERIFIED';
+  if (status === 'NEEDS_CORRECTION') return 'NEEDS CORRECTION';
+  return 'UNVERIFIED';
+}
+
+function sortedTasks(tasks = state.tasks) {
+  return [...tasks].sort((a, b) => {
+    const stageCompare = String(a.stageKey).localeCompare(String(b.stageKey), undefined, { numeric: true });
+    if (stageCompare !== 0) return stageCompare;
+    if (a.order !== b.order) return a.order - b.order;
+    return a.name.localeCompare(b.name);
+  });
+}
+
+function renderSummary() {
+  const counts = state.tasks.reduce((acc, task) => {
+    acc[task.verification] = (acc[task.verification] || 0) + 1;
+    return acc;
+  }, {});
+  el('summary-grid').innerHTML = `
+    <div class="summary-card"><span>Provisional tasks</span><strong>${state.tasks.length}</strong></div>
+    <div class="summary-card"><span>Unverified</span><strong>${counts.UNVERIFIED || 0}</strong></div>
+    <div class="summary-card"><span>Needs correction</span><strong>${counts.NEEDS_CORRECTION || 0}</strong></div>
+    <div class="summary-card"><span>Verified</span><strong>${counts.VERIFIED || 0}</strong></div>
+  `;
+}
+
+function renderReviewList() {
+  const filter = el('review-status-filter').value;
+  const tasks = sortedTasks().filter((task) => !filter || task.verification === filter);
+  el('review-list').innerHTML = tasks.map((task) => {
+    const deps = dependencyNames(task);
+    return `
+      <article class="task-row ${selectedTaskId === task.id ? 'selected' : ''}" data-task-id="${task.id}">
+        <div class="task-row-top">
+          <div>
+            <div class="eyebrow">Stage ${task.stageKey} — ${task.stageName}</div>
+            <h3>${escapeHtml(task.name)}</h3>
+          </div>
+          <span class="pill ${verificationClass(task.verification)}">${verificationLabel(task.verification)}</span>
+        </div>
+        <div class="task-meta">Crew: ${escapeHtml(task.crew)} · Time: ${escapeHtml(task.duration)}</div>
+        <div class="task-dependency">${deps.length ? `Requires: ${deps.map(escapeHtml).join('; ')}` : 'No task prerequisite recorded'}</div>
+      </article>
+    `;
+  }).join('') || '<div class="empty-state">No tasks match this filter.</div>';
+
+  document.querySelectorAll('.task-row').forEach((row) => {
+    row.addEventListener('click', () => selectTask(row.dataset.taskId));
+  });
+}
+
+function selectTask(taskId) {
+  selectedTaskId = taskId;
+  const task = taskById(taskId);
+  if (!task) return;
+
+  el('review-empty').hidden = true;
+  el('review-detail').hidden = false;
+  el('detail-stage').textContent = `Stage ${task.stageKey} — ${task.stageName}`;
+  el('detail-task-name').textContent = task.name;
+  el('detail-task-id').textContent = `Stable prototype identity: ${task.id}`;
+  el('detail-verification').textContent = verificationLabel(task.verification);
+  el('detail-verification').className = `pill ${verificationClass(task.verification)}`;
+
+  el('edit-task-name').value = task.name;
+  el('edit-crew').value = task.crew;
+  el('edit-duration').value = task.duration;
+  el('edit-captain').value = task.captain;
+  el('edit-equipment').value = task.equipment;
+  el('edit-completion').value = task.completion;
+  el('edit-notes').value = task.notes;
+  el('edit-actual-dates').value = task.actual?.dates || '';
+  el('edit-actual-crew').value = task.actual?.crew || '';
+  el('edit-actual-duration').value = task.actual?.duration || '';
+  el('edit-actual-notes').value = task.actual?.notes || '';
+
+  const deps = dependencyNames(task);
+  el('detail-dependencies').innerHTML = deps.length
+    ? deps.map((name) => `<span class="chip">${escapeHtml(name)}</span>`).join('')
+    : '<span class="muted">No task prerequisite recorded.</span>';
+  el('detail-material').textContent = task.material || 'No physical material relationship recorded.';
+
+  renderReviewList();
+}
+
+function saveSelectedTask() {
+  const task = taskById(selectedTaskId);
+  if (!task) return;
+  task.name = el('edit-task-name').value.trim() || task.name;
+  task.crew = el('edit-crew').value.trim();
+  task.duration = el('edit-duration').value.trim();
+  task.captain = el('edit-captain').value.trim();
+  task.equipment = el('edit-equipment').value.trim();
+  task.completion = el('edit-completion').value.trim();
+  task.notes = el('edit-notes').value.trim();
+  task.actual = {
+    dates: el('edit-actual-dates').value.trim(),
+    crew: el('edit-actual-crew').value.trim(),
+    duration: el('edit-actual-duration').value.trim(),
+    notes: el('edit-actual-notes').value.trim()
+  };
+  saveState();
+  renderAll();
+  selectTask(task.id);
+}
+
+function setVerification(status) {
+  const task = taskById(selectedTaskId);
+  if (!task) return;
+  saveSelectedTask();
+  task.verification = status;
+  saveState();
+  renderAll();
+  selectTask(task.id);
+}
+
+function renderLibrary() {
+  const grouped = new Map();
+  sortedTasks().forEach((task) => {
+    const key = `${task.stageKey}|${task.stageName}`;
+    if (!grouped.has(key)) grouped.set(key, []);
+    grouped.get(key).push(task);
+  });
+
+  el('library-list').innerHTML = [...grouped.entries()].map(([key, tasks]) => {
+    const [stageKey, stageName] = key.split('|');
+    return `
+      <section class="library-stage">
+        <div class="library-stage-heading">Stage ${stageKey} — ${stageName}</div>
+        ${tasks.map((task, index) => `
+          <div class="library-task">
+            <div class="library-order">${index + 1}</div>
+            <div>
+              <strong>${escapeHtml(task.name)}</strong>
+              <div class="task-meta">${task.id} · ${verificationLabel(task.verification)}</div>
+            </div>
+            <div class="task-meta">${dependencyNames(task).length ? `Requires: ${dependencyNames(task).map(escapeHtml).join('; ')}` : 'No prerequisite'}</div>
+            <div class="library-actions">
+              <button type="button" class="small secondary move-up" data-task-id="${task.id}" ${index === 0 ? 'disabled' : ''}>↑</button>
+              <button type="button" class="small secondary move-down" data-task-id="${task.id}" ${index === tasks.length - 1 ? 'disabled' : ''}>↓</button>
+              <button type="button" class="small open-task" data-task-id="${task.id}">Review</button>
+            </div>
+          </div>
+        `).join('')}
+      </section>
+    `;
+  }).join('');
+
+  document.querySelectorAll('.open-task').forEach((button) => {
+    button.addEventListener('click', () => {
+      showView('review');
+      selectTask(button.dataset.taskId);
+    });
+  });
+  document.querySelectorAll('.move-up').forEach((button) => button.addEventListener('click', () => moveTask(button.dataset.taskId, -1)));
+  document.querySelectorAll('.move-down').forEach((button) => button.addEventListener('click', () => moveTask(button.dataset.taskId, 1)));
+}
+
+function moveTask(taskId, direction) {
+  const task = taskById(taskId);
+  if (!task) return;
+  const sameStage = sortedTasks().filter((candidate) => candidate.stageKey === task.stageKey && candidate.stageName === task.stageName);
+  const index = sameStage.findIndex((candidate) => candidate.id === taskId);
+  const swap = sameStage[index + direction];
+  if (!swap) return;
+  const old = task.order;
+  task.order = swap.order;
+  swap.order = old;
+  if (task.order === swap.order) {
+    task.order = index + direction;
+    swap.order = index;
+  }
+  saveState();
+  renderLibrary();
+}
+
+function addProvisionalTask() {
+  const stageKey = prompt('Stage key (example 26):');
+  if (!stageKey) return;
+  const stageName = prompt('Stage / area name:');
+  if (!stageName) return;
+  const name = prompt('Practical Setup task name:');
+  if (!name) return;
+  const id = `PROV-${Date.now()}`;
+  state.tasks.push({
+    id, stageKey: stageKey.trim(), stageName: stageName.trim(), order: 999,
+    name: name.trim(), verification: 'UNVERIFIED',
+    crew: 'To verify', duration: 'To verify', captain: 'To verify', equipment: 'To verify',
+    completion: 'To verify', notes: 'Added in prototype for review.', dependencies: [],
+    material: 'To verify', actual: { dates: '', crew: '', duration: '', notes: '' }
+  });
+  saveState();
+  renderAll();
+  showView('review');
+  selectTask(id);
+}
+
+function unloadTasks() {
+  return sortedTasks().filter((task) => task.unload);
+}
+
+function movementGroupForTask(taskId) {
+  return state.movement.groups.find((group) => group.taskId === taskId);
+}
+
+function renderMovementTaskOptions() {
+  const select = el('movement-task-select');
+  const previous = select.value;
+  select.innerHTML = unloadTasks().map((task) => {
+    const group = movementGroupForTask(task.id);
+    const suffix = group?.status === 'UNLOADED' ? ' — complete' : '';
+    return `<option value="${task.id}">${escapeHtml(task.name)}${suffix}</option>`;
+  }).join('');
+  if ([...select.options].some((option) => option.value === previous)) select.value = previous;
+  renderMovementTaskDetail();
+}
+
+function renderMovementTaskDetail() {
+  const task = taskById(el('movement-task-select').value);
+  if (!task?.unload) {
+    el('movement-task-detail').innerHTML = '<span class="muted">No unload task selected.</span>';
+    return;
+  }
+  const group = movementGroupForTask(task.id);
+  const inheritedLocation = group.status === 'ONBOARD' ? state.movement.location : group.location;
+  el('movement-task-detail').innerHTML = `
+    <strong>${escapeHtml(task.name)}</strong><br>
+    Destination: ${escapeHtml(task.unload.destination)}<br>
+    Expected group: ${task.unload.count} Displays<br>
+    Current group state: <span class="pill ${group.status === 'UNLOADED' ? 'unloaded' : 'onboard'}">${group.status === 'UNLOADED' ? 'UNLOADED' : 'WITH CONTAINER 34'}</span><br>
+    Current Setup location: ${escapeHtml(inheritedLocation || 'Unknown')}
+  `;
+  el('confirm-unload').disabled = group.status === 'UNLOADED';
+}
+
+function logMovement(type, description) {
+  state.movement.events.unshift({
+    type,
+    description,
+    at: new Date().toLocaleString()
+  });
+}
+
+function moveContainerToSelectedDestination() {
+  const task = taskById(el('movement-task-select').value);
+  if (!task?.unload) return;
+  const previous = state.movement.location;
+  state.movement.location = task.unload.destination;
+  logMovement('CONTAINER SCAN', `Container 34 moved from ${previous} to ${task.unload.destination}. Only Display groups still with the Container follow this movement.`);
+  saveState();
+  renderMovement();
+}
+
+function confirmSelectedUnload() {
+  const task = taskById(el('movement-task-select').value);
+  if (!task?.unload) return;
+  const group = movementGroupForTask(task.id);
+  if (!group || group.status === 'UNLOADED') return;
+
+  if (state.movement.location !== task.unload.destination) {
+    const ok = confirm(`Container 34 is currently at "${state.movement.location}" in the prototype. Move it to ${task.unload.destination} first?`);
+    if (!ok) return;
+    moveContainerToSelectedDestination();
+  }
+
+  group.status = 'UNLOADED';
+  group.location = task.unload.destination;
+  logMovement('BULK UNLOAD', `${task.name}: ${group.count} Displays detached from Container 34 at ${group.location}. They will not follow later Container scans.`);
+  saveState();
+  renderAll();
+}
+
+function renderMovement() {
+  const onboard = state.movement.groups.filter((group) => group.status === 'ONBOARD').reduce((sum, group) => sum + group.count, 0);
+  const unloaded = state.movement.groups.filter((group) => group.status === 'UNLOADED').reduce((sum, group) => sum + group.count, 0);
+  el('container-location').textContent = state.movement.location;
+  el('container-onboard').textContent = `${onboard} Displays`;
+  el('container-unloaded').textContent = `${unloaded} Displays`;
+
+  el('arch-groups').innerHTML = state.movement.groups.map((group) => {
+    const effectiveLocation = group.status === 'ONBOARD' ? state.movement.location : group.location;
+    return `
+      <article class="arch-group">
+        <div class="eyebrow">Stage ${group.stageKey}</div>
+        <h3>${escapeHtml(group.name)}</h3>
+        <div class="group-count">${group.count}</div>
+        <span class="pill ${group.status === 'UNLOADED' ? 'unloaded' : 'onboard'}">${group.status === 'UNLOADED' ? 'UNLOADED' : 'WITH CONTAINER 34'}</span>
+        <div class="task-meta" style="margin-top:8px">Setup location: ${escapeHtml(effectiveLocation || 'Unknown')}</div>
+      </article>
+    `;
+  }).join('');
+
+  el('movement-log').innerHTML = state.movement.events.length
+    ? state.movement.events.map((event) => `
+        <div class="event-row"><strong>${escapeHtml(event.type)} — ${escapeHtml(event.description)}</strong><span>${escapeHtml(event.at)}</span></div>
+      `).join('')
+    : '<div class="empty-state">No prototype movement events yet. Choose an unload task and simulate a Container scan.</div>';
+
+  renderMovementTaskOptions();
+}
+
+function renderAll() {
+  renderSummary();
+  renderReviewList();
+  renderLibrary();
+  renderMovement();
+}
+
+function showView(name) {
+  document.querySelectorAll('.tab').forEach((button) => button.classList.toggle('active', button.dataset.view === name));
+  document.querySelectorAll('.view').forEach((view) => view.classList.remove('active-view'));
+  el(`${name}-view`).classList.add('active-view');
+}
+
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#039;');
+}
+
+document.querySelectorAll('.tab').forEach((button) => button.addEventListener('click', () => showView(button.dataset.view)));
+el('review-status-filter').addEventListener('change', renderReviewList);
+el('save-task').addEventListener('click', saveSelectedTask);
+el('mark-verified').addEventListener('click', () => setVerification('VERIFIED'));
+el('mark-correction').addEventListener('click', () => setVerification('NEEDS_CORRECTION'));
+el('mark-unverified').addEventListener('click', () => setVerification('UNVERIFIED'));
+el('add-task').addEventListener('click', addProvisionalTask);
+el('movement-task-select').addEventListener('change', renderMovementTaskDetail);
+el('move-container').addEventListener('click', moveContainerToSelectedDestination);
+el('confirm-unload').addEventListener('click', confirmSelectedUnload);
+el('reset-prototype').addEventListener('click', () => {
+  if (!confirm('Reset all prototype edits, verification states, and movement events?')) return;
+  localStorage.removeItem(STORAGE_KEY);
+  state = defaultState();
+  selectedTaskId = null;
+  el('review-detail').hidden = true;
+  el('review-empty').hidden = false;
+  renderAll();
+});
+
+renderAll();

--- a/Setup/Application/setup_instruction_live.js
+++ b/Setup/Application/setup_instruction_live.js
@@ -1,0 +1,124 @@
+/* Optional live Procedure-review integration for the Setup prototype. */
+
+const instructionNotExpected = new Set([
+  'OPS-FOOD',
+  'OPS-RENTALS',
+  'OPS-VOLTRAILER',
+  'CMD-DELIVER'
+]);
+
+function ensureInstructionFileContainers() {
+  const section = document.getElementById('instruction-review-section');
+  if (!section) return;
+  const roles = section.querySelectorAll('.instruction-role');
+  if (roles.length < 3) return;
+
+  if (!document.getElementById('instruction-current-files')) {
+    const current = document.createElement('div');
+    current.id = 'instruction-current-files';
+    current.className = 'instruction-file-list';
+    roles[0].appendChild(current);
+  }
+  if (!document.getElementById('instruction-source-files')) {
+    const source = document.createElement('div');
+    source.id = 'instruction-source-files';
+    source.className = 'instruction-file-list';
+    roles[1].appendChild(source);
+  }
+  if (!document.getElementById('instruction-archive-files')) {
+    const archive = document.createElement('div');
+    archive.id = 'instruction-archive-files';
+    archive.className = 'instruction-file-list';
+    roles[2].appendChild(archive);
+  }
+  if (!document.getElementById('instruction-live-warnings')) {
+    const warnings = document.createElement('div');
+    warnings.id = 'instruction-live-warnings';
+    warnings.className = 'instruction-live-warnings';
+    section.querySelector('.publication-flow')?.insertAdjacentElement('afterend', warnings);
+  }
+}
+
+function renderNamedFiles(targetId, files, { current = false } = {}) {
+  const target = document.getElementById(targetId);
+  if (!target) return;
+  if (!files?.length) {
+    target.innerHTML = '<span class="muted">None found.</span>';
+    return;
+  }
+
+  target.innerHTML = files.map((file) => {
+    const name = escapeHtml(file.name || 'Unnamed file');
+    if (current && file.url) {
+      return `<a class="instruction-file-link" href="${escapeHtml(file.url)}" target="_blank" rel="noopener">${name}</a>`;
+    }
+    const ext = file.extension ? ` <span class="muted">${escapeHtml(file.extension)}</span>` : '';
+    return `<div class="instruction-file-name">${name}${ext}</div>`;
+  }).join('');
+}
+
+async function loadLiveInstructionReview(task) {
+  ensureInstructionFileContainers();
+  if (!task) return;
+
+  const currentState = document.getElementById('instruction-current-state');
+  const currentFiles = document.getElementById('instruction-current-files');
+  const sourceFiles = document.getElementById('instruction-source-files');
+  const archiveFiles = document.getElementById('instruction-archive-files');
+  const warnings = document.getElementById('instruction-live-warnings');
+
+  if (instructionNotExpected.has(task.id)) {
+    if (currentState) currentState.textContent = 'No field Setup instruction is expected for this support task unless a Manager deliberately links one later.';
+    if (currentFiles) currentFiles.innerHTML = '';
+    if (sourceFiles) sourceFiles.innerHTML = '';
+    if (archiveFiles) archiveFiles.innerHTML = '';
+    if (warnings) warnings.innerHTML = '';
+    return;
+  }
+
+  if (currentState) currentState.textContent = 'Checking the current Procedure resolver…';
+  if (currentFiles) currentFiles.innerHTML = '';
+  if (sourceFiles) sourceFiles.innerHTML = '';
+  if (archiveFiles) archiveFiles.innerHTML = '';
+  if (warnings) warnings.innerHTML = '';
+
+  try {
+    const response = await fetch(`/api/setup-instructions?stage_key=${encodeURIComponent(task.stageKey)}`, {
+      headers: { Accept: 'application/json' }
+    });
+    if (!response.ok) {
+      const errorPayload = await response.json().catch(() => ({}));
+      throw new Error(errorPayload.error || `Instruction API returned ${response.status}`);
+    }
+
+    const payload = await response.json();
+    const data = payload.instructions || {};
+    if (currentState) {
+      currentState.textContent = `Resolved Stage/Sub-stage ${task.stageKey}; Procedure status: ${data.status || 'unknown'}.`;
+    }
+    renderNamedFiles('instruction-current-files', data.current_documents || [], { current: true });
+    renderNamedFiles('instruction-source-files', data.source_docs || []);
+    renderNamedFiles('instruction-archive-files', data.archive || []);
+
+    if (warnings && data.warnings?.length) {
+      warnings.innerHTML = data.warnings.map((warning) => `<div>${escapeHtml(warning)}</div>`).join('');
+    }
+  } catch (error) {
+    if (currentState) {
+      currentState.textContent = 'Live instruction files are not connected in this run. The task/procedure review fields below still work locally.';
+    }
+    if (currentFiles) currentFiles.innerHTML = '<span class="muted">Run the Flask prototype backend with DB + Display Folders configuration to show current PDFs.</span>';
+    if (sourceFiles) sourceFiles.innerHTML = '<span class="muted">Not connected.</span>';
+    if (archiveFiles) archiveFiles.innerHTML = '<span class="muted">Not connected.</span>';
+    if (warnings) warnings.innerHTML = `<div>${escapeHtml(error.message || error)}</div>`;
+  }
+}
+
+const baseSelectTaskForLiveInstructions = selectTask;
+selectTask = function selectTaskWithLiveInstructions(taskId) {
+  baseSelectTaskForLiveInstructions(taskId);
+  loadLiveInstructionReview(taskById(taskId));
+};
+
+ensureInstructionFileContainers();
+if (selectedTaskId) loadLiveInstructionReview(taskById(selectedTaskId));

--- a/Setup/Application/setup_instruction_live.js
+++ b/Setup/Application/setup_instruction_live.js
@@ -1,4 +1,4 @@
-/* Optional live Procedure-review integration for the Setup prototype. */
+/* Manager-facing live Setup Procedure integration for the 2025 prototype. */
 
 const instructionNotExpected = new Set([
   'OPS-FOOD',
@@ -7,79 +7,151 @@ const instructionNotExpected = new Set([
   'CMD-DELIVER'
 ]);
 
-function ensureInstructionFileContainers() {
+function ensureManagerProcedurePanel() {
   const section = document.getElementById('instruction-review-section');
-  if (!section) return;
-  const roles = section.querySelectorAll('.instruction-role');
-  if (roles.length < 3) return;
+  if (!section) return null;
 
-  if (!document.getElementById('instruction-current-files')) {
-    const current = document.createElement('div');
-    current.id = 'instruction-current-files';
-    current.className = 'instruction-file-list';
-    roles[0].appendChild(current);
+  const heading = section.querySelector('.section-title h3');
+  if (heading) heading.textContent = 'Setup Procedure';
+
+  // The old three-folder governance cards were useful for engineering but are
+  // too indirect for a Manager doing corrections. Keep the underlying folder
+  // roles in the backend; present the action here.
+  section.querySelector('.instruction-role-grid')?.setAttribute('hidden', '');
+  section.querySelector('.publication-flow')?.setAttribute('hidden', '');
+  section.querySelector('.instruction-boundary')?.setAttribute('hidden', '');
+
+  section.querySelectorAll('.action-row button[disabled]').forEach((button) => {
+    button.hidden = true;
+  });
+
+  let panel = document.getElementById('manager-procedure-panel');
+  if (!panel) {
+    panel = document.createElement('div');
+    panel.id = 'manager-procedure-panel';
+    panel.className = 'manager-procedure-panel';
+    panel.innerHTML = `
+      <div class="manager-procedure-card editable-procedure-card">
+        <div class="eyebrow">Editable procedure</div>
+        <div id="manager-editable-procedure" class="manager-procedure-content">
+          <span class="muted">Checking for the editable Google Doc…</span>
+        </div>
+      </div>
+      <div class="manager-procedure-card published-procedure-card">
+        <div class="eyebrow">Published field PDF</div>
+        <div id="manager-current-pdf" class="manager-procedure-content">
+          <span class="muted">Checking for the current PDF…</span>
+        </div>
+      </div>
+      <div id="manager-procedure-reminder" class="manager-procedure-reminder">
+        If you edit the Google Doc, replace the published PDF before marking the instruction verified.
+      </div>
+      <div id="instruction-live-warnings" class="instruction-live-warnings"></div>
+    `;
+
+    const editGrid = section.querySelector('.instruction-edit-grid');
+    if (editGrid) {
+      editGrid.insertAdjacentElement('beforebegin', panel);
+    } else {
+      section.appendChild(panel);
+    }
   }
-  if (!document.getElementById('instruction-source-files')) {
-    const source = document.createElement('div');
-    source.id = 'instruction-source-files';
-    source.className = 'instruction-file-list';
-    roles[1].appendChild(source);
-  }
-  if (!document.getElementById('instruction-archive-files')) {
-    const archive = document.createElement('div');
-    archive.id = 'instruction-archive-files';
-    archive.className = 'instruction-file-list';
-    roles[2].appendChild(archive);
-  }
-  if (!document.getElementById('instruction-live-warnings')) {
-    const warnings = document.createElement('div');
-    warnings.id = 'instruction-live-warnings';
-    warnings.className = 'instruction-live-warnings';
-    section.querySelector('.publication-flow')?.insertAdjacentElement('afterend', warnings);
-  }
+  return panel;
 }
 
-function renderNamedFiles(targetId, files, { current = false } = {}) {
-  const target = document.getElementById(targetId);
+function procedureActionLink(label, href, className = '') {
+  if (!href) return '';
+  return `<a class="procedure-action ${className}" href="${escapeHtml(href)}" target="_blank" rel="noopener">${escapeHtml(label)}</a>`;
+}
+
+function renderEditableProcedures(files) {
+  const target = document.getElementById('manager-editable-procedure');
   if (!target) return;
+
   if (!files?.length) {
-    target.innerHTML = '<span class="muted">None found.</span>';
+    target.innerHTML = `
+      <strong>No editable .gdoc source found for this Setup scope.</strong>
+      <div class="procedure-help">Review the Stage's Procedures\\Setup\\Archive and SourceDocs folders.</div>
+    `;
     return;
   }
 
   target.innerHTML = files.map((file) => {
-    const name = escapeHtml(file.name || 'Unnamed file');
-    if (current && file.url) {
-      return `<a class="instruction-file-link" href="${escapeHtml(file.url)}" target="_blank" rel="noopener">${name}</a>`;
-    }
-    const ext = file.extension ? ` <span class="muted">${escapeHtml(file.extension)}</span>` : '';
-    return `<div class="instruction-file-name">${name}${ext}</div>`;
+    const role = file.role === 'ARCHIVE' ? 'Archive source' : 'SourceDocs source';
+    const openAction = file.edit_url
+      ? procedureActionLink('Open Editable Procedure', file.edit_url)
+      : '<span class="procedure-action-disabled">Google Docs link could not be read from this .gdoc shortcut</span>';
+    const exportAction = file.pdf_export_url
+      ? procedureActionLink('Export Updated PDF', file.pdf_export_url, 'secondary')
+      : '';
+
+    return `
+      <div class="procedure-source-item">
+        <strong class="procedure-file-name">${escapeHtml(file.name || 'Unnamed .gdoc')}</strong>
+        <div class="procedure-source-role">${escapeHtml(role)}</div>
+        <div class="procedure-full-path">${escapeHtml(file.path || '')}</div>
+        <div class="procedure-actions">${openAction}${exportAction}</div>
+      </div>
+    `;
   }).join('');
 }
 
+function renderPublishedPdfs(files) {
+  const target = document.getElementById('manager-current-pdf');
+  if (!target) return;
+
+  if (!files?.length) {
+    target.innerHTML = `
+      <strong>No published Setup PDF found.</strong>
+      <div class="procedure-help">After correcting the editable procedure, publish the approved PDF directly in Procedures\\Setup.</div>
+    `;
+    return;
+  }
+
+  target.innerHTML = files.map((file) => `
+    <div class="procedure-pdf-item">
+      <strong class="procedure-file-name">${escapeHtml(file.name || 'Unnamed PDF')}</strong>
+      <div class="procedure-full-path">${escapeHtml(file.path || '')}</div>
+      <div class="procedure-actions">
+        ${file.url ? procedureActionLink('Open Current PDF', file.url, 'secondary') : ''}
+      </div>
+    </div>
+  `).join('');
+}
+
+function renderProcedureWarnings(warnings, resolutionMode) {
+  const target = document.getElementById('instruction-live-warnings');
+  if (!target) return;
+  const visibleWarnings = (warnings || []).filter((warning) => {
+    // The local fallback warning is useful engineering context but should not
+    // dominate the Manager workflow. Show only a compact mode note for it.
+    return !String(warning).includes('Local prototype exact-Stage-key');
+  });
+  const modeNote = resolutionMode === 'local-drive-prototype'
+    ? '<div class="procedure-mode-note">Local prototype: resolved from the mounted Display Folders by exact Stage key.</div>'
+    : '';
+  target.innerHTML = `${modeNote}${visibleWarnings.map((warning) => `<div>${escapeHtml(warning)}</div>`).join('')}`;
+}
+
 async function loadLiveInstructionReview(task) {
-  ensureInstructionFileContainers();
+  ensureManagerProcedurePanel();
   if (!task) return;
 
-  const currentState = document.getElementById('instruction-current-state');
-  const currentFiles = document.getElementById('instruction-current-files');
-  const sourceFiles = document.getElementById('instruction-source-files');
-  const archiveFiles = document.getElementById('instruction-archive-files');
+  const editableTarget = document.getElementById('manager-editable-procedure');
+  const currentTarget = document.getElementById('manager-current-pdf');
   const warnings = document.getElementById('instruction-live-warnings');
 
   if (instructionNotExpected.has(task.id)) {
-    if (currentState) currentState.textContent = 'No field Setup instruction is expected for this support task unless a Manager deliberately links one later.';
-    if (currentFiles) currentFiles.innerHTML = '';
-    if (sourceFiles) sourceFiles.innerHTML = '';
-    if (archiveFiles) archiveFiles.innerHTML = '';
+    if (editableTarget) {
+      editableTarget.innerHTML = '<strong>No Setup Procedure expected for this support task.</strong>';
+    }
+    if (currentTarget) currentTarget.innerHTML = '<span class="muted">Not applicable.</span>';
     if (warnings) warnings.innerHTML = '';
     return;
   }
 
-  if (currentState) currentState.textContent = 'Checking the current Procedure resolver…';
-  if (currentFiles) currentFiles.innerHTML = '';
-  if (sourceFiles) sourceFiles.innerHTML = '';
-  if (archiveFiles) archiveFiles.innerHTML = '';
+  if (editableTarget) editableTarget.innerHTML = '<span class="muted">Checking for the editable Google Doc…</span>';
+  if (currentTarget) currentTarget.innerHTML = '<span class="muted">Checking for the published PDF…</span>';
   if (warnings) warnings.innerHTML = '';
 
   try {
@@ -88,29 +160,23 @@ async function loadLiveInstructionReview(task) {
     });
     if (!response.ok) {
       const errorPayload = await response.json().catch(() => ({}));
-      throw new Error(errorPayload.error || `Instruction API returned ${response.status}`);
+      throw new Error(errorPayload.error || `Setup Procedure API returned ${response.status}`);
     }
 
     const payload = await response.json();
     const data = payload.instructions || {};
-    if (currentState) {
-      currentState.textContent = `Resolved Stage/Sub-stage ${task.stageKey}; Procedure status: ${data.status || 'unknown'}.`;
-    }
-    renderNamedFiles('instruction-current-files', data.current_documents || [], { current: true });
-    renderNamedFiles('instruction-source-files', data.source_docs || []);
-    renderNamedFiles('instruction-archive-files', data.archive || []);
-
-    if (warnings && data.warnings?.length) {
-      warnings.innerHTML = data.warnings.map((warning) => `<div>${escapeHtml(warning)}</div>`).join('');
-    }
+    renderEditableProcedures(data.editable_sources || []);
+    renderPublishedPdfs(data.current_documents || []);
+    renderProcedureWarnings(data.warnings || [], data.resolution_mode);
   } catch (error) {
-    if (currentState) {
-      currentState.textContent = 'Live instruction files are not connected in this run. The task/procedure review fields below still work locally.';
+    if (editableTarget) {
+      editableTarget.innerHTML = `
+        <strong>Setup Procedure could not be resolved.</strong>
+        <div class="procedure-help">${escapeHtml(error.message || error)}</div>
+      `;
     }
-    if (currentFiles) currentFiles.innerHTML = '<span class="muted">Run the Flask prototype backend with DB + Display Folders configuration to show current PDFs.</span>';
-    if (sourceFiles) sourceFiles.innerHTML = '<span class="muted">Not connected.</span>';
-    if (archiveFiles) archiveFiles.innerHTML = '<span class="muted">Not connected.</span>';
-    if (warnings) warnings.innerHTML = `<div>${escapeHtml(error.message || error)}</div>`;
+    if (currentTarget) currentTarget.innerHTML = '<span class="muted">Not resolved.</span>';
+    if (warnings) warnings.innerHTML = '';
   }
 }
 
@@ -120,5 +186,5 @@ selectTask = function selectTaskWithLiveInstructions(taskId) {
   loadLiveInstructionReview(taskById(taskId));
 };
 
-ensureInstructionFileContainers();
+ensureManagerProcedurePanel();
 if (selectedTaskId) loadLiveInstructionReview(taskById(selectedTaskId));

--- a/Setup/Application/setup_instruction_live.js
+++ b/Setup/Application/setup_instruction_live.js
@@ -14,16 +14,15 @@ function ensureManagerProcedurePanel() {
   const heading = section.querySelector('.section-title h3');
   if (heading) heading.textContent = 'Setup Procedure';
 
-  // Keep engineering/folder-governance content out of the Manager workflow.
-  const legacyRoleGrid = section.querySelector('.instruction-role-grid');
-  const legacyFlow = section.querySelector('.publication-flow');
-  const legacyBoundary = section.querySelector('.instruction-boundary');
-  if (legacyRoleGrid) legacyRoleGrid.style.display = 'none';
-  if (legacyFlow) legacyFlow.style.display = 'none';
-  if (legacyBoundary) legacyBoundary.style.display = 'none';
+  // The old three-folder governance cards were useful for engineering but are
+  // too indirect for a Manager doing corrections. Keep the underlying folder
+  // roles in the backend; present the action here.
+  section.querySelector('.instruction-role-grid')?.setAttribute('hidden', '');
+  section.querySelector('.publication-flow')?.setAttribute('hidden', '');
+  section.querySelector('.instruction-boundary')?.setAttribute('hidden', '');
 
   section.querySelectorAll('.action-row button[disabled]').forEach((button) => {
-    button.style.display = 'none';
+    button.hidden = true;
   });
 
   let panel = document.getElementById('manager-procedure-panel');
@@ -65,12 +64,6 @@ function procedureActionLink(label, href, className = '') {
   return `<a class="procedure-action ${className}" href="${escapeHtml(href)}" target="_blank" rel="noopener">${escapeHtml(label)}</a>`;
 }
 
-function allGdocSources(data) {
-  const sourceDocs = (data?.source_docs || []).filter((file) => file.extension === '.gdoc');
-  const archive = (data?.archive || []).filter((file) => file.extension === '.gdoc');
-  return [...sourceDocs, ...archive];
-}
-
 function chooseEditableProcedureFiles(files) {
   const candidates = files || [];
   const sourceDocs = candidates.filter((file) => file.role === 'SOURCEDOC');
@@ -88,7 +81,43 @@ function chooseEditableProcedureFiles(files) {
   };
 }
 
-function renderEditableProcedures(files) {
+async function openEditableProcedure(stageKey, fileName, button) {
+  const originalText = button?.textContent || 'Open Editable Procedure';
+  if (button) {
+    button.disabled = true;
+    button.textContent = 'Opening…';
+  }
+
+  try {
+    const response = await fetch('/api/setup-instructions/open-editable', {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ stage_key: stageKey, name: fileName })
+    });
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      throw new Error(payload.error || `Open Editable Procedure returned ${response.status}`);
+    }
+    if (button) button.textContent = 'Opened';
+    window.setTimeout(() => {
+      if (button) {
+        button.disabled = false;
+        button.textContent = originalText;
+      }
+    }, 1200);
+  } catch (error) {
+    if (button) {
+      button.disabled = false;
+      button.textContent = originalText;
+    }
+    window.alert(error.message || error);
+  }
+}
+
+function renderEditableProcedures(files, stageKey) {
   const target = document.getElementById('manager-editable-procedure');
   if (!target) return;
 
@@ -111,9 +140,6 @@ function renderEditableProcedures(files) {
     const role = file.role === 'ARCHIVE'
       ? 'Legacy editable source in Archive'
       : 'Editable source in SourceDocs';
-    const openAction = file.edit_url
-      ? procedureActionLink('Open Editable Procedure', file.edit_url)
-      : '<span class="procedure-action-disabled">Editable .gdoc found, but its Google Docs URL could not yet be extracted.</span>';
     const exportAction = file.pdf_export_url
       ? procedureActionLink('Export Updated PDF', file.pdf_export_url, 'secondary')
       : '';
@@ -123,10 +149,19 @@ function renderEditableProcedures(files) {
         <strong class="procedure-file-name">${escapeHtml(file.name || 'Unnamed .gdoc')}</strong>
         <div class="procedure-source-role">${escapeHtml(role)}</div>
         <div class="procedure-full-path">${escapeHtml(file.path || '')}</div>
-        <div class="procedure-actions">${openAction}${exportAction}</div>
+        <div class="procedure-actions">
+          <button type="button" class="procedure-action" data-open-editable data-file-name="${escapeHtml(file.name || '')}">Open Editable Procedure</button>
+          ${exportAction}
+        </div>
       </div>
     `;
   }).join('')}`;
+
+  target.querySelectorAll('[data-open-editable]').forEach((button) => {
+    button.addEventListener('click', () => {
+      openEditableProcedure(stageKey, button.dataset.fileName || '', button);
+    });
+  });
 }
 
 function renderPublishedPdfs(files) {
@@ -156,6 +191,8 @@ function renderProcedureWarnings(warnings, resolutionMode) {
   const target = document.getElementById('instruction-live-warnings');
   if (!target) return;
   const visibleWarnings = (warnings || []).filter((warning) => {
+    // The local fallback warning is useful engineering context but should not
+    // dominate the Manager workflow. Show only a compact mode note for it.
     return !String(warning).includes('Local prototype exact-Stage-key');
   });
   const modeNote = resolutionMode === 'local-drive-prototype'
@@ -196,11 +233,7 @@ async function loadLiveInstructionReview(task) {
 
     const payload = await response.json();
     const data = payload.instructions || {};
-
-    // Do not rely on backend edit-link extraction to decide whether a .gdoc
-    // exists. A real .gdoc is still an editable source even when its shortcut
-    // metadata format is not yet understood by the prototype parser.
-    renderEditableProcedures(allGdocSources(data));
+    renderEditableProcedures(data.editable_sources || [], task.stageKey);
     renderPublishedPdfs(data.current_documents || []);
     renderProcedureWarnings(data.warnings || [], data.resolution_mode);
   } catch (error) {

--- a/Setup/Application/setup_instruction_live.js
+++ b/Setup/Application/setup_instruction_live.js
@@ -14,15 +14,16 @@ function ensureManagerProcedurePanel() {
   const heading = section.querySelector('.section-title h3');
   if (heading) heading.textContent = 'Setup Procedure';
 
-  // The old three-folder governance cards were useful for engineering but are
-  // too indirect for a Manager doing corrections. Keep the underlying folder
-  // roles in the backend; present the action here.
-  section.querySelector('.instruction-role-grid')?.setAttribute('hidden', '');
-  section.querySelector('.publication-flow')?.setAttribute('hidden', '');
-  section.querySelector('.instruction-boundary')?.setAttribute('hidden', '');
+  // Keep engineering/folder-governance content out of the Manager workflow.
+  const legacyRoleGrid = section.querySelector('.instruction-role-grid');
+  const legacyFlow = section.querySelector('.publication-flow');
+  const legacyBoundary = section.querySelector('.instruction-boundary');
+  if (legacyRoleGrid) legacyRoleGrid.style.display = 'none';
+  if (legacyFlow) legacyFlow.style.display = 'none';
+  if (legacyBoundary) legacyBoundary.style.display = 'none';
 
   section.querySelectorAll('.action-row button[disabled]').forEach((button) => {
-    button.hidden = true;
+    button.style.display = 'none';
   });
 
   let panel = document.getElementById('manager-procedure-panel');
@@ -62,6 +63,12 @@ function ensureManagerProcedurePanel() {
 function procedureActionLink(label, href, className = '') {
   if (!href) return '';
   return `<a class="procedure-action ${className}" href="${escapeHtml(href)}" target="_blank" rel="noopener">${escapeHtml(label)}</a>`;
+}
+
+function allGdocSources(data) {
+  const sourceDocs = (data?.source_docs || []).filter((file) => file.extension === '.gdoc');
+  const archive = (data?.archive || []).filter((file) => file.extension === '.gdoc');
+  return [...sourceDocs, ...archive];
 }
 
 function chooseEditableProcedureFiles(files) {
@@ -106,7 +113,7 @@ function renderEditableProcedures(files) {
       : 'Editable source in SourceDocs';
     const openAction = file.edit_url
       ? procedureActionLink('Open Editable Procedure', file.edit_url)
-      : '<span class="procedure-action-disabled">Google Docs link could not be read from this .gdoc shortcut</span>';
+      : '<span class="procedure-action-disabled">Editable .gdoc found, but its Google Docs URL could not yet be extracted.</span>';
     const exportAction = file.pdf_export_url
       ? procedureActionLink('Export Updated PDF', file.pdf_export_url, 'secondary')
       : '';
@@ -149,8 +156,6 @@ function renderProcedureWarnings(warnings, resolutionMode) {
   const target = document.getElementById('instruction-live-warnings');
   if (!target) return;
   const visibleWarnings = (warnings || []).filter((warning) => {
-    // The local fallback warning is useful engineering context but should not
-    // dominate the Manager workflow. Show only a compact mode note for it.
     return !String(warning).includes('Local prototype exact-Stage-key');
   });
   const modeNote = resolutionMode === 'local-drive-prototype'
@@ -191,7 +196,11 @@ async function loadLiveInstructionReview(task) {
 
     const payload = await response.json();
     const data = payload.instructions || {};
-    renderEditableProcedures(data.editable_sources || []);
+
+    // Do not rely on backend edit-link extraction to decide whether a .gdoc
+    // exists. A real .gdoc is still an editable source even when its shortcut
+    // metadata format is not yet understood by the prototype parser.
+    renderEditableProcedures(allGdocSources(data));
     renderPublishedPdfs(data.current_documents || []);
     renderProcedureWarnings(data.warnings || [], data.resolution_mode);
   } catch (error) {

--- a/Setup/Application/setup_instruction_live.js
+++ b/Setup/Application/setup_instruction_live.js
@@ -64,20 +64,46 @@ function procedureActionLink(label, href, className = '') {
   return `<a class="procedure-action ${className}" href="${escapeHtml(href)}" target="_blank" rel="noopener">${escapeHtml(label)}</a>`;
 }
 
+function chooseEditableProcedureFiles(files) {
+  const candidates = files || [];
+  const sourceDocs = candidates.filter((file) => file.role === 'SOURCEDOC');
+  if (sourceDocs.length) {
+    return {
+      files: sourceDocs,
+      compatibilityFallback: false
+    };
+  }
+
+  const archive = candidates.filter((file) => file.role === 'ARCHIVE');
+  return {
+    files: archive,
+    compatibilityFallback: archive.length > 0
+  };
+}
+
 function renderEditableProcedures(files) {
   const target = document.getElementById('manager-editable-procedure');
   if (!target) return;
 
-  if (!files?.length) {
+  const selection = chooseEditableProcedureFiles(files);
+  const selectedFiles = selection.files;
+
+  if (!selectedFiles.length) {
     target.innerHTML = `
       <strong>No editable .gdoc source found for this Setup scope.</strong>
-      <div class="procedure-help">Review the Stage's Procedures\\Setup\\Archive and SourceDocs folders.</div>
+      <div class="procedure-help">Checked Procedures\\Setup\\SourceDocs first, then the existing Procedures\\Setup\\Archive legacy location.</div>
     `;
     return;
   }
 
-  target.innerHTML = files.map((file) => {
-    const role = file.role === 'ARCHIVE' ? 'Archive source' : 'SourceDocs source';
+  const compatibilityNotice = selection.compatibilityFallback
+    ? `<div class="procedure-help"><strong>Legacy compatibility:</strong> no editable .gdoc was found in SourceDocs, so this existing Archive .gdoc is being used in place for the 2025 verification pass. The Setup system does not move it.</div>`
+    : '';
+
+  target.innerHTML = `${compatibilityNotice}${selectedFiles.map((file) => {
+    const role = file.role === 'ARCHIVE'
+      ? 'Legacy editable source in Archive'
+      : 'Editable source in SourceDocs';
     const openAction = file.edit_url
       ? procedureActionLink('Open Editable Procedure', file.edit_url)
       : '<span class="procedure-action-disabled">Google Docs link could not be read from this .gdoc shortcut</span>';
@@ -93,7 +119,7 @@ function renderEditableProcedures(files) {
         <div class="procedure-actions">${openAction}${exportAction}</div>
       </div>
     `;
-  }).join('');
+  }).join('')}`;
 }
 
 function renderPublishedPdfs(files) {

--- a/Setup/Application/setup_review_clarity.css
+++ b/Setup/Application/setup_review_clarity.css
@@ -1,0 +1,59 @@
+.review-stage {
+  display: grid;
+  gap: 8px;
+  margin-bottom: 14px;
+}
+
+.review-stage-heading {
+  padding: 8px 10px;
+  border-radius: 7px;
+  background: #eef3f7;
+  border: 1px solid var(--border);
+  font-weight: 800;
+  font-size: .88rem;
+}
+
+.review-stage .task-row {
+  margin: 0;
+}
+
+.stage-gap-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  border: 1px dashed var(--border);
+  border-radius: 8px;
+  background: #fafbfc;
+  padding: 12px;
+}
+
+.missing-stage .review-stage-heading,
+.missing-stage .library-stage-heading {
+  background: #fff8e8;
+}
+
+.missing-stage .stage-gap-row {
+  border-left: 5px solid var(--warning);
+}
+
+#summary-grid {
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+}
+
+@media (max-width: 1100px) {
+  #summary-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 650px) {
+  #summary-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .stage-gap-row {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}

--- a/Setup/Application/setup_review_clarity.js
+++ b/Setup/Application/setup_review_clarity.js
@@ -1,0 +1,280 @@
+/*
+ * Setup prototype review clarity / Stage coverage.
+ *
+ * The 2025 verification queue is annual review state. The reusable task catalog
+ * is persistent task knowledge and must not present that annual state as if it
+ * were part of the reusable definition.
+ *
+ * Stage coverage is independent from reconstructed task coverage. Current
+ * governed Stage/Sub-stage identities are shown even when no provisional Setup
+ * task has yet been reconstructed for that scope.
+ */
+
+const setupStageCatalog = [
+  ['00', 'HWY 42'],
+  ['01', 'Front Entrance'],
+  ['02', 'Triangle'],
+  ['03', 'Welcome Area'],
+  ['03a', 'Mega Cube'],
+  ['04', 'Food Collection'],
+  ['05', 'Festive Trees'],
+  ['05a', 'Mega Star'],
+  ['06', 'Post Office'],
+  ['07', 'Whoville'],
+  ['07a', 'Who Forest'],
+  ['08', 'Elf Choir'],
+  ['09', 'Global Warming'],
+  ['10', 'Stars'],
+  ['11', 'Sledders'],
+  ['13', 'Winter Wonderland'],
+  ['14', 'Icicle Tunnel'],
+  ['15', 'Church-Bells'],
+  ['16', 'Northern Lights'],
+  ['17', 'Candyland'],
+  ['18', 'Dancing Forest'],
+  ['19', "Santa's Workshop"],
+  ['20', 'Snow Storm'],
+  ['21', 'Polar Bear Playground'],
+  ['22', 'Glistening Grove'],
+  ['23', 'Peanuts'],
+  ['24', 'Traditional Christmas'],
+  ['25', 'Racing Arches'],
+  ['26', 'Magic Igloo'],
+  ['30', "Santa's Station"]
+].map(([stageKey, stageName]) => ({ stageKey, stageName }));
+
+function setupStageSort(a, b) {
+  return String(a.stageKey).localeCompare(String(b.stageKey), undefined, {
+    numeric: true,
+    sensitivity: 'base'
+  });
+}
+
+function setupStageEntries() {
+  const byKey = new Map(setupStageCatalog.map((stage) => [stage.stageKey, { ...stage, governed: true }]));
+
+  // Preserve task contexts that are deliberately outside the normal governed
+  // Stage list (for example a special operational area) instead of hiding them.
+  state.tasks.forEach((task) => {
+    if (!byKey.has(task.stageKey)) {
+      byKey.set(task.stageKey, {
+        stageKey: task.stageKey,
+        stageName: task.stageName || 'Setup context',
+        governed: false
+      });
+    }
+  });
+
+  return [...byKey.values()].sort(setupStageSort);
+}
+
+function tasksForStageKey(stageKey) {
+  return sortedTasks().filter((task) => task.stageKey === stageKey);
+}
+
+function addProvisionalTaskForStage(stageKey) {
+  const stage = setupStageEntries().find((item) => item.stageKey === stageKey);
+  if (!stage) return;
+
+  const name = prompt(`Practical Setup task for Stage ${stage.stageKey} — ${stage.stageName}:`);
+  if (!name?.trim()) return;
+
+  const id = `PROV-${Date.now()}`;
+  state.tasks.push({
+    id,
+    stageKey: stage.stageKey,
+    stageName: stage.stageName,
+    order: 999,
+    name: name.trim(),
+    verification: 'UNVERIFIED',
+    crew: 'To verify',
+    duration: 'To verify',
+    captain: 'To verify',
+    equipment: 'To verify',
+    completion: 'To verify',
+    notes: 'Added during 2025 Setup verification; reusable definition still requires review.',
+    dependencies: [],
+    material: 'To verify',
+    actual: { dates: '', crew: '', duration: '', notes: '' }
+  });
+
+  saveState();
+  renderAll();
+  showView('review');
+  selectTask(id);
+}
+
+function setupTaskReviewMarkup(task) {
+  const deps = dependencyNames(task);
+  const taskContext = task.stageName ? `<div class="task-meta">Task context: ${escapeHtml(task.stageName)}</div>` : '';
+  return `
+    <article class="task-row ${selectedTaskId === task.id ? 'selected' : ''}" data-task-id="${escapeHtml(task.id)}">
+      <div class="task-row-top">
+        <div>
+          <h3>${escapeHtml(task.name)}</h3>
+        </div>
+        <span class="pill ${verificationClass(task.verification)}">2025 ${verificationLabel(task.verification)}</span>
+      </div>
+      ${taskContext}
+      <div class="task-meta">Crew: ${escapeHtml(task.crew)} · Time: ${escapeHtml(task.duration)}</div>
+      <div class="task-dependency">${deps.length ? `Requires: ${deps.map(escapeHtml).join('; ')}` : 'No task prerequisite recorded'}</div>
+    </article>
+  `;
+}
+
+renderSummary = function renderClearAnnualSummary() {
+  const counts = state.tasks.reduce((acc, task) => {
+    acc[task.verification] = (acc[task.verification] || 0) + 1;
+    return acc;
+  }, {});
+  const missingStageCount = setupStageEntries().filter((stage) => tasksForStageKey(stage.stageKey).length === 0).length;
+
+  el('summary-grid').innerHTML = `
+    <div class="summary-card"><span>Reusable tasks</span><strong>${state.tasks.length}</strong></div>
+    <div class="summary-card"><span>2025 unverified</span><strong>${counts.UNVERIFIED || 0}</strong></div>
+    <div class="summary-card"><span>2025 needs correction</span><strong>${counts.NEEDS_CORRECTION || 0}</strong></div>
+    <div class="summary-card"><span>2025 verified</span><strong>${counts.VERIFIED || 0}</strong></div>
+    <div class="summary-card"><span>Stages with no tasks yet</span><strong>${missingStageCount}</strong></div>
+  `;
+};
+
+renderReviewList = function renderAnnualVerificationQueue() {
+  const filter = el('review-status-filter').value;
+  const sections = [];
+
+  setupStageEntries().forEach((stage) => {
+    const allStageTasks = tasksForStageKey(stage.stageKey);
+    const visibleTasks = allStageTasks.filter((task) => !filter || task.verification === filter);
+
+    if (!allStageTasks.length) {
+      if (filter && filter !== 'UNVERIFIED') return;
+      sections.push(`
+        <section class="review-stage missing-stage">
+          <div class="review-stage-heading">Stage ${escapeHtml(stage.stageKey)} — ${escapeHtml(stage.stageName)}</div>
+          <div class="stage-gap-row">
+            <div>
+              <strong>No provisional 2025 Setup tasks reconstructed yet.</strong>
+              <div class="task-meta">This Stage exists; the missing task definition is a reconstruction gap, not proof that no Setup work exists.</div>
+            </div>
+            <button type="button" class="small add-stage-task" data-stage-key="${escapeHtml(stage.stageKey)}">Add Task</button>
+          </div>
+        </section>
+      `);
+      return;
+    }
+
+    if (!visibleTasks.length) return;
+    sections.push(`
+      <section class="review-stage">
+        <div class="review-stage-heading">Stage ${escapeHtml(stage.stageKey)} — ${escapeHtml(stage.stageName)}</div>
+        ${visibleTasks.map(setupTaskReviewMarkup).join('')}
+      </section>
+    `);
+  });
+
+  el('review-list').innerHTML = sections.join('') || '<div class="empty-state">No 2025 tasks match this filter.</div>';
+
+  document.querySelectorAll('.task-row').forEach((row) => {
+    row.addEventListener('click', () => selectTask(row.dataset.taskId));
+  });
+  document.querySelectorAll('.add-stage-task').forEach((button) => {
+    button.addEventListener('click', (event) => {
+      event.stopPropagation();
+      addProvisionalTaskForStage(button.dataset.stageKey || '');
+    });
+  });
+};
+
+renderLibrary = function renderReusableTaskCatalog() {
+  const sections = setupStageEntries().map((stage) => {
+    const tasks = tasksForStageKey(stage.stageKey);
+    if (!tasks.length) {
+      return `
+        <section class="library-stage missing-stage">
+          <div class="library-stage-heading">Stage ${escapeHtml(stage.stageKey)} — ${escapeHtml(stage.stageName)}</div>
+          <div class="stage-gap-row">
+            <div>
+              <strong>No reusable Setup tasks reconstructed yet.</strong>
+              <div class="task-meta">Add tasks only when the practical work boundary is understood.</div>
+            </div>
+            <button type="button" class="small add-stage-task" data-stage-key="${escapeHtml(stage.stageKey)}">Add Task</button>
+          </div>
+        </section>
+      `;
+    }
+
+    return `
+      <section class="library-stage">
+        <div class="library-stage-heading">Stage ${escapeHtml(stage.stageKey)} — ${escapeHtml(stage.stageName)}</div>
+        ${tasks.map((task, index) => `
+          <div class="library-task">
+            <div class="library-order">${index + 1}</div>
+            <div>
+              <strong>${escapeHtml(task.name)}</strong>
+              <div class="task-meta">Reusable task ID: ${escapeHtml(task.id)}</div>
+            </div>
+            <div class="task-meta">${dependencyNames(task).length ? `Requires: ${dependencyNames(task).map(escapeHtml).join('; ')}` : 'No prerequisite'}</div>
+            <div class="library-actions">
+              <button type="button" class="small secondary move-up" data-task-id="${escapeHtml(task.id)}" ${index === 0 ? 'disabled' : ''}>↑</button>
+              <button type="button" class="small secondary move-down" data-task-id="${escapeHtml(task.id)}" ${index === tasks.length - 1 ? 'disabled' : ''}>↓</button>
+              <button type="button" class="small open-task" data-task-id="${escapeHtml(task.id)}">Open Detail</button>
+            </div>
+          </div>
+        `).join('')}
+      </section>
+    `;
+  });
+
+  el('library-list').innerHTML = sections.join('');
+
+  document.querySelectorAll('.open-task').forEach((button) => {
+    button.addEventListener('click', () => {
+      showView('review');
+      selectTask(button.dataset.taskId);
+    });
+  });
+  document.querySelectorAll('.move-up').forEach((button) => button.addEventListener('click', () => moveTask(button.dataset.taskId, -1)));
+  document.querySelectorAll('.move-down').forEach((button) => button.addEventListener('click', () => moveTask(button.dataset.taskId, 1)));
+  document.querySelectorAll('.add-stage-task').forEach((button) => {
+    button.addEventListener('click', () => addProvisionalTaskForStage(button.dataset.stageKey || ''));
+  });
+};
+
+const baseSelectTaskForReviewClarity = selectTask;
+selectTask = function selectTaskWithAnnualClarity(taskId) {
+  baseSelectTaskForReviewClarity(taskId);
+  const task = taskById(taskId);
+  if (!task) return;
+
+  const pill = el('detail-verification');
+  if (pill) pill.textContent = `2025 ${verificationLabel(task.verification)}`;
+
+  const verifiedButton = el('mark-verified');
+  const correctionButton = el('mark-correction');
+  const unverifiedButton = el('mark-unverified');
+  if (verifiedButton) verifiedButton.textContent = 'Mark 2025 Verified';
+  if (correctionButton) correctionButton.textContent = '2025 Needs Correction';
+  if (unverifiedButton) unverifiedButton.textContent = 'Back to 2025 Unverified';
+};
+
+function applySetupReviewLabels() {
+  const reviewTab = document.querySelector('.tab[data-view="review"]');
+  const libraryTab = document.querySelector('.tab[data-view="library"]');
+  if (reviewTab) reviewTab.textContent = '2025 Verification';
+  if (libraryTab) libraryTab.textContent = 'Manage Reusable Tasks';
+
+  const reviewTitle = document.querySelector('#review-view .section-title h2');
+  if (reviewTitle) reviewTitle.textContent = '2025 Verification Queue';
+  const reviewHint = document.querySelector('#review-view .hint');
+  if (reviewHint) reviewHint.textContent = 'This is the 2025 annual review queue. The status belongs to 2025; the reusable task definition itself carries forward to later seasons.';
+
+  const libraryEyebrow = document.querySelector('#library-view .eyebrow');
+  const libraryTitle = document.querySelector('#library-view .section-title h2');
+  const libraryHint = document.querySelector('#library-view .hint');
+  if (libraryEyebrow) libraryEyebrow.textContent = 'Permanent reusable knowledge';
+  if (libraryTitle) libraryTitle.textContent = 'Reusable Task Catalog';
+  if (libraryHint) libraryHint.textContent = 'Managers maintain permanent task identity, order, prerequisites, normal crew/resources, and task boundaries here. Annual 2025 verification status is intentionally not shown in this catalog.';
+}
+
+applySetupReviewLabels();
+renderAll();

--- a/Setup/Application/setup_review_clarity.js
+++ b/Setup/Application/setup_review_clarity.js
@@ -172,12 +172,13 @@ renderReviewList = function renderAnnualVerificationQueue() {
     `);
   });
 
-  el('review-list').innerHTML = sections.join('') || '<div class="empty-state">No 2025 tasks match this filter.</div>';
+  const reviewList = el('review-list');
+  reviewList.innerHTML = sections.join('') || '<div class="empty-state">No 2025 tasks match this filter.</div>';
 
-  document.querySelectorAll('.task-row').forEach((row) => {
+  reviewList.querySelectorAll('.task-row').forEach((row) => {
     row.addEventListener('click', () => selectTask(row.dataset.taskId));
   });
-  document.querySelectorAll('.add-stage-task').forEach((button) => {
+  reviewList.querySelectorAll('.add-stage-task').forEach((button) => {
     button.addEventListener('click', (event) => {
       event.stopPropagation();
       addProvisionalTaskForStage(button.dataset.stageKey || '');
@@ -225,17 +226,18 @@ renderLibrary = function renderReusableTaskCatalog() {
     `;
   });
 
-  el('library-list').innerHTML = sections.join('');
+  const libraryList = el('library-list');
+  libraryList.innerHTML = sections.join('');
 
-  document.querySelectorAll('.open-task').forEach((button) => {
+  libraryList.querySelectorAll('.open-task').forEach((button) => {
     button.addEventListener('click', () => {
       showView('review');
       selectTask(button.dataset.taskId);
     });
   });
-  document.querySelectorAll('.move-up').forEach((button) => button.addEventListener('click', () => moveTask(button.dataset.taskId, -1)));
-  document.querySelectorAll('.move-down').forEach((button) => button.addEventListener('click', () => moveTask(button.dataset.taskId, 1)));
-  document.querySelectorAll('.add-stage-task').forEach((button) => {
+  libraryList.querySelectorAll('.move-up').forEach((button) => button.addEventListener('click', () => moveTask(button.dataset.taskId, -1)));
+  libraryList.querySelectorAll('.move-down').forEach((button) => button.addEventListener('click', () => moveTask(button.dataset.taskId, 1)));
+  libraryList.querySelectorAll('.add-stage-task').forEach((button) => {
     button.addEventListener('click', () => addProvisionalTaskForStage(button.dataset.stageKey || ''));
   });
 };

--- a/Setup/Application/setup_review_extensions.css
+++ b/Setup/Application/setup_review_extensions.css
@@ -1,0 +1,73 @@
+.instruction-review-section {
+  background: #fbfcfd;
+}
+
+.instruction-role-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.instruction-role {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: white;
+  padding: 11px 12px;
+  display: grid;
+  gap: 5px;
+}
+
+.instruction-role strong {
+  font-size: .9rem;
+}
+
+.instruction-role span {
+  color: var(--muted);
+  font-size: .82rem;
+}
+
+.instruction-role.current {
+  border-left: 4px solid var(--success);
+}
+
+.instruction-role.working {
+  border-left: 4px solid var(--accent);
+}
+
+.instruction-role.archive {
+  border-left: 4px solid var(--warning);
+}
+
+.publication-flow {
+  border: 1px dashed var(--border);
+  border-radius: 8px;
+  background: #f7f9fb;
+  padding: 10px 12px;
+  margin-bottom: 12px;
+  font-size: .86rem;
+  line-height: 1.5;
+}
+
+.instruction-edit-grid {
+  display: grid;
+  grid-template-columns: minmax(220px, .7fr) minmax(360px, 1.7fr);
+  gap: 12px;
+  align-items: start;
+}
+
+.instruction-boundary {
+  margin: 10px 0 0;
+}
+
+code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: .9em;
+}
+
+@media (max-width: 900px) {
+  .instruction-role-grid,
+  .instruction-edit-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/Setup/Application/setup_review_extensions.css
+++ b/Setup/Application/setup_review_extensions.css
@@ -60,6 +60,41 @@
   margin: 10px 0 0;
 }
 
+.instruction-file-list {
+  display: grid;
+  gap: 5px;
+  margin-top: 5px;
+}
+
+.instruction-file-link,
+.instruction-file-name {
+  display: block;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: #f8fafb;
+  padding: 7px 8px;
+  font-size: .82rem;
+  word-break: break-word;
+}
+
+.instruction-file-link {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 700;
+}
+
+.instruction-file-link:hover {
+  text-decoration: underline;
+}
+
+.instruction-live-warnings {
+  display: grid;
+  gap: 5px;
+  margin: 0 0 12px;
+  color: var(--warning);
+  font-size: .82rem;
+}
+
 code {
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: .9em;

--- a/Setup/Application/setup_review_extensions.css
+++ b/Setup/Application/setup_review_extensions.css
@@ -95,9 +95,31 @@
   font-size: .82rem;
 }
 
+/*
+ * Desktop task-detail workspace:
+ * the detail card is sticky, so it must own a viewport-bounded scroll area.
+ * Without this, long task/procedure detail extends below the viewport and the
+ * lower controls cannot be reached while the card remains sticky.
+ */
+@media (min-width: 1051px) {
+  .detail-card {
+    max-height: calc(100vh - 112px);
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    scrollbar-gutter: stable;
+  }
+}
+
 code {
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: .9em;
+}
+
+@media (max-width: 1050px) {
+  .detail-card {
+    max-height: none;
+    overflow: visible;
+  }
 }
 
 @media (max-width: 900px) {

--- a/Setup/Application/setup_review_extensions.css
+++ b/Setup/Application/setup_review_extensions.css
@@ -87,20 +87,135 @@
   text-decoration: underline;
 }
 
+/* Manager Procedure workflow: make the actions primary and keep folder-role
+   details out of the normal review path. */
+.manager-procedure-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(0, 1fr);
+  gap: 12px;
+  margin: 2px 0 16px;
+}
+
+.manager-procedure-card {
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  background: white;
+  padding: 14px;
+  min-width: 0;
+}
+
+.editable-procedure-card {
+  border-left: 5px solid var(--accent);
+}
+
+.published-procedure-card {
+  border-left: 5px solid var(--success);
+}
+
+.manager-procedure-content {
+  margin-top: 7px;
+}
+
+.procedure-source-item,
+.procedure-pdf-item {
+  display: grid;
+  gap: 6px;
+}
+
+.procedure-source-item + .procedure-source-item,
+.procedure-pdf-item + .procedure-pdf-item {
+  border-top: 1px solid var(--border);
+  margin-top: 12px;
+  padding-top: 12px;
+}
+
+.procedure-file-name {
+  font-size: 1rem;
+}
+
+.procedure-source-role,
+.procedure-help,
+.procedure-mode-note {
+  color: var(--muted);
+  font-size: .82rem;
+  line-height: 1.4;
+}
+
+.procedure-full-path {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: .78rem;
+  line-height: 1.45;
+  word-break: break-all;
+  background: #f7f9fb;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 7px 8px;
+}
+
+.procedure-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.procedure-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 38px;
+  border: 1px solid var(--accent);
+  border-radius: 7px;
+  background: var(--accent);
+  color: white;
+  padding: 8px 12px;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.procedure-action.secondary {
+  background: white;
+  color: var(--text);
+  border-color: var(--border);
+}
+
+.procedure-action:hover {
+  filter: brightness(.96);
+}
+
+.procedure-action-disabled {
+  display: inline-flex;
+  align-items: center;
+  min-height: 38px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: #f4f5f6;
+  color: var(--muted);
+  padding: 8px 12px;
+  font-size: .82rem;
+}
+
+.manager-procedure-reminder {
+  grid-column: 1 / -1;
+  border: 1px solid #e4b44f;
+  border-left: 5px solid var(--warning);
+  border-radius: 8px;
+  background: var(--warning-soft);
+  padding: 11px 12px;
+  font-weight: 700;
+  line-height: 1.45;
+}
+
 .instruction-live-warnings {
+  grid-column: 1 / -1;
   display: grid;
   gap: 5px;
-  margin: 0 0 12px;
   color: var(--warning);
   font-size: .82rem;
 }
 
-/*
- * Desktop task-detail workspace:
- * the detail card is sticky, so it must own a viewport-bounded scroll area.
- * Without this, long task/procedure detail extends below the viewport and the
- * lower controls cannot be reached while the card remains sticky.
- */
+/* Desktop task-detail workspace: the detail card is sticky, so it must own a
+   viewport-bounded scroll area. */
 @media (min-width: 1051px) {
   .detail-card {
     max-height: calc(100vh - 112px);
@@ -124,7 +239,13 @@ code {
 
 @media (max-width: 900px) {
   .instruction-role-grid,
-  .instruction-edit-grid {
+  .instruction-edit-grid,
+  .manager-procedure-panel {
     grid-template-columns: 1fr;
+  }
+
+  .manager-procedure-reminder,
+  .instruction-live-warnings {
+    grid-column: 1;
   }
 }

--- a/Setup/Application/setup_review_extensions.js
+++ b/Setup/Application/setup_review_extensions.js
@@ -1,0 +1,418 @@
+/*
+ * 2025 Setup verification prototype extensions.
+ *
+ * Adds a broader provisional task catalog and an instruction-review surface
+ * without changing PostgreSQL or the production Procedure application.
+ */
+
+const supplementalTasks = [
+  {
+    id: 'MC-FRAME', stageKey: '03a', stageName: 'Mega Cube', order: 10,
+    name: 'Install Mega Cube Frame and Panels', verification: 'UNVERIFIED',
+    crew: 'To verify', duration: 'To verify', captain: 'To verify', equipment: 'To verify',
+    completion: 'Mega Cube frame and panels are installed and ready for controller/final hookup work.',
+    notes: 'Representative reusable task reconstructed from Setup planning discussion; verify exact task boundary.',
+    dependencies: [], material: 'Required Mega Cube Displays/Containers to be resolved from current Production Database.',
+    actual: { dates: '', crew: '', duration: '', notes: '' }
+  },
+  {
+    id: 'MC-CONTROLLER', stageKey: '03a', stageName: 'Mega Cube', order: 20,
+    name: 'Controller / Final Hookup', verification: 'UNVERIFIED',
+    crew: 'To verify', duration: 'To verify', captain: 'To verify', equipment: 'To verify',
+    completion: 'Mega Cube controller/final hookup work is complete.',
+    notes: 'Verify whether this is independently schedulable or belongs in the frame/panel task.',
+    dependencies: ['MC-FRAME'], material: 'Controller and wiring relationships to be resolved from current Production Database.',
+    actual: { dates: '', crew: '', duration: '', notes: '' }
+  },
+  {
+    id: 'OPS-FOOD', stageKey: '04', stageName: 'General / Operations', order: 10,
+    name: 'Arrange Volunteer Food', verification: 'UNVERIFIED',
+    crew: 'To verify', duration: 'To verify', captain: 'To verify', equipment: 'None / to verify',
+    completion: 'Volunteer food arrangements for the applicable Setup period are confirmed.',
+    notes: 'Inventory-independent support task with Stage 04 general-area context.',
+    dependencies: [], material: 'No Display/KIT material required.',
+    actual: { dates: '', crew: '', duration: '', notes: '' }
+  },
+  {
+    id: 'OPS-RENTALS', stageKey: '04', stageName: 'General / Operations', order: 20,
+    name: 'Arrange Rental Equipment', verification: 'UNVERIFIED',
+    crew: 'To verify', duration: 'To verify', captain: 'To verify', equipment: 'Rental equipment planning',
+    completion: 'Required rental equipment and availability are confirmed.',
+    notes: 'Inventory-independent support task with Stage 04 general-area context.',
+    dependencies: [], material: 'No Display/KIT material required.',
+    actual: { dates: '', crew: '', duration: '', notes: '' }
+  },
+  {
+    id: 'OPS-VOLTRAILER', stageKey: '04', stageName: 'General / Operations', order: 30,
+    name: 'Position Volunteer Trailer', verification: 'UNVERIFIED',
+    crew: 'To verify', duration: 'To verify', captain: 'To verify', equipment: 'Truck / trailer capability',
+    completion: 'Volunteer Trailer is positioned in the intended Stage 04 general area.',
+    notes: 'Inventory-independent support task with field context.',
+    dependencies: [], material: 'No Display/KIT material required unless a reviewed support Container relationship is later justified.',
+    actual: { dates: '', crew: '', duration: '', notes: '' }
+  },
+  {
+    id: 'FC-ARCHES', stageKey: '04', stageName: 'Food Collection', order: 20,
+    name: 'Install Food Collection Arches', verification: 'UNVERIFIED',
+    crew: 'To verify', duration: 'To verify', captain: 'To verify', equipment: 'To verify',
+    completion: 'Food Collection arches are installed in their intended field positions.',
+    notes: 'Late-season timing may apply; verify exact date window and relationship to traffic-lane work.',
+    dependencies: ['FC-UNLOAD'], material: 'Food Collection arch Displays from Container 34 plus any reviewed support material.',
+    actual: { dates: '', crew: '', duration: '', notes: '' }
+  },
+  {
+    id: 'FC-TRAFFIC', stageKey: '04', stageName: 'Food Collection', order: 30,
+    name: 'Set Food Collection Traffic Lanes', verification: 'UNVERIFIED',
+    crew: 'To verify', duration: 'To verify', captain: 'To verify', equipment: 'To verify',
+    completion: 'Food Collection traffic lanes are configured for the intended event flow.',
+    notes: 'Intentionally delayed until near VIP night; verify exact reusable date/window guidance.',
+    dependencies: [], material: 'To verify.',
+    actual: { dates: '', crew: '', duration: '', notes: '' }
+  },
+  {
+    id: 'WH-SCAFFOLD', stageKey: '07', stageName: 'Whoville', order: 10,
+    name: 'Set Whoville Scaffold', verification: 'UNVERIFIED',
+    crew: 'To verify', duration: 'To verify', captain: 'To verify', equipment: 'Scaffold / to verify',
+    completion: 'Required Whoville scaffold is positioned and ready for dependent work.',
+    notes: 'Verify exact relationship to Mt Crumpit and other Whoville work.',
+    dependencies: [], material: 'To verify.',
+    actual: { dates: '', crew: '', duration: '', notes: '' }
+  },
+  {
+    id: 'WH-CRUMPIT', stageKey: '07', stageName: 'Whoville', order: 20,
+    name: 'Install Mt Crumpit Panels', verification: 'UNVERIFIED',
+    crew: 'To verify', duration: 'To verify', captain: 'To verify', equipment: 'To verify',
+    completion: 'Mt Crumpit panels are installed.',
+    notes: 'Provisional task boundary.',
+    dependencies: ['WH-SCAFFOLD'], material: 'Required Displays/Containers to verify.',
+    actual: { dates: '', crew: '', duration: '', notes: '' }
+  },
+  {
+    id: 'WH-SPIRAL', stageKey: '07', stageName: 'Whoville', order: 30,
+    name: 'Install Who Spiral Tree and Star', verification: 'UNVERIFIED',
+    crew: 'To verify', duration: 'To verify', captain: 'To verify', equipment: 'To verify',
+    completion: 'Who Spiral Tree and Star are installed.',
+    notes: 'Provisional task boundary.',
+    dependencies: [], material: 'Required Displays/Containers to verify.',
+    actual: { dates: '', crew: '', duration: '', notes: '' }
+  },
+  {
+    id: 'WH-CHARACTERS', stageKey: '07', stageName: 'Whoville', order: 40,
+    name: 'Place Whoville Characters', verification: 'UNVERIFIED',
+    crew: 'To verify', duration: 'To verify', captain: 'To verify', equipment: 'To verify',
+    completion: 'Whoville character Displays are placed in their intended field locations.',
+    notes: 'Provisional reusable task.',
+    dependencies: [], material: 'Required Displays/Containers to verify.',
+    actual: { dates: '', crew: '', duration: '', notes: '' }
+  },
+  {
+    id: 'WH-WHOHOUSE', stageKey: '07', stageName: 'Whoville', order: 50,
+    name: 'Build / Finish Who House on Arch Trailer', verification: 'UNVERIFIED',
+    crew: 'To verify', duration: 'To verify', captain: 'To verify', equipment: 'Arch Trailer / to verify',
+    completion: 'Arch Trailer is empty and in Whoville, and the Who House is built/finished on the trailer base.',
+    notes: 'Container 34 becomes the Who House base only after its cargo is unloaded. Who House itself is stored elsewhere and must not be assigned to Container 34.',
+    dependencies: ['RA-UNLOAD', 'PB-UNLOAD', 'IT-UNLOAD', 'ST-UNLOAD', 'CL-UNLOAD', 'FC-UNLOAD'],
+    material: 'Container 34 as support/base after unload; Who House material comes from its own current Production Database relationships.',
+    actual: { dates: '', crew: '', duration: '', notes: '' }
+  },
+  {
+    id: 'EC-SCAFFOLD', stageKey: '08', stageName: 'Elf Choir', order: 10,
+    name: 'Set Scaffold and Elves', verification: 'UNVERIFIED',
+    crew: 'To verify', duration: 'To verify', captain: 'To verify', equipment: 'Scaffold / to verify',
+    completion: 'Elf Choir scaffold and elf Displays are installed.',
+    notes: 'Verify final wording and whether scaffold and elves remain one practical task.',
+    dependencies: [], material: 'Required Displays/Containers to verify.',
+    actual: { dates: '', crew: '', duration: '', notes: '' }
+  },
+  {
+    id: 'EC-NOTES', stageKey: '08', stageName: 'Elf Choir', order: 20,
+    name: 'Install Notes and Conductor', verification: 'UNVERIFIED',
+    crew: 'To verify', duration: 'To verify', captain: 'To verify', equipment: 'To verify',
+    completion: 'Notes and conductor Displays are installed.',
+    notes: 'Provisional reusable task.',
+    dependencies: ['EC-SCAFFOLD'], material: 'Required Displays/Containers to verify.',
+    actual: { dates: '', crew: '', duration: '', notes: '' }
+  },
+  {
+    id: 'ST-HARNESS', stageKey: '10', stageName: 'Stars', order: 20,
+    name: 'Install Star Harness', verification: 'UNVERIFIED',
+    crew: 'To verify', duration: 'To verify', captain: 'To verify', equipment: 'To verify',
+    completion: 'Star harness is installed and ready for the 24 stars.',
+    notes: 'Provisional task boundary.',
+    dependencies: ['ST-UNLOAD'], material: 'Harness/support material plus current Star Display relationships.',
+    actual: { dates: '', crew: '', duration: '', notes: '' }
+  },
+  {
+    id: 'ST-HANG', stageKey: '10', stageName: 'Stars', order: 30,
+    name: 'Put Up 24 Stars', verification: 'UNVERIFIED',
+    crew: 'To verify', duration: 'To verify', captain: 'To verify', equipment: 'To verify',
+    completion: 'All 24 Star Stage stars are installed.',
+    notes: 'All 24 stars are carried on Container 34 during transport.',
+    dependencies: ['ST-HARNESS'], material: '24 Star Displays currently transported on Container 34.',
+    actual: { dates: '', crew: '', duration: '', notes: '' }
+  },
+  {
+    id: 'IT-INSTALL', stageKey: '14', stageName: 'Icicle Tunnel', order: 20,
+    name: 'Install Icicle Tunnel', verification: 'UNVERIFIED',
+    crew: 'To verify', duration: 'To verify', captain: 'To verify', equipment: 'To verify',
+    completion: 'Icicle Tunnel Display group is installed.',
+    notes: 'Provisional reusable task after bulk unload.',
+    dependencies: ['IT-UNLOAD'], material: '36 Icicle Tunnel Displays currently transported on Container 34.',
+    actual: { dates: '', crew: '', duration: '', notes: '' }
+  },
+  {
+    id: 'CL-ARCH', stageKey: '17', stageName: 'Candyland', order: 20,
+    name: 'Install Candyland Arch and Pinwheels', verification: 'UNVERIFIED',
+    crew: 'To verify', duration: 'To verify', captain: 'To verify', equipment: 'To verify',
+    completion: 'Candyland arch and pinwheels are installed.',
+    notes: 'Provisional reusable task.',
+    dependencies: ['CL-UNLOAD'], material: 'Candyland Arch Displays from Container 34 plus pinwheels/current support relationships.',
+    actual: { dates: '', crew: '', duration: '', notes: '' }
+  },
+  {
+    id: 'CL-LOLLIPOP', stageKey: '17', stageName: 'Candyland', order: 30,
+    name: 'Position Lollipop Trailer', verification: 'UNVERIFIED',
+    crew: 'To verify', duration: 'To verify', captain: 'To verify', equipment: 'Truck / trailer capability',
+    completion: 'Lollipop Trailer is positioned in Candyland.',
+    notes: 'Verify exact task/material relationship.',
+    dependencies: [], material: 'Current Production Database relationship to verify.',
+    actual: { dates: '', crew: '', duration: '', notes: '' }
+  },
+  {
+    id: 'CL-BENCHES', stageKey: '17', stageName: 'Candyland', order: 40,
+    name: 'Set Tree Benches', verification: 'UNVERIFIED',
+    crew: 'To verify', duration: 'To verify', captain: 'To verify', equipment: 'To verify',
+    completion: 'Candyland tree benches are placed.',
+    notes: 'Provisional reusable task.',
+    dependencies: [], material: 'Current Production Database relationship to verify.',
+    actual: { dates: '', crew: '', duration: '', notes: '' }
+  },
+  {
+    id: 'CL-GINGERBREAD', stageKey: '17', stageName: 'Candyland', order: 50,
+    name: 'Install Gingerbread House and Panels', verification: 'UNVERIFIED',
+    crew: 'To verify', duration: 'To verify', captain: 'To verify', equipment: 'To verify',
+    completion: 'Gingerbread House and panels are installed.',
+    notes: 'Provisional reusable task.',
+    dependencies: [], material: 'Current Production Database relationship to verify.',
+    actual: { dates: '', crew: '', duration: '', notes: '' }
+  },
+  {
+    id: 'CL-CANES', stageKey: '17', stageName: 'Candyland', order: 60,
+    name: 'Install Candy Canes', verification: 'UNVERIFIED',
+    crew: 'To verify', duration: 'To verify', captain: 'To verify', equipment: 'To verify',
+    completion: 'Candy cane Displays are installed.',
+    notes: 'Provisional reusable task.',
+    dependencies: [], material: 'Current Production Database relationship to verify.',
+    actual: { dates: '', crew: '', duration: '', notes: '' }
+  },
+  {
+    id: 'PB-THROW', stageKey: '21', stageName: 'Polar Bear Playground', order: 20,
+    name: 'Install Throwing Bears and Arch', verification: 'UNVERIFIED',
+    crew: 'To verify', duration: 'To verify', captain: 'To verify', equipment: 'To verify',
+    completion: 'Throwing Bears and Polar Bear arch are installed.',
+    notes: 'Provisional reusable task.',
+    dependencies: ['PB-UNLOAD'], material: 'Polar Bear arch group from Container 34 plus required current Displays/Containers.',
+    actual: { dates: '', crew: '', duration: '', notes: '' }
+  },
+  {
+    id: 'PB-IGLOOS', stageKey: '21', stageName: 'Polar Bear Playground', order: 30,
+    name: 'Install Polar Bear Igloos', verification: 'UNVERIFIED',
+    crew: 'To verify', duration: 'To verify', captain: 'To verify', equipment: 'To verify',
+    completion: 'Polar Bear igloos are installed.',
+    notes: 'Provisional reusable task.',
+    dependencies: [], material: 'Current Production Database relationship to verify.',
+    actual: { dates: '', crew: '', duration: '', notes: '' }
+  },
+  {
+    id: 'PB-PANELS', stageKey: '21', stageName: 'Polar Bear Playground', order: 40,
+    name: 'Install Polar Bear Panels', verification: 'UNVERIFIED',
+    crew: 'To verify', duration: 'To verify', captain: 'To verify', equipment: 'To verify',
+    completion: 'Polar Bear Playground panels are installed.',
+    notes: 'Provisional reusable task.',
+    dependencies: [], material: 'Current Production Database relationship to verify.',
+    actual: { dates: '', crew: '', duration: '', notes: '' }
+  },
+  {
+    id: 'RA-HARNESS', stageKey: '25', stageName: 'Racing Arches', order: 20,
+    name: 'Install Racing Arch Harness', verification: 'UNVERIFIED',
+    crew: 'To verify', duration: 'To verify', captain: 'To verify', equipment: 'To verify',
+    completion: 'Racing Arch harness/support is installed and ready for arches.',
+    notes: 'Provisional reusable task.',
+    dependencies: ['RA-UNLOAD'], material: 'Harness/support plus Racing Arch Display group.',
+    actual: { dates: '', crew: '', duration: '', notes: '' }
+  },
+  {
+    id: 'RA-ARCHES', stageKey: '25', stageName: 'Racing Arches', order: 30,
+    name: 'Install Racing Arches', verification: 'UNVERIFIED',
+    crew: 'To verify', duration: 'To verify', captain: 'To verify', equipment: 'To verify',
+    completion: 'Racing Arches are installed.',
+    notes: 'Provisional reusable task after harness/support work.',
+    dependencies: ['RA-HARNESS'], material: '48 Racing Arches Displays currently transported on Container 34.',
+    actual: { dates: '', crew: '', duration: '', notes: '' }
+  },
+  {
+    id: 'MI-LOCATES', stageKey: '26', stageName: 'Magic Igloo', order: 5,
+    name: 'Locates / Field Cleared', verification: 'UNVERIFIED',
+    crew: 'To verify', duration: 'To verify', captain: 'To verify', equipment: 'Locate process / to verify',
+    completion: 'Required field locates/clearance for Magic Igloo work are complete.',
+    notes: 'Beginning readiness task; technical locating remains owned by the applicable site/GIS process.',
+    dependencies: [], material: 'No Display/KIT material required.',
+    actual: { dates: '', crew: '', duration: '', notes: '' }
+  },
+  {
+    id: 'MI-POWER', stageKey: '26', stageName: 'Magic Igloo', order: 40,
+    name: 'Plug In / Power Up / Test', verification: 'UNVERIFIED',
+    crew: 'To verify', duration: 'To verify', captain: 'To verify', equipment: 'To verify',
+    completion: 'Magic Igloo applicable installed work is powered/tested and verified ready.',
+    notes: 'Power-up eligibility is task-specific; exact grass-cutting/readiness rule still requires leader review.',
+    dependencies: ['MI-FINISH'], material: 'Installed Magic Igloo Displays and power/wiring relationships.',
+    actual: { dates: '', crew: '', duration: '', notes: '' }
+  },
+  {
+    id: 'CMD-DELIVER', stageKey: '40', stageName: 'Command Center', order: 10,
+    name: 'Deliver Command Center', verification: 'UNVERIFIED',
+    crew: 'To verify', duration: 'To verify', captain: 'To verify', equipment: 'Truck / delivery capability',
+    completion: 'Command Center is delivered to its Stage 40 field context.',
+    notes: 'Inventory-independent support/placement task with Stage 40 context.',
+    dependencies: [], material: 'No Display/KIT material required unless a reviewed support relationship is later justified.',
+    actual: { dates: '', crew: '', duration: '', notes: '' }
+  }
+];
+
+function ensureSupplementalTasks() {
+  const existingIds = new Set(state.tasks.map((task) => task.id));
+  supplementalTasks.forEach((task) => {
+    if (!existingIds.has(task.id)) state.tasks.push(structuredClone(task));
+  });
+
+  const frame = taskById('MI-FRAME');
+  if (frame && !(frame.dependencies || []).includes('MI-LOCATES')) {
+    frame.dependencies = ['MI-LOCATES', ...(frame.dependencies || [])];
+  }
+
+  saveState();
+}
+
+function ensureInstructionSection() {
+  if (document.getElementById('instruction-review-section')) return;
+  const materialSection = document.getElementById('detail-material')?.closest('.detail-section');
+  if (!materialSection) return;
+
+  const section = document.createElement('section');
+  section.id = 'instruction-review-section';
+  section.className = 'detail-section instruction-review-section';
+  section.innerHTML = `
+    <div class="section-title">
+      <div>
+        <div class="eyebrow">Procedure review</div>
+        <h3>Setup Instructions</h3>
+      </div>
+      <span id="instruction-verification-pill" class="pill unverified">UNVERIFIED</span>
+    </div>
+    <div class="instruction-role-grid">
+      <div class="instruction-role current">
+        <strong>Current field instruction</strong>
+        <span>Published PDF directly in <code>Procedures\\Setup</code></span>
+        <div id="instruction-current-state" class="task-meta">Static prototype is not yet connected to the Procedure resolver.</div>
+      </div>
+      <div class="instruction-role working">
+        <strong>Editable working source</strong>
+        <span><code>Procedures\\Setup\\SourceDocs</code></span>
+        <div class="task-meta">Create/use the editable copy here. Do not edit the archived historical original in place.</div>
+      </div>
+      <div class="instruction-role archive">
+        <strong>Historical / legacy source</strong>
+        <span><code>Procedures\\Setup\\Archive</code></span>
+        <div class="task-meta">Review historical material here when validating the 2025 task and procedure.</div>
+      </div>
+    </div>
+    <div class="publication-flow">
+      Archive source → working copy in SourceDocs → review/edit → publish approved PDF directly in Procedures\\Setup
+    </div>
+    <div class="instruction-edit-grid">
+      <label>Instruction verification
+        <select id="instruction-verification">
+          <option value="UNVERIFIED">Unverified</option>
+          <option value="VERIFIED">Verified / current instruction is good</option>
+          <option value="NEEDS_REVISION">Needs revision</option>
+          <option value="NO_CURRENT_PDF">No current PDF / needs publishing</option>
+        </select>
+      </label>
+      <label>Instruction review / revision notes
+        <textarea id="instruction-review-notes" rows="5" placeholder="What is correct, obsolete, missing, or should change in the Setup instruction?"></textarea>
+      </label>
+    </div>
+    <div class="action-row">
+      <button id="save-instruction-review" type="button">Save Prototype Instruction Review</button>
+      <button type="button" class="secondary" disabled title="Requires Procedure resolver/backend integration">Open Current PDF — connect backend</button>
+      <button type="button" class="secondary" disabled title="Requires controlled authoring/publishing write path">Create Working Copy / Publish PDF — future governed write</button>
+    </div>
+    <div class="hint instruction-boundary">
+      The production Procedure application and Display Folders mount are currently read-only. This prototype records review intent only; it does not modify Google Drive or publish PDFs.
+    </div>
+  `;
+  materialSection.insertAdjacentElement('afterend', section);
+
+  document.getElementById('save-instruction-review').addEventListener('click', saveInstructionReview);
+}
+
+function instructionReviewFor(task) {
+  if (!task.instructionReview) {
+    task.instructionReview = { status: 'UNVERIFIED', notes: '' };
+  }
+  return task.instructionReview;
+}
+
+function renderInstructionReview(task) {
+  ensureInstructionSection();
+  if (!task) return;
+  const review = instructionReviewFor(task);
+  const select = document.getElementById('instruction-verification');
+  const notes = document.getElementById('instruction-review-notes');
+  if (select) select.value = review.status || 'UNVERIFIED';
+  if (notes) notes.value = review.notes || '';
+
+  const pill = document.getElementById('instruction-verification-pill');
+  if (pill) {
+    const label = review.status === 'VERIFIED'
+      ? 'VERIFIED'
+      : review.status === 'NEEDS_REVISION'
+        ? 'NEEDS REVISION'
+        : review.status === 'NO_CURRENT_PDF'
+          ? 'NO CURRENT PDF'
+          : 'UNVERIFIED';
+    pill.textContent = label;
+    pill.className = `pill ${review.status === 'VERIFIED' ? 'verified' : review.status === 'UNVERIFIED' ? 'unverified' : 'correction'}`;
+  }
+
+  const currentState = document.getElementById('instruction-current-state');
+  if (currentState) {
+    currentState.textContent = `For Stage ${task.stageKey} — ${task.stageName}: connect the Setup app to the existing Procedure resolver to enumerate the current published PDF and Manager-only Archive/SourceDocs review sources.`;
+  }
+}
+
+function saveInstructionReview() {
+  const task = taskById(selectedTaskId);
+  if (!task) return;
+  const review = instructionReviewFor(task);
+  review.status = document.getElementById('instruction-verification')?.value || 'UNVERIFIED';
+  review.notes = document.getElementById('instruction-review-notes')?.value.trim() || '';
+  saveState();
+  renderInstructionReview(task);
+}
+
+const baseSelectTaskForInstructionReview = selectTask;
+selectTask = function selectTaskWithInstructionReview(taskId) {
+  baseSelectTaskForInstructionReview(taskId);
+  renderInstructionReview(taskById(taskId));
+};
+
+const baseRenderAllForSupplementalTasks = renderAll;
+renderAll = function renderAllWithSupplementalTasks() {
+  baseRenderAllForSupplementalTasks();
+  if (selectedTaskId) renderInstructionReview(taskById(selectedTaskId));
+};
+
+ensureSupplementalTasks();
+ensureInstructionSection();
+renderAll();


### PR DESCRIPTION
## Purpose

Create the first browser-native Setup Session validation surface so the 2025 reconstruction can be reviewed in a usable UI instead of relying on the difficult spreadsheet layout.

## Scope

Prototype only. No PostgreSQL schema changes and no production writes.

Adds `Setup/Application/` with:

- `2025 — Historical Verification` season context;
- provisional reusable task review;
- separate reusable-definition and 2025-actual sections;
- `UNVERIFIED`, `VERIFIED`, and `NEEDS CORRECTION` states;
- a broader representative task library across Setup areas instead of only Arch Trailer unload tasks;
- provisional Magic Igloo phased work;
- reusable Container 34 / Arch Trailer unload tasks;
- confirmed 121-Display Arch Trailer grouping across six Stages;
- shared-Container movement simulation where only Display groups still traveling with the Container follow later moves;
- bulk unload behavior that detaches the selected task group from later Container movement;
- Setup Instruction review status/notes on each task detail;
- optional read-only Flask integration that reuses the current Procedure/shared field-context resolver to show current Setup PDFs plus SourceDocs/Archive filenames;
- local browser persistence for prototype edits only.

## Procedure review direction

Preserve the existing document roles:

```text
Procedures\Setup\<current>.pdf       current field instruction
Procedures\Setup\SourceDocs\        editable working source
Procedures\Setup\Archive\           historical/superseded evidence
```

For 2025 verification, review the archived source beside the reusable task, create/use a working copy in SourceDocs when revision is needed, then publish the approved PDF directly in `Procedures\Setup`. Do not edit the archived historical original in place.

The prototype read side can enumerate current PDFs/SourceDocs/Archive when configured. It does not write or publish documents.

## Design intent

The UI is the validation tool. Reconstruction evidence remains provisional until managers/team leaders can review and correct it through the application.

The prototype follows the browser-native FieldWiring / Controller Inventory direction rather than forcing complex Setup workflow into generic Directus collection forms.

## Boundary

This PR does not:

- create Setup tables;
- create a production Setup Session;
- write movement history;
- modify Google Drive;
- edit an archived Google Doc;
- create a SourceDocs working copy;
- convert/publish a new PDF;
- establish final Manager/Admin authorization;
- deploy a production service;
- approve reconstructed 2025 task order, dependencies, dates, or actuals.

Supports #122. Documentation authority remains under `12_Setup_and_Deployment`; draft documentation PR #123 remains separate.