### PR TITLE
Release current Setup operator and engineering documentation

### DIFF
--- a/Docs/00_Project_Overview/Google_Drive/README.md
+++ b/Docs/00_Project_Overview/Google_Drive/README.md
@@ -1,6 +1,6 @@
 # Google Drive / Display Folder Operations
 
-This is the operator starting point for maintaining the Google Shared Drive **Display Folders** structure used by Folder Alignment, Field Wiring, Preview Authoring, and the Procedures system.
+This is the operator starting point for maintaining the Google Shared Drive **Display Folders** structure used by Folder Alignment, Field Wiring, Preview Authoring, the Procedures system, and Setup Session field-document support.
 
 Use this page to choose the task you are doing. You do not need to understand the database, resolver, or application architecture to follow these procedures.
 
@@ -10,6 +10,22 @@ If you are repairing or organizing an existing Stage/Scene, start with:
 
 - [Repair or Organize an Existing Stage / Scene](operatorSOP/Repair_Existing_Stage_Scene.md)
 
+If you are creating the non-LOR Procedure root for truly park-wide Setup work such as street-light work, site breakers, or other infrastructure tasks with no appropriate Stage/Scene owner, start with:
+
+- [Create the Park Infrastructure Procedure Folder](operatorSOP/Create_Site_Infrastructure_Procedure_Folder.md)
+
+The approved physical folder name is:
+
+```text
+G:\Shared drives\Display Folders\41 Park Infrastructure-PI
+```
+
+The leading `41` is only a human sort aid. The space after `41` is intentional and keeps this folder outside the active Folder Alignment top-level `NN-...` Stage candidate pattern.
+
+`41 Park Infrastructure-PI` has no LOR Preview and does not create Stage 41.
+
+Do not use this folder merely because a Stage has no wired inventory. For example, `40-CommandCenter` remains a legitimate Stage because it has its own current Stage/Preview context; its Setup tasks and Procedures belong under Stage 40 when that is the correct operational owner.
+
 ## What Do You Need To Do?
 
 - [Run Folder Alignment](../../01_LOR_System/02_Data_Extraction/Folder_Alignment/operatorSOP/Run_Folder_Alignment.md)
@@ -17,6 +33,7 @@ If you are repairing or organizing an existing Stage/Scene, start with:
 - [Repair or organize an existing Stage / Scene](operatorSOP/Repair_Existing_Stage_Scene.md)
 - [Add or verify MSB marker files](operatorSOP/Add_Verify_Marker_Files.md)
 - [Create a new Stage / Sub-stage / Scene documentation folder](operatorSOP/Create_Stage_Substage_Scene_Folder.md)
+- [Create the `41 Park Infrastructure-PI` non-LOR Procedure folder](operatorSOP/Create_Site_Infrastructure_Procedure_Folder.md)
 - [Align a legacy Setup document to the correct Stage / Scene](operatorSOP/Align_Legacy_Setup_Documents.md)
 - [Publish a current Setup instruction](operatorSOP/Publish_Current_Setup_Instruction.md)
 - [Create or update a field wiring diagram](../../01_LOR_System/01_Preview_Authoring/D_Create_Wiring_Backgrounds..md)
@@ -36,7 +53,8 @@ The normal team workflow should use those field systems to find current Wiring a
 
 | Material | Current published location | Working/history location |
 |---|---|---|
-| Setup PDF | `Procedures\Setup` | `SourceDocs` / `Archive` |
+| Stage/Scene Setup PDF | `<scope>\Procedures\Setup` | `SourceDocs` / `Archive` |
+| Park-wide / no-Stage Setup PDF | `41 Park Infrastructure-PI\Procedures\Setup` | `SourceDocs` / `Archive` |
 | Setup instruction images | `Procedures\Setup\images` | — |
 | Takedown PDF | `Procedures\Takedown` | `SourceDocs` / `Archive` |
 | Takedown instruction images | `Procedures\Takedown\images` | — |
@@ -48,6 +66,8 @@ The normal team workflow should use those field systems to find current Wiring a
 
 Putting a current field document in `Archive` or `SourceDocs` can prevent the field application from presenting it as current material.
 
+`41 Park Infrastructure-PI` is a controlled **non-LOR** Setup Procedure root. The numeric prefix exists only to keep the folder near the numbered park areas in normal sorting. It does not create LOR Stage 41, and `PI` is not an LOR Stage short code.
+
 ## Engineering
 
 Engineering documentation is intentionally separate from the operator procedures.
@@ -55,9 +75,10 @@ Engineering documentation is intentionally separate from the operator procedures
 Start here only when you need to understand, troubleshoot, validate, or change how the Google Drive integrations work:
 
 - [Google Drive Engineering](engineering/README.md)
+- [Folder Alignment Park Infrastructure non-LOR boundary](../../01_LOR_System/02_Data_Extraction/Folder_Alignment/engineering/Park_Infrastructure_Non_LOR_Root_2026-09-07.md)
 
 ## If You Are Unsure
 
 Do not guess by moving, renaming, deleting, or creating a folder based only on a similar filename.
 
-Use the Folder Alignment worklist, preserve uncertain legacy material, and flag the item for review.
+Use the Folder Alignment worklist for Stage/Scene material, preserve uncertain legacy material, and flag the item for review. For truly park-wide Setup work with no Stage/Scene owner, use the dedicated `41 Park Infrastructure-PI` Procedure-root procedure rather than forcing the work into LOR organization.

--- a/Docs/00_Project_Overview/Google_Drive/operatorSOP/Add_Verify_Marker_Files.md
+++ b/Docs/00_Project_Overview/Google_Drive/operatorSOP/Add_Verify_Marker_Files.md
@@ -8,14 +8,14 @@
 | Audience | Production documentation maintainers and Folder Alignment reviewers |
 | Status | CURRENT |
 | Owner | Production documentation owner / administrator |
-| Last Reviewed | 2026-08-23 |
-| Keywords | marker, Display Folders, Field Wiring, Procedures, PreviewBackground, Google Drive, Folder Alignment |
+| Last Reviewed | 2026-09-07 |
+| Keywords | marker, Display Folders, Field Wiring, Procedures, PreviewBackground, Google Drive, Folder Alignment, Park Infrastructure |
 
 [↑ Google Drive / Display Folder Operations](../README.md)
 
 ## Purpose
 
-Use this procedure when adding or checking marker files in Google Drive folders used by the current **Field Wiring** or **Procedures** systems.
+Use this procedure when adding or checking marker files in Google Drive folders used by the current **Field Wiring** or **Procedures** systems, including the controlled non-LOR `41 Park Infrastructure-PI` Procedure root used by Setup Session.
 
 The marker tells people and the MSB field-document systems that the folder is part of the controlled current structure.
 
@@ -33,10 +33,11 @@ Do not shorten, rename, move, or delete an approved marker.
 
 ## Before You Start
 
-- Work from an already-reviewed Stage, Sub-stage, or Scene location.
-- Do not rename or move the Stage/Scene root as part of adding a marker.
+- For Stage/Sub-stage/Scene material, work from an already-reviewed structured location.
+- For park-wide/no-Stage Setup Procedures, work only from the approved `Display Folders\41 Park Infrastructure-PI` root.
+- Do not rename or move an approved root as part of adding a marker.
 - Do not add marker files to every folder just because the folder exists.
-- If you are unsure whether a folder is a current Stage/Scene source, stop and check the Folder Alignment worklist before marking it.
+- If you are unsure whether a folder is a current controlled source, stop and check the applicable operator procedure before marking it.
 
 ## Field Wiring Marker Locations
 
@@ -68,7 +69,7 @@ Do **not** add separate markers to `Wiring\BackgroundStage` or `Wiring\MusicalSt
 
 Do **not** mark `SourceDocs` as current field content.
 
-## Procedures Marker Locations
+## Stage / Scene Procedures Marker Locations
 
 ```text
 <Stage / Sub-stage / Scene root>     YES
@@ -105,6 +106,44 @@ Do **not** add separate markers to `Inspection`, `Setup`, `Takedown`, or their `
 
 Do **not** mark `Archive` or `SourceDocs` as current field content.
 
+## Park Infrastructure Procedures Marker Locations
+
+The non-LOR Setup Procedure root uses the same Procedure marker pattern without pretending to be a Stage or Scene:
+
+```text
+41 Park Infrastructure-PI                        YES
+41 Park Infrastructure-PI\Procedures             YES
+Procedures\Inspection                            NO
+Procedures\Setup                                 NO
+Procedures\Takedown                              NO
+Procedures\Setup\images                          NO
+Procedures\Takedown\images                       NO
+Archive                                           NO
+SourceDocs                                        NO
+```
+
+Expected structure:
+
+```text
+41 Park Infrastructure-PI\
+├── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
+└── Procedures\
+    ├── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
+    ├── Inspection\
+    ├── Setup\
+    │   ├── Archive\
+    │   ├── images\
+    │   └── SourceDocs\
+    └── Takedown\
+        ├── Archive\
+        ├── images\
+        └── SourceDocs\
+```
+
+Do not add `PreviewBackground` or `Wiring` merely because normal Stage folders have those branches. `41 Park Infrastructure-PI` is not LOR-derived.
+
+Use [Create the Park Infrastructure Procedure Folder](Create_Site_Infrastructure_Procedure_Folder.md) for the complete build checklist.
+
 ## Photos
 
 The general `Photos` folder is not currently a Field Wiring or Procedures source folder.
@@ -113,17 +152,18 @@ Do not add a field-source marker to `Photos` merely because the folder exists.
 
 ## Procedure
 
-1. Open the reviewed Stage, Sub-stage, or Scene folder.
-2. Confirm the folder name matches the intended location from Folder Alignment.
+1. Open the reviewed controlled root.
+2. Confirm the folder is the intended Stage/Sub-stage/Scene or the approved `41 Park Infrastructure-PI` root.
 3. Check whether the marker already exists in the root.
-4. If the root is a current controlled Stage/Sub-stage/Scene source and the marker is missing, add the exact marker filename.
+4. If the root is a current controlled source and the marker is missing, add the exact marker filename.
 5. If the folder uses Field Wiring, open `Wiring` and verify the same marker exists directly in `Wiring`.
 6. Do **not** add markers inside `BackgroundStage`, `MusicalStage`, or their `SourceDocs` folders.
 7. If the folder uses Procedures, open `Procedures` and verify the marker exists directly in `Procedures`.
 8. Do **not** add markers inside `Inspection`, `Setup`, `Takedown`, their `images` folders, `Archive`, or `SourceDocs`.
-9. If `PreviewBackground` is being used as a current LOR/application source, verify the marker exists directly in that `PreviewBackground` folder.
-10. Leave unrelated legacy folders unmarked unless they are deliberately reviewed and brought into the current controlled structure.
-11. Verify the final placement using the checklists below.
+9. For Stage/Sub-stage/Scene roots, if `PreviewBackground` is being used as a current LOR/application source, verify the marker exists directly in that `PreviewBackground` folder.
+10. For `41 Park Infrastructure-PI`, do not create or mark a `PreviewBackground` merely to imitate Stage structure.
+11. Leave unrelated legacy folders unmarked unless they are deliberately reviewed and brought into the current controlled structure.
+12. Verify the final placement using the checklists below.
 
 ## Local Notes Inside a Marker
 
@@ -149,27 +189,30 @@ Do not place passwords, credentials, API keys, or private personal information i
 
 ## Procedures Verification Checklist
 
-- [ ] Stage/Sub-stage/Scene root marker is present.
+- [ ] Controlled root marker is present.
 - [ ] `Procedures` marker is present.
 - [ ] `Inspection`, `Setup`, and `Takedown` are the controlled child names when that structure is used.
 - [ ] Those task folders do not have separate marker requirements.
 - [ ] Setup/Takedown `images` folders do not have separate marker requirements.
 - [ ] `Archive` and `SourceDocs` are not marked as current field content.
+- [ ] `41 Park Infrastructure-PI`, when used, has no fake Stage/Scene/LOR helpers added solely for Procedure resolution.
 - [ ] No approved marker was renamed or deleted.
 
 ## Expected Result
 
-The Stage/Scene root and the applicable subsystem root are marked exactly as shown above, without extra marker files in the fixed child branches.
+The controlled root and the applicable subsystem root are marked exactly as shown above, without extra marker files in the fixed child branches.
 
 ## If Something Is Wrong
 
 - **A marker exists in `BackgroundStage`, `MusicalStage`, `Setup`, `Takedown`, `Inspection`, or an `images` folder:** do not use that extra marker as authority. Flag it for cleanup/review.
-- **A root, `Wiring`, or `Procedures` marker is missing:** add it only after confirming that the folder is the correct current controlled location.
-- **You are unsure whether the folder is a Scene, Display/group, or legacy folder:** do not add a marker based on guesswork. Review Folder Alignment first.
+- **A controlled root, `Wiring`, or `Procedures` marker is missing:** add it only after confirming that the folder is the correct current controlled location.
+- **You are unsure whether a folder is a Scene, Display/group, legacy folder, or `41 Park Infrastructure-PI`:** do not add a marker based on guesswork. Review the applicable folder-creation/alignment procedure first.
 - **A marker utility gives instructions different from this procedure:** stop and do not run it until the utility has been reviewed against the current marker rule.
 
 ## Related Documents
 
 - [Repair or Organize an Existing Stage / Scene](Repair_Existing_Stage_Scene.md)
 - [Create a New Stage / Sub-stage / Scene Documentation Folder](Create_Stage_Substage_Scene_Folder.md)
+- [Create the Park Infrastructure Procedure Folder](Create_Site_Infrastructure_Procedure_Folder.md)
+- [Folder Alignment Park Infrastructure non-LOR boundary](../../../01_LOR_System/02_Data_Extraction/Folder_Alignment/engineering/Park_Infrastructure_Non_LOR_Root_2026-09-07.md)
 - [Google Drive Engineering](../engineering/README.md)

--- a/Docs/00_Project_Overview/Google_Drive/operatorSOP/Create_Site_Infrastructure_Procedure_Folder.md
+++ b/Docs/00_Project_Overview/Google_Drive/operatorSOP/Create_Site_Infrastructure_Procedure_Folder.md
@@ -1,0 +1,222 @@
+# Create the Park Infrastructure Procedure Folder
+
+| Document Control | Value |
+|---|---|
+| Document Type | Operational SOP |
+| System | Google Shared Drive — Display Folders |
+| Task | Create the controlled non-LOR Procedure root for park-wide Setup work |
+| Audience | Production documentation maintainers and Setup Managers |
+| Status | CURRENT FOR SETUP V0.3 BUILD-OUT |
+| Owner | Setup and Deployment / Production documentation owner |
+| Last Reviewed | 2026-09-07 |
+| Keywords | Park Infrastructure, site-wide, Setup, Procedures, Google Drive, non-LOR, street lights, breakers, power |
+
+[↑ Google Drive / Display Folder Operations](../README.md)
+
+## Purpose
+
+Use this procedure to create and maintain the controlled Google Drive folder that owns **park-wide / infrastructure Setup Procedures** which do not belong to any existing LOR Stage, Sub-stage, or Scene.
+
+Examples include:
+
+- remove street lights where required for show operation;
+- convert street-light circuits to show power by switching the approved fuses;
+- turn on site breakers; and
+- other park-wide infrastructure work that has no appropriate Stage/Scene owner.
+
+These are real Setup tasks, but they are **not LOR tasks** and must not be assigned to a fake Stage or Scene merely to obtain a Procedure path.
+
+Do not use this folder merely because a Stage has no wired inventory items. `40-CommandCenter`, for example, is a real Stage with its own current LOR Preview even though that Preview may contain no wired inventory items. Command Center Setup tasks and Procedures remain Stage-40 work when Stage 40 is the correct operational owner.
+
+## Approved Folder Name and Location
+
+Create this folder directly under the existing Google Shared Drive **Display Folders** root:
+
+```text
+G:\Shared drives\Display Folders\41 Park Infrastructure-PI
+```
+
+The leading `41` keeps this operational folder beside the numbered park-area folders in normal Windows/Google Drive sorting.
+
+The space after `41` is intentional. The active Folder Alignment Stage inventory recognizes top-level Stage candidates in the `NN-...` form, so:
+
+```text
+41 Park Infrastructure-PI
+```
+
+remains outside that Stage pattern.
+
+`PI` is a human-facing Park Infrastructure code only. It is not an LOR Stage short code and does not create Stage 41.
+
+Do not create an LOR Preview, Stage, Scene, `PreviewBackground`, or `Wiring` branch for this folder merely to satisfy another system.
+
+## Create This Folder Structure
+
+```text
+41 Park Infrastructure-PI/
+│
+├── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
+│
+└── Procedures/
+    ├── _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
+    │
+    ├── Inspection/
+    │
+    ├── Setup/
+    │   ├── Archive/
+    │   ├── images/
+    │   └── SourceDocs/
+    │
+    └── Takedown/
+        ├── Archive/
+        ├── images/
+        └── SourceDocs/
+```
+
+This intentionally reuses the existing Procedure subsystem structure while omitting Stage/LOR-only helpers that do not apply.
+
+There is no generic `Procedures\SourceDocs` folder. Setup and Takedown each own their own `SourceDocs` folder.
+
+## Marker Locations
+
+Use the exact standard marker filename:
+
+```text
+_MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
+```
+
+Required markers:
+
+```text
+41 Park Infrastructure-PI root       YES
+Procedures                           YES
+Procedures\Inspection               NO
+Procedures\Setup                    NO
+Procedures\Takedown                 NO
+Procedures\Setup\images             NO
+Procedures\Takedown\images          NO
+Archive                              NO
+SourceDocs                           NO
+```
+
+The root marker identifies the approved controlled non-LOR documentation root. The `Procedures` marker guards the Procedure subsystem branch.
+
+Do not add markers to every child folder.
+
+## What Goes Where
+
+### Current published field PDFs
+
+Put the current PDFs directly in:
+
+```text
+41 Park Infrastructure-PI\Procedures\Setup
+```
+
+Examples may eventually include:
+
+```text
+Street Light Removal.pdf
+Street Light Power Conversion.pdf
+Site Power and Breaker Setup.pdf
+```
+
+The exact current document names may evolve. The folder contract is authoritative; this procedure does not require those literal PDFs to exist.
+
+### Editable source documents
+
+Put editable working/source material in:
+
+```text
+41 Park Infrastructure-PI\Procedures\Setup\SourceDocs
+```
+
+A Google Doc may remain the editable source while its published PDF is the normal Captain/field copy.
+
+### Historical or superseded material
+
+Put superseded Setup material in:
+
+```text
+41 Park Infrastructure-PI\Procedures\Setup\Archive
+```
+
+Archived files are not current field authority.
+
+### Procedure images
+
+Put Setup Procedure images in:
+
+```text
+41 Park Infrastructure-PI\Procedures\Setup\images
+```
+
+Do not create a separate competing image folder for the same Procedure family.
+
+## Procedure
+
+1. Open `G:\Shared drives\Display Folders`.
+2. Confirm there is not already another reviewed Park Infrastructure root.
+3. Create or use `41 Park Infrastructure-PI` exactly as shown.
+4. Create the complete `Procedures` structure shown above.
+5. Add the standard marker directly in the `41 Park Infrastructure-PI` root.
+6. Add the standard marker directly in `41 Park Infrastructure-PI\Procedures`.
+7. Do **not** add markers to `Inspection`, `Setup`, `Takedown`, `images`, `Archive`, or `SourceDocs`.
+8. Put current published Setup PDFs directly in `Procedures\Setup`.
+9. Put editable Setup source documents in `Procedures\Setup\SourceDocs`.
+10. Put superseded/historical Setup material in `Procedures\Setup\Archive`.
+11. Put Procedure-local Setup images in `Procedures\Setup\images`.
+12. Do not create an LOR Preview, fake Stage/Scene, `PreviewBackground`, or `Wiring` branch for this root unless a later approved use independently requires one.
+13. Verify the completed structure against the checklist below.
+
+## Build Checklist
+
+- [ ] `G:\Shared drives\Display Folders\41 Park Infrastructure-PI` exists.
+- [ ] The root marker is present.
+- [ ] `Procedures` exists and has its marker.
+- [ ] `Inspection`, `Setup`, and `Takedown` exist.
+- [ ] `Setup\Archive`, `Setup\images`, and `Setup\SourceDocs` exist.
+- [ ] `Takedown\Archive`, `Takedown\images`, and `Takedown\SourceDocs` exist.
+- [ ] No extra child-folder markers were added.
+- [ ] No fake Stage, Scene, Preview, or LOR naming was introduced.
+- [ ] Current PDFs will be stored directly in `Procedures\Setup`.
+- [ ] Editable Setup sources will be stored in `Procedures\Setup\SourceDocs`.
+- [ ] Historical/superseded Setup material will be stored in `Procedures\Setup\Archive`.
+
+## Setup Application Boundary
+
+The Setup Session application identifies tasks assigned here as **Site-wide / Infrastructure** work.
+
+The intended resolution path is:
+
+```text
+Reusable Setup task
+    -> Site-wide / Infrastructure scope
+    -> controlled 41 Park Infrastructure-PI root
+    -> validate root marker
+    -> validate Procedures marker
+    -> Procedures\Setup
+    -> current published field PDF(s)
+```
+
+LOR Stage/Scene resolution is not involved in this path.
+
+Scheduling is still fully available because Setup Session schedules reusable/annual task records; scheduling does not require an LOR Stage.
+
+The browser must never accept an arbitrary filesystem path from an operator to select a Procedure root.
+
+## If Something Is Wrong
+
+- **A task already has a legitimate Stage/Scene owner:** use that existing Stage/Scene scope instead of moving the task here merely because it lacks wired inventory.
+- **A Stage/Scene folder was created for Park Infrastructure:** stop; do not add fake LOR context. Use this non-LOR root.
+- **The folder already exists with legacy material:** do not overwrite or bulk-move files. Review the material before restructuring it.
+- **A current PDF is in `Archive` or `SourceDocs`:** it will not be treated as the normal current field publication; move/re-publish only after review.
+- **You are unsure whether a task is park-wide or Stage/Scene work:** keep the task unscope-corrected and review it before moving documentation.
+
+## Related Documents
+
+- [Add and Verify MSB Display Folder Marker Files](Add_Verify_Marker_Files.md)
+- [Publish a Current Setup Instruction](Publish_Current_Setup_Instruction.md)
+- [Folder Alignment Park Infrastructure non-LOR boundary](../../../01_LOR_System/02_Data_Extraction/Folder_Alignment/engineering/Park_Infrastructure_Non_LOR_Root_2026-09-07.md)
+- [Site-wide Setup Procedure Root Design](../../../02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/11_Site_Wide_Setup_Procedure_Root_Design_2026-09-07.md)
+- [Google Drive Engineering](../engineering/README.md)

--- a/Docs/00_Project_Overview/Google_Drive/operatorSOP/README.md
+++ b/Docs/00_Project_Overview/Google_Drive/operatorSOP/README.md
@@ -9,6 +9,7 @@ Use this page when you already know you need to maintain the Google Shared Drive
 - [Repair or Organize an Existing Stage / Scene](Repair_Existing_Stage_Scene.md)
 - [Add and Verify MSB Display Folder Marker Files](Add_Verify_Marker_Files.md)
 - [Create a New Stage / Sub-stage / Scene Documentation Folder](Create_Stage_Substage_Scene_Folder.md)
+- [Create the `41 Park Infrastructure-PI` Procedure Folder](Create_Site_Infrastructure_Procedure_Folder.md)
 - [Align a Legacy Setup Document](Align_Legacy_Setup_Documents.md)
 - [Publish a Current Setup Instruction](Publish_Current_Setup_Instruction.md)
 - [Run Folder Alignment](../../../01_LOR_System/02_Data_Extraction/Folder_Alignment/operatorSOP/Run_Folder_Alignment.md)
@@ -17,8 +18,9 @@ Use this page when you already know you need to maintain the Google Shared Drive
 
 ## Which System Owns Which Task?
 
-- **Google Drive / Display Folders** owns folder/document placement, markers, publication, and legacy document alignment.
-- **Folder Alignment** owns generating and reviewing the read-only alignment worklist.
+- **Google Drive / Display Folders** owns folder/document placement, markers, publication, legacy document alignment, and the controlled `41 Park Infrastructure-PI` Procedure root.
+- **Folder Alignment** owns generating and reviewing the read-only Stage/Scene alignment worklist. `41 Park Infrastructure-PI` is intentionally non-LOR and does not become a Folder Alignment Stage/Scene target. The space after `41` is deliberate because top-level `NN-` names are Stage candidates.
 - **Preview Authoring / Field Wiring** owns creating the actual field wiring diagram.
+- **Setup and Deployment** owns which reusable Setup tasks are Stage/Scene-scoped versus Site-wide / Infrastructure and how those tasks are planned/executed.
 
 Do not duplicate a procedure into another subsystem just to make it easier to find. The portals should link to the one current authority.

--- a/Docs/01_LOR_System/02_Data_Extraction/Folder_Alignment/README.md
+++ b/Docs/01_LOR_System/02_Data_Extraction/Folder_Alignment/README.md
@@ -33,6 +33,24 @@ Use the responsible Google Drive operator procedure
 Run Folder Alignment again when a fresh worklist is useful
 ```
 
+## Reserved Non-LOR Top-Level Folder
+
+The Google `Display Folders` root now also contains this controlled Setup/Procedure root:
+
+```text
+41 Park Infrastructure-PI
+```
+
+This folder is **not** an LOR Stage, Sub-stage, or Scene. It intentionally has no LOR Preview and no Stage 41 database/LOR identity.
+
+The leading `41` exists only to keep the folder in a useful human sort position next to the numbered park areas. The space after `41` is deliberate: the active Folder Alignment Stage inventory recognizes top-level Stage candidates using the `NN-...` form, so `41 Park Infrastructure-PI` remains outside that Stage pattern.
+
+Folder Alignment must not suggest converting, renaming, or promoting this folder into a Stage merely because it is stored beside numbered Stage folders.
+
+Use the Google Drive procedure [Create the Park Infrastructure Procedure Folder](../../../00_Project_Overview/Google_Drive/operatorSOP/Create_Site_Infrastructure_Procedure_Folder.md) for its controlled structure.
+
+This does **not** change Stage 40 Command Center. `40-CommandCenter` remains a legitimate Stage and may own Setup tasks/Procedures even when its LOR Preview contains no wired inventory items.
+
 ## Engineering
 
 For design, resolver/classification behavior, report model, regression fixtures, or code changes, use:
@@ -41,6 +59,8 @@ For design, resolver/classification behavior, report model, regression fixtures,
 
 ## Important Boundary
 
-Folder Alignment owns the **read-only comparison and worklist**.
+Folder Alignment owns the **read-only comparison and worklist** for LOR-aligned Stage/Sub-stage/Scene documentation.
+
+`41 Park Infrastructure-PI` is a governed non-LOR exception outside that hierarchy. Setup and Deployment owns the tasks assigned to that scope, while Google Drive / Display Folder procedures own its physical documentation structure.
 
 Google Drive / Display Folder procedures own the human changes made after reviewing the worklist. Do not duplicate those maintenance procedures here.

--- a/Docs/01_LOR_System/02_Data_Extraction/Folder_Alignment/engineering/Park_Infrastructure_Non_LOR_Root_2026-09-07.md
+++ b/Docs/01_LOR_System/02_Data_Extraction/Folder_Alignment/engineering/Park_Infrastructure_Non_LOR_Root_2026-09-07.md
@@ -1,0 +1,113 @@
+# Park Infrastructure Non-LOR Root — Folder Alignment Boundary — 2026-09-07
+
+| Document control | Value |
+|---|---|
+| Status | CURRENT DESIGN BOUNDARY |
+| Owner | Folder Alignment / Google Drive / Setup and Deployment |
+| Folder | `G:\Shared drives\Display Folders\41 Park Infrastructure-PI` |
+| Issue | #122 |
+
+## Purpose
+
+Document the controlled top-level Google Drive folder used for Setup work that has no appropriate LOR Stage/Sub-stage/Scene owner.
+
+```text
+41 Park Infrastructure-PI
+```
+
+This folder is part of the governed `Display Folders` repository but is intentionally **outside the LOR Stage/Sub-stage/Scene hierarchy**.
+
+## Why the Name Looks This Way
+
+The leading `41` exists only to keep the folder in the useful human sort position after the existing numbered park areas.
+
+The space after `41` is deliberate:
+
+```text
+41 Park Infrastructure-PI
+```
+
+The active Folder Alignment implementation recognizes top-level Stage-folder candidates with:
+
+```text
+NN-...
+```
+
+Therefore `41 Park Infrastructure-PI` does not match the Stage-folder classifier.
+
+`PI` is a human-facing Park Infrastructure abbreviation only. It is not an LOR Stage short code.
+
+## LOR Boundary
+
+No LOR Preview is created for this folder and there is no Stage 41 identity derived from it.
+
+Folder existence alone does not create an LOR Stage.
+
+Setup scheduling for tasks assigned to this scope is owned by Setup Session reusable/annual task records and does not require LOR membership.
+
+Procedure lookup for no-Stage Setup tasks explicitly targets this governed folder and validates its marker plus its `Procedures` marker before exposing current Setup PDFs.
+
+## What Belongs Here
+
+Examples include genuinely park-wide/no-owner Setup work such as:
+
+- removing street lights where needed for show operation;
+- converting street-light circuits to show power by switching approved fuses;
+- turning on site breakers;
+- other park-wide infrastructure tasks that do not belong to one existing Stage or Scene.
+
+Do not move a task here merely because it has no wired inventory items.
+
+## Important Counterexample — Stage 40 Command Center
+
+`40-CommandCenter` is a legitimate field Stage and remains part of the Stage hierarchy.
+
+A current LOR Preview exists for Command Center even though that Preview may contain no wired inventory items. That does not invalidate Stage 40 and does not move Command Center Setup work into Park Infrastructure.
+
+Command Center Setup tasks and Procedures should use Stage 40 when that is their appropriate operational owner.
+
+## Folder Alignment Behavior
+
+Folder Alignment should:
+
+- continue classifying actual Stage roots from the established `NN-...` contract;
+- ignore `41 Park Infrastructure-PI` as an LOR Stage candidate;
+- not report its absence from LOR as a defect;
+- not recommend renaming it into a Stage form; and
+- leave Setup/Procedure ownership of this non-LOR root to Setup and Google Drive governance.
+
+If a future Folder Alignment implementation widens its top-level folder classifier, this reserved non-LOR root must remain explicitly protected.
+
+## Controlled Structure
+
+The Google Drive operator procedure owns the folder structure:
+
+- [Create the Park Infrastructure Procedure Folder](../../../../00_Project_Overview/Google_Drive/operatorSOP/Create_Site_Infrastructure_Procedure_Folder.md)
+
+Current root:
+
+```text
+41 Park Infrastructure-PI\
+    _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
+    Procedures\
+        _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
+        Inspection\
+        Setup\
+            Archive\
+            images\
+            SourceDocs\
+        Takedown\
+            Archive\
+            images\
+            SourceDocs\
+```
+
+No LOR Preview, `PreviewBackground`, or Wiring branch is required merely because the folder exists.
+
+## Related Authority
+
+- [Folder Alignment](../README.md)
+- [Folder Alignment Engineering Design](Folder_Alignment_Engineering_Design.md)
+- [Google Drive / Display Folder Operations](../../../../00_Project_Overview/Google_Drive/README.md)
+- [Setup and Deployment](../../../../02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/README.md)
+- Issue #122

--- a/Docs/01_LOR_System/02_Data_Extraction/Folder_Alignment/engineering/README.md
+++ b/Docs/01_LOR_System/02_Data_Extraction/Folder_Alignment/engineering/README.md
@@ -9,6 +9,7 @@ Ordinary operation belongs in the [Folder Alignment](../README.md) operator port
 ## Current Engineering Authority
 
 - [Folder Alignment Engineering Design](Folder_Alignment_Engineering_Design.md)
+- [Park Infrastructure Non-LOR Root — Folder Alignment Boundary](Park_Infrastructure_Non_LOR_Root_2026-09-07.md)
 
 ## Implementation
 
@@ -32,7 +33,17 @@ Folder Alignment owns:
 - worklist/report behavior; and
 - the bounded additive PreviewBackground updater contract.
 
-Google Drive / Display Folder maintenance procedures own the human document/folder changes performed after review.
+The controlled top-level folder:
+
+```text
+41 Park Infrastructure-PI
+```
+
+is an intentional **non-LOR** Setup/Procedure root under `Display Folders`. It must remain outside Stage/Sub-stage/Scene classification. Its leading `41` is a human sort aid only; the space after `41` deliberately avoids the active top-level `NN-...` Stage candidate pattern.
+
+Do not infer Stage 41 from this folder, and do not use lack of wired inventory as evidence that an existing Stage belongs here. `40-CommandCenter`, for example, remains a real Stage even when its Preview has no wired inventory items.
+
+Google Drive / Display Folder maintenance procedures own the human document/folder changes performed after review. Setup and Deployment owns which reusable tasks are assigned to Stage/Scene versus Site-wide / Infrastructure scope.
 
 ## Documentation Layout
 
@@ -43,6 +54,7 @@ Folder_Alignment/
 ├── engineering/
 │   ├── README.md              this engineering handoff
 │   ├── Folder_Alignment_Engineering_Design.md
+│   ├── Park_Infrastructure_Non_LOR_Root_2026-09-07.md
 │   └── Internal_Web_Backbone_Handoff.md
 └── images/                    subsystem documentation images when needed
 ```

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/11_Site_Wide_Setup_Procedure_Root_Design_2026-09-07.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/11_Site_Wide_Setup_Procedure_Root_Design_2026-09-07.md
@@ -1,0 +1,152 @@
+# Site-wide Setup Procedure Root Design — 2026-09-07
+
+| Document control | Value |
+|---|---|
+| Status | DESIGN DIRECTION — Issue #122; not yet Production deployed |
+| Owner | Setup and Deployment |
+| Scope | Non-LOR Setup work such as park-wide site power, street lights, breakers, and other infrastructure tasks with no appropriate Stage/Scene owner |
+
+## Problem
+
+Setup Session has a demonstrated class of critical reusable work that does not belong to any LOR Stage or Scene and must not be forced into one merely to obtain a Procedure path.
+
+Examples identified during Manager review include:
+
+- remove street lights where required for show operation;
+- convert street-light circuits to show power by switching approved fuses;
+- turn on site breakers; and
+- other genuinely park-wide infrastructure work with no appropriate Stage/Scene owner.
+
+These are real Setup tasks because they require intentional planning, may have prerequisites/resources, can be missed, and produce useful annual execution history. They are not LOR-authored work and should not derive identity or filesystem placement from LOR Preview/Scene evidence.
+
+A task does **not** become Site-wide merely because it has no wired inventory items. `40-CommandCenter`, for example, is a legitimate Stage with its own current LOR Preview even though that Preview may contain no wired inventory items. Command Center Setup tasks and Procedures remain Stage-40 work when Stage 40 is the correct operational owner.
+
+## Required boundary
+
+The existing Stage/Scene Procedure contract remains authoritative for LOR/physical-area-scoped documentation:
+
+```text
+<Stage / Sub-stage / Scene root>/
+    marker
+    Procedures/
+        marker
+        Inspection/
+        Setup/
+            Archive/
+            images/
+            SourceDocs/
+        Takedown/
+            Archive/
+            images/
+            SourceDocs/
+```
+
+Site-wide/infrastructure Setup work needs the **same Procedure subsystem structure and marker behavior**, but its documentation root must be resolved from explicit Setup task scope rather than from LOR Stage/Scene context.
+
+Do not create a fake Stage, fake Scene, fake LOR Preview, or LOR-derived folder merely to host these documents.
+
+## Approved controlled non-LOR root
+
+Keep the documentation in the existing Google Shared Drive `Display Folders` repository so Setup does not create a second unrelated document repository.
+
+The approved folder is:
+
+```text
+G:\Shared drives\Display Folders\41 Park Infrastructure-PI\
+    _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
+    Procedures\
+        _MSB-DB-Source-Folder_READ-ME-FIRST-AND-DO-NOT-DELETE.txt
+        Inspection\
+        Setup\
+            Archive\
+            images\
+            SourceDocs\
+        Takedown\
+            Archive\
+            images\
+            SourceDocs\
+```
+
+The leading `41` keeps this folder adjacent to the existing numbered park-area folders in normal Windows/Google Drive sorting. **The space after `41` is deliberate.**
+
+Current Folder Alignment recognizes top-level Stage candidates using the `NN-...` form. Therefore:
+
+```text
+41 Park Infrastructure-PI
+```
+
+remains outside the Stage-folder classifier while still sorting in the intended location.
+
+`PI` is a human-facing Park Infrastructure code only. It is not an LOR Stage short code and does not establish Stage 41.
+
+The shared FieldWiring/Procedure structured-scope resolver remains unchanged. It starts from known database/LOR Stage context and does not enumerate the Display Folders root looking for this folder.
+
+## Resolution model
+
+For site-wide Setup tasks, the flow is:
+
+```text
+Reusable Setup task
+    -> explicit Site-wide / Infrastructure scope
+    -> controlled 41 Park Infrastructure-PI root
+    -> validate root marker
+    -> validate Procedures marker
+    -> fixed Procedures/Setup branch
+    -> current direct published PDF(s)
+    -> Captain / Perform Work screen
+```
+
+The non-LOR root is selected server-side from governed Setup context. Browser input must not become an arbitrary filesystem path.
+
+This is an extension of the Procedure-root contract, not a second generic filesystem resolver. The existing Stage/Sub-stage/Scene resolver remains unchanged for LOR/area-scoped work.
+
+## Procedure ownership and field presentation
+
+Site-wide Setup Procedures remain field-facing Setup Instructions and use the same source/published rules as Stage/Scene Setup Instructions:
+
+- current published PDF/rendered document is the normal Captain/field copy;
+- editable Google Doc or other source remains Manager/contributor maintenance material;
+- `Archive` and `SourceDocs` remain outside normal field presentation;
+- Setup-local `images` remains the supporting image location; and
+- multiple current PDFs may exist when that is genuinely useful, but the Setup application should present the Procedure(s) applicable to the selected task rather than requiring the Captain to browse unrelated documents.
+
+## Integration with Setup Session
+
+Site-wide/infrastructure tasks participate in the normal Setup model:
+
+- reusable task identity and ordering;
+- reusable global Setup planning baseline;
+- annual planned-order override;
+- prerequisites;
+- resources/equipment;
+- rolling-horizon scheduling;
+- parallel crew lanes;
+- Captain progress/completion;
+- current material/location context where applicable; and
+- annual historical learning.
+
+They do **not** require LOR membership.
+
+Scheduling remains fully available because Setup Session schedules reusable/annual task records, not LOR folders.
+
+## Engineering work still required
+
+Before Production deployment:
+
+1. create and mark `41 Park Infrastructure-PI` according to the Google Drive operator procedure;
+2. verify Setup task scope identifies park-wide/no-Stage work without inventing a Stage/Scene;
+3. verify Procedure-root resolution safely consumes only the approved non-LOR root;
+4. keep tests proving LOR Stage/Scene resolution remains unchanged;
+5. keep tests proving arbitrary browser filesystem paths cannot select a non-LOR root;
+6. validate Captain-screen current published PDF presentation from a site-wide task; and
+7. update any remaining documentation authority that still assumes all Setup Procedure roots are Stage/Scene roots.
+
+## Related authority
+
+- `Docs/00_Project_Overview/Google_Drive/operatorSOP/Create_Site_Infrastructure_Procedure_Folder.md`
+- `Docs/01_LOR_System/02_Data_Extraction/Folder_Alignment/engineering/Park_Infrastructure_Non_LOR_Root_2026-09-07.md`
+- `System_Documentation/Project_Rules/Stage_Setup_Documentation_Standard.md`
+- `Docs/00_Project_Overview/Google_Drive/engineering/Google_Drive_Path_Resolution_Contract.md`
+- `Procedures/Application/README.md`
+- `Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/10_Setup_Resolver_Canonical_Documentation_Root_2026-08-28.md`
+- Issue #122

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/README.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/README.md
@@ -1,405 +1,101 @@
 # Setup and Deployment
 
-## Current State
+| Document Control | Value |
+|---|---|
+| Document Type | Operator / User Portal |
+| System | Production Database — Setup and Deployment |
+| Audience | MSB volunteers, reviewers, managers, and Setup operators |
+| Status | CURRENT — Production runtime operational; Setup UI/workflow in live evaluation |
+| Owner | MSB Production Database / Setup administrator |
+| Last Reviewed | 2026-09-07 |
+| Keywords | Setup, 2025 review, training, 2026 plan, Setup procedures, deployment |
 
-**Status: DOCUMENTATION ACTIVE / PROCEDURE FIELD ACCESS PRODUCTION-OPERATIONAL**
+Setup and Deployment covers the work of planning and carrying out the annual move from storage to the park, plus the information crews need while installing the show.
 
-This subsystem covers planning, scheduling, staging, loading, scanning, and moving tested displays and containers from storage to the park for annual setup, plus takedown-related field documentation where it belongs with the same Stage material.
-
-The Stage-oriented folder structure already exists. Setup/Takedown instructions are being organized into those existing Stage folders and use the same Stage-oriented convention already used by Wiring documentation.
-
-The operational database/application workflow for scheduling, pick lists, load order, and forklift scanning is not yet fully engineered. No operator procedure should imply those planned functions are implemented until verified from the current database/application.
-
-**FieldWiring, Display Scan, and the standalone Procedure application are accepted production baselines.** Procedure is production-operational at `https://my.sheboyganlights.org/procedures/` and uses the shared Field Context resolver plus the existing read-only Google `Display Folders` mount. Do not rediscover or redesign those accepted systems merely to continue Setup/Deployment work.
-
-The bounded **Procedure Display Scan Integration** is accepted production behavior: the Display scan hub passes permanent `display_id` to `/procedures/?display_id=<display_id>`, and Setup/Takedown/Inspection selection remains inside Procedure. Controller Inventory V0.4.0 is also merged and production-operational. Human Procedure-document authoring/alignment and the broader scheduling/pick/load/forklift workflow remain separate work streams.
-
-MSB has purchased a **Zebra DS3678-HD cordless ultra-rugged 1-D/2-D scanner kit** for the workshop forklift. It uses the Zebra 3600-series USB cradle and supports USB HID keyboard input. Because this is the **HD (High Density)** variant rather than an ER/XR extended-range model, its actual suitability from the forklift seat must be tested with real MSB Container and Storage Location labels before it is accepted as the final forklift-distance standard. See [Scanner Hardware and Tablet Integration](../07_Labeling_and_Scanning/Scanner_Hardware_and_Tablet_Integration.md).
-
-## Design Intent
-
-The Setup and Deployment subsystem will provide a repeatable operational plan for moving displays and containers from storage to the park while keeping field instructions easy to find from the same established Stage organization used by Wiring.
-
-Testing answers:
-
-> Is this display/container ready?
-
-Setup and Deployment answers:
-
-> When should it move, what should move with it, in what order, and what instructions does the crew need at the Stage?
-
-The intended high-level workflow remains:
+The Setup application is now live at:
 
 ```text
-Testing Complete / Ready for Setup
-            ↓
-Schedule Display / Container
-            ↓
-Assign Calendar Pull Date
-            ↓
-Build Pick / Load List
-            ↓
-Forklift Driver Queue
-            ↓
-Scan / Confirm Container or Display
-            ↓
-Load in Planned Order
-            ↓
-Deliver to Park
-            ↓
-Confirm Movement / Destination
+https://my.sheboyganlights.org/setup/
 ```
 
-The goal is to replace informal yearly scheduling and remembered load sequences with a durable, repeatable operational process without disrupting the existing Stage-folder documentation crews already use.
+The current working session is **2025 — Historical Verification**. It uses real Production data so managers can reconstruct what happened in 2025, learn the workflow, improve reusable Setup knowledge, and identify UI/workflow problems before the 2026 Setup Session is created.
 
-## Stage Setup Documentation Boundary
+The application is operational, but the Setup/UI subsystem is still in **live evaluation**. The current review period is intended to generate questions, corrections, suggestions, and usability findings before final acceptance.
 
-Field-facing **Stage Setup Instructions are a separate document class from repository Operational SOPs**.
+## Start Here
 
-They are used by volunteers physically setting up Stages/Scenes in the park and should remain simple, visual, and Stage-oriented. Their normal published experience may be a PDF or other rendered field document even when the editable source is a Google Doc or controlled repository source/template.
+### Review the 2025 Setup history
 
-The project-specific governance for these documents is defined in the [Stage Setup Documentation Standard](../../../../System_Documentation/Project_Rules/Stage_Setup_Documentation_Standard.md).
+Managers and authorized reviewers should start with:
 
-The controlled structural starting point is the [Stage Setup Instruction Template](../../../../System_Documentation/Templates/Stage_Setup_Instruction_Template.md).
+[Review and Correct the 2025 Setup History](operatorSOP/Review_2025_Setup_History.md)
 
-A separate contributor/operator procedure is still required for creating, revising, archiving, publishing, and verifying Setup Instructions from that template/source. That contributor workflow should not be confused with the field instruction itself.
+During this review you may, where supported by evidence:
 
-## Stage Folder Documentation Contract
+- verify or correct 2025 annual information;
+- add missing reusable Setup tasks;
+- correct task scope and normal order;
+- add or correct prerequisites;
+- add or correct equipment/resources;
+- improve normal crew/time/readiness information;
+- review current Setup procedures; and
+- record questions or suggestions for the Setup workflow.
 
-The existing Google Shared Drive Stage/Scene folder structure is the human-facing organizational anchor for setup work.
+Do not change information merely to make a record look complete. Unknown information may remain UNVERIFIED or be marked NEEDS CORRECTION.
 
-- Wiring and Setup/Takedown documentation share the same Stage-oriented organizational model.
-- The existing Google Drive document-organization and Folder Alignment work controls the actual folder structure and migration of legacy material.
-- Setup instructions should be placed and maintained within the existing Stage/Scene structure rather than creating a separate unrelated setup-document tree.
-- [Wiring System](../09_Wiring_System/README.md) owns wiring content in that structure.
-- Setup and Deployment owns setup/takedown instruction behavior and the application integration contract for finding applicable Procedure documents.
-- [Labeling and Scanning](../07_Labeling_and_Scanning/README.md) owns permanent QR/scanning integration patterns, but QR lookup does not become the content authority.
-- [Procedure System Field Context Handoff](00_Procedure_System_Field_Context_Handoff_2026-08-22.md) remains the architecture handoff that resolved the original Procedure/FieldWiring conflicts.
+### Find current Stage Setup instructions
 
-This framework does not by itself define or approve a new database schema.
-
-## Document Resolution and Field UX
-
-The accepted current field-access path is:
+For current published Setup/Takedown/Inspection documents by Display, Stage, Sub-stage, or Scene, use:
 
 ```text
-Display QR or manual Display/Stage/Scene lookup
-    ↓
-Permanent Display identity when applicable
-    ↓
-Production Database relationships
-    ↓
-shared/proven FieldWiring structured Stage / Sub-stage / Scene resolver
-    ↓
-fixed applicable structured root
-    ↓
-validate structured-root marker
-    ↓
-validate <scope>/Procedures marker
-    ↓
-Procedure task adapter selects fixed child
-    ↓
-<scope>/Procedures/Setup
-or <scope>/Procedures/Takedown
-or <scope>/Procedures/Inspection
-    ↓
-bounded current-document discovery from the read-only Google filesystem
-    ↓
-my.sheboyganlights.org
-    ↓
-current field PDF / rendered instruction
+https://my.sheboyganlights.org/procedures/
 ```
 
-The QR code identifies the asset. It does not contain a Google Drive folder path or manually maintained direct Procedure-document URL.
+Field-facing Stage Setup Instructions remain separate from repository operator procedures. They are the documents crews use while physically installing Stages/Scenes in the park.
 
-The Production Database owns the durable identities and relationships used to determine the structured Stage/Scene context. The database does not become the editing system for Procedure content.
+## What Do You Need To Do?
 
-For the current read-only Procedure browser, a PostgreSQL row or stored Google document ID for every current published PDF is **not a prerequisite**. Once the current structured root and marked `Procedures` subsystem root are validated, the application selects the exact known `Setup`, `Takedown`, or `Inspection` child and enumerates the current published files directly in that task folder while excluding `Archive` and `SourceDocs`.
+- [Review or correct the 2025 Setup history](operatorSOP/Review_2025_Setup_History.md)
+- [See all Setup operator procedures](operatorSOP/README.md)
+- [Maintain or publish Stage Setup documents](../../../00_Project_Overview/Google_Drive/README.md)
+- [Open the Setup application](https://my.sheboyganlights.org/setup/)
+- [Open Setup/Procedure documents](https://my.sheboyganlights.org/procedures/)
+- [Engineering / development / recovery](engineering/README.md)
 
-Durable per-document metadata remains a future engineering option when approval workflow, revision history, source-to-publication lineage, supersession, audit, or stable document identity demonstrates a need for it. Do not create schema merely because older documentation listed document-ID storage as unresolved.
+## Important 2025 Review Rule
 
-`my.sheboyganlights.org` is the normal field presentation layer. Field volunteers should not need to understand the GitHub repository, database schema, Google Drive organization, or source-document mechanics to reach the current Setup instruction.
-
-## Resolver Reuse Boundary
-
-Procedure **reuses the proven shared FieldWiring structured-scope resolver** rather than maintaining a second independent Display-to-Stage/Scene algorithm.
-
-The shared resolver answers:
-
-> Which current marked Stage / Sub-stage / Scene root owns this context?
-
-The Procedure adapter then answers:
-
-> Which current documents are published in the selected Procedure task branch beneath that already-resolved root?
-
-This means Wiring and Procedures share scope resolution but do not share task-specific content rules:
+There are two different kinds of information in the Setup application:
 
 ```text
-resolved structured root
-    |
-    +--> FieldWiring -> marked Wiring root -> BackgroundStage or MusicalStage
-    |
-    +--> Procedures  -> marked Procedures root -> Setup, Takedown, or Inspection
+2025 annual information
+    = what happened or was planned in 2025
+
+Reusable Task information
+    = normal Setup knowledge that may carry forward
 ```
 
-Both systems use the same subsystem-root marker pattern: the resolved structured scope is marked, then the owning application subsystem root (`Wiring` or `Procedures`) is marked. Their fixed child branches are selected by folder name and do not require a second marker layer. `Archive` and `SourceDocs` remain excluded from normal field presentation.
+A correction that only applies to 2025 belongs in the 2025 annual history. A correction to how MSB normally performs a task belongs in the reusable task definition.
 
-## Scan / Forklift Direction
+The selected Setup Session controls the allowable operational year. The 2025 session accepts 2025 operational dates only. Audit timestamps still show when the change was actually recorded.
 
-The permanent Display scan platform is production-operational and resolves `DISP:<display_id>` using permanent Production Database identity. Procedure Display Scan Integration consumes that existing identity contract; no physical Display QR redesign is required.
+Only an Administrator may create a new annual Setup Session or promote an annual order into the future reusable baseline.
 
-The agreed operator-facing Scan behavior is:
+## Current Evaluation Boundary
 
-```text
-Display scan hub
-    -> Procedures
-        -> /procedures/?display_id=<permanent display_id>
-            -> existing Procedure page
-                -> operator chooses Setup, Takedown, or Inspection
-```
+Production deployment is accepted, but final UI/workflow acceptance is intentionally open while managers use the 2025 session.
 
-The Scan hub passes only `display_id`, does not duplicate the three Procedure task buttons, and does not call Procedure merely to decide whether the link should render. This is accepted production behavior. Do not invent a second resolver, encode Stage/Scene/Google paths in the QR, or make the Display hub depend on Procedure health merely to render the Procedures action.
+Current known boundaries:
 
-Setup is also expected to become a high-volume scan workflow for deployment operations rather than only document lookup.
-
-Durable physical identities remain the starting point:
-
-```text
-DISP:<permanent display_id>
-CONT:<permanent container_id>
-LOC:<operational storage/location code>
-CTRL:<permanent controller_id>
-```
-
-Annual setup dates, load numbers, staging status, and other transient workflow state must not be encoded into the permanent labels.
-
-The application should be designed so both of these input paths produce the same canonical asset/location payload:
-
-```text
-industrial scanner -> HID keyboard input
-phone/tablet camera -> camera decoder
-```
-
-The purchased Zebra DS3678-HD gives the project a real industrial hardware acceptance target. Its USB HID behavior fits the browser-first design, but the hardware must be tested against actual label size/density and actual forklift position before deciding whether HD range is adequate or an ER/XR scanner is required for some tasks.
-
-The 2026-09-03 ADF correction is input-method evidence only: the Zebra emitted compact canonical identifiers correctly in Google Docs. The current Container route is accepted because it opens the Directus Container record and assigned Displays. `LOC` still has no complete route and remains #88. The deployed `CTRL` route hands permanent Controller identity to the existing production Controller Inventory Search/detail page; manual compact/full-URL entry passed, and the route adds no Setup movement meaning. Physical printed-label/device acceptance remains pending.
-
-Likely setup interactions may include both scan orders:
-
-```text
-Container -> Location
-Location -> Container
-```
-
-The real setup-day process must determine what each pair means: pull confirmation, staging, load assignment, destination validation, storage relocation, or another business event. Do not invent transaction semantics from the scanner hardware.
-
-## Annual Operating Cycle
-
-`ref.season` remains the annual operational context. The documented working cycle is approximately:
-
-- Testing begins in January.
-- Setup/show preparation begins around the end of September.
-- Takedown begins around January 1.
-- After takedown, the next testing cycle begins again.
-
-Detailed testing-season procedures belong with [Testing System](../05_Testing_System/README.md); detailed Setup field instructions live with the established Stage/Scene documentation structure.
-
-## Design Principles
-
-### PostgreSQL remains the operational system of record
-
-Scheduling, operational movement events, load grouping, scan confirmations, deployment status, and durable Stage/Scene/asset relationships remain in the Production Database when those workflows are engineered.
-
-Generic container movement history is not a goal. Movement/history should be recorded only when the Setup/Deployment workflow actually needs a reconstructable event trail.
-
-### Google Shared Drive remains the field-document repository
-
-The shared read-only server filesystem exists so Procedure applications can consume the same human-maintained `Display Folders` hierarchy already used by FieldWiring.
-
-Do not create a second Procedure-only Google hierarchy, duplicate mount, downloaded mirror, or database binary-document store merely to present current procedures.
-
-### Field document content remains separate from database internals
-
-The database resolves the current physical context without requiring field volunteers to operate inside PostgreSQL, Directus, GitHub, or Google Drive.
-
-A simple PDF/rendered instruction at the Stage/Scene level is preferred when that gives the crew the best user experience.
-
-### Directus is an initial management interface, not the field-document UX requirement
-
-The scheduling and management portion of this subsystem is expected to be controlled through Directus initially where practical.
-
-A dedicated task-focused field interface may be added where Directus is not suitable. Any such application must continue to use the Production Database as the authoritative operational data source.
-
-### Testing remains a separate subsystem
-
-Testing and Setup/Deployment are related but distinct workflows.
-
-A successful test may establish that an item is ready for setup, but the Testing subsystem does not own deployment dates, load order, transport grouping, park delivery, or the content of Stage Setup Instructions.
-
-### Preserve useful yearly deployment and documentation history
-
-The system should preserve the actual sequence used each year when that history is useful for planning the next season. Historical deployment records should not be overwritten merely because a new year's schedule is created.
-
-Legacy and superseded Setup instructions should be archived through the established Stage documentation process rather than deleted or left mixed with current field instructions.
-
-## Current and Planned Responsibilities
-
-Already production-operational:
-
-- current Setup/Takedown/Inspection document lookup by Display/Stage/Scene;
-- field-friendly Procedure presentation through `my.sheboyganlights.org/procedures/`;
-- shared Field Context resolution and read-only Google `Display Folders` consumption;
-- the one-button Procedures action on the Display scan hub;
-- Controller Inventory V0.4.0 and its exact-controller deep-link input.
-
-Current bounded Scan follow-on:
-
-- complete physical printed-label Zebra and phone/tablet acceptance for the deployed Controller route after LabelPrintService can print the first label;
-- continue #88 for Location identity resolution and the minimum Setup-owned workflow;
-- physically accept relevant Location label behavior before volume printing Location labels.
-
-Separate planned operational work includes:
-
-- setup season/session context;
-- calendar pull scheduling;
-- pick lists;
-- load/trip grouping and sequence;
-- forklift scanning;
-- Container/Location validation;
-- meaningful pull/stage/load/delivery confirmations;
-- prior-year sequence reference;
-- optional durable per-document publication metadata when a demonstrated workflow requires it.
-
-These planned operational items are design targets, not implemented schema commitments unless verified in the current database.
-
-## System Boundaries and Dependencies
-
-This subsystem depends on existing Production Database identities and relationships, including where applicable:
-
-- permanent Display identity and Stage/Scene relationships;
-- the accepted FieldWiring structured-context behavior;
-- the accepted Display scan platform;
-- the accepted standalone Procedure application;
-- the shared read-only Google `Display Folders` filesystem;
-- containers and storage locations;
-- testing readiness/state;
-- people/volunteer identity;
-- rugged tablet/industrial scanner hardware;
-- Stage/Scene identity and established documentation organization; and
-- site/stage/location information needed for deployment planning.
-
-It must not redefine permanent Display IDs, Container IDs, storage identities, LOR wiring/topology, or other identities already owned by existing subsystems.
-
-Containers of type **KIT** already exist and may hold loose setup materials instead of Displays. Detailed kit-contents inventory remains a separate future Setup/Deployment need.
-
-## Known Limitations / Open Work
-
-The standalone Procedure field-access application is accepted production work. Do not reopen its shared resolver, Google hierarchy, Procedure marker contract, or current-document discovery architecture unless a demonstrated production defect requires it.
-
-Current Procedure-related open work is separated into these scopes:
-
-- **Procedure Display Scan Integration** — accepted production behavior; preserve the permanent `display_id` handoff and downstream ownership boundary;
-- **Procedure document authoring/alignment** — continue the legacy Setup-document review, alignment, archive, and publication work in the existing Stage/Scene `Display Folders` hierarchy;
-- **Contributor/operator documentation** — finalize the Stage Setup Instruction contributor workflow and the editable-source versus published-PDF relationship where Google Docs remain in use;
-- **additional field acceptance as needed** — complete any broader PC/phone/tablet, print, or offline validation required for the 2026 field workflow; and
-- **durable document metadata only if justified** — engineer Google document IDs or published references only when a demonstrated publication/history requirement cannot be met by the current controlled-folder contract.
-
-Separate Setup/Deployment operational work still includes scheduling, readiness, pull/load planning, Container/Location movement semantics, forklift workflow, hardware acceptance, and related annual workflow state. Do not mix those business-process questions into Procedure Display Scan Integration.
-
-## Resume Development
-
-### Current production baseline
-
-Begin from current `main` and the current responsible runbooks. Do not rediscover the old live-only scan extension, redesign the physical QR, rebuild the Google filesystem connection, or reconstruct Procedure deployment from chat history.
-
-Read first:
-
-1. [Procedure Application README](../../../../Procedures/Application/README.md) — current standalone Procedure application contract, production status, and Scan entry contract;
-2. [Labeling and Scanning](../07_Labeling_and_Scanning/README.md) — current Scan platform and Controller handoff state;
-3. [Deployed Display Scan Runtime Boundary](../07_Labeling_and_Scanning/Deployed_Display_Scan_Runtime_Boundary.md) — current Git/runtime boundary and accepted live Scan baseline;
-4. [FieldWiring Scan Integration Engineering Handoff](../07_Labeling_and_Scanning/FieldWiring_Scan_Integration_Engineering_Handoff_2026-08-22.md) — accepted additive scan integration pattern and failure boundary;
-5. [Procedure System Field Context Handoff — 2026-08-22](00_Procedure_System_Field_Context_Handoff_2026-08-22.md) — architecture precedence for Procedure/Field Context;
-6. [Field Context Resolution Contract](../07_Labeling_and_Scanning/Field_Context_Resolution_Contract.md);
-7. [Stage Setup Documentation Standard](../../../../System_Documentation/Project_Rules/Stage_Setup_Documentation_Standard.md); and
-8. [MSB-Server-Management Display Scan Extension Deployment and Recovery](https://github.com/Gregovate/MSB-Server-Management/blob/main/docs/directus/Display_Scan_Extension_Deployment_and_Recovery.md) before any scan deployment.
-
-### Controller Scan Integration — route deployed; physical-label acceptance pending
-
-The accepted identity and UX handoff is:
-
-```text
-camera QR: https://db.sheboyganlights.org/scan/CTRL/<controller_id>
-Zebra/manual: CTRL:<controller_id>
-    -> /scan/CTRL/<controller_id>
-    -> /fieldwiring/controllers?controller_id=<controller_id>
-    -> existing Controller Inventory filters Search and opens exact detail
-```
-
-The deployed route reuses permanent `ref.controller.controller_id` and the existing Controller browser. Manual compact/full-URL production input passed. It must still pass real-label Zebra/phone/tablet and useful-distance acceptance before volume Controller label printing.
-
-This work must not create:
-
-- a second Controller result application;
-- a second Controller identity;
-- Controller database or movement mutations merely from scanning;
-- annual Setup state in the permanent Controller label; or
-- a dependency on Zebra-specific formatting.
-
-Follow the existing Server Management scan-extension runbook for live hash verification, rollback capture, staging, syntax validation, restart, and regression testing. Operational discoveries made during this work must be written into the responsible runbook before later steps depend on them.
-
-### Setup workflow engineering
-
-Separately document the real setup-day process from the people who:
-
-- schedule pulls;
-- operate the forklift;
-- identify containers/locations;
-- stage material;
-- load trailers/trucks;
-- receive loads at the park;
-- place containers/displays at their destinations.
-
-Define business events and exception handling before designing schema, Directus Flows, scan-session state, or a dedicated deployment application.
-
-### Hardware acceptance
-
-Begin hardware testing with the [Scanner Hardware and Tablet Integration](../07_Labeling_and_Scanning/Scanner_Hardware_and_Tablet_Integration.md) handoff and the purchased Zebra DS3678-HD. Use actual labels and measured working distances rather than theoretical family-level specifications.
-
-### Setup-document authoring work
-
-For Setup-document authoring/alignment work, continue with:
-
-1. the [Stage Setup Documentation Standard](../../../../System_Documentation/Project_Rules/Stage_Setup_Documentation_Standard.md);
-2. the current [Google Drive Document Organization Procedure](../../../00_Project_Overview/01-Google_Drive_Document_Organization_Procedure.md);
-3. the current Folder Alignment work/report;
-4. the controlled [Stage Setup Instruction Template](../../../../System_Documentation/Templates/Stage_Setup_Instruction_Template.md); and
-5. the real Stage/Scene documents currently being reviewed and archived.
-
-Do not redesign the established Stage folder structure while solving Procedure QR integration, PDF publishing, or intranet UX.
+- no 2026 Setup Session has been created;
+- Pick List generation is not yet a live Production workflow;
+- Container/Display movement and scanning write commands remain outside this review boundary; and
+- the open Setup PRs remain the active engineering workstream until live-use findings are resolved.
 
 ## Related Systems
 
-- [Testing System](../05_Testing_System/README.md) — establishes testing state/readiness before deployment.
-- [Containers and Storage](../04_Containers_and_Storage/README.md) — owns container identity, assignments, storage-location relationships, and KIT container identity.
-- [Wiring System](../09_Wiring_System/README.md) — provides the proven structured field-context implementation while retaining its own wiring content rules.
-- [Labeling and Scanning](../07_Labeling_and_Scanning/README.md) — owns permanent labels and the accepted scan-routing integration pattern.
-- [FieldWiring Scan Integration Engineering Handoff](../07_Labeling_and_Scanning/FieldWiring_Scan_Integration_Engineering_Handoff_2026-08-22.md) — accepted production Display scan baseline.
-- [Scanner Hardware and Tablet Integration](../07_Labeling_and_Scanning/Scanner_Hardware_and_Tablet_Integration.md) — owns the purchased Zebra scanner baseline and hardware/browser-input acceptance contract.
-- [People and Identity](../03_People_and_Identity/README.md) — provides durable person/user identity and audit attribution.
-- [Site Infrastructure / GIS](../11_Site_Infrastructure_GIS/README.md) — may provide destination/location context where applicable.
+- [Operator procedures](operatorSOP/README.md)
+- [Engineering handoff](engineering/README.md)
+- [Labeling and Scanning](../07_Labeling_and_Scanning/README.md)
+- [Wiring System](../09_Wiring_System/README.md)
 
-## Related Documentation
-
-- [Procedure Application README](../../../../Procedures/Application/README.md)
-- [Procedure System Field Context Handoff — 2026-08-22](00_Procedure_System_Field_Context_Handoff_2026-08-22.md)
-- [Stage Setup Documentation Standard](../../../../System_Documentation/Project_Rules/Stage_Setup_Documentation_Standard.md)
-- [Stage Setup Instruction Template](../../../../System_Documentation/Templates/Stage_Setup_Instruction_Template.md)
-- [Google Drive Document Organization Procedure](../../../00_Project_Overview/01-Google_Drive_Document_Organization_Procedure.md)
-- [Field Context Resolution Contract](../07_Labeling_and_Scanning/Field_Context_Resolution_Contract.md)
-- [FieldWiring Drive Context Resolver Engineering Design](../09_Wiring_System/FieldWiring_Drive_Context_Resolver_Engineering_Design.md)
-- [Documentation Maintenance Rule](../../../../System_Documentation/Standards/Documentation_Maintenance_Rule.md)
-- [Document Control Standard](../../../../System_Documentation/Standards/Document_Control_Standard.md)
-- [Linking and Navigation Standard](../../../../System_Documentation/Standards/Linking_and_Navigation_Standard.md)
-- [MSB-Server-Management Display Scan Extension Deployment and Recovery](https://github.com/Gregovate/MSB-Server-Management/blob/main/docs/directus/Display_Scan_Extension_Deployment_and_Recovery.md)
-
-Repository Operational SOPs remain appropriate for database/application tasks in this subsystem when those tasks are implemented. They are not the storage or format model for the field-facing Stage Setup Instructions themselves.
+The prior engineering-heavy Setup/Deployment root portal remains preserved at [`engineering/Legacy_Setup_and_Deployment_Engineering_Portal_2026-09-07.md`](engineering/Legacy_Setup_and_Deployment_Engineering_Portal_2026-09-07.md) so established technical history and inbound references are not lost.

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/Setup_Session_Shared_Review_and_Season_Year_Guard_2026-09-07.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/Setup_Session_Shared_Review_and_Season_Year_Guard_2026-09-07.md
@@ -1,0 +1,161 @@
+# Setup Session Shared Review and Season-Year Guard — 2026-09-07
+
+## Purpose
+
+This document defines the safety boundary for the shared Production-backed Setup Session review/training workflow and for future annual Setup planning.
+
+The immediate operating target is the existing **2025 `HISTORICAL_VERIFICATION` Setup Session**. A small group of authenticated reviewers may use the Setup application to improve the reconstructed 2025 record and reusable Setup knowledge before the 2026 Setup Session is created.
+
+This is not a disposable sandbox. Saved changes are Production Database records.
+
+## Core rule: the Setup Session owns the operational year
+
+The selected annual Setup Session is the authority for operator-entered operational dates.
+
+```text
+2025 Setup Session
+    -> operational dates must be in 2025
+
+2026 Setup Session
+    -> operational dates must be in 2026
+```
+
+The rule is generic. It is not a hard-coded 2025 exception.
+
+Current guarded operational values are:
+
+- `ops.setup_work_day.work_date`;
+- `ops.setup_session_task.planned_date`;
+- `ops.setup_session_task.actual_started_at`;
+- `ops.setup_session_task.actual_completed_at`; and
+- `ops.setup_movement_event.occurred_at` when movement commands are later introduced.
+
+Operational timestamp year checks use `America/Chicago`, consistent with the existing MSB FieldWiring runtime timezone contract.
+
+## Audit timestamps are not historical operational dates
+
+Audit/recording timestamps must continue to show when the database change actually happened.
+
+The season-year rule therefore does **not** rewrite or constrain:
+
+- `created_at`;
+- `updated_at`; or
+- `ops.setup_task_progress.recorded_at`.
+
+For example, if a Manager records a 2025 historical correction during September 2026:
+
+```text
+actual work date/time    -> 2025
+recorded/updated time    -> 2026
+```
+
+Both facts are useful and should remain truthful.
+
+## Enforcement layers
+
+The year boundary is enforced in two places.
+
+### Database authority
+
+Database triggers reject operational dates/timestamps that do not match the associated `ops.setup_session.season_year`.
+
+This prevents a bad year from being written even if a browser check is bypassed or another approved application later calls the same command layer.
+
+The governed work-day and historical-review commands also perform explicit year validation so the operator receives a clear error instead of relying only on a trigger failure.
+
+### Browser guidance
+
+The Setup browser limits date and date-time controls to January 1 through December 31 of the currently selected Setup Session year.
+
+For a historical-verification session it also presents a visible banner explaining that:
+
+- saved changes are permanent records for that historical session;
+- operational dates are limited to that session year;
+- the historical review does not create or schedule a future Setup Session; and
+- future-baseline promotion is Administrator-only.
+
+The browser boundary improves usability, but the database remains the authority.
+
+## Shared 2025 review is Production-backed, not disposable
+
+The shared 2025 review is intentionally useful as both reconstruction work and Manager training.
+
+Authorized reviewers may improve:
+
+- 2025 annual verification state;
+- 2025 annual crew/time/date evidence where known;
+- 2025 annual notes;
+- 2025 annual planned order and work-day assignments if useful for reconstruction/training;
+- reusable task scope;
+- reusable prerequisites;
+- normal crew/time expectations;
+- reusable equipment/resource relationships; and
+- reusable Procedure organization.
+
+The distinction between annual and reusable data remains important:
+
+- **annual 2025 edits** describe the 2025 occurrence;
+- **reusable task edits** are permanent Setup knowledge and may be inherited by later seasons.
+
+A reviewer must therefore not treat the 2025 shared application as throwaway test data.
+
+## Future-season authority boundary
+
+Two actions can affect future annual planning and are reserved for Setup Administrators:
+
+1. create/manage the annual Setup Session; and
+2. promote a current annual planned order into the reusable future baseline.
+
+Managers/reviewers may reorder the active annual session because that is normal annual planning/reconstruction work. They cannot use that order to redefine the future baseline.
+
+This prevents a one-year anomaly, training experiment, or 2025 reconstruction choice from silently becoming the starting order for 2026 or later.
+
+## 2026 transition
+
+There is currently no 2026 Setup Session in the accepted Production baseline.
+
+When an Administrator explicitly creates the 2026 Setup Session:
+
+- the application selects the 2026 annual context;
+- browser operational date bounds become `2026-01-01` through `2026-12-31`;
+- database year guards require 2026 for operational dates/timestamps attached to that session; and
+- the 2025 historical record remains separate and unchanged except through explicit 2025 review actions.
+
+Creating 2026 does not require changing the season-year guard implementation.
+
+## Access and sharing
+
+A URL does not grant Setup write authority.
+
+Shared review must remain behind the existing authenticated application boundary. A person who receives the link must still resolve through the existing Cloudflare/Directus Setup capability model.
+
+Current authority direction:
+
+- **Reader / field user** — view permitted Setup information;
+- **Manager / reviewer** — maintain the active annual review/planning data and reusable Setup knowledge within Manager commands;
+- **Administrator** — Manager capabilities plus annual Setup Session creation and future-baseline promotion.
+
+Do not expose generic table DML merely to make shared review easier.
+
+## Current execution boundary
+
+This shared review does not expand movement/scanning authority.
+
+The Captain/Perform Work screen may show current material/location context, but narrow movement/scanning write commands remain a separate guarded implementation step.
+
+The Production-backed 2025 review therefore does not create movement semantics merely from scans or from review activity.
+
+## Related implementation
+
+- `Setup/Database/017_enforce_setup_session_year_and_admin_promotion.sql`
+- `Setup/Application/setup_session_year_guard.js`
+- `Setup/Application/setup_session_year_guard.css`
+- `Setup/Application/setup_next_api.py`
+- `Setup/Application/test_setup_session_year_guard_contract.py`
+- `Setup/Acceptance/setup_v03_production_preflight.sql`
+
+## Related operator documentation
+
+See:
+
+`Docs/02_Production_Database/02_Operational_SOPs/Setup/Setup_Session_Manager_Review_Guide.md`

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Internal_Web_Backbone_Handoff.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Internal_Web_Backbone_Handoff.md
@@ -1,0 +1,245 @@
+# Setup and Deployment — Internal Web Backbone Handoff
+
+| Document Control | Value |
+|---|---|
+| Document Type | Internal Web Backbone Integration Handoff |
+| Source System | Production Database — Setup and Deployment |
+| Consuming System | `Gregovate/MSB-Internal-Web-Backbone` |
+| Status | IMPLEMENTED — Backbone PR #11 merged; live publish/verification pending |
+| Owner | MSB Production Database / Setup documentation owner |
+| Last Reviewed | 2026-09-07 |
+
+## Purpose
+
+Define what the Internal Web Backbone should expose for Setup and Deployment without copying engineering history into the operator experience or creating a competing documentation authority.
+
+The source Setup subsystem remains authoritative. The Backbone should publish navigation/search/application entry points that lead users to the current controlled source or protected application.
+
+## Current Source-System State
+
+The Production Setup application is live and protected at:
+
+```text
+https://my.sheboyganlights.org/setup/
+```
+
+Accepted source-side checks include:
+
+```text
+Synology /setup/ route                = operational
+public Setup health                   = PASS
+Cloudflare-authenticated browser use  = PASS
+2025 Production data rendering        = PASS
+post-deployment invariants            = PASS
+```
+
+The **runtime is accepted**, but the Setup UI/workflow remains in live evaluation while Managers use the real 2025 Historical Verification session. Backbone navigation should therefore present the application as available for current 2025 review/training without implying that all Setup features are final.
+
+## Canonical Operator Portal
+
+Canonical source portal:
+
+```text
+Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/README.md
+```
+
+Canonical operator procedure index:
+
+```text
+Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/operatorSOP/README.md
+```
+
+Detailed Manager guide:
+
+```text
+Docs/02_Production_Database/02_Operational_SOPs/Setup/Setup_Session_Manager_Review_Guide.md
+```
+
+These source documents remain in the open Setup PR stack and are not yet on Production Database `main`. Backbone therefore does **not** link ordinary users to those GitHub `main` paths yet. The live application is the stable current operator entry point.
+
+## Preferred Application Entry Point
+
+Normal protected Setup action link:
+
+```text
+https://my.sheboyganlights.org/setup/
+```
+
+This is a `my.` action application and requires the established Google/Cloudflare Access perimeter.
+
+Do not send ordinary users to repository application source, database migration files, server runbooks, old preview listeners, or obsolete hand-built Setup navigation pages.
+
+## Obsolete Backbone Page
+
+The former static Production Setup/Takedown page:
+
+```text
+my/committees/production/setup-takedown-testing/index.html
+```
+
+is obsolete.
+
+Do not:
+
+- update or revive its direct Google Doc list;
+- link to it from current Production navigation;
+- treat it as the current Setup portal; or
+- make new Setup workflows depend on it.
+
+The live Setup application and the current Procedure application replace the need for that hand-built page:
+
+```text
+https://my.sheboyganlights.org/setup/
+https://my.sheboyganlights.org/procedures/
+```
+
+The obsolete static artifact may be removed later through the Backbone repository's controlled deployment/removal process. Its existence must not block current Production navigation work.
+
+## Operator Tasks That Should Be Discoverable
+
+Primary current task:
+
+- **Review and Correct the 2025 Setup History** — Managers/reviewers use the real Production-backed 2025 Historical Verification session to verify annual history, add/correct reusable tasks and resources, improve reusable Setup knowledge, ask questions, and suggest workflow/UI improvements before the 2026 Setup Session is created.
+
+Canonical source procedure:
+
+```text
+operatorSOP/Review_2025_Setup_History.md
+```
+
+Useful supporting action link:
+
+- **Open Setup Application** — `https://my.sheboyganlights.org/setup/`
+
+Future Setup task choices should be added only after the corresponding workflow is production-operational and documented in the source subsystem.
+
+## Suggested Plain-Language Copy
+
+Primary card/action title:
+
+```text
+Review 2025 Setup
+```
+
+Description:
+
+> Review what happened during 2025 Setup, correct what you know, add missing reusable tasks or resources, and help improve the Setup workflow before the 2026 plan is created.
+
+Secondary label/status when useful:
+
+```text
+Live review / training
+```
+
+Do not label the application as a prototype or as fully finalized. The accurate operator meaning is that it is live Production software currently being evaluated through real 2025 review work.
+
+## Search / Discovery Metadata
+
+Useful search terms:
+
+```text
+Setup
+2025 Setup
+Historical Verification
+Setup training
+review Setup history
+add Setup task
+Setup resources
+verify Setup task
+reusable Setup task
+2026 Setup baseline
+Setup plan
+```
+
+## Important Operator Meaning
+
+Backbone presentation should preserve this distinction in plain language:
+
+```text
+2025 annual changes
+    = corrections to 2025 history
+
+Reusable Task changes
+    = permanent Setup knowledge that may carry forward
+```
+
+The selected Setup Session controls the allowed operational year. The 2025 review area accepts 2025 operational dates only.
+
+## Authorization / Link Boundary
+
+The `/setup/` link may be visible as an internal action destination, but possession of the link does not grant application capability.
+
+The protected application performs its own authenticated identity and authorization checks. Backbone must not recreate Setup Manager/Administrator authorization logic.
+
+## Exclude from Normal Operator Navigation
+
+Do not expose these as normal task choices or search destinations:
+
+```text
+engineering/
+Setup/Acceptance/
+Setup/Database/
+Setup/Application/ source files
+old disposable preview URLs/ports
+historical dated engineering handoffs
+PostgreSQL rollback archive paths
+server systemd/nginx/UFW instructions
+```
+
+Engineering material may remain available through a clearly separated contributor/engineering path when appropriate, but it must not compete with operator navigation.
+
+## Current Feature Boundary
+
+Do not advertise the following as current operator workflows:
+
+- Pick List generation; or
+- Container/Display movement/scanning write commands.
+
+Those remain outside the current accepted Production-ready boundary.
+
+## Backbone Implementation
+
+Backbone PR **#11** merged to `main` on 2026-09-07.
+
+Implemented source:
+
+```text
+my/committees/production/index.html
+```
+
+The Production page now includes:
+
+- **Review 2025 Setup — Live Review / Training** -> `https://my.sheboyganlights.org/setup/`;
+- plain-English 2025 review/training purpose text;
+- the existing Procedure application retained as the field Setup/Takedown/Inspection destination; and
+- visible version indicator `Production Portal v1.2 — Updated 2026-09-07`.
+
+Live publish remains pending the Backbone controlled publisher dry-run and verified one-file deployment.
+
+## Acceptance Criteria
+
+Backbone integration is VERIFIED only when all applicable checks pass:
+
+1. the Production index/task navigation includes an appropriate Setup action;
+2. the action points to `https://my.sheboyganlights.org/setup/`;
+3. the 2025 historical review purpose is understandable in plain language;
+4. the obsolete static Setup/Takedown page is not linked or promoted;
+5. engineering/acceptance/database source paths are absent from normal operator navigation;
+6. no duplicate editable copy of the source operator procedure is created in Backbone;
+7. maintained `index.html` pages preserve their required visible version indicators; and
+8. deployed intranet verification confirms the intended Production page reaches the protected Setup application.
+
+## Backbone State
+
+```text
+IMPLEMENTED — PR #11 merged; live publish/verification pending
+```
+
+After deployed intranet verification, change this state to `VERIFIED` and record the acceptance evidence.
+
+## Related Documents
+
+- [Setup operator portal](../README.md)
+- [Setup operator procedures](../operatorSOP/README.md)
+- [Setup engineering portal](README.md)
+- [Setup Session Production Engineering Handoff](Setup_Session_Production_Engineering_Handoff_2026-09-07.md)

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Legacy_Setup_and_Deployment_Engineering_Portal_2026-09-07.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Legacy_Setup_and_Deployment_Engineering_Portal_2026-09-07.md
@@ -1,0 +1,405 @@
+# Setup and Deployment
+
+## Current State
+
+**Status: DOCUMENTATION ACTIVE / PROCEDURE FIELD ACCESS PRODUCTION-OPERATIONAL**
+
+This subsystem covers planning, scheduling, staging, loading, scanning, and moving tested displays and containers from storage to the park for annual setup, plus takedown-related field documentation where it belongs with the same Stage material.
+
+The Stage-oriented folder structure already exists. Setup/Takedown instructions are being organized into those existing Stage folders and use the same Stage-oriented convention already used by Wiring documentation.
+
+The operational database/application workflow for scheduling, pick lists, load order, and forklift scanning is not yet fully engineered. No operator procedure should imply those planned functions are implemented until verified from the current database/application.
+
+**FieldWiring, Display Scan, and the standalone Procedure application are accepted production baselines.** Procedure is production-operational at `https://my.sheboyganlights.org/procedures/` and uses the shared Field Context resolver plus the existing read-only Google `Display Folders` mount. Do not rediscover or redesign those accepted systems merely to continue Setup/Deployment work.
+
+The bounded **Procedure Display Scan Integration** is accepted production behavior: the Display scan hub passes permanent `display_id` to `/procedures/?display_id=<display_id>`, and Setup/Takedown/Inspection selection remains inside Procedure. Controller Inventory V0.4.0 is also merged and production-operational. Human Procedure-document authoring/alignment and the broader scheduling/pick/load/forklift workflow remain separate work streams.
+
+MSB has purchased a **Zebra DS3678-HD cordless ultra-rugged 1-D/2-D scanner kit** for the workshop forklift. It uses the Zebra 3600-series USB cradle and supports USB HID keyboard input. Because this is the **HD (High Density)** variant rather than an ER/XR extended-range model, its actual suitability from the forklift seat must be tested with real MSB Container and Storage Location labels before it is accepted as the final forklift-distance standard. See [Scanner Hardware and Tablet Integration](../07_Labeling_and_Scanning/Scanner_Hardware_and_Tablet_Integration.md).
+
+## Design Intent
+
+The Setup and Deployment subsystem will provide a repeatable operational plan for moving displays and containers from storage to the park while keeping field instructions easy to find from the same established Stage organization used by Wiring.
+
+Testing answers:
+
+> Is this display/container ready?
+
+Setup and Deployment answers:
+
+> When should it move, what should move with it, in what order, and what instructions does the crew need at the Stage?
+
+The intended high-level workflow remains:
+
+```text
+Testing Complete / Ready for Setup
+            ↓
+Schedule Display / Container
+            ↓
+Assign Calendar Pull Date
+            ↓
+Build Pick / Load List
+            ↓
+Forklift Driver Queue
+            ↓
+Scan / Confirm Container or Display
+            ↓
+Load in Planned Order
+            ↓
+Deliver to Park
+            ↓
+Confirm Movement / Destination
+```
+
+The goal is to replace informal yearly scheduling and remembered load sequences with a durable, repeatable operational process without disrupting the existing Stage-folder documentation crews already use.
+
+## Stage Setup Documentation Boundary
+
+Field-facing **Stage Setup Instructions are a separate document class from repository Operational SOPs**.
+
+They are used by volunteers physically setting up Stages/Scenes in the park and should remain simple, visual, and Stage-oriented. Their normal published experience may be a PDF or other rendered field document even when the editable source is a Google Doc or controlled repository source/template.
+
+The project-specific governance for these documents is defined in the [Stage Setup Documentation Standard](../../../../System_Documentation/Project_Rules/Stage_Setup_Documentation_Standard.md).
+
+The controlled structural starting point is the [Stage Setup Instruction Template](../../../../System_Documentation/Templates/Stage_Setup_Instruction_Template.md).
+
+A separate contributor/operator procedure is still required for creating, revising, archiving, publishing, and verifying Setup Instructions from that template/source. That contributor workflow should not be confused with the field instruction itself.
+
+## Stage Folder Documentation Contract
+
+The existing Google Shared Drive Stage/Scene folder structure is the human-facing organizational anchor for setup work.
+
+- Wiring and Setup/Takedown documentation share the same Stage-oriented organizational model.
+- The existing Google Drive document-organization and Folder Alignment work controls the actual folder structure and migration of legacy material.
+- Setup instructions should be placed and maintained within the existing Stage/Scene structure rather than creating a separate unrelated setup-document tree.
+- [Wiring System](../09_Wiring_System/README.md) owns wiring content in that structure.
+- Setup and Deployment owns setup/takedown instruction behavior and the application integration contract for finding applicable Procedure documents.
+- [Labeling and Scanning](../07_Labeling_and_Scanning/README.md) owns permanent QR/scanning integration patterns, but QR lookup does not become the content authority.
+- [Procedure System Field Context Handoff](00_Procedure_System_Field_Context_Handoff_2026-08-22.md) remains the architecture handoff that resolved the original Procedure/FieldWiring conflicts.
+
+This framework does not by itself define or approve a new database schema.
+
+## Document Resolution and Field UX
+
+The accepted current field-access path is:
+
+```text
+Display QR or manual Display/Stage/Scene lookup
+    ↓
+Permanent Display identity when applicable
+    ↓
+Production Database relationships
+    ↓
+shared/proven FieldWiring structured Stage / Sub-stage / Scene resolver
+    ↓
+fixed applicable structured root
+    ↓
+validate structured-root marker
+    ↓
+validate <scope>/Procedures marker
+    ↓
+Procedure task adapter selects fixed child
+    ↓
+<scope>/Procedures/Setup
+or <scope>/Procedures/Takedown
+or <scope>/Procedures/Inspection
+    ↓
+bounded current-document discovery from the read-only Google filesystem
+    ↓
+my.sheboyganlights.org
+    ↓
+current field PDF / rendered instruction
+```
+
+The QR code identifies the asset. It does not contain a Google Drive folder path or manually maintained direct Procedure-document URL.
+
+The Production Database owns the durable identities and relationships used to determine the structured Stage/Scene context. The database does not become the editing system for Procedure content.
+
+For the current read-only Procedure browser, a PostgreSQL row or stored Google document ID for every current published PDF is **not a prerequisite**. Once the current structured root and marked `Procedures` subsystem root are validated, the application selects the exact known `Setup`, `Takedown`, or `Inspection` child and enumerates the current published files directly in that task folder while excluding `Archive` and `SourceDocs`.
+
+Durable per-document metadata remains a future engineering option when approval workflow, revision history, source-to-publication lineage, supersession, audit, or stable document identity demonstrates a need for it. Do not create schema merely because older documentation listed document-ID storage as unresolved.
+
+`my.sheboyganlights.org` is the normal field presentation layer. Field volunteers should not need to understand the GitHub repository, database schema, Google Drive organization, or source-document mechanics to reach the current Setup instruction.
+
+## Resolver Reuse Boundary
+
+Procedure **reuses the proven shared FieldWiring structured-scope resolver** rather than maintaining a second independent Display-to-Stage/Scene algorithm.
+
+The shared resolver answers:
+
+> Which current marked Stage / Sub-stage / Scene root owns this context?
+
+The Procedure adapter then answers:
+
+> Which current documents are published in the selected Procedure task branch beneath that already-resolved root?
+
+This means Wiring and Procedures share scope resolution but do not share task-specific content rules:
+
+```text
+resolved structured root
+    |
+    +--> FieldWiring -> marked Wiring root -> BackgroundStage or MusicalStage
+    |
+    +--> Procedures  -> marked Procedures root -> Setup, Takedown, or Inspection
+```
+
+Both systems use the same subsystem-root marker pattern: the resolved structured scope is marked, then the owning application subsystem root (`Wiring` or `Procedures`) is marked. Their fixed child branches are selected by folder name and do not require a second marker layer. `Archive` and `SourceDocs` remain excluded from normal field presentation.
+
+## Scan / Forklift Direction
+
+The permanent Display scan platform is production-operational and resolves `DISP:<display_id>` using permanent Production Database identity. Procedure Display Scan Integration consumes that existing identity contract; no physical Display QR redesign is required.
+
+The agreed operator-facing Scan behavior is:
+
+```text
+Display scan hub
+    -> Procedures
+        -> /procedures/?display_id=<permanent display_id>
+            -> existing Procedure page
+                -> operator chooses Setup, Takedown, or Inspection
+```
+
+The Scan hub passes only `display_id`, does not duplicate the three Procedure task buttons, and does not call Procedure merely to decide whether the link should render. This is accepted production behavior. Do not invent a second resolver, encode Stage/Scene/Google paths in the QR, or make the Display hub depend on Procedure health merely to render the Procedures action.
+
+Setup is also expected to become a high-volume scan workflow for deployment operations rather than only document lookup.
+
+Durable physical identities remain the starting point:
+
+```text
+DISP:<permanent display_id>
+CONT:<permanent container_id>
+LOC:<operational storage/location code>
+CTRL:<permanent controller_id>
+```
+
+Annual setup dates, load numbers, staging status, and other transient workflow state must not be encoded into the permanent labels.
+
+The application should be designed so both of these input paths produce the same canonical asset/location payload:
+
+```text
+industrial scanner -> HID keyboard input
+phone/tablet camera -> camera decoder
+```
+
+The purchased Zebra DS3678-HD gives the project a real industrial hardware acceptance target. Its USB HID behavior fits the browser-first design, but the hardware must be tested against actual label size/density and actual forklift position before deciding whether HD range is adequate or an ER/XR scanner is required for some tasks.
+
+The 2026-09-03 ADF correction is input-method evidence only: the Zebra emitted compact canonical identifiers correctly in Google Docs. The current Container route is accepted because it opens the Directus Container record and assigned Displays. `LOC` still has no complete route and remains #88. The deployed `CTRL` route hands permanent Controller identity to the existing production Controller Inventory Search/detail page; manual compact/full-URL entry passed, and the route adds no Setup movement meaning. Physical printed-label/device acceptance remains pending.
+
+Likely setup interactions may include both scan orders:
+
+```text
+Container -> Location
+Location -> Container
+```
+
+The real setup-day process must determine what each pair means: pull confirmation, staging, load assignment, destination validation, storage relocation, or another business event. Do not invent transaction semantics from the scanner hardware.
+
+## Annual Operating Cycle
+
+`ref.season` remains the annual operational context. The documented working cycle is approximately:
+
+- Testing begins in January.
+- Setup/show preparation begins around the end of September.
+- Takedown begins around January 1.
+- After takedown, the next testing cycle begins again.
+
+Detailed testing-season procedures belong with [Testing System](../05_Testing_System/README.md); detailed Setup field instructions live with the established Stage/Scene documentation structure.
+
+## Design Principles
+
+### PostgreSQL remains the operational system of record
+
+Scheduling, operational movement events, load grouping, scan confirmations, deployment status, and durable Stage/Scene/asset relationships remain in the Production Database when those workflows are engineered.
+
+Generic container movement history is not a goal. Movement/history should be recorded only when the Setup/Deployment workflow actually needs a reconstructable event trail.
+
+### Google Shared Drive remains the field-document repository
+
+The shared read-only server filesystem exists so Procedure applications can consume the same human-maintained `Display Folders` hierarchy already used by FieldWiring.
+
+Do not create a second Procedure-only Google hierarchy, duplicate mount, downloaded mirror, or database binary-document store merely to present current procedures.
+
+### Field document content remains separate from database internals
+
+The database resolves the current physical context without requiring field volunteers to operate inside PostgreSQL, Directus, GitHub, or Google Drive.
+
+A simple PDF/rendered instruction at the Stage/Scene level is preferred when that gives the crew the best user experience.
+
+### Directus is an initial management interface, not the field-document UX requirement
+
+The scheduling and management portion of this subsystem is expected to be controlled through Directus initially where practical.
+
+A dedicated task-focused field interface may be added where Directus is not suitable. Any such application must continue to use the Production Database as the authoritative operational data source.
+
+### Testing remains a separate subsystem
+
+Testing and Setup/Deployment are related but distinct workflows.
+
+A successful test may establish that an item is ready for setup, but the Testing subsystem does not own deployment dates, load order, transport grouping, park delivery, or the content of Stage Setup Instructions.
+
+### Preserve useful yearly deployment and documentation history
+
+The system should preserve the actual sequence used each year when that history is useful for planning the next season. Historical deployment records should not be overwritten merely because a new year's schedule is created.
+
+Legacy and superseded Setup instructions should be archived through the established Stage documentation process rather than deleted or left mixed with current field instructions.
+
+## Current and Planned Responsibilities
+
+Already production-operational:
+
+- current Setup/Takedown/Inspection document lookup by Display/Stage/Scene;
+- field-friendly Procedure presentation through `my.sheboyganlights.org/procedures/`;
+- shared Field Context resolution and read-only Google `Display Folders` consumption;
+- the one-button Procedures action on the Display scan hub;
+- Controller Inventory V0.4.0 and its exact-controller deep-link input.
+
+Current bounded Scan follow-on:
+
+- complete physical printed-label Zebra and phone/tablet acceptance for the deployed Controller route after LabelPrintService can print the first label;
+- continue #88 for Location identity resolution and the minimum Setup-owned workflow;
+- physically accept relevant Location label behavior before volume printing Location labels.
+
+Separate planned operational work includes:
+
+- setup season/session context;
+- calendar pull scheduling;
+- pick lists;
+- load/trip grouping and sequence;
+- forklift scanning;
+- Container/Location validation;
+- meaningful pull/stage/load/delivery confirmations;
+- prior-year sequence reference;
+- optional durable per-document publication metadata when a demonstrated workflow requires it.
+
+These planned operational items are design targets, not implemented schema commitments unless verified in the current database.
+
+## System Boundaries and Dependencies
+
+This subsystem depends on existing Production Database identities and relationships, including where applicable:
+
+- permanent Display identity and Stage/Scene relationships;
+- the accepted FieldWiring structured-context behavior;
+- the accepted Display scan platform;
+- the accepted standalone Procedure application;
+- the shared read-only Google `Display Folders` filesystem;
+- containers and storage locations;
+- testing readiness/state;
+- people/volunteer identity;
+- rugged tablet/industrial scanner hardware;
+- Stage/Scene identity and established documentation organization; and
+- site/stage/location information needed for deployment planning.
+
+It must not redefine permanent Display IDs, Container IDs, storage identities, LOR wiring/topology, or other identities already owned by existing subsystems.
+
+Containers of type **KIT** already exist and may hold loose setup materials instead of Displays. Detailed kit-contents inventory remains a separate future Setup/Deployment need.
+
+## Known Limitations / Open Work
+
+The standalone Procedure field-access application is accepted production work. Do not reopen its shared resolver, Google hierarchy, Procedure marker contract, or current-document discovery architecture unless a demonstrated production defect requires it.
+
+Current Procedure-related open work is separated into these scopes:
+
+- **Procedure Display Scan Integration** — accepted production behavior; preserve the permanent `display_id` handoff and downstream ownership boundary;
+- **Procedure document authoring/alignment** — continue the legacy Setup-document review, alignment, archive, and publication work in the existing Stage/Scene `Display Folders` hierarchy;
+- **Contributor/operator documentation** — finalize the Stage Setup Instruction contributor workflow and the editable-source versus published-PDF relationship where Google Docs remain in use;
+- **additional field acceptance as needed** — complete any broader PC/phone/tablet, print, or offline validation required for the 2026 field workflow; and
+- **durable document metadata only if justified** — engineer Google document IDs or published references only when a demonstrated publication/history requirement cannot be met by the current controlled-folder contract.
+
+Separate Setup/Deployment operational work still includes scheduling, readiness, pull/load planning, Container/Location movement semantics, forklift workflow, hardware acceptance, and related annual workflow state. Do not mix those business-process questions into Procedure Display Scan Integration.
+
+## Resume Development
+
+### Current production baseline
+
+Begin from current `main` and the current responsible runbooks. Do not rediscover the old live-only scan extension, redesign the physical QR, rebuild the Google filesystem connection, or reconstruct Procedure deployment from chat history.
+
+Read first:
+
+1. [Procedure Application README](../../../../Procedures/Application/README.md) — current standalone Procedure application contract, production status, and Scan entry contract;
+2. [Labeling and Scanning](../07_Labeling_and_Scanning/README.md) — current Scan platform and Controller handoff state;
+3. [Deployed Display Scan Runtime Boundary](../07_Labeling_and_Scanning/Deployed_Display_Scan_Runtime_Boundary.md) — current Git/runtime boundary and accepted live Scan baseline;
+4. [FieldWiring Scan Integration Engineering Handoff](../07_Labeling_and_Scanning/FieldWiring_Scan_Integration_Engineering_Handoff_2026-08-22.md) — accepted additive scan integration pattern and failure boundary;
+5. [Procedure System Field Context Handoff — 2026-08-22](00_Procedure_System_Field_Context_Handoff_2026-08-22.md) — architecture precedence for Procedure/Field Context;
+6. [Field Context Resolution Contract](../07_Labeling_and_Scanning/Field_Context_Resolution_Contract.md);
+7. [Stage Setup Documentation Standard](../../../../System_Documentation/Project_Rules/Stage_Setup_Documentation_Standard.md); and
+8. [MSB-Server-Management Display Scan Extension Deployment and Recovery](https://github.com/Gregovate/MSB-Server-Management/blob/main/docs/directus/Display_Scan_Extension_Deployment_and_Recovery.md) before any scan deployment.
+
+### Controller Scan Integration — route deployed; physical-label acceptance pending
+
+The accepted identity and UX handoff is:
+
+```text
+camera QR: https://db.sheboyganlights.org/scan/CTRL/<controller_id>
+Zebra/manual: CTRL:<controller_id>
+    -> /scan/CTRL/<controller_id>
+    -> /fieldwiring/controllers?controller_id=<controller_id>
+    -> existing Controller Inventory filters Search and opens exact detail
+```
+
+The deployed route reuses permanent `ref.controller.controller_id` and the existing Controller browser. Manual compact/full-URL production input passed. It must still pass real-label Zebra/phone/tablet and useful-distance acceptance before volume Controller label printing.
+
+This work must not create:
+
+- a second Controller result application;
+- a second Controller identity;
+- Controller database or movement mutations merely from scanning;
+- annual Setup state in the permanent Controller label; or
+- a dependency on Zebra-specific formatting.
+
+Follow the existing Server Management scan-extension runbook for live hash verification, rollback capture, staging, syntax validation, restart, and regression testing. Operational discoveries made during this work must be written into the responsible runbook before later steps depend on them.
+
+### Setup workflow engineering
+
+Separately document the real setup-day process from the people who:
+
+- schedule pulls;
+- operate the forklift;
+- identify containers/locations;
+- stage material;
+- load trailers/trucks;
+- receive loads at the park;
+- place containers/displays at their destinations.
+
+Define business events and exception handling before designing schema, Directus Flows, scan-session state, or a dedicated deployment application.
+
+### Hardware acceptance
+
+Begin hardware testing with the [Scanner Hardware and Tablet Integration](../07_Labeling_and_Scanning/Scanner_Hardware_and_Tablet_Integration.md) handoff and the purchased Zebra DS3678-HD. Use actual labels and measured working distances rather than theoretical family-level specifications.
+
+### Setup-document authoring work
+
+For Setup-document authoring/alignment work, continue with:
+
+1. the [Stage Setup Documentation Standard](../../../../System_Documentation/Project_Rules/Stage_Setup_Documentation_Standard.md);
+2. the current [Google Drive Document Organization Procedure](../../../00_Project_Overview/01-Google_Drive_Document_Organization_Procedure.md);
+3. the current Folder Alignment work/report;
+4. the controlled [Stage Setup Instruction Template](../../../../System_Documentation/Templates/Stage_Setup_Instruction_Template.md); and
+5. the real Stage/Scene documents currently being reviewed and archived.
+
+Do not redesign the established Stage folder structure while solving Procedure QR integration, PDF publishing, or intranet UX.
+
+## Related Systems
+
+- [Testing System](../05_Testing_System/README.md) — establishes testing state/readiness before deployment.
+- [Containers and Storage](../04_Containers_and_Storage/README.md) — owns container identity, assignments, storage-location relationships, and KIT container identity.
+- [Wiring System](../09_Wiring_System/README.md) — provides the proven structured field-context implementation while retaining its own wiring content rules.
+- [Labeling and Scanning](../07_Labeling_and_Scanning/README.md) — owns permanent labels and the accepted scan-routing integration pattern.
+- [FieldWiring Scan Integration Engineering Handoff](../07_Labeling_and_Scanning/FieldWiring_Scan_Integration_Engineering_Handoff_2026-08-22.md) — accepted production Display scan baseline.
+- [Scanner Hardware and Tablet Integration](../07_Labeling_and_Scanning/Scanner_Hardware_and_Tablet_Integration.md) — owns the purchased Zebra scanner baseline and hardware/browser-input acceptance contract.
+- [People and Identity](../03_People_and_Identity/README.md) — provides durable person/user identity and audit attribution.
+- [Site Infrastructure / GIS](../11_Site_Infrastructure_GIS/README.md) — may provide destination/location context where applicable.
+
+## Related Documentation
+
+- [Procedure Application README](../../../../Procedures/Application/README.md)
+- [Procedure System Field Context Handoff — 2026-08-22](00_Procedure_System_Field_Context_Handoff_2026-08-22.md)
+- [Stage Setup Documentation Standard](../../../../System_Documentation/Project_Rules/Stage_Setup_Documentation_Standard.md)
+- [Stage Setup Instruction Template](../../../../System_Documentation/Templates/Stage_Setup_Instruction_Template.md)
+- [Google Drive Document Organization Procedure](../../../00_Project_Overview/01-Google_Drive_Document_Organization_Procedure.md)
+- [Field Context Resolution Contract](../07_Labeling_and_Scanning/Field_Context_Resolution_Contract.md)
+- [FieldWiring Drive Context Resolver Engineering Design](../09_Wiring_System/FieldWiring_Drive_Context_Resolver_Engineering_Design.md)
+- [Documentation Maintenance Rule](../../../../System_Documentation/Standards/Documentation_Maintenance_Rule.md)
+- [Document Control Standard](../../../../System_Documentation/Standards/Document_Control_Standard.md)
+- [Linking and Navigation Standard](../../../../System_Documentation/Standards/Linking_and_Navigation_Standard.md)
+- [MSB-Server-Management Display Scan Extension Deployment and Recovery](https://github.com/Gregovate/MSB-Server-Management/blob/main/docs/directus/Display_Scan_Extension_Deployment_and_Recovery.md)
+
+Repository Operational SOPs remain appropriate for database/application tasks in this subsystem when those tasks are implemented. They are not the storage or format model for the field-facing Stage Setup Instructions themselves.

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/README.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/README.md
@@ -1,0 +1,141 @@
+# Setup and Deployment Engineering
+
+| Document Control | Value |
+|---|---|
+| Document Type | Engineering Handoff Portal |
+| System | Production Database — Setup and Deployment |
+| Audience | Greg, maintainers, database administrators, future engineering sessions |
+| Status | CURRENT HANDOFF — Production runtime accepted; UI/workflow in live evaluation |
+| Owner | MSB Production Database engineering |
+| Last Reviewed | 2026-09-07 |
+
+This is the engineering starting point for Setup Session architecture, database behavior, application contracts, deployment state, and resume information.
+
+The operator-facing instructions are separate under [`../operatorSOP/`](../operatorSOP/README.md).
+
+## Current State
+
+Production deployment is operational and accepted at the runtime level.
+
+```text
+public application             = https://my.sheboyganlights.org/setup/
+application version            = V0.3.4-shared-season-guard-review
+2025 Setup Session             = HISTORICAL_VERIFICATION
+2025 annual tasks              = 57
+2025 UNVERIFIED tasks          = 57
+2026 Setup Sessions            = 0
+Setup work days                = 0
+Setup movement events          = 0
+active reusable Setup tasks    = 57
+```
+
+Accepted runtime state includes:
+
+```text
+/opt/msb-setup                 = permanent detached worktree
+msb-setup.service              = active / enabled
+msb-setup-google-links.service = active / enabled
+listener                       = 192.168.5.9:8794
+UFW                            = 8794/tcp from Synology 192.168.5.4 only
+Synology /setup/ route         = active
+Cloudflare-authenticated view  = PASS; real 2025 data rendered
+post-reboot invariants         = PASS
+```
+
+The Setup/UI subsystem is **not final**. The three Setup PRs remain open drafts while managers use the 2025 session for real reconstruction/training and expose usability, workflow, data-model, and documentation problems.
+
+## Start Here
+
+- [Setup Session Production Engineering Handoff — 2026-09-07](Setup_Session_Production_Engineering_Handoff_2026-09-07.md) — current database/application/runtime state, accepted deployment evidence, open PR structure, and live-evaluation resume point.
+- [Internal Web Backbone Handoff](Internal_Web_Backbone_Handoff.md) — source-subsystem contract for intranet navigation/search/application entry points.
+- [Setup Session Shared Review and Season-Year Guard](../Setup_Session_Shared_Review_and_Season_Year_Guard_2026-09-07.md) — annual-vs-reusable data boundary and session-year enforcement.
+
+## Authoritative Implementation Sources
+
+Application source:
+
+```text
+Setup/Application/
+```
+
+Database migration source:
+
+```text
+Setup/Database/
+```
+
+Production acceptance/install material:
+
+```text
+Setup/Acceptance/
+```
+
+The Production Database repository owns Setup application/business/database behavior. `Gregovate/MSB-Server-Management` owns deployed service, listener, firewall, reverse-proxy, restart/recovery, and host permission facts.
+
+## Current PR Structure
+
+The active Setup work remains intentionally open across three draft PRs:
+
+```text
+#123  reconnaissance / planning documentation lineage
+#124  browser UI / verification lineage
+#125  Production foundation / database / runtime lineage
+```
+
+Do not merge/close this stack merely because the application is reachable. Final normalization and merge should wait until enough real 2025 review use has occurred to identify and resolve material UI/workflow findings.
+
+## Critical Runtime Permission Boundary
+
+`msbadmin` is the SSH administrator but does not have the `msb-docs-read` traversal permissions used by the `fieldwiring` runtime account on `/mnt/msb-display-folders` and `/mnt/msb-setup-google-links`.
+
+Runtime-path validation must run as `fieldwiring`. Server-side detail and recovery procedure belong in `Gregovate/MSB-Server-Management`.
+
+## Known Boundaries / Open Work
+
+Current live-review scope includes:
+
+- 2025 annual review/verification;
+- reusable task creation/copy and maintenance;
+- task scope/order/prerequisite/resource maintenance;
+- supported planning/review controls;
+- Procedure/document context; and
+- authenticated multi-user browser access.
+
+Still outside the accepted Production-ready workflow:
+
+- Pick List generation; and
+- Container/Display movement/scanning write commands.
+
+Live evaluation should also capture questions and suggestions that are not traditional software defects. The 2025 review is the usability and operating-model test bed before 2026 is created.
+
+## Resume Development
+
+Before changing this subsystem:
+
+1. read the Production Database Project Rules;
+2. review PRs #123, #124, and #125 together rather than treating one as the whole subsystem;
+3. read the Production Engineering Handoff linked above;
+4. review current live-use findings from managers/reviewers;
+5. preserve the accepted 2025/2026 annual-vs-reusable boundary;
+6. use `Gregovate/MSB-Server-Management` for current runtime/service/proxy facts; and
+7. keep operator docs and engineering docs synchronized when behavior changes.
+
+Current resume point:
+
+```text
+Production runtime                    = ACCEPTED
+Cloudflare-authenticated 2025 view    = ACCEPTED
+post-deployment invariants            = ACCEPTED
+UI/workflow                           = LIVE EVALUATION
+2026 Setup Session                    = NOT CREATED
+PR #123 / #124 / #125                 = OPEN DRAFTS
+Backbone source handoff               = READY FOR IMPLEMENTATION
+```
+
+## Related Systems
+
+- [Setup and Deployment operator portal](../README.md)
+- [Operator procedures](../operatorSOP/README.md)
+- [Detailed Manager Review Guide](../../../02_Operational_SOPs/Setup/Setup_Session_Manager_Review_Guide.md)
+- [Labeling and Scanning](../../07_Labeling_and_Scanning/README.md)
+- [Wiring System](../../09_Wiring_System/README.md)

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Session_Production_Engineering_Handoff_2026-09-07.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Session_Production_Engineering_Handoff_2026-09-07.md
@@ -1,0 +1,286 @@
+# Setup Session Production Engineering Handoff — 2026-09-07
+
+| Document Control | Value |
+|---|---|
+| Document Type | Engineering Handoff |
+| System | Production Database — Setup Session |
+| Status | CURRENT HANDOFF — Production runtime accepted; UI/workflow in live evaluation |
+| Owner | MSB Production Database engineering |
+| Last Reviewed | 2026-09-07 |
+
+## Purpose
+
+Preserve the accepted Setup Session V0.3.4 Production state, operating model, security boundaries, runtime dependencies, rollback evidence, open PR structure, and current live-evaluation resume point so later work can start from repository evidence instead of chat history.
+
+## Current Operating Model
+
+The real 2025 Production-backed Setup Session is the shared historical reconstruction and training area.
+
+Authorized reviewers use it to:
+
+- reconstruct and correct 2025 annual Setup facts;
+- learn the Setup application using real data;
+- add or correct reusable Setup tasks, resources, prerequisites, scope, order, and other permanent Setup knowledge where appropriate;
+- verify records where evidence exists;
+- leave uncertain records UNVERIFIED or mark them NEEDS CORRECTION; and
+- identify UI/workflow/data-model/documentation problems before the 2026 Setup Session is created.
+
+The selected Setup Session owns the allowable operational year:
+
+```text
+2025 session -> 2025 operational dates/timestamps only
+2026 session -> 2026 operational dates/timestamps only
+```
+
+Audit/recording timestamps remain current truthful timestamps.
+
+## Production Database Promotion
+
+Production V0.3.4 promotion is accepted.
+
+Durable migration sequence applied:
+
+```text
+008
+009
+010
+011
+013
+014
+015
+016
+017
+```
+
+Migration `012` was intentionally excluded because it contains disposable browser-review reset/seed behavior and must never be applied to Production.
+
+Validated pre-promotion rollback archive:
+
+```text
+/home/msbadmin/backups/setup-v034/msb_pre_setup_v034_20260907T202706Z.dump
+SHA256 e09bd97010b464fe307a9fbe0192c9ca4189fd562215f4eaa93e02a2d08f89a5
+```
+
+The archive is PostgreSQL custom format and `pg_restore -l` validation passed.
+
+## Accepted Production Data State
+
+Final post-cutover / post-reboot read-only invariant check:
+
+```text
+setup_session_id          = 1
+season_year               = 2025
+session_status            = HISTORICAL_VERIFICATION
+annual_tasks              = 57
+unverified_tasks          = 57
+sessions_2026             = 0
+work_days                 = 0
+movement_events           = 0
+active_reusable_tasks     = 57
+```
+
+This proves deployment, Directus reload, and host reboot did not alter Setup operational data.
+
+## Accepted Application / Runtime State
+
+Protected Production entry point:
+
+```text
+https://my.sheboyganlights.org/setup/
+```
+
+Application version:
+
+```text
+V0.3.4-shared-season-guard-review
+```
+
+Permanent source/runtime:
+
+```text
+/opt/msb-setup
+source SHA = c0639c5b04de667176a8d8eef14fce0409f03ec6
+msb-setup.service = active / enabled
+listener = 192.168.5.9:8794
+msb-setup-google-links.service = active / enabled
+```
+
+Accepted network/proxy state:
+
+```text
+UFW 8794/tcp ALLOW IN 192.168.5.4
+Synology /setup -> /setup/ redirect = PASS
+/setup/ root = HTTP 200
+/setup/api/health = expected V0.3.4 payload
+Cloudflare-authenticated browser access = PASS
+real 2025 Production data rendered = PASS
+Procedures regression = PASS
+```
+
+The first Setup Synology route cutover was safely rolled back after the first immediate post-reload request returned Synology 404. The Server Management reverse-proxy runbook was corrected with a bounded post-reload readiness gate. The accepted retry became healthy on attempt 2.
+
+## Host Reboot / Directus Reload
+
+Ubuntu required a reboot for:
+
+```text
+linux-image-7.0.0-31-generic
+```
+
+One controlled host reboot both activated the kernel and reloaded Directus after the Setup schema promotion.
+
+Accepted post-reboot state:
+
+```text
+kernel                         = 7.0.0-31-generic
+reboot-required marker         = cleared
+msb-postgres                   = running / healthy / unless-stopped
+msb-directus                   = running / unless-stopped
+Directus image                 = directus/directus:11.17.1
+Directus extensions            = directus-extension-scan, directus-extension-stamp-actor-fields
+Directus startup               = online; no blocking startup errors
+fieldwiring.service            = active / enabled
+msb-procedures.service         = active / enabled
+msb-display-folders.service    = active / enabled
+msb-setup-google-links.service = active / enabled
+msb-setup.service              = active / enabled
+FieldWiring health             = V0.4.0 PASS
+Procedures health              = V0.1.0 PASS
+Setup health                   = V0.3.4 PASS
+public Setup / Procedures      = PASS
+```
+
+Two noncritical staging containers were not recovered by guesswork. One exited cleanly with `restart=no`; another no longer existed and had no repository-owned lifecycle contract. Server Management records this staging-container lifecycle documentation gap.
+
+## Authorization Boundary
+
+The protected Setup API uses:
+
+```text
+Cloudflare Access authenticated email
+  -> Setup backend capability lookup
+  -> Directus/ref.person authorization source
+  -> narrow PostgreSQL command functions
+```
+
+A shared link alone does not grant write authority.
+
+Managers/reviewers may work on the 2025 annual session and reusable Setup knowledge according to capability. Only Administrators may:
+
+- create annual Setup Sessions; and
+- promote an annual plan order to the reusable future baseline.
+
+`fieldwiring_app` does not receive broad table DML merely to support browser actions.
+
+## Annual vs Reusable Boundary
+
+```text
+annual 2025 change
+    = 2025 historical fact/state
+
+Reusable Task change
+    = permanent Setup knowledge that may carry forward
+```
+
+Reviewers must not encode a one-off 2025 condition into reusable knowledge merely to make the historical record fit.
+
+## Runtime / Filesystem Boundary
+
+Server/runtime authority is `Gregovate/MSB-Server-Management`.
+
+Critical runtime identity:
+
+```text
+service account          = fieldwiring
+supplementary group      = msb-docs-read
+Display Folders mount    = /mnt/msb-display-folders (read-only)
+Google native link view  = /mnt/msb-setup-google-links
+```
+
+`msbadmin` is the SSH/system administrator but does not have the same runtime traversal rights. Filesystem/runtime validation under these paths must run as `fieldwiring`.
+
+## Current Live-Evaluation Scope
+
+Managers can use the 2025 session for real review/training work, including:
+
+- annual verification/correction;
+- reusable task creation/copy and maintenance;
+- task scope/order maintenance;
+- prerequisites;
+- structured equipment/resources;
+- supported planning/review controls; and
+- Procedure/document context.
+
+Still outside the current accepted Production-ready workflow:
+
+- Pick List generation; and
+- Container/Display movement/scanning write commands.
+
+Do not create fake work days, fake movements, or throwaway Production records merely to test the UI.
+
+## Open PR Structure
+
+The Setup subsystem remains open across three draft Production Database PRs:
+
+```text
+#123  Document Setup Session subsystem reconnaissance
+#124  Prototype 2025 Setup Session verification UI
+#125  Build Setup Session production foundation
+```
+
+These PRs intentionally remain open while the 2025 session is used in practice. Production availability is not the same as final UI/workflow acceptance.
+
+Before final merge:
+
+1. gather enough real 2025 review use to expose material UI/workflow issues;
+2. correct accepted defects and documentation errors;
+3. keep operator/plain-English and engineering documentation synchronized;
+4. complete the Internal Web Backbone integration and deployed navigation verification;
+5. review issues/findings from managers;
+6. normalize the three-PR stack without losing lineage; and
+7. merge only when the subsystem is ready to be treated as the accepted baseline for 2026 planning.
+
+## Internal Web Backbone State
+
+Source handoff is now **READY FOR IMPLEMENTATION** because the protected `/setup/` route is operational and authenticated 2025 data rendering has passed.
+
+Backbone implementation must still:
+
+- present Setup as a task/action, not an engineering document tree;
+- link to `https://my.sheboyganlights.org/setup/`;
+- make the 2025 review procedure discoverable in plain language; and
+- avoid exposing engineering/database/acceptance internals to ordinary operators.
+
+Source handoff:
+
+[Internal Web Backbone Handoff](Internal_Web_Backbone_Handoff.md)
+
+Backbone issue:
+
+```text
+Gregovate/MSB-Internal-Web-Backbone #10
+```
+
+## Resume Point
+
+```text
+Database V0.3.4 promotion           = ACCEPTED
+Production runtime                  = ACCEPTED
+Cloudflare-authenticated 2025 view  = ACCEPTED
+post-deployment invariants          = ACCEPTED
+2025 historical session             = 57 / 57 UNVERIFIED at deployment baseline
+2026 session                        = absent
+UI/workflow                         = LIVE EVALUATION
+PR #123 / #124 / #125               = OPEN DRAFTS
+Backbone source handoff             = READY FOR IMPLEMENTATION
+```
+
+Next engineering work should come from real manager/reviewer findings and the Backbone integration, not from reconstructing deployment state.
+
+## Related Documents
+
+- [Setup engineering portal](README.md)
+- [Setup operator procedures](../operatorSOP/README.md)
+- [Manager Review Guide](../../../02_Operational_SOPs/Setup/Setup_Session_Manager_Review_Guide.md)
+- [Shared Review and Season-Year Guard](../Setup_Session_Shared_Review_and_Season_Year_Guard_2026-09-07.md)
+- [Internal Web Backbone Handoff](Internal_Web_Backbone_Handoff.md)

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/operatorSOP/README.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/operatorSOP/README.md
@@ -1,0 +1,64 @@
+# Setup and Deployment Operator Procedures
+
+| Document Control | Value |
+|---|---|
+| Document Type | Operator Portal |
+| System | Production Database — Setup and Deployment |
+| Audience | MSB reviewers, managers, and Setup operators |
+| Status | CURRENT — Production runtime operational; UI/workflow in live evaluation |
+| Owner | MSB Production Database / Setup administrator |
+| Last Reviewed | 2026-09-07 |
+| Keywords | Setup, 2025, historical review, training, reusable tasks, resources, 2026 baseline |
+
+Use this area for plain-English instructions for working in the Setup application. Engineering, database, service, permission, and deployment details belong in [`../engineering/`](../engineering/README.md).
+
+## Current Application
+
+Open the protected Setup application at:
+
+```text
+https://my.sheboyganlights.org/setup/
+```
+
+The current shared working session is:
+
+```text
+2025 — Historical Verification
+```
+
+The application uses real Production data. It is available for manager/reviewer use now, but the UI/workflow is still being evaluated through real 2025 review work.
+
+## What Do You Need To Do?
+
+- [Review and Correct the 2025 Setup History](Review_2025_Setup_History.md) — verify 2025 information, improve reusable Setup knowledge, add missing tasks/resources where appropriate, and record questions or suggestions.
+
+Additional task procedures will be added only when the corresponding workflow is actually production-operational.
+
+## Important Boundaries
+
+- The 2025 review area uses real Production data.
+- Annual 2025 corrections stay with the 2025 Setup Session.
+- Reusable Task changes are permanent Setup knowledge and may affect future seasons.
+- Operational dates entered for the selected Setup Session must be in that session's year.
+- Only an Administrator may create a new annual Setup Session or carry annual order forward as the future reusable baseline.
+- Pick Lists and Container/Display movement/scanning writes are not part of the current live-review workflow.
+- Do not create fake records merely to test the UI. Use real review work and report workflow/UI findings instead.
+
+## During Live Evaluation
+
+Managers and reviewers are encouraged to:
+
+- open tasks and compare annual 2025 information with reusable task information;
+- add genuinely missing reusable tasks;
+- add/correct resources and prerequisites;
+- correct task scope, order, crew/time expectations, and notes where supported;
+- verify records only when they have actually been reviewed;
+- leave uncertain information UNVERIFIED or mark it NEEDS CORRECTION;
+- ask questions and make suggestions about confusing, missing, or inefficient workflow; and
+- report UI problems instead of working around them silently.
+
+## Related Documents
+
+- [Setup and Deployment](../README.md)
+- [Engineering handoff](../engineering/README.md)
+- [Detailed Manager Review Guide](../../../02_Operational_SOPs/Setup/Setup_Session_Manager_Review_Guide.md)

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/operatorSOP/Review_2025_Setup_History.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/operatorSOP/Review_2025_Setup_History.md
@@ -1,0 +1,186 @@
+# Review and Correct the 2025 Setup History
+
+| Document Control | Value |
+|---|---|
+| Document Type | Operator Procedure |
+| System | Production Database — Setup and Deployment |
+| Task | Review and correct the 2025 Setup history |
+| Audience | Authorized Setup reviewers and managers |
+| Status | CURRENT — live 2025 review/training workflow; UI/workflow evaluation remains open |
+| Owner | MSB Setup administrator |
+| Last Reviewed | 2026-09-07 |
+| Keywords | Setup, 2025, historical review, training, reusable task, resources, verification |
+
+## Purpose
+
+Use the real 2025 Setup Session to reconstruct what happened during the 2025 Setup season, improve reusable Setup knowledge, and learn the Setup application before the 2026 Setup Session is created.
+
+This is both a historical review area and a training area. Changes are real Production changes. The application itself is also still under live evaluation, so questions, suggestions, confusing screens, missing controls, and workflow problems should be reported rather than silently worked around.
+
+## Open the Setup Application
+
+Use:
+
+```text
+https://my.sheboyganlights.org/setup/
+```
+
+Sign in through the normal MSB Google/Cloudflare Access login when prompted.
+
+## Confirm You Are Working in 2025
+
+At the top of the Setup application, confirm the selected session is:
+
+```text
+2025 — Historical Verification
+```
+
+For this session:
+
+```text
+allowed operational dates = 2025 only
+```
+
+The browser limits operational dates to 2025 and the database independently enforces the same rule. A correction recorded during 2026 may still have a 2025 operational date; its audit/update timestamp remains the real 2026 recording time.
+
+## Understand the Two Kinds of Changes
+
+### 2025 annual history
+
+These changes describe what happened or was planned in 2025. Examples include:
+
+- verification state;
+- actual crew count or duration when known;
+- actual start/completion information when known;
+- annual notes;
+- 2025-specific planned order; and
+- 2025 work-day/scheduling information when useful for reconstruction.
+
+These changes belong to 2025 and do not become 2026 history.
+
+### Reusable Task knowledge
+
+These changes describe how MSB normally performs Setup work. Examples include:
+
+- task name and active state;
+- Park Infrastructure / Stage / Scene scope;
+- normal local sequence/order;
+- normal crew size and expected duration;
+- prerequisites;
+- equipment/resources and quantities;
+- completion point;
+- readiness/weather notes; and
+- other reusable instructions that should carry forward.
+
+Reusable Task changes are permanent Setup knowledge and may become part of the starting point for future seasons.
+
+Before changing reusable information, ask:
+
+> Is this a general Setup rule we want to carry forward, or is this only something that happened in 2025?
+
+If it happened only in 2025, record it in the annual history instead.
+
+## Review a Task
+
+1. Open the 2025 Historical Verification session.
+2. Select a task from the review list.
+3. Read the reusable task information and the 2025 annual information separately.
+4. Compare the record with what you know, current procedures, and other reliable 2025 evidence.
+5. Correct only fields you can support.
+6. Add useful annual notes when the information is specific to 2025.
+7. Set the verification state only after the record has actually been reviewed.
+
+Normal verification states are:
+
+```text
+UNVERIFIED
+VERIFIED
+NEEDS CORRECTION
+```
+
+Do not mark a task VERIFIED merely because it exists.
+
+## Add Missing Tasks
+
+If a real Setup activity is missing, Managers may add a reusable task when the work should exist as a normal Setup task beyond just one historical occurrence.
+
+Before adding it, decide the appropriate scope:
+
+```text
+Park Infrastructure / no LOR Stage
+Stage-level / General
+Scene
+```
+
+Use **Add Task Here** in the appropriate scope. Use **Copy** when a new reusable task is substantially similar to an existing one, then review the copied definition carefully.
+
+Do not create a task for every ordinary action. A task is useful when it can realistically be missed, affects planning/readiness/resources, needs progress/completion tracking, or preserves historical learning worth carrying forward.
+
+## Review Resources and Prerequisites
+
+For reusable tasks, check whether the practical requirements are represented correctly.
+
+Examples include:
+
+- lifts;
+- vehicles;
+- trailers;
+- tools;
+- powered stake pounders;
+- other recurring equipment/resources; and
+- predecessor tasks that must complete first.
+
+Use structured resources and prerequisites where they represent repeatable Setup knowledge. Do not invent quantities or dependencies just to fill fields.
+
+## Procedures and Instructions
+
+Where a Setup task has a current published Setup procedure, the application may show that procedure and, for authorized Managers, the editable source used to maintain it.
+
+If an editable procedure is corrected, the current published PDF must also be updated before the instruction is treated as current.
+
+Detailed document-publishing instructions are owned by the Google Drive / Display Folder workflow. Do not reorganize folders merely to make the Setup review screen look cleaner.
+
+## Ask Questions and Make Suggestions
+
+The application is intentionally being evaluated through real use. During the review period, report things such as:
+
+- information that is hard to understand;
+- fields that appear unnecessary;
+- missing information you need to make a Setup decision;
+- awkward or repetitive steps;
+- task organization that does not match how crews actually work;
+- resources or prerequisites that are difficult to represent;
+- confusing wording;
+- missing search/filter/navigation behavior; and
+- ideas that would make the 2026 Setup process easier.
+
+A useful finding does not have to be a software bug. Workflow and data-model suggestions are part of this review.
+
+## What Reviewers Cannot Do
+
+Normal reviewers/managers cannot:
+
+- create the 2026 Setup Session; or
+- use **Use Current Order as Future Baseline** unless they have Administrator authority.
+
+Those controls are intentionally restricted so training/review work in the 2025 session cannot accidentally create or promote future-season state.
+
+Pick List generation and Container/Display movement/scanning writes are not part of the current live-review workflow.
+
+## What Successful Review Looks Like
+
+A useful 2025 review leaves:
+
+- 2025 annual facts corrected where evidence exists;
+- uncertain information left UNVERIFIED or marked NEEDS CORRECTION;
+- missing reusable tasks added where appropriate;
+- reusable task scope, resources, prerequisites, order, and normal expectations improved where the change should carry forward;
+- no 2026 operational dates in the 2025 session;
+- no fake records created only for testing; and
+- questions, suggestions, and UI/workflow issues captured for follow-up before final subsystem acceptance.
+
+## Related Documents
+
+- [Setup operator procedures](README.md)
+- [Detailed Manager Review Guide](../../../02_Operational_SOPs/Setup/Setup_Session_Manager_Review_Guide.md)
+- [Setup engineering handoff](../engineering/README.md)

--- a/Docs/02_Production_Database/02_Operational_SOPs/Setup/README.md
+++ b/Docs/02_Production_Database/02_Operational_SOPs/Setup/README.md
@@ -1,0 +1,80 @@
+# Setup Session Operator Procedures
+
+This folder contains operator/Manager procedures for the live Setup Session application.
+
+## Current State
+
+The protected Production application is operational at:
+
+```text
+https://my.sheboyganlights.org/setup/
+```
+
+The current shared working session is the real Production-backed:
+
+```text
+2025 — Historical Verification
+```
+
+Production deployment is accepted, but the **Setup UI/workflow remains in live evaluation**. Managers are expected to use the 2025 session for real reconstruction/training work and report questions, suggestions, confusing behavior, and workflow problems before final subsystem acceptance.
+
+## Start Here
+
+- [Setup Session Manager Review Guide](Setup_Session_Manager_Review_Guide.md) — plain-English guide for reviewing 2025 history, adding/correcting reusable tasks, resources and prerequisites, verification, planning/order concepts, procedures, and the annual-vs-reusable distinction.
+
+The 2025 shared review is **not disposable**. Authorized saves are real 2025 or reusable Production Database changes.
+
+## Session-Year Safety
+
+The selected annual Setup Session controls the allowable operational year:
+
+```text
+2025 historical review -> 2025 operational dates only
+2026 Setup Session      -> 2026 operational dates only
+```
+
+The browser constrains date controls, and the Production Database independently enforces the same rule. Audit/recording timestamps remain real current timestamps.
+
+Only a Setup Administrator may:
+
+- create/manage an annual Setup Session; or
+- promote an annual planned order into the reusable future baseline.
+
+See the engineering contract:
+
+- [Setup Session Shared Review and Season-Year Guard — 2026-09-07](../../01_System_Architecture/12_Setup_and_Deployment/Setup_Session_Shared_Review_and_Season_Year_Guard_2026-09-07.md)
+
+## Related Google Drive Procedure
+
+Truly park-wide Setup work with no appropriate LOR Stage/Scene uses the controlled non-LOR root:
+
+```text
+G:\Shared drives\Display Folders\41 Park Infrastructure-PI
+```
+
+Build and maintain it from:
+
+- [Create the Park Infrastructure Procedure Folder](../../../00_Project_Overview/Google_Drive/operatorSOP/Create_Site_Infrastructure_Procedure_Folder.md)
+
+Do not create a fake LOR Stage, Scene, or Preview for Park Infrastructure merely to hold these Procedures.
+
+`40-CommandCenter` is different: it has a real LOR Preview and remains legitimate Stage 40 even though its Preview currently has no wired inventory items. Command Center trailer/WiFi/gateway/hotspot Setup work belongs to Stage 40, not Park Infrastructure.
+
+## Current Implementation Boundary
+
+Live now:
+
+- Production-backed 2025 historical review/training;
+- Manager/reviewer task verification and correction;
+- reusable task creation/copy and maintenance;
+- scope/order/prerequisite/resource maintenance;
+- annual planning/review controls supported by the current application;
+- Procedure/document context; and
+- protected authenticated browser access.
+
+Still outside the current Production-ready boundary:
+
+- Pick List generation; and
+- Container/Display movement/scanning write commands.
+
+Do not document those later layers as live Production behavior until their separate acceptance gates pass.

--- a/Docs/02_Production_Database/02_Operational_SOPs/Setup/Setup_Session_Manager_Review_Guide.md
+++ b/Docs/02_Production_Database/02_Operational_SOPs/Setup/Setup_Session_Manager_Review_Guide.md
@@ -1,0 +1,326 @@
+# Setup Session Manager Review Guide
+
+| Document Control | Value |
+|---|---|
+| Document Type | Operator / Manager Procedure |
+| System | Production Database — Setup Session |
+| Audience | Setup Managers, reviewers, and administrators |
+| Status | CURRENT — live 2025 review/training workflow; UI/workflow evaluation remains open |
+| Owner | MSB Production Database / Setup administrator |
+| Last Reviewed | 2026-09-07 |
+
+## Purpose
+
+Use this guide for the live Setup application and the Production-backed **2025 Historical Verification** session.
+
+The 2025 session has two purposes:
+
+- reconstruct and improve the real 2025 Setup record; and
+- train future Setup Managers by using the actual workflow before the 2026 Setup Session is created.
+
+This is **not disposable test data**. Changes saved in the application are real Production Database records.
+
+The application itself is still under live evaluation. Managers should report questions, suggestions, missing information, confusing screens, and workflow problems instead of silently adapting around them.
+
+## Open the Application
+
+Use:
+
+```text
+https://my.sheboyganlights.org/setup/
+```
+
+Sign in through the normal MSB Google/Cloudflare Access login.
+
+Confirm the selected session is:
+
+```text
+2025 — Historical Verification
+```
+
+## The Most Important Safety Rule
+
+The selected Setup Session controls the allowable operational year.
+
+```text
+2025 Historical Verification
+    -> work dates and historical actual dates must be in 2025
+
+2026 Setup Session
+    -> work dates and operational dates must be in 2026
+```
+
+The browser limits date controls to the selected year, and the database independently rejects an operational date from the wrong year.
+
+Audit timestamps remain truthful. If you correct a 2025 task during 2026, the historical operational date may be 2025 while the database records the correction as having been made in 2026.
+
+## Roles and Authority
+
+A shared link does not grant authority. Each user must authenticate and have the appropriate Setup capability.
+
+Current responsibilities are:
+
+- **Reader / field user** — view permitted Setup information;
+- **Manager / reviewer** — review and correct annual 2025 information, maintain reusable tasks, task scope, prerequisites, resources, order, and supported planning information; and
+- **Administrator** — all Manager capabilities plus annual Setup Session creation and promotion of an annual order into the reusable future baseline.
+
+Only an Administrator should create the 2026 Setup Session.
+
+Only an Administrator can use **Use Current Order as Future Baseline**.
+
+## Annual 2025 Information vs Reusable Setup Knowledge
+
+This distinction is fundamental.
+
+### Annual 2025 information
+
+Annual information describes what happened or was planned in 2025:
+
+- verification state;
+- annual planned order;
+- 2025 work-day/date/shift/crew-lane assignments when used;
+- 2025 crew/time evidence;
+- annual notes; and
+- progress/completion evidence.
+
+These records belong only to the 2025 Setup Session.
+
+### Reusable Setup knowledge
+
+Reusable information describes how the work normally exists across seasons:
+
+- task name and active state;
+- Park Infrastructure / Stage / Scene scope;
+- normal local sequence/order;
+- normal crew range and expected duration;
+- equipment/resources;
+- prerequisites;
+- completion point;
+- readiness/weather notes; and
+- reusable whole-Setup baseline order.
+
+Edits to reusable information are intentionally permanent and may be used when the Administrator later creates 2026.
+
+Before changing reusable information, ask:
+
+> Is this a normal Setup rule we want to carry forward, or is this only something that happened in 2025?
+
+If it only happened in 2025, keep it in annual history.
+
+## Review and Verify Existing Tasks
+
+For each task you review:
+
+1. Open the task in the 2025 session.
+2. Read the reusable definition and annual 2025 information separately.
+3. Compare them with what you know and with reliable procedures/evidence.
+4. Correct only information you can support.
+5. Add annual notes when useful 2025-specific detail should be preserved.
+6. Set the verification state only after the record has actually been reviewed.
+
+Verification states are:
+
+```text
+UNVERIFIED
+VERIFIED
+NEEDS CORRECTION
+```
+
+Leave a task UNVERIFIED when you do not know enough. Use NEEDS CORRECTION when you know something is wrong but the correct answer still needs work.
+
+Do not mark a task VERIFIED merely because the task exists.
+
+## Add Missing Reusable Tasks
+
+If real Setup work is missing, Managers may add a reusable task when that work should normally exist beyond one historical occurrence.
+
+Use **Add Task Here** in the correct scope. Use **Copy** when the new task is substantially similar to an existing task, then review the copy carefully.
+
+A task is useful when it:
+
+- can realistically be missed;
+- affects readiness, planning, or resources;
+- has meaningful prerequisites;
+- needs useful progress/completion tracking; or
+- preserves operational learning worth carrying forward.
+
+Do not create separate tasks for ordinary actions that are already implied by the real work.
+
+## Choose the Correct Scope
+
+Reusable tasks can belong to three practical scopes.
+
+### Park Infrastructure / no LOR Stage
+
+Use this only for park-wide work with no appropriate LOR Stage or Scene owner.
+
+Examples include street-light and site-breaker work.
+
+These Procedures use:
+
+```text
+G:\Shared drives\Display Folders\41 Park Infrastructure-PI
+```
+
+Do not create a fake LOR Stage, Scene, or Preview merely to hold park-wide work.
+
+### Stage-level / General
+
+Use Stage-level when the task belongs to a real LOR Stage generally but should not be forced into a Scene.
+
+`40-CommandCenter` is the important example. It remains legitimate Stage 40 because it has a real LOR Preview, even though its Preview currently has no wired inventory items.
+
+### Scene
+
+Use Scene scope when a current LOR Scene is the natural reusable organizational home for the work.
+
+The Manager assigns Scene scope explicitly. Do not infer Scene ownership merely from a task or Display name.
+
+## Review Resources
+
+Use structured resources for recurring requirements such as:
+
+- lifts;
+- vehicles;
+- trailers;
+- tools;
+- stake pounders; and
+- other equipment required to perform the task.
+
+Review:
+
+- the correct resource;
+- quantity;
+- Required vs Preferred status; and
+- whether the requirement belongs as reusable knowledge.
+
+Do not invent quantities merely to fill a field.
+
+If a resource itself is missing from the catalog and the application permits you to add it, use a clear durable name that represents the real equipment/resource rather than a one-time note.
+
+## Review Prerequisites and Readiness
+
+A prerequisite means another reusable task must complete first.
+
+Example:
+
+```text
+Locates / Field Cleared
+    -> Set Scaffold and Elves
+        -> Install Notes and Conductor
+```
+
+Readiness is different from a prerequisite. A task may have all prerequisites satisfied but still be NOT_READY because of weather, leaves, access, equipment, or another practical condition.
+
+Use prerequisites only for real repeatable dependencies. Do not build a rigid serial chain just because tasks were performed in that order once.
+
+## Review Order
+
+The system keeps two different whole-Setup orders.
+
+### Reusable baseline order
+
+This is the normal starting order learned over time. Only an Administrator may promote an annual order into this future baseline.
+
+### Annual planned order
+
+This is the current Setup Session's working opinion of what should happen next.
+
+It may legitimately differ because of weather, volunteer turnout, equipment, access, road work, leaves, material problems, or opportunities to complete another area early.
+
+A strange 2025 order should remain a 2025 fact unless it represents a genuinely better reusable rule.
+
+## Rolling-Horizon Planning
+
+The Setup system is not intended to be a rigid Gantt schedule.
+
+The normal operating cycle is:
+
+```text
+know all remaining Setup work
+    -> keep it in useful order
+    -> check prerequisites/readiness/resources
+    -> schedule only the next few practical days
+    -> perform work
+    -> record progress/completion
+    -> return to the remaining backlog
+```
+
+Most unfinished work should remain unscheduled most of the time. That is normal.
+
+## Multi-Day Work and Progress
+
+Do not split a practical task merely because it lasts more than one work period.
+
+One annual task may remain IN_PROGRESS while progress is recorded over several work periods. Complete it only when the practical job is complete.
+
+## Procedures
+
+Stage- and Scene-scoped tasks use the established marked Google Drive Procedure structure.
+
+Park Infrastructure uses:
+
+```text
+G:\Shared drives\Display Folders\41 Park Infrastructure-PI
+```
+
+Where the application shows a current published Setup PDF, review whether it still matches the work. Authorized Managers may also see the editable source used to maintain it.
+
+If an editable procedure is corrected, update the current published PDF before treating the instruction as current.
+
+## Ask Questions and Make Suggestions
+
+This review period is also how we improve the application before the 2026 Setup cycle.
+
+Report things such as:
+
+- a field or label you do not understand;
+- missing information you need to make a decision;
+- information that appears duplicated or unnecessary;
+- a task that belongs in a different place;
+- difficulty representing a resource or prerequisite;
+- an awkward or repetitive workflow;
+- missing search/filter/navigation behavior;
+- a screen that does not match how Setup crews actually work;
+- a task/data problem that the application makes hard to correct; and
+- ideas that would make 2026 planning or field work easier.
+
+A useful finding does not have to be a software bug. Operational suggestions are part of the evaluation.
+
+## Current Live Boundary
+
+Live now:
+
+- Production-backed 2025 review/training;
+- verification and correction of annual 2025 information;
+- reusable task creation/copy and maintenance;
+- task scope/order/prerequisite/resource maintenance;
+- supported annual planning/review controls;
+- Procedure/document context; and
+- authenticated browser access.
+
+Not yet part of the current Production-ready workflow:
+
+- Pick List generation; and
+- Container/Display movement/scanning write commands.
+
+Do not infer a movement event merely because an identifier was scanned or a review action occurred.
+
+## 2025 Review to 2026 Transition
+
+There is currently no 2026 Setup Session.
+
+When the Administrator decides the 2025 reconstruction is useful enough and explicitly creates 2026:
+
+- 2026 gets its own annual task rows;
+- the date guard changes automatically to 2026;
+- 2025 annual records remain 2025 records; and
+- reusable task knowledge continues forward.
+
+No Manager/reviewer action inside the 2025 session should implicitly create or schedule 2026.
+
+## Related Documents
+
+- [Setup operator portal](../../01_System_Architecture/12_Setup_and_Deployment/README.md)
+- [2025 review procedure](../../01_System_Architecture/12_Setup_and_Deployment/operatorSOP/Review_2025_Setup_History.md)
+- [Setup Session Shared Review and Season-Year Guard](../../01_System_Architecture/12_Setup_and_Deployment/Setup_Session_Shared_Review_and_Season_Year_Guard_2026-09-07.md)

--- a/System_Documentation/Project_Rules/Documentation_Subsystem_Conversion_Tracker.md
+++ b/System_Documentation/Project_Rules/Documentation_Subsystem_Conversion_Tracker.md
@@ -6,7 +6,7 @@
 | Repository | MSB Production Database Project |
 | Status | CURRENT |
 | Owner | Production documentation owner / administrator |
-| Last Reviewed | 2026-08-24 |
+| Last Reviewed | 2026-09-07 |
 
 ## Purpose
 
@@ -52,11 +52,13 @@ A subsystem is not `CONVERTED` until all applicable items are complete:
 |---|---|---|---|---|---|---|
 | Google Drive / Display Folder Operations | BACKBONE PENDING | COMPLETE — no embedded Markdown images found in the current engineering overview, path contract, or converted operator procedures; subsystem `images/` established | COMPLETE for affected tool references — Google Drive docs link to Folder Alignment/Preview Authoring owners rather than relocating their executables | EXISTS | PENDING — Backbone issue #2 | Source conversion complete. Operator portal/SOP split complete; engineering overview and path contract relocated under `engineering/`; old paths are compatibility pointers; canonical operator/engineering links validated; stale System Blueprint reference replaced with current Production Database architecture portal. |
 | Folder Alignment | BACKBONE PENDING | COMPLETE — no embedded Markdown images found in the current engineering design or converted operator procedures; subsystem `images/` established | COMPLETE — Windows/Linux Folder Alignment launchers still target `Folder_Alignment/folder_alignment.py`; PreviewBackground launchers still target `update_previewbackground_folders.py`; Procedures updater still targets `update_procedure_structure.py`; all targets verified present | EXISTS | PENDING — Backbone issue #2 | Source conversion complete. Operator portal, run/review SOPs, engineering portal, engineering design relocation, compatibility pointer, canonical links, and parent Data Extraction engineering link verified. |
+| Setup / Takedown / Procedure | IN PROGRESS — live UI/workflow evaluation | NOT YET REQUIRED — no new subsystem documentation images added during the V0.3.4 conversion | COMPLETE for current conversion — Setup application/acceptance paths preserved; no working implementation files moved; current application/runtime authority and operator/engineering links reviewed | EXISTS | IMPLEMENTED — Backbone PR #11 merged; controlled live publish/verification pending under issue #10 | Production runtime accepted at `https://my.sheboyganlights.org/setup/`; operator portal, operatorSOP portal, 2025 review procedure, Manager guide, engineering portal/handoff, application README, and acceptance docs updated for live Production use. The three Setup PRs remain open while Managers evaluate the UI/workflow. Obsolete `my/committees/production/setup-takedown-testing/index.html` is no longer a current navigation dependency. |
 | Parser / Data Extraction | LEGACY | NOT STARTED | CURRENT PATHS VERIFIED DURING PROOF — `run_parse_props.ps1` still targets `Parser/parse_props_v7_scene_parser.py`; `run_lor_runner.ps1` still targets `lor_operator_runner.py`, `parse_props_v7_scene_parser.py`, `lor_version_checker.py`, and `LOR2DB/01_Ingest/postgres_ingest_from_lor_sqlite_v7.py`; all targets verified present | N/A for this proof | N/A | Parser is not being converted in PR #62. This verification only confirms the current documentation restructuring did not break parser/runner execution paths. |
 
 ## Active Backbone Work
 
 - `Gregovate/MSB-Internal-Web-Backbone` issue **#2** — `Integrate converted Google Drive and Folder Alignment operator portals`
+- `Gregovate/MSB-Internal-Web-Backbone` issue **#10** — `Integrate Setup operator portal and /setup application`; Backbone PR **#11** merged, controlled live Production-index publish and verification pending.
 
 Source conversion and live intranet deployment are separate milestones. Do not mark these subsystems `VERIFIED` until the deployed Backbone result is checked.
 
@@ -68,7 +70,6 @@ The sequence below is not a commitment to convert everything at once. Convert on
 |---|---|---|
 | Preview Authoring | LEGACY | Contains current operator procedures including wiring-diagram creation; image ownership and any tool/script references must be inventoried before moving docs. |
 | Field Wiring | LEGACY | Current engineering documentation under Production Database architecture; operator experience is primarily the production application. |
-| Setup / Takedown / Procedure | LEGACY | Current engineering/handoff history is mixed under Setup/Deployment architecture; field Stage instructions are a separate document class. |
 | Labeling and Scanning | LEGACY | Cross-system operator and engineering ownership requires review before conversion. |
 | Testing / Repairs | LEGACY | Existing central Operational SOP structure remains valid until this subsystem is deliberately reviewed. |
 | Containers | LEGACY | Existing operator SOPs remain in current location until subsystem ownership/navigation review. |


### PR DESCRIPTION
## Purpose

Release the current Setup/Deployment operator and engineering documentation to `main` without merging the still-open Setup application/schema/UI stack.

## Why this is separate

The live Setup application is already operational at `https://my.sheboyganlights.org/setup/`, but the current plain-English Setup portals, Manager guide, engineering handoffs, and supporting Park Infrastructure/Folder Alignment documentation were still trapped in open Setup PRs. That made the Internal Web Backbone unable to link users to the canonical Setup README/procedures on `main`.

## Scope

Documentation only. No `Setup/Application`, `Setup/Database`, migrations, tests, runtime code, or Production configuration changes.

Includes:
- current Setup operator/user portal;
- Setup operator procedure index and 2025 review procedure;
- detailed Manager Review Guide;
- Setup engineering portal, production handoff, shared-review/year-guard contract, and Backbone handoff;
- preserved legacy engineering portal;
- Park Infrastructure non-LOR procedure/root documentation;
- affected Google Drive and Folder Alignment portals/engineering boundary; and
- documentation conversion tracker.

## Current state represented

- Production runtime operational and accepted;
- real 2025 Historical Verification session in live use;
- 2026 Setup Session not created;
- Setup UI/workflow remains LIVE EVALUATION;
- PRs #123/#124/#125 remain open for application/UI evaluation and are not closed by this documentation release.

## Backbone dependency

This release makes the canonical Setup documentation paths real on `main`, allowing the Production intranet to link users to the Setup README/procedures as intended.