### PR TITLE
Normalize Field Wiring GA4 page title

### DIFF
--- a/Docs/02_Production_Database/01_System_Architecture/09_Wiring_System/FieldWiring_Internal_Analytics_Contract_2026-08-31.md
+++ b/Docs/02_Production_Database/01_System_Architecture/09_Wiring_System/FieldWiring_Internal_Analytics_Contract_2026-08-31.md
@@ -33,6 +33,24 @@ Each page loads the asset with an explicit cache/version parameter:
 static/analytics.js?v=2026-08-31.1
 ```
 
+## Canonical GA4 Page Titles
+
+GA4 receives `document.title` as `page_title`, so spelling/spacing differences fragment the Pages and Screens report even when URLs belong to the same subsystem.
+
+Canonical current titles are:
+
+```text
+/fieldwiring/         -> MSB Field Wiring
+/fieldwiring/wiring   -> MSB Field Wiring
+/fieldwiring/controllers -> MSB Controller Inventory
+```
+
+The landing page previously used `MSB FieldWiring` while the wiring-detail page used `MSB Field Wiring`. That caused GA4 to show separate `FieldWiring` and `Field Wiring` rows. The source title is now normalized and the analytics contract test guards against reintroducing the mismatch.
+
+Historical GA4 data collected under the old title remains historical and will not be rewritten. New traffic should use the canonical title.
+
+Use `page_path` when analysis needs to distinguish the Field Wiring landing page from the wiring-detail page; do not create inconsistent page titles merely to distinguish routes.
+
 ## Privacy Boundary
 
 FieldWiring URLs can contain Production Database identifiers such as:
@@ -86,6 +104,8 @@ FieldWiring/Application/test_internal_analytics_contract.py
 The automated gate verifies:
 
 - all three FieldWiring pages load the versioned analytics asset;
+- Field Wiring landing/detail pages use the canonical `MSB Field Wiring` title;
+- Controller Inventory retains its separate canonical title;
 - the approved Measurement ID is used;
 - Google Signals and advertising personalization are disabled;
 - page measurement is pathname-only and does not use query strings/raw URLs;

--- a/FieldWiring/Application/index.html
+++ b/FieldWiring/Application/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>MSB FieldWiring</title>
+  <title>MSB Field Wiring</title>
   <script src="static/analytics.js?v=2026-08-31.1"></script>
   <link rel="stylesheet" href="fieldwiring.css">
 </head>

--- a/FieldWiring/Application/test_internal_analytics_contract.py
+++ b/FieldWiring/Application/test_internal_analytics_contract.py
@@ -13,6 +13,18 @@ def test_fieldwiring_pages_load_versioned_analytics_asset() -> None:
         assert expected in source
 
 
+def test_fieldwiring_pages_use_canonical_ga4_titles() -> None:
+    index_source = (BASE_DIR / "index.html").read_text(encoding="utf-8")
+    wiring_source = (BASE_DIR / "wiring.html").read_text(encoding="utf-8")
+    controller_source = (BASE_DIR / "controllers.html").read_text(encoding="utf-8")
+
+    assert "<title>MSB Field Wiring</title>" in index_source
+    assert "<title>MSB Field Wiring</title>" in wiring_source
+    assert "<title>MSB FieldWiring</title>" not in index_source
+    assert "<title>MSB FieldWiring</title>" not in wiring_source
+    assert "<title>MSB Controller Inventory</title>" in controller_source
+
+
 def test_analytics_uses_approved_internal_ga4_property() -> None:
     source = (BASE_DIR / "static" / "analytics.js").read_text(encoding="utf-8")
     assert MEASUREMENT_ID in source


### PR DESCRIPTION
## Purpose

Correct a GA4 reporting split where the Field Wiring landing page reported `MSB FieldWiring` while the wiring-detail page reported `MSB Field Wiring`.

Because the shared analytics loader sends `document.title` as `page_title`, GA4 showed separate `FieldWiring` and `Field Wiring` rows for the same subsystem.

## Change

- normalizes `FieldWiring/Application/index.html` to `<title>MSB Field Wiring</title>`;
- preserves `MSB Field Wiring` on the wiring-detail page;
- preserves `MSB Controller Inventory` as the distinct Controller Inventory title;
- adds regression coverage in `FieldWiring/Application/test_internal_analytics_contract.py`; and
- updates `FieldWiring_Internal_Analytics_Contract_2026-08-31.md` with the canonical title rule.

## Analytics behavior

Route distinction continues through sanitized `page_path` (`/fieldwiring/` vs `/fieldwiring/wiring`). We do not need inconsistent page titles to distinguish screens.

Historical GA4 rows collected under the old title remain historical; new traffic should use the canonical title.

## Deployment boundary

This is user-facing browser source and is not approved for Production deployment merely by opening this PR. Follow the existing browser-review and Production deployment runbooks before changing the live FieldWiring service.