### PR TITLE
Refresh Setup documentation for accepted 185-task Production catalog

### DIFF
--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/README.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/README.md
@@ -5,22 +5,37 @@
 | Document Type | Operator / User Portal |
 | System | Production Database — Setup and Deployment |
 | Audience | MSB volunteers, reviewers, managers, and Setup operators |
-| Status | CURRENT — Production runtime operational; Setup UI/workflow in live evaluation |
+| Status | CURRENT — Production reusable catalog rebuilt; 2025 review and live task development continue |
 | Owner | MSB Production Database / Setup administrator |
-| Last Reviewed | 2026-09-07 |
+| Last Reviewed | 2026-09-09 |
 | Keywords | Setup, 2025 review, training, 2026 plan, Setup procedures, deployment |
 
 Setup and Deployment covers the work of planning and carrying out the annual move from storage to the park, plus the information crews need while installing the show.
 
-The Setup application is now live at:
+The Setup application is live at:
 
 ```text
 https://my.sheboyganlights.org/setup/
 ```
 
-The current working session is **2025 — Historical Verification**. It uses real Production data so managers can reconstruct what happened in 2025, learn the workflow, improve reusable Setup knowledge, and identify UI/workflow problems before the 2026 Setup Session is created.
+The current working session is **2025 — Historical Verification**. It uses real Production data so managers can reconstruct what happened in 2025, improve reusable Setup knowledge, and identify workflow problems before the 2026 Setup Session is created.
 
-The application is operational, but the Setup/UI subsystem is still in **live evaluation**. The current review period is intended to generate questions, corrections, suggestions, and usability findings before final acceptance.
+## Current PostgreSQL Working Baseline
+
+The reusable task reconstruction was deployed to Production on 2026-09-09. The current working baseline in PostgreSQL is:
+
+```text
+active reusable tasks      = 185
+total reusable task rows   = 187
+reusable dependencies      = 0
+2026 Setup Sessions        = 0
+```
+
+The two additional reusable rows are retired identities preserved for history. The dependency set is intentionally empty pending the reviewed predecessor/readiness pass.
+
+The reviewed reconstruction workbook and historical schedules remain evidence for how this baseline was built, but they are **not the ongoing master task list**. From this point forward, continue building, correcting, organizing, and reviewing reusable Setup tasks against the **current Production PostgreSQL data**. New historical evidence may inform a task correction, but the current PostgreSQL catalog is the working source of truth.
+
+The application remains in live evaluation. Managers should continue to report missing tasks, incorrect scope/order, prerequisite/readiness needs, and UI/workflow problems rather than silently working around them.
 
 ## Start Here
 
@@ -82,14 +97,17 @@ Only an Administrator may create a new annual Setup Session or promote an annual
 
 ## Current Evaluation Boundary
 
-Production deployment is accepted, but final UI/workflow acceptance is intentionally open while managers use the 2025 session.
+The reconstructed reusable catalog is accepted in Production, but Issue #122 remains open because the broader Setup Session workflow is not finished.
 
 Current known boundaries:
 
 - no 2026 Setup Session has been created;
+- the current PostgreSQL reusable catalog is the working baseline and will continue to be corrected as real task knowledge is found;
+- the predecessor/readiness pass is still required before creating 2026; the current reusable dependency count is intentionally zero;
 - Pick List generation is not yet a live Production workflow;
-- Container/Display movement and scanning write commands remain outside this review boundary; and
-- the open Setup PRs remain the active engineering workstream until live-use findings are resolved.
+- Container/Display movement and scanning write commands remain outside the current live workflow;
+- known catalog corrections can still be found during live review, such as the missing physical Frosty setup task discovered immediately after deployment; and
+- Stage-level ↔ Scene drag/drop is tracked separately in Issue #133 and is not a blocker to continuing catalog work.
 
 ## Related Systems
 

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/README.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/README.md
@@ -5,28 +5,32 @@
 | Document Type | Engineering Handoff Portal |
 | System | Production Database — Setup and Deployment |
 | Audience | Greg, maintainers, database administrators, future engineering sessions |
-| Status | CURRENT HANDOFF — Production runtime accepted; UI/workflow in live evaluation |
+| Status | CURRENT HANDOFF — Production catalog reconstruction accepted; live PostgreSQL catalog is the working baseline |
 | Owner | MSB Production Database engineering |
-| Last Reviewed | 2026-09-07 |
+| Last Reviewed | 2026-09-09 |
 
-This is the engineering starting point for Setup Session architecture, database behavior, application contracts, deployment state, and resume information.
+This is the engineering starting point for Setup Session architecture, database behavior, application contracts, deployment state, task development, and resume information.
 
 The operator-facing instructions are separate under [`../operatorSOP/`](../operatorSOP/README.md).
 
 ## Current State
 
-Production deployment is operational and accepted at the runtime level.
+Production deployment is operational and accepted.
 
 ```text
 public application             = https://my.sheboyganlights.org/setup/
 application version            = V0.3.4-shared-season-guard-review
+current deployed Setup SHA     = 5a8a317357ffa5d77c38bc4df63fe6c7b451dbaf
 2025 Setup Session             = HISTORICAL_VERIFICATION
-2025 annual tasks              = 57
-2025 UNVERIFIED tasks          = 57
 2026 Setup Sessions            = 0
-Setup work days                = 0
-Setup movement events          = 0
-active reusable Setup tasks    = 57
+active reusable Setup tasks    = 185
+total reusable task rows       = 187
+reusable dependencies          = 0
+effort LIGHT                   = 8
+effort MODERATE                = 12
+effort HEAVY                   = 4
+effort unreviewed              = 161
+Production Setup fingerprint   = f0b98ac75e297a08eabc3df040708c08
 ```
 
 Accepted runtime state includes:
@@ -38,15 +42,38 @@ msb-setup-google-links.service = active / enabled
 listener                       = 192.168.5.9:8794
 UFW                            = 8794/tcp from Synology 192.168.5.4 only
 Synology /setup/ route         = active
-Cloudflare-authenticated view  = PASS; real 2025 data rendered
-post-reboot invariants         = PASS
+Cloudflare-authenticated view  = PASS
+protected no-identity path     = HTTP 401 PASS
+live Setup regression          = 134 passed
 ```
 
-The Setup/UI subsystem is **not final**. The three Setup PRs remain open drafts while managers use the 2025 session for real reconstruction/training and expose usability, workflow, data-model, and documentation problems.
+The 185-task reusable catalog reconstruction is accepted in Production. The dependency set is intentionally zero pending the reviewed predecessor/readiness pass.
+
+## Current Task Development Authority
+
+The one-time large reconstruction import is complete.
+
+The current **Production PostgreSQL reusable catalog** is now the working task baseline. Continue adding, correcting, moving, and enriching reusable tasks against current PostgreSQL data through governed Setup application/database commands.
+
+Historical sources remain evidence:
+
+- the reviewed one-list reconstruction workbook;
+- 2025 Setup notes/spreadsheets; and
+- the recovered 2022 Project schedule.
+
+They are not a parallel ongoing master task list.
+
+Immediate live finding after catalog deployment:
+
+- transport-only `Bring Frosty to park` was correctly excluded as logistics;
+- physical reusable `Set Up Frosty` was not created and is therefore missing from the current catalog;
+- Frosty setup must precede the applicable Stars setup work during the predecessor pass.
+
+This is the expected post-import workflow: correct the current PostgreSQL catalog rather than reopening the workbook as the master.
 
 ## Start Here
 
-- [Setup Session Production Engineering Handoff — 2026-09-07](Setup_Session_Production_Engineering_Handoff_2026-09-07.md) — current database/application/runtime state, accepted deployment evidence, open PR structure, and live-evaluation resume point.
+- [Setup Session Production Engineering Handoff — 2026-09-07](Setup_Session_Production_Engineering_Handoff_2026-09-07.md) — original database/application/runtime deployment baseline and rollback context. Treat its task counts/SHA as dated acceptance history, not current state.
 - [Internal Web Backbone Handoff](Internal_Web_Backbone_Handoff.md) — source-subsystem contract for intranet navigation/search/application entry points.
 - [Setup Session Shared Review and Season-Year Guard](../Setup_Session_Shared_Review_and_Season_Year_Guard_2026-09-07.md) — annual-vs-reusable data boundary and session-year enforcement.
 
@@ -70,19 +97,42 @@ Production acceptance/install material:
 Setup/Acceptance/
 ```
 
-The Production Database repository owns Setup application/business/database behavior. `Gregovate/MSB-Server-Management` owns deployed service, listener, firewall, reverse-proxy, restart/recovery, and host permission facts.
+The Production Database repository owns Setup application/business/database behavior. `Gregovate/MSB-Server-Management` owns deployed service, listener, firewall, reverse-proxy, restart/recovery, host permissions, and Production deployment runbooks.
 
-## Current PR Structure
+## Current PR / Issue Structure
 
-The active Setup work remains intentionally open across three draft PRs:
+The current Setup work is coordinated through:
 
 ```text
-#123  reconnaissance / planning documentation lineage
-#124  browser UI / verification lineage
-#125  Production foundation / database / runtime lineage
+#122  Setup Session engineering / planning / Pick List / movement umbrella
+#125  Production foundation / application lineage and eventual merge/closeout
+#133  Stage-level ↔ Scene drag/drop usability follow-up
+#130  global People / Capability / Qualification catalog consumed by Setup
+#132  Captain work-report duration / multi-day effort capture
+#113  shared Scan application readiness / identity capture integration
 ```
 
-Do not merge/close this stack merely because the application is reachable. Final normalization and merge should wait until enough real 2025 review use has occurred to identify and resolve material UI/workflow findings.
+PR #125 remains open/draft because the Setup subsystem is not yet ready for final lineage normalization/merge even though the current Production runtime and catalog are accepted.
+
+## Known Boundaries / Open Work
+
+Still unresolved or intentionally separate:
+
+- live reusable-catalog corrections as real task knowledge is found, beginning with missing `Set Up Frosty`;
+- reviewed predecessor/readiness pass across the current catalog;
+- classification of sequencing evidence into hard predecessor versus preferred order versus readiness condition;
+- cross-Stage candidate planning surface and short-horizon scheduling workflow;
+- Morning / Afternoon / All Day scheduling, parallel crews, and multi-day carry-forward behavior;
+- controlled reassign/merge when a 2025 annual item belongs to a different reusable task;
+- authoritative Controller context from FieldWiring / Controller Inventory;
+- Pick List generation and tablet workflow;
+- mixed-stage Container annual mobilization/unload-group state and ordered-access rules;
+- Container/Display movement/scanning writes and park-location execution evidence; and
+- future People capability/qualification integration for crew suitability.
+
+Issue #133 is useful but non-blocking because task scope can already be changed through governed task controls.
+
+No 2026 Setup Session should be created until the current catalog and predecessor/readiness model are useful enough for planning.
 
 ## Critical Runtime Permission Boundary
 
@@ -90,46 +140,31 @@ Do not merge/close this stack merely because the application is reachable. Final
 
 Runtime-path validation must run as `fieldwiring`. Server-side detail and recovery procedure belong in `Gregovate/MSB-Server-Management`.
 
-## Known Boundaries / Open Work
-
-Current live-review scope includes:
-
-- 2025 annual review/verification;
-- reusable task creation/copy and maintenance;
-- task scope/order/prerequisite/resource maintenance;
-- supported planning/review controls;
-- Procedure/document context; and
-- authenticated multi-user browser access.
-
-Still outside the accepted Production-ready workflow:
-
-- Pick List generation; and
-- Container/Display movement/scanning write commands.
-
-Live evaluation should also capture questions and suggestions that are not traditional software defects. The 2025 review is the usability and operating-model test bed before 2026 is created.
-
 ## Resume Development
 
 Before changing this subsystem:
 
 1. read the Production Database Project Rules;
-2. review PRs #123, #124, and #125 together rather than treating one as the whole subsystem;
-3. read the Production Engineering Handoff linked above;
-4. review current live-use findings from managers/reviewers;
-5. preserve the accepted 2025/2026 annual-vs-reusable boundary;
-6. use `Gregovate/MSB-Server-Management` for current runtime/service/proxy facts; and
-7. keep operator docs and engineering docs synchronized when behavior changes.
+2. inspect the current Production PostgreSQL reusable catalog first; do not reconstruct the active task list from chat memory or old spreadsheets;
+3. review Issue #122 and PR #125 for the newest accepted findings and closeout state;
+4. preserve the annual-2025-versus-reusable-task boundary;
+5. classify predecessor evidence carefully rather than recreating a rigid historical sequence;
+6. use Issue #130 / People and Identity for global capability/qualification work;
+7. use Issue #113 / Labeling and Scanning for shared scan capture/resolution contracts;
+8. use `Gregovate/MSB-Server-Management` for current runtime/service/proxy/deployment facts; and
+9. keep operator docs and engineering docs synchronized when accepted behavior changes.
 
 Current resume point:
 
 ```text
 Production runtime                    = ACCEPTED
-Cloudflare-authenticated 2025 view    = ACCEPTED
-post-deployment invariants            = ACCEPTED
-UI/workflow                           = LIVE EVALUATION
+Production reusable catalog           = 185 active tasks
+current task working source           = PostgreSQL
+reusable dependency set               = intentionally empty / rebuild next
 2026 Setup Session                    = NOT CREATED
-PR #123 / #124 / #125                 = OPEN DRAFTS
-Backbone source handoff               = READY FOR IMPLEMENTATION
+Pick List                             = NOT YET PRODUCTION WORKFLOW
+movement/location writes              = NOT YET PRODUCTION WORKFLOW
+PR #125                               = OPEN DRAFT / lineage closeout pending
 ```
 
 ## Related Systems

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/operatorSOP/README.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/operatorSOP/README.md
@@ -44,8 +44,34 @@ The current PostgreSQL catalog is now the working source for task development. T
 ## What Do You Need To Do?
 
 - [Review and Correct the 2025 Setup History](Review_2025_Setup_History.md) — verify 2025 information, improve reusable Setup knowledge, add missing tasks/resources where appropriate, and record questions or suggestions.
+- [Detailed Manager Review Guide](../../../02_Operational_SOPs/Setup/Setup_Session_Manager_Review_Guide.md) — includes current rules for task scope, Display ownership, Containers, predecessors/readiness, and reusable task development.
 
 Additional task procedures will be added only when the corresponding workflow is actually Production-operational.
+
+## Important Task-Building Rules
+
+Keep these concepts separate:
+
+```text
+Task scope        = where the work belongs
+Display ownership = which Displays are part of that reusable work package
+Container         = storage/transport mechanism for Displays/material
+```
+
+Important operator rules:
+
+- a task can belong to a Stage/Scene even when **no Display is assigned** to it;
+- example: `Grease Bearings` belongs at `01-Front Gate` even though it should not own GateWrap/GateWreath Displays;
+- one Display may belong to **zero or one** reusable Setup task, never two;
+- one reusable task may own many Displays or none;
+- do not create one task per panel merely to make Display relationships easy;
+- use practical crew/work-package tasks such as `Set Up Traffic Signs`, `Set Up MSB & Rotary Signs`, or `Volunteer Path Setup` when those are independently planned/tracked jobs;
+- Stage/Scene placement does not automatically mean every task in that scope owns every Display in the scope;
+- Containers normally tell us where Displays are stored and how they get to the park; they do not define task scope;
+- some Containers are themselves part of the deployed show (`display_pallet`) and may remain at the park until Takedown instead of returning to the workshop after unloading; and
+- the current Material / Logistics panel is still being corrected to follow these rules, so do not move tasks to the wrong scope or duplicate Display assignments just to make that panel look populated.
+
+See the detailed Manager guide for the full operating model and examples.
 
 ## Important Boundaries
 
@@ -56,7 +82,7 @@ Additional task procedures will be added only when the corresponding workflow is
 - Operational dates entered for the selected Setup Session must be in that session's year.
 - Only an Administrator may create a new annual Setup Session or carry annual order forward as the future reusable baseline.
 - Do not create the 2026 Setup Session until the current catalog and predecessor/readiness pass are useful enough for planning.
-- Pick Lists and Container/Display movement/scanning writes are not part of the current live workflow.
+- Pick Lists, governed task-to-Display ownership editing, and Container/Display movement/scanning writes are not part of the current live workflow.
 - Do not create fake records merely to test the UI. Use real review work and report workflow/UI findings instead.
 
 ## During Live Evaluation
@@ -67,6 +93,7 @@ Managers and reviewers are encouraged to:
 - add genuinely missing reusable tasks discovered during live review;
 - add/correct resources and prerequisites;
 - correct task scope, order, crew/time expectations, effort, and notes where supported;
+- identify the practical Display work package for Display-bearing tasks without creating one task per Display;
 - verify records only when they have actually been reviewed;
 - leave uncertain information UNVERIFIED or mark it NEEDS CORRECTION;
 - ask questions and make suggestions about confusing, missing, or inefficient workflow; and

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/operatorSOP/README.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/operatorSOP/README.md
@@ -5,9 +5,9 @@
 | Document Type | Operator Portal |
 | System | Production Database — Setup and Deployment |
 | Audience | MSB reviewers, managers, and Setup operators |
-| Status | CURRENT — Production runtime operational; UI/workflow in live evaluation |
+| Status | CURRENT — Production reusable catalog rebuilt; live review/task development continues |
 | Owner | MSB Production Database / Setup administrator |
-| Last Reviewed | 2026-09-07 |
+| Last Reviewed | 2026-09-09 |
 | Keywords | Setup, 2025, historical review, training, reusable tasks, resources, 2026 baseline |
 
 Use this area for plain-English instructions for working in the Setup application. Engineering, database, service, permission, and deployment details belong in [`../engineering/`](../engineering/README.md).
@@ -26,22 +26,37 @@ The current shared working session is:
 2025 — Historical Verification
 ```
 
-The application uses real Production data. It is available for manager/reviewer use now, but the UI/workflow is still being evaluated through real 2025 review work.
+The application uses real Production data.
+
+The reusable catalog reconstruction was accepted in Production on 2026-09-09. Current working baseline:
+
+```text
+active reusable tasks    = 185
+total reusable rows      = 187
+reusable prerequisites   = 0
+2026 Setup Sessions      = 0
+```
+
+The prerequisite count is intentionally zero until the reviewed predecessor/readiness pass rebuilds the real dependency model.
+
+The current PostgreSQL catalog is now the working source for task development. The reconstruction workbook and historical schedules remain evidence, but operators/managers should continue adding and correcting real reusable tasks in the live Setup application rather than maintaining a separate spreadsheet master.
 
 ## What Do You Need To Do?
 
 - [Review and Correct the 2025 Setup History](Review_2025_Setup_History.md) — verify 2025 information, improve reusable Setup knowledge, add missing tasks/resources where appropriate, and record questions or suggestions.
 
-Additional task procedures will be added only when the corresponding workflow is actually production-operational.
+Additional task procedures will be added only when the corresponding workflow is actually Production-operational.
 
 ## Important Boundaries
 
 - The 2025 review area uses real Production data.
 - Annual 2025 corrections stay with the 2025 Setup Session.
 - Reusable Task changes are permanent Setup knowledge and may affect future seasons.
+- Continue reusable task development against the current PostgreSQL catalog; do not recreate a parallel spreadsheet master.
 - Operational dates entered for the selected Setup Session must be in that session's year.
 - Only an Administrator may create a new annual Setup Session or carry annual order forward as the future reusable baseline.
-- Pick Lists and Container/Display movement/scanning writes are not part of the current live-review workflow.
+- Do not create the 2026 Setup Session until the current catalog and predecessor/readiness pass are useful enough for planning.
+- Pick Lists and Container/Display movement/scanning writes are not part of the current live workflow.
 - Do not create fake records merely to test the UI. Use real review work and report workflow/UI findings instead.
 
 ## During Live Evaluation
@@ -49,13 +64,15 @@ Additional task procedures will be added only when the corresponding workflow is
 Managers and reviewers are encouraged to:
 
 - open tasks and compare annual 2025 information with reusable task information;
-- add genuinely missing reusable tasks;
+- add genuinely missing reusable tasks discovered during live review;
 - add/correct resources and prerequisites;
-- correct task scope, order, crew/time expectations, and notes where supported;
+- correct task scope, order, crew/time expectations, effort, and notes where supported;
 - verify records only when they have actually been reviewed;
 - leave uncertain information UNVERIFIED or mark it NEEDS CORRECTION;
 - ask questions and make suggestions about confusing, missing, or inefficient workflow; and
 - report UI problems instead of working around them silently.
+
+A current example is the missing physical `Set Up Frosty` task discovered after catalog deployment. The old transport entry `Bring Frosty to park` remains logistics evidence; the live catalog needs the reusable physical setup task and its Stars prerequisite relationship.
 
 ## Related Documents
 

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/operatorSOP/Review_2025_Setup_History.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/operatorSOP/Review_2025_Setup_History.md
@@ -6,16 +6,25 @@
 | System | Production Database — Setup and Deployment |
 | Task | Review and correct the 2025 Setup history |
 | Audience | Authorized Setup reviewers and managers |
-| Status | CURRENT — live 2025 review/training workflow; UI/workflow evaluation remains open |
+| Status | CURRENT — live 2025 review plus current reusable-task development |
 | Owner | MSB Setup administrator |
-| Last Reviewed | 2026-09-07 |
+| Last Reviewed | 2026-09-09 |
 | Keywords | Setup, 2025, historical review, training, reusable task, resources, verification |
 
 ## Purpose
 
-Use the real 2025 Setup Session to reconstruct what happened during the 2025 Setup season, improve reusable Setup knowledge, and learn the Setup application before the 2026 Setup Session is created.
+Use the real 2025 Setup Session to preserve/correct 2025 history while improving reusable Setup knowledge before the 2026 Setup Session is created.
 
-This is both a historical review area and a training area. Changes are real Production changes. The application itself is also still under live evaluation, so questions, suggestions, confusing screens, missing controls, and workflow problems should be reported rather than silently worked around.
+Changes are real Production changes. The reusable catalog reconstruction was accepted in Production on 2026-09-09, and current PostgreSQL is now the working source for task development.
+
+```text
+active reusable tasks    = 185
+total reusable rows      = 187
+reusable prerequisites   = 0
+2026 Setup Sessions      = 0
+```
+
+Historical spreadsheets/schedules remain evidence; they are not a parallel ongoing task master.
 
 ## Open the Setup Application
 
@@ -41,7 +50,7 @@ For this session:
 allowed operational dates = 2025 only
 ```
 
-The browser limits operational dates to 2025 and the database independently enforces the same rule. A correction recorded during 2026 may still have a 2025 operational date; its audit/update timestamp remains the real 2026 recording time.
+The browser limits operational dates to 2025 and the database independently enforces the same rule. Audit/update timestamps remain the real current recording time.
 
 ## Understand the Two Kinds of Changes
 
@@ -49,14 +58,12 @@ The browser limits operational dates to 2025 and the database independently enfo
 
 These changes describe what happened or was planned in 2025. Examples include:
 
-- verification state;
+- verification/reconciliation state;
 - actual crew count or duration when known;
 - actual start/completion information when known;
 - annual notes;
 - 2025-specific planned order; and
 - 2025 work-day/scheduling information when useful for reconstruction.
-
-These changes belong to 2025 and do not become 2026 history.
 
 ### Reusable Task knowledge
 
@@ -66,45 +73,39 @@ These changes describe how MSB normally performs Setup work. Examples include:
 - Park Infrastructure / Stage / Scene scope;
 - normal local sequence/order;
 - normal crew size and expected duration;
-- prerequisites;
+- Physical Effort;
+- prerequisites/readiness;
 - equipment/resources and quantities;
-- completion point;
-- readiness/weather notes; and
+- completion point; and
 - other reusable instructions that should carry forward.
 
-Reusable Task changes are permanent Setup knowledge and may become part of the starting point for future seasons.
+Reusable Task changes are permanent Setup knowledge and may become part of future seasons.
 
-Before changing reusable information, ask:
+## Review / Reconciliation States
 
-> Is this a general Setup rule we want to carry forward, or is this only something that happened in 2025?
-
-If it happened only in 2025, record it in the annual history instead.
-
-## Review a Task
-
-1. Open the 2025 Historical Verification session.
-2. Select a task from the review list.
-3. Read the reusable task information and the 2025 annual information separately.
-4. Compare the record with what you know, current procedures, and other reliable 2025 evidence.
-5. Correct only fields you can support.
-6. Add useful annual notes when the information is specific to 2025.
-7. Set the verification state only after the record has actually been reviewed.
-
-Normal verification states are:
+Current states are:
 
 ```text
 UNVERIFIED
+NEEDS_CORRECTION
 VERIFIED
-NEEDS CORRECTION
+ASSIGNED
 ```
 
-Do not mark a task VERIFIED merely because it exists.
+- `UNVERIFIED` — not yet sufficiently reviewed.
+- `NEEDS_CORRECTION` — known to need work.
+- `VERIFIED` — accepted annual record after review.
+- `ASSIGNED` — accepted as belonging to its current reusable task definition.
 
-## Add Missing Tasks
+`ASSIGNED` is a reconciliation state, not an execution/completion state. Assigned items leave the default actionable queue but remain available through the Assigned filter.
 
-If a real Setup activity is missing, Managers may add a reusable task when the work should exist as a normal Setup task beyond just one historical occurrence.
+Reassigning/merging an annual item to a different reusable task remains a separate governed workflow.
 
-Before adding it, decide the appropriate scope:
+## Add Missing Reusable Tasks
+
+If real Setup work is missing, Managers may add a reusable task when the work should normally exist beyond one historical occurrence.
+
+Use the correct scope:
 
 ```text
 Park Infrastructure / no LOR Stage
@@ -112,25 +113,23 @@ Stage-level / General
 Scene
 ```
 
-Use **Add Task Here** in the appropriate scope. Use **Copy** when a new reusable task is substantially similar to an existing one, then review the copied definition carefully.
+Use **Add Task Here** or **Copy** where appropriate.
 
-Do not create a task for every ordinary action. A task is useful when it can realistically be missed, affects planning/readiness/resources, needs progress/completion tracking, or preserves historical learning worth carrying forward.
+Do not create a reusable task for ordinary transport merely because an old schedule recorded it. Example: `Bring Frosty to park` remains logistics evidence; the missing reusable work is physical `Set Up Frosty`.
 
-## Review Resources and Prerequisites
+## Review Resources, Effort, Prerequisites, and Readiness
 
-For reusable tasks, check whether the practical requirements are represented correctly.
+For reusable tasks, check whether practical requirements are represented correctly:
 
-Examples include:
+- lifts/vehicles/trailers/tools;
+- powered stake pounders or other recurring resources;
+- Physical Effort where known;
+- predecessor tasks that must complete first; and
+- readiness conditions that block work even when predecessors are complete.
 
-- lifts;
-- vehicles;
-- trailers;
-- tools;
-- powered stake pounders;
-- other recurring equipment/resources; and
-- predecessor tasks that must complete first.
+The current prerequisite set is intentionally empty after reconstruction. Rebuild dependencies deliberately and distinguish hard predecessor, preferred order, and readiness condition. Do not invent dependencies merely to fill fields.
 
-Use structured resources and prerequisites where they represent repeatable Setup knowledge. Do not invent quantities or dependencies just to fill fields.
+Current confirmed example: `Set Up Frosty` must be added and must precede the applicable Stars setup work.
 
 ## Procedures and Instructions
 
@@ -138,46 +137,40 @@ Where a Setup task has a current published Setup procedure, the application may 
 
 If an editable procedure is corrected, the current published PDF must also be updated before the instruction is treated as current.
 
-Detailed document-publishing instructions are owned by the Google Drive / Display Folder workflow. Do not reorganize folders merely to make the Setup review screen look cleaner.
-
 ## Ask Questions and Make Suggestions
 
-The application is intentionally being evaluated through real use. During the review period, report things such as:
+Report things such as:
 
 - information that is hard to understand;
-- fields that appear unnecessary;
-- missing information you need to make a Setup decision;
+- missing information needed to make a Setup decision;
 - awkward or repetitive steps;
-- task organization that does not match how crews actually work;
+- task organization that does not match real work;
 - resources or prerequisites that are difficult to represent;
-- confusing wording;
 - missing search/filter/navigation behavior; and
-- ideas that would make the 2026 Setup process easier.
+- ideas that would make 2026 planning or field work easier.
 
-A useful finding does not have to be a software bug. Workflow and data-model suggestions are part of this review.
+Issue #133 separately tracks Stage-level ↔ Scene drag/drop. The limitation is non-blocking because governed scope editing still exists.
 
 ## What Reviewers Cannot Do
 
 Normal reviewers/managers cannot:
 
 - create the 2026 Setup Session; or
-- use **Use Current Order as Future Baseline** unless they have Administrator authority.
+- promote an annual order into the reusable future baseline unless they have Administrator authority.
 
-Those controls are intentionally restricted so training/review work in the 2025 session cannot accidentally create or promote future-season state.
-
-Pick List generation and Container/Display movement/scanning writes are not part of the current live-review workflow.
+Pick List generation and Container/Display movement/scanning writes are not part of the current live workflow.
 
 ## What Successful Review Looks Like
 
-A useful 2025 review leaves:
+A useful review leaves:
 
 - 2025 annual facts corrected where evidence exists;
 - uncertain information left UNVERIFIED or marked NEEDS CORRECTION;
-- missing reusable tasks added where appropriate;
-- reusable task scope, resources, prerequisites, order, and normal expectations improved where the change should carry forward;
-- no 2026 operational dates in the 2025 session;
+- accepted annual-to-reusable identity mappings marked ASSIGNED where appropriate;
+- missing reusable tasks added directly to the current PostgreSQL catalog;
+- reusable task scope, resources, effort, prerequisites/readiness, order, and normal expectations improved where the change should carry forward;
 - no fake records created only for testing; and
-- questions, suggestions, and UI/workflow issues captured for follow-up before final subsystem acceptance.
+- no 2026 Session created before the catalog/predecessor model is ready.
 
 ## Related Documents
 

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/operatorSOP/Review_2025_Setup_History.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/operatorSOP/Review_2025_Setup_History.md
@@ -117,6 +117,64 @@ Use **Add Task Here** or **Copy** where appropriate.
 
 Do not create a reusable task for ordinary transport merely because an old schedule recorded it. Example: `Bring Frosty to park` remains logistics evidence; the missing reusable work is physical `Set Up Frosty`.
 
+## Keep Scope, Display Ownership, and Containers Separate
+
+This is an important Setup rule while reviewing/building reusable tasks.
+
+### Scope = where the work belongs
+
+A task may belong to a Stage or Scene even when no Display is associated with that task.
+
+Example:
+
+```text
+Grease Bearings
+    -> belongs at 01-Front Gate
+    -> no Display assignment required
+```
+
+Do not move a task to another Stage merely because its Material / Logistics panel is empty.
+
+### Display ownership = the physical work package
+
+A Display may belong to **at most one** reusable Setup task. A reusable task may own many Displays or none.
+
+```text
+one Display -> zero or one reusable Setup task
+```
+
+Do not create one Setup task per panel just to represent Display relationships. Build the task at the practical crew/work-package level.
+
+Examples:
+
+- one `Set Up Traffic Signs` task may own the complete Traffic Sign Display group;
+- one `Set Up MSB & Rotary Signs` task may own that sign group;
+- `Volunteer Path Setup` may be its own task when it is normally assigned to a parallel crew;
+- `Grease Bearings` can remain a Front Gate task with no Display ownership.
+
+A LOR Scene/display group can help identify which Displays belong together, but Stage/Scene placement alone does not mean every task in that scope owns all Displays in that scope.
+
+### Containers = storage and transport
+
+Containers normally tell us **where the Displays are stored and how they get to the park**. They do not determine task scope and do not create Display ownership.
+
+For Display-bearing work, the intended chain is:
+
+```text
+Setup task
+    -> assigned Displays
+    -> current Display-to-Container assignments
+    -> current storage/location
+```
+
+Some Containers become part of the deployed show and are marked accordingly (`display_pallet`). Those Containers may remain at the park after unloading and return during Takedown rather than automatically returning to the workshop when Setup is complete.
+
+### Current UI limitation
+
+The Material / Logistics panel is still being corrected to follow this model. It may currently show all Displays from a Scene for a task that owns none, or zero Displays for a Stage-level task whose Display work package has not yet been assigned.
+
+Do not create fake tasks, duplicate a Display into multiple tasks, or move a task to the wrong Stage/Scene to make the Material panel look populated. Report the intended Display work package and continue building the correct task definition.
+
 ## Review Resources, Effort, Prerequisites, and Readiness
 
 For reusable tasks, check whether practical requirements are represented correctly:
@@ -146,6 +204,7 @@ Report things such as:
 - awkward or repetitive steps;
 - task organization that does not match real work;
 - resources or prerequisites that are difficult to represent;
+- missing or misleading Material / Logistics relationships;
 - missing search/filter/navigation behavior; and
 - ideas that would make 2026 planning or field work easier.
 
@@ -158,7 +217,7 @@ Normal reviewers/managers cannot:
 - create the 2026 Setup Session; or
 - promote an annual order into the reusable future baseline unless they have Administrator authority.
 
-Pick List generation and Container/Display movement/scanning writes are not part of the current live workflow.
+Pick List generation, governed task-to-Display ownership editing, and Container/Display movement/scanning writes are not part of the current live workflow.
 
 ## What Successful Review Looks Like
 
@@ -169,6 +228,7 @@ A useful review leaves:
 - accepted annual-to-reusable identity mappings marked ASSIGNED where appropriate;
 - missing reusable tasks added directly to the current PostgreSQL catalog;
 - reusable task scope, resources, effort, prerequisites/readiness, order, and normal expectations improved where the change should carry forward;
+- practical Display work packages identified without creating one task per Display or assigning a Display to multiple tasks;
 - no fake records created only for testing; and
 - no 2026 Session created before the catalog/predecessor model is ready.
 

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/operatorSOP/Review_2025_Setup_History.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/operatorSOP/Review_2025_Setup_History.md
@@ -189,6 +189,27 @@ The current prerequisite set is intentionally empty after reconstruction. Rebuil
 
 Current confirmed example: `Set Up Frosty` must be added and must precede the applicable Stars setup work.
 
+### Area-specific grounds readiness
+
+Grass cutting/mulching is a **readiness condition**, not one blanket park-wide predecessor. Different parts of the park become ready at different times.
+
+For example, `Lay Cords` in Stage 00 may have hard Setup-task predecessors such as the applicable sign-setup tasks, while also requiring this field condition:
+
+```text
+Mowing/mulching complete in the Stage 00 HWY 42 cord-laying area.
+```
+
+Do **not** create a fake global `Grass Cutting Complete` task unless MSB actually performs and tracks that work as a Setup task. Do not wait for all grass cutting/mulching in the park to finish before considering one area ready.
+
+The current `Readiness note` field is informational only. It can preserve the reusable area-specific rule now, but it does not yet change scheduler availability. A future structured readiness control must allow each task/work area to become READY independently.
+
+When building tasks now:
+
+1. add actual Setup tasks that must finish first as prerequisites;
+2. put area-specific external conditions such as mowing/mulching in the Readiness note;
+3. do not turn preferred order or field conditions into fake task dependencies; and
+4. report any readiness condition that must eventually control **Available to Schedule**.
+
 ## Procedures and Instructions
 
 Where a Setup task has a current published Setup procedure, the application may show that procedure and, for authorized Managers, the editable source used to maintain it.
@@ -205,6 +226,7 @@ Report things such as:
 - task organization that does not match real work;
 - resources or prerequisites that are difficult to represent;
 - missing or misleading Material / Logistics relationships;
+- missing structured readiness behavior needed for field conditions;
 - missing search/filter/navigation behavior; and
 - ideas that would make 2026 planning or field work easier.
 
@@ -217,7 +239,7 @@ Normal reviewers/managers cannot:
 - create the 2026 Setup Session; or
 - promote an annual order into the reusable future baseline unless they have Administrator authority.
 
-Pick List generation, governed task-to-Display ownership editing, and Container/Display movement/scanning writes are not part of the current live workflow.
+Pick List generation, governed task-to-Display ownership editing, structured annual readiness gating, and Container/Display movement/scanning writes are not part of the current live workflow.
 
 ## What Successful Review Looks Like
 
@@ -229,6 +251,7 @@ A useful review leaves:
 - missing reusable tasks added directly to the current PostgreSQL catalog;
 - reusable task scope, resources, effort, prerequisites/readiness, order, and normal expectations improved where the change should carry forward;
 - practical Display work packages identified without creating one task per Display or assigning a Display to multiple tasks;
+- area-specific readiness captured without inventing one blanket park-wide completion condition;
 - no fake records created only for testing; and
 - no 2026 Session created before the catalog/predecessor model is ready.
 

--- a/Docs/02_Production_Database/02_Operational_SOPs/Setup/README.md
+++ b/Docs/02_Production_Database/02_Operational_SOPs/Setup/README.md
@@ -16,7 +16,18 @@ The current shared working session is the real Production-backed:
 2025 — Historical Verification
 ```
 
-Production deployment is accepted, but the **Setup UI/workflow remains in live evaluation**. Managers are expected to use the 2025 session for real reconstruction/training work and report questions, suggestions, confusing behavior, and workflow problems before final subsystem acceptance.
+The reusable catalog reconstruction was accepted in Production on 2026-09-09. The current PostgreSQL working baseline is:
+
+```text
+active reusable tasks    = 185
+total reusable rows      = 187
+reusable prerequisites   = 0
+2026 Setup Sessions      = 0
+```
+
+Production deployment is accepted, but the **broader Setup UI/workflow remains in live evaluation**. Managers should continue real review/task-development work against current PostgreSQL data and report questions, suggestions, confusing behavior, and workflow problems before final subsystem acceptance.
+
+The reconstruction workbook and historical schedules remain evidence. They are not a parallel ongoing master task list.
 
 ## Start Here
 
@@ -39,6 +50,8 @@ Only a Setup Administrator may:
 
 - create/manage an annual Setup Session; or
 - promote an annual planned order into the reusable future baseline.
+
+There is currently no 2026 Setup Session. Do not create it until the current reusable catalog and the reviewed predecessor/readiness model are useful enough for planning.
 
 See the engineering contract:
 
@@ -65,16 +78,21 @@ Do not create a fake LOR Stage, Scene, or Preview for Park Infrastructure merely
 Live now:
 
 - Production-backed 2025 historical review/training;
+- the current 185-task reusable PostgreSQL catalog;
 - Manager/reviewer task verification and correction;
 - reusable task creation/copy and maintenance;
-- scope/order/prerequisite/resource maintenance;
+- scope/order/prerequisite/resource/effort maintenance through governed controls;
 - annual planning/review controls supported by the current application;
 - Procedure/document context; and
 - protected authenticated browser access.
 
 Still outside the current Production-ready boundary:
 
+- reviewed predecessor/readiness completion across the reconstructed catalog;
+- cross-Stage candidate planning / short-horizon scheduler workflow;
 - Pick List generation; and
-- Container/Display movement/scanning write commands.
+- Container/Display movement/scanning write commands and park-location execution evidence.
 
-Do not document those later layers as live Production behavior until their separate acceptance gates pass.
+A current known catalog correction is missing physical `Set Up Frosty`; transport-only `Bring Frosty to park` remains logistics evidence. Frosty setup must be added to the current catalog and precede the applicable Stars work.
+
+Do not document later layers as live Production behavior until their separate acceptance gates pass.

--- a/Docs/02_Production_Database/02_Operational_SOPs/Setup/Setup_Session_Manager_Review_Guide.md
+++ b/Docs/02_Production_Database/02_Operational_SOPs/Setup/Setup_Session_Manager_Review_Guide.md
@@ -162,6 +162,98 @@ The Manager assigns scope explicitly. Do not infer Scene ownership merely from a
 
 Issue #133 tracks the current drag/drop limitation between Stage-level and Scene scope. That limitation is non-blocking because governed scope editing still exists.
 
+## Understand Task Scope, Display Ownership, and Containers
+
+These are three different concepts. Do not use one as a substitute for another.
+
+### Task scope answers: where does this work belong?
+
+Stage/Scene scope describes the physical Setup area or organizational home of the work. A task may belong to a Stage or Scene even when **no Display is assigned to that task**.
+
+Example:
+
+```text
+Grease Bearings
+    -> belongs at 01-Front Gate
+    -> requires the gate bearings to be greased
+    -> has no Display work-package assignment
+```
+
+Do not move that task to Santa's Workshop or another area merely because no Display is attached to it. The task belongs where the work is physically performed.
+
+### Display ownership answers: which Displays are this task's physical work package?
+
+Display assignment is optional and separate from task scope.
+
+Current operating rule:
+
+```text
+one Display
+    -> zero or one reusable Setup task
+
+one reusable Setup task
+    -> zero, one, or many Displays
+```
+
+A Display must **not** appear in two different reusable Setup tasks. If a Display belongs to a Setup work package, one task owns that Display for reusable Setup planning/reporting.
+
+Do not create one task per panel merely to make Display relationships easy. Build tasks at the practical crew/work-package level.
+
+Examples:
+
+```text
+Set Up Traffic Signs
+    -> one reusable task
+    -> owns all Traffic Sign Displays assigned to that work package
+
+Set Up MSB & Rotary Signs
+    -> one reusable task
+    -> owns the MSB/Rotary sign Displays assigned to that work package
+
+Volunteer Path Setup
+    -> separate reusable task when it is normally assigned to a parallel crew
+```
+
+LOR Scene/display-group information may help identify a logical batch of Displays, but it does **not** mean every task located in that Scene automatically owns every Display in that Scene.
+
+### Containers answer: how do the Displays/material get to the park?
+
+A Container is normally the storage/transport mechanism. It does not determine the task's Stage/Scene scope and does not create Display ownership.
+
+For Display-bearing tasks, the intended direction is:
+
+```text
+reusable Setup task
+    -> its assigned Display work package
+    -> each Display's current Container assignment
+    -> current storage/location information
+```
+
+This allows the future Pick List to determine what physical Containers must move without forcing operators to define task scope from Container storage.
+
+Some Containers are themselves used as part of the deployed show. Containers marked as part of a Display (the existing `display_pallet` concept) are not ordinary empty transport Containers after Setup. When their deployed role requires them to remain at the park, they stay there through the show and return during Takedown rather than automatically returning to the workshop when their cargo is unloaded.
+
+Keep that deployed-Container behavior separate from reusable task-to-Display ownership.
+
+### Current Material / Logistics UI limitation
+
+The current Material / Logistics resolver does not yet fully enforce this operating model. In particular, Scene scope can currently cause Displays to appear under a task even when the task does not own those Displays, while some Stage-level Display-bearing tasks can show zero Displays because their explicit work-package assignment has not been populated.
+
+Treat those Material / Logistics results as **under active correction** while the task/Display ownership workflow is built. Do not create fake tasks or move tasks to the wrong scope to make that panel look populated.
+
+While building the reusable catalog now, focus on:
+
+- the correct practical task boundary;
+- correct Stage/Scene location;
+- crew size and expected duration;
+- completion point;
+- equipment/resources;
+- effort;
+- predecessors; and
+- readiness conditions.
+
+When a task clearly represents a Display work package, record/report the intended group of Displays so the governed assignment can be established. Do not manually duplicate one Display across multiple tasks.
+
 ## Review Resources and Effort
 
 Use structured resources for recurring requirements such as lifts, vehicles, trailers, tools, and stake pounders.
@@ -233,6 +325,8 @@ Live now:
 
 Not yet Production-operational as complete workflows:
 
+- Manager-facing task-to-Display ownership assignment;
+- corrected Material / Logistics resolution under the one-Display/one-task rule;
 - cross-Stage candidate planning / short-horizon scheduler surface;
 - Pick List generation;
 - mixed-stage Container annual mobilization/unload-state workflow; and

--- a/Docs/02_Production_Database/02_Operational_SOPs/Setup/Setup_Session_Manager_Review_Guide.md
+++ b/Docs/02_Production_Database/02_Operational_SOPs/Setup/Setup_Session_Manager_Review_Guide.md
@@ -5,22 +5,32 @@
 | Document Type | Operator / Manager Procedure |
 | System | Production Database — Setup Session |
 | Audience | Setup Managers, reviewers, and administrators |
-| Status | CURRENT — live 2025 review/training workflow; UI/workflow evaluation remains open |
+| Status | CURRENT — live 2025 review plus current reusable-task development |
 | Owner | MSB Production Database / Setup administrator |
-| Last Reviewed | 2026-09-07 |
+| Last Reviewed | 2026-09-09 |
 
 ## Purpose
 
 Use this guide for the live Setup application and the Production-backed **2025 Historical Verification** session.
 
-The 2025 session has two purposes:
-
-- reconstruct and improve the real 2025 Setup record; and
-- train future Setup Managers by using the actual workflow before the 2026 Setup Session is created.
+The 2025 session remains the annual review/training context, but the reusable catalog is now also the live working baseline for 2026 preparation.
 
 This is **not disposable test data**. Changes saved in the application are real Production Database records.
 
-The application itself is still under live evaluation. Managers should report questions, suggestions, missing information, confusing screens, and workflow problems instead of silently adapting around them.
+## Current PostgreSQL Baseline
+
+The reusable catalog reconstruction was accepted in Production on 2026-09-09:
+
+```text
+active reusable tasks      = 185
+total reusable task rows   = 187
+reusable prerequisites     = 0
+2026 Setup Sessions        = 0
+```
+
+The prerequisite count is intentionally zero pending the reviewed predecessor/readiness pass.
+
+The reviewed reconstruction workbook, 2025 notes, and recovered 2022 schedule remain evidence. They are not a parallel task master. Continue building and correcting reusable tasks against the **current PostgreSQL catalog**.
 
 ## Open the Application
 
@@ -32,7 +42,7 @@ https://my.sheboyganlights.org/setup/
 
 Sign in through the normal MSB Google/Cloudflare Access login.
 
-Confirm the selected session is:
+Confirm the selected annual session is:
 
 ```text
 2025 — Historical Verification
@@ -46,27 +56,15 @@ The selected Setup Session controls the allowable operational year.
 2025 Historical Verification
     -> work dates and historical actual dates must be in 2025
 
-2026 Setup Session
+future 2026 Setup Session
     -> work dates and operational dates must be in 2026
 ```
 
-The browser limits date controls to the selected year, and the database independently rejects an operational date from the wrong year.
+Audit timestamps remain truthful current timestamps.
 
-Audit timestamps remain truthful. If you correct a 2025 task during 2026, the historical operational date may be 2025 while the database records the correction as having been made in 2026.
+Only an Administrator may create a new annual Setup Session or promote an annual order into the reusable future baseline.
 
-## Roles and Authority
-
-A shared link does not grant authority. Each user must authenticate and have the appropriate Setup capability.
-
-Current responsibilities are:
-
-- **Reader / field user** — view permitted Setup information;
-- **Manager / reviewer** — review and correct annual 2025 information, maintain reusable tasks, task scope, prerequisites, resources, order, and supported planning information; and
-- **Administrator** — all Manager capabilities plus annual Setup Session creation and promotion of an annual order into the reusable future baseline.
-
-Only an Administrator should create the 2026 Setup Session.
-
-Only an Administrator can use **Use Current Order as Future Baseline**.
+Do **not** create the 2026 Setup Session yet. The current catalog and predecessor/readiness model must first be useful enough for planning.
 
 ## Annual 2025 Information vs Reusable Setup Knowledge
 
@@ -76,14 +74,12 @@ This distinction is fundamental.
 
 Annual information describes what happened or was planned in 2025:
 
-- verification state;
+- verification/reconciliation state;
 - annual planned order;
-- 2025 work-day/date/shift/crew-lane assignments when used;
 - 2025 crew/time evidence;
-- annual notes; and
-- progress/completion evidence.
-
-These records belong only to the 2025 Setup Session.
+- annual notes;
+- progress/completion evidence; and
+- 2025 work-day/date/shift assignments where used.
 
 ### Reusable Setup knowledge
 
@@ -93,13 +89,12 @@ Reusable information describes how the work normally exists across seasons:
 - Park Infrastructure / Stage / Scene scope;
 - normal local sequence/order;
 - normal crew range and expected duration;
+- Physical Effort (`LIGHT`, `MODERATE`, `HEAVY`, or unreviewed);
 - equipment/resources;
 - prerequisites;
 - completion point;
 - readiness/weather notes; and
 - reusable whole-Setup baseline order.
-
-Edits to reusable information are intentionally permanent and may be used when the Administrator later creates 2026.
 
 Before changing reusable information, ask:
 
@@ -107,44 +102,45 @@ Before changing reusable information, ask:
 
 If it only happened in 2025, keep it in annual history.
 
-## Review and Verify Existing Tasks
+## Review / Reconciliation States
 
-For each task you review:
-
-1. Open the task in the 2025 session.
-2. Read the reusable definition and annual 2025 information separately.
-3. Compare them with what you know and with reliable procedures/evidence.
-4. Correct only information you can support.
-5. Add annual notes when useful 2025-specific detail should be preserved.
-6. Set the verification state only after the record has actually been reviewed.
-
-Verification states are:
+Current annual verification/reconciliation states are:
 
 ```text
 UNVERIFIED
+NEEDS_CORRECTION
 VERIFIED
-NEEDS CORRECTION
+ASSIGNED
 ```
 
-Leave a task UNVERIFIED when you do not know enough. Use NEEDS CORRECTION when you know something is wrong but the correct answer still needs work.
+Use them as follows:
 
-Do not mark a task VERIFIED merely because the task exists.
+- `UNVERIFIED` — not yet sufficiently reviewed;
+- `NEEDS_CORRECTION` — known to be wrong/incomplete and still needs work;
+- `VERIFIED` — reviewed as the accepted annual record;
+- `ASSIGNED` — the annual item is accepted as belonging to its current reusable task definition.
 
-## Add Missing Reusable Tasks
+`ASSIGNED` is a **reconciliation state, not execution/completion state**. Assigned rows are preserved and can be filtered deliberately, but leave the default actionable review queue.
 
-If real Setup work is missing, Managers may add a reusable task when that work should normally exist beyond one historical occurrence.
+Reassigning/merging an annual item to a different reusable task remains a separate governed workflow.
 
-Use **Add Task Here** in the correct scope. Use **Copy** when the new task is substantially similar to an existing task, then review the copy carefully.
+## Add or Correct Reusable Tasks
+
+If real Setup work is missing, Managers may add a reusable task when the work should normally exist beyond one historical occurrence.
+
+Use **Add Task Here** in the correct scope. Use **Copy** when a new task is substantially similar to an existing task, then review the copy carefully.
 
 A task is useful when it:
 
 - can realistically be missed;
 - affects readiness, planning, or resources;
 - has meaningful prerequisites;
-- needs useful progress/completion tracking; or
+- needs progress/completion tracking; or
 - preserves operational learning worth carrying forward.
 
-Do not create separate tasks for ordinary actions that are already implied by the real work.
+Do not create separate reusable tasks for ordinary transport when movement/logistics owns that action.
+
+Current example: `Bring Frosty to park` is logistics evidence and should not become the reusable task. The missing reusable work is physical **`Set Up Frosty`**, and Frosty setup must precede the applicable Stars setup work.
 
 ## Choose the Correct Scope
 
@@ -154,170 +150,107 @@ Reusable tasks can belong to three practical scopes.
 
 Use this only for park-wide work with no appropriate LOR Stage or Scene owner.
 
-Examples include street-light and site-breaker work.
-
-These Procedures use:
-
-```text
-G:\Shared drives\Display Folders\41 Park Infrastructure-PI
-```
-
-Do not create a fake LOR Stage, Scene, or Preview merely to hold park-wide work.
-
 ### Stage-level / General
 
 Use Stage-level when the task belongs to a real LOR Stage generally but should not be forced into a Scene.
-
-`40-CommandCenter` is the important example. It remains legitimate Stage 40 because it has a real LOR Preview, even though its Preview currently has no wired inventory items.
 
 ### Scene
 
 Use Scene scope when a current LOR Scene is the natural reusable organizational home for the work.
 
-The Manager assigns Scene scope explicitly. Do not infer Scene ownership merely from a task or Display name.
+The Manager assigns scope explicitly. Do not infer Scene ownership merely from a task or Display name.
 
-## Review Resources
+Issue #133 tracks the current drag/drop limitation between Stage-level and Scene scope. That limitation is non-blocking because governed scope editing still exists.
 
-Use structured resources for recurring requirements such as:
+## Review Resources and Effort
 
-- lifts;
-- vehicles;
-- trailers;
-- tools;
-- stake pounders; and
-- other equipment required to perform the task.
+Use structured resources for recurring requirements such as lifts, vehicles, trailers, tools, and stake pounders.
 
 Review:
 
-- the correct resource;
+- correct resource;
 - quantity;
-- Required vs Preferred status; and
+- Required vs Preferred status;
+- Physical Effort where known; and
 - whether the requirement belongs as reusable knowledge.
 
-Do not invent quantities merely to fill a field.
-
-If a resource itself is missing from the catalog and the application permits you to add it, use a clear durable name that represents the real equipment/resource rather than a one-time note.
+Do not invent quantities or effort values merely to fill fields.
 
 ## Review Prerequisites and Readiness
 
 A prerequisite means another reusable task must complete first.
 
-Example:
+Readiness is different: a task may have all predecessors complete but still be blocked by leaves, weather, access, equipment, grass cutting, or another practical condition.
+
+The 2026-09-09 catalog reconstruction intentionally reset all reusable dependencies. The next review pass must rebuild them deliberately and distinguish:
 
 ```text
-Locates / Field Cleared
-    -> Set Scaffold and Elves
-        -> Install Notes and Conductor
+HARD PREDECESSOR
+PREFERRED ORDER
+READINESS CONDITION
 ```
 
-Readiness is different from a prerequisite. A task may have all prerequisites satisfied but still be NOT_READY because of weather, leaves, access, equipment, or another practical condition.
+Do not rebuild a rigid chain merely because tasks happened in that order once.
 
-Use prerequisites only for real repeatable dependencies. Do not build a rigid serial chain just because tasks were performed in that order once.
+## Review Order and Planning
 
-## Review Order
-
-The system keeps two different whole-Setup orders.
-
-### Reusable baseline order
-
-This is the normal starting order learned over time. Only an Administrator may promote an annual order into this future baseline.
-
-### Annual planned order
-
-This is the current Setup Session's working opinion of what should happen next.
-
-It may legitimately differ because of weather, volunteer turnout, equipment, access, road work, leaves, material problems, or opportunities to complete another area early.
-
-A strange 2025 order should remain a 2025 fact unless it represents a genuinely better reusable rule.
-
-## Rolling-Horizon Planning
-
-The Setup system is not intended to be a rigid Gantt schedule.
-
-The normal operating cycle is:
+Keep these concepts separate:
 
 ```text
-know all remaining Setup work
-    -> keep it in useful order
-    -> check prerequisites/readiness/resources
-    -> schedule only the next few practical days
-    -> perform work
-    -> record progress/completion
-    -> return to the remaining backlog
+Stage / Scene organization
+reusable local task order
+reusable whole-Setup baseline order
+annual planned order
+short-horizon work-day / shift / crew plan
 ```
 
-Most unfinished work should remain unscheduled most of the time. That is normal.
+Setup is not intended to be a rigid season-long Gantt schedule. Plan the next practical few work days, then revise as progress, weather, volunteer turnout, equipment, and site conditions change.
 
-## Multi-Day Work and Progress
-
-Do not split a practical task merely because it lasts more than one work period.
-
-One annual task may remain IN_PROGRESS while progress is recorded over several work periods. Complete it only when the practical job is complete.
+Tasks may span multiple days and may use parallel crews. A task remains `IN_PROGRESS` until its practical completion point is reached.
 
 ## Procedures
 
-Stage- and Scene-scoped tasks use the established marked Google Drive Procedure structure.
-
-Park Infrastructure uses:
+Stage- and Scene-scoped tasks use the established Google Drive Procedure structure. Park Infrastructure uses:
 
 ```text
 G:\Shared drives\Display Folders\41 Park Infrastructure-PI
 ```
 
-Where the application shows a current published Setup PDF, review whether it still matches the work. Authorized Managers may also see the editable source used to maintain it.
-
-If an editable procedure is corrected, update the current published PDF before treating the instruction as current.
-
-## Ask Questions and Make Suggestions
-
-This review period is also how we improve the application before the 2026 Setup cycle.
-
-Report things such as:
-
-- a field or label you do not understand;
-- missing information you need to make a decision;
-- information that appears duplicated or unnecessary;
-- a task that belongs in a different place;
-- difficulty representing a resource or prerequisite;
-- an awkward or repetitive workflow;
-- missing search/filter/navigation behavior;
-- a screen that does not match how Setup crews actually work;
-- a task/data problem that the application makes hard to correct; and
-- ideas that would make 2026 planning or field work easier.
-
-A useful finding does not have to be a software bug. Operational suggestions are part of the evaluation.
+Where the application shows a current published Setup PDF, review whether it still matches the work. If an editable procedure is corrected, update the published PDF before treating the instruction as current.
 
 ## Current Live Boundary
 
 Live now:
 
 - Production-backed 2025 review/training;
-- verification and correction of annual 2025 information;
-- reusable task creation/copy and maintenance;
-- task scope/order/prerequisite/resource maintenance;
-- supported annual planning/review controls;
+- 185-active-task reusable PostgreSQL catalog;
+- annual review/reconciliation including `ASSIGNED`;
+- reusable task create/copy/maintenance;
+- Stage/Scene scope and order maintenance;
+- resource, effort, prerequisite, crew/time/readiness maintenance;
 - Procedure/document context; and
 - authenticated browser access.
 
-Not yet part of the current Production-ready workflow:
+Not yet Production-operational as complete workflows:
 
-- Pick List generation; and
-- Container/Display movement/scanning write commands.
+- cross-Stage candidate planning / short-horizon scheduler surface;
+- Pick List generation;
+- mixed-stage Container annual mobilization/unload-state workflow; and
+- Container/Display movement/scanning writes and park-location execution evidence.
 
-Do not infer a movement event merely because an identifier was scanned or a review action occurred.
+## Current Task Development Rule
 
-## 2025 Review to 2026 Transition
+Use current PostgreSQL first.
 
-There is currently no 2026 Setup Session.
+```text
+current reusable task data
+    -> identify gap/correction
+    -> verify scope and practical task boundary
+    -> correct/add through governed Setup controls
+    -> add predecessor/readiness/resource/effort knowledge when known
+```
 
-When the Administrator decides the 2025 reconstruction is useful enough and explicitly creates 2026:
-
-- 2026 gets its own annual task rows;
-- the date guard changes automatically to 2026;
-- 2025 annual records remain 2025 records; and
-- reusable task knowledge continues forward.
-
-No Manager/reviewer action inside the 2025 session should implicitly create or schedule 2026.
+Do not restart a large spreadsheet import merely because a missing task is discovered.
 
 ## Related Documents
 


### PR DESCRIPTION
## Purpose

Refresh the CURRENT Setup operator and engineering documentation after the 2026-09-09 reusable-catalog Production deployment.

## Current accepted Production baseline

```text
Setup SHA                  = 5a8a317357ffa5d77c38bc4df63fe6c7b451dbaf
active reusable tasks      = 185
total reusable task rows   = 187
reusable dependencies      = 0
2026 Setup Sessions        = 0
Production fingerprint     = f0b98ac75e297a08eabc3df040708c08
```

## Documentation corrections

- establish current Production PostgreSQL as the ongoing reusable-task working baseline;
- make clear that the reviewed reconstruction workbook / 2025 notes / recovered 2022 schedule are evidence, not a parallel task master;
- update operator and engineering portals from the old 57-task baseline;
- document the intentional dependency reset and predecessor/readiness pass gate before 2026 creation;
- add current `ASSIGNED` reconciliation-state semantics to operator guidance;
- document the post-deployment Frosty catalog gap (`Set Up Frosty`) and Stars predecessor requirement;
- document the operator-facing distinction between task scope, Display work-package ownership, and Container transport/storage;
- state that a task may belong to a Stage/Scene with no Displays (for example `Grease Bearings` at `01-Front Gate`);
- state the accepted reusable work-package rule that one Display may belong to zero or one reusable Setup task, while one task may own many Displays or none;
- warn operators not to create one task per panel, duplicate Displays across tasks, or move tasks to the wrong Stage/Scene merely to populate Material / Logistics;
- document that Containers normally derive from current Display storage/transport assignments, while Containers that are themselves part of the deployed show (`display_pallet`) may remain at the park until Takedown;
- mark the current Material / Logistics resolver and Manager-facing task-to-Display ownership workflow as incomplete/under correction;
- keep Pick List and movement/location workflows correctly marked as not yet Production-operational;
- keep Issue #133 as a separate non-blocking Stage-level ↔ Scene drag/drop follow-up.

Dated acceptance/handoff documents are intentionally preserved as historical records rather than rewritten to look current.

Related: Issue #122, PR #125, Issue #133.