### PR TITLE
Place Save Effort beside Physical Effort selector

### DIFF
--- a/Setup/Application/setup_catalog_effort.js
+++ b/Setup/Application/setup_catalog_effort.js
@@ -7,6 +7,29 @@ function setupEffortLabel(value) {
   return normalized || 'Not reviewed';
 }
 
+function placeSetupEffortSaveControl() {
+  const select = el('edit-effort-level');
+  const button = el('save-task-effort');
+  const label = select?.closest('label');
+  if (!select || !button || !label) return;
+  if (el('setup-effort-editor-row')) return;
+
+  const row = document.createElement('div');
+  row.id = 'setup-effort-editor-row';
+  row.className = 'compact-grid';
+
+  const actions = document.createElement('div');
+  actions.className = 'action-row manager-only setup-effort-save-actions';
+  const note = document.createElement('span');
+  note.className = 'muted';
+  note.textContent = 'Effort saves separately from Save Reusable Task.';
+
+  label.parentElement.insertBefore(row, label);
+  row.appendChild(label);
+  actions.append(button, note);
+  row.appendChild(actions);
+}
+
 function applySetupEffortToTasks() {
   for (const task of appState.tasks || []) {
     task.effort_level = setupEffortState.get(Number(task.setup_task_id)) ?? null;
@@ -105,9 +128,11 @@ if (typeof reloadTasks === 'function') {
   };
 }
 
+placeSetupEffortSaveControl();
 el('save-task-effort')?.addEventListener('click', saveSelectedSetupEffort);
 
 window.addEventListener('load', () => {
+  placeSetupEffortSaveControl();
   applySetupEffortAccess();
   loadSetupEfforts().catch((error) => {
     console.error('Setup effort metadata could not be loaded', error);

--- a/Setup/Application/test_setup_catalog_effort_contract.py
+++ b/Setup/Application/test_setup_catalog_effort_contract.py
@@ -45,3 +45,13 @@ def test_effort_editor_and_catalog_badge_are_present():
     assert "can_manage_setup" in js
     assert "setup_effort_badge" not in js  # class stays hyphenated for CSS/DOM consistency
     assert "setup-effort-badge" in js
+
+
+def test_effort_save_control_is_moved_beside_effort_editor_and_explains_separate_save():
+    js = text(BASE / "setup_catalog_effort.js")
+    assert "function placeSetupEffortSaveControl()" in js
+    assert "setup-effort-editor-row" in js
+    assert "row.className = 'compact-grid'" in js
+    assert "actions.append(button, note)" in js
+    assert "Effort saves separately from Save Reusable Task." in js
+    assert "placeSetupEffortSaveControl();" in js


### PR DESCRIPTION
## Purpose

Reduce a live Setup Manager usability trap discovered while building the reusable task catalog.

Current Production behavior intentionally saves `effort_level` through its own governed command. `Save Reusable Task` does not persist Physical Effort. Because `Save Effort` currently sits down in the general reusable-task action row, it is easy to change the effort selector and assume `Save Reusable Task` saved it.

## Change

- move the existing `Save Effort` control at runtime into the same two-column row as the Physical Effort selector;
- add the explicit note `Effort saves separately from Save Reusable Task.`;
- preserve the existing narrow effort API/database command and authorization boundary;
- add contract coverage for the placement/explanation behavior.

No database or Production mutation is included.

Based on accepted Production Setup SHA `5a8a317357ffa5d77c38bc4df63fe6c7b451dbaf`.

Related: #122, #125.