### PR TITLE
Restore Delete Task for reusable Catalog reconstruction cleanup

### DIFF
--- a/Setup/Application/setup_training_review_refinement.js
+++ b/Setup/Application/setup_training_review_refinement.js
@@ -17,6 +17,39 @@
     }
   }
 
+  function selectedSeason() {
+    return (appState.seasons || []).find(
+      (season) => Number(season.season_year) === Number(appState.seasonYear)
+    ) || null;
+  }
+
+  function syncReconstructionDeleteControl() {
+    const button = document.getElementById('delete-reconstruction-task');
+    if (!button) return;
+    const task = typeof taskById === 'function' ? taskById(appState.selectedTaskId) : null;
+    const season = selectedSeason();
+    const shouldHide = !(
+      appState.access?.can_manage_setup
+      && season?.session_status === 'HISTORICAL_VERIFICATION'
+      && task?.setup_task_id != null
+    );
+
+    button.textContent = 'Delete Task';
+    button.title = 'Delete a mistaken reusable task during 2025 Historical Verification. The database refuses deletion when protected planning or execution history exists.';
+    if (button.hidden !== shouldHide) button.hidden = shouldHide;
+  }
+
+  function ensureReconstructionDeleteObserver() {
+    const button = document.getElementById('delete-reconstruction-task');
+    if (!button || button.dataset.catalogDeleteVisibilityObserver === '1') return;
+    button.dataset.catalogDeleteVisibilityObserver = '1';
+    new MutationObserver(() => syncReconstructionDeleteControl()).observe(
+      button,
+      { attributes: true, attributeFilter: ['hidden'] }
+    );
+    syncReconstructionDeleteControl();
+  }
+
   function ensureCaptainTypeahead() {
     const search = document.getElementById('setup-captain-search');
     const select = document.getElementById('setup-captain-person');
@@ -183,6 +216,8 @@
 
   function initializeRefinements() {
     relocateCatalogReturnControl();
+    ensureReconstructionDeleteObserver();
+    syncReconstructionDeleteControl();
     ensureCaptainTypeahead();
     observeMaterialContext();
   }
@@ -195,4 +230,5 @@
   );
 
   document.addEventListener('click', () => requestAnimationFrame(initializeRefinements), true);
+  document.addEventListener('change', () => requestAnimationFrame(initializeRefinements), true);
 })();

--- a/Setup/Application/setup_training_review_refinement.js
+++ b/Setup/Application/setup_training_review_refinement.js
@@ -17,25 +17,17 @@
     }
   }
 
-  function selectedSeason() {
-    return (appState.seasons || []).find(
-      (season) => Number(season.season_year) === Number(appState.seasonYear)
-    ) || null;
-  }
-
   function syncReconstructionDeleteControl() {
     const button = document.getElementById('delete-reconstruction-task');
     if (!button) return;
     const task = typeof taskById === 'function' ? taskById(appState.selectedTaskId) : null;
-    const season = selectedSeason();
     const shouldHide = !(
       appState.access?.can_manage_setup
-      && season?.session_status === 'HISTORICAL_VERIFICATION'
       && task?.setup_task_id != null
     );
 
     button.textContent = 'Delete Task';
-    button.title = 'Delete a mistaken reusable task during 2025 Historical Verification. The database refuses deletion when protected planning or execution history exists.';
+    button.title = 'Delete a mistaken reusable task while cleaning the reconstructed Catalog. The database refuses deletion when protected planning or execution history exists.';
     if (button.hidden !== shouldHide) button.hidden = shouldHide;
   }
 
@@ -48,6 +40,48 @@
       { attributes: true, attributeFilter: ['hidden'] }
     );
     syncReconstructionDeleteControl();
+  }
+
+  async function deleteSelectedCatalogTask(event) {
+    const button = event.target.closest('#delete-reconstruction-task');
+    if (!button) return;
+
+    event.preventDefault();
+    event.stopImmediatePropagation();
+
+    const task = typeof taskById === 'function' ? taskById(appState.selectedTaskId) : null;
+    if (!task || !appState.access?.can_manage_setup) return;
+
+    const confirmed = window.confirm(
+      `Delete "${task.task_name}" completely from the Reusable Task Catalog?\n\n`
+      + 'Use this for reconstruction mistakes, duplicates, and bad task definitions that must not be propagated into 2026. '
+      + 'The database will refuse deletion if the task has protected planning or execution history.\n\n'
+      + 'This cannot be undone.'
+    );
+    if (!confirmed) return;
+
+    try {
+      setBusy(true);
+      const result = await api(
+        `api/setup/tasks/${task.setup_task_id}/reconstruction-delete`,
+        commandOptions('DELETE', {})
+      );
+      const deleted = result.deleted_task || {};
+      appState.selectedTaskId = null;
+      await reloadTasks(null);
+      if (typeof renderLibrary === 'function') renderLibrary();
+      showView('library');
+      setAlert(
+        `Deleted task ${deleted.setup_task_id || task.setup_task_id}. `
+        + `${deleted.deleted_annual_rows ?? 0} annual reconstruction row(s) were also removed.`,
+        'ok'
+      );
+    } catch (error) {
+      setAlert(error.message || error, 'error');
+      window.alert(error.message || error);
+    } finally {
+      setBusy(false);
+    }
   }
 
   function ensureCaptainTypeahead() {
@@ -229,6 +263,7 @@
     { childList: true, subtree: true }
   );
 
+  document.addEventListener('click', deleteSelectedCatalogTask, true);
   document.addEventListener('click', () => requestAnimationFrame(initializeRefinements), true);
   document.addEventListener('change', () => requestAnimationFrame(initializeRefinements), true);
 })();

--- a/Setup/Application/test_setup_catalog_delete_restore_contract.py
+++ b/Setup/Application/test_setup_catalog_delete_restore_contract.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+
+
+def test_catalog_delete_is_manager_visible_without_annual_reconstruction_row():
+    js = (ROOT / "setup_training_review_refinement.js").read_text(encoding="utf-8")
+    assert "button.textContent = 'Delete Task'" in js
+    assert "appState.access?.can_manage_setup" in js
+    assert "task?.setup_task_id != null" in js
+    assert "setup_session_task_id" not in js
+    assert "season?.session_status" not in js
+    assert "reconstruction mistakes, duplicates, and bad task definitions" in js
+
+
+def test_catalog_delete_uses_existing_governed_fail_closed_command():
+    js = (ROOT / "setup_training_review_refinement.js").read_text(encoding="utf-8")
+    assert "deleteSelectedCatalogTask" in js
+    assert "reconstruction-delete" in js
+    assert "commandOptions('DELETE', {})" in js
+    assert "protected planning or execution history" in js
+    assert "event.stopImmediatePropagation()" in js
+    assert "showView('library')" in js

--- a/Setup/Application/test_setup_training_ux_contract.py
+++ b/Setup/Application/test_setup_training_ux_contract.py
@@ -180,15 +180,21 @@ def test_reusable_task_match_action_is_explicit_about_target_and_scope():
     assert "MATCH CONFIRMED" in js
 
 
-def test_reconstruction_delete_is_visible_only_in_historical_manager_context():
-    js = read("setup_training_ux.js")
+def test_reconstruction_delete_is_visible_for_catalog_only_tasks_in_historical_manager_context():
+    base_js = read("setup_training_ux.js")
+    refinement_js = read("setup_training_review_refinement.js")
     css = read("setup_training_ux.css")
-    assert "Delete Reconstruction Task" in js
-    assert "HISTORICAL_VERIFICATION" in js
-    assert "setup_session_task_id != null" in js
-    assert "reconstruction-delete" in js
-    assert "commandOptions('DELETE', {})" in js
-    assert "work-day, progress, movement, planning, or actual execution history" in js
+    combined = base_js + "\n" + refinement_js
+    assert "Delete Reconstruction Task" in base_js
+    assert "button.textContent = 'Delete Task'" in refinement_js
+    assert "HISTORICAL_VERIFICATION" in combined
+    assert "appState.access?.can_manage_setup" in refinement_js
+    assert "task?.setup_task_id != null" in refinement_js
+    assert "catalogDeleteVisibilityObserver" in refinement_js
+    assert "attributeFilter: ['hidden']" in refinement_js
+    assert "reconstruction-delete" in base_js
+    assert "commandOptions('DELETE', {})" in base_js
+    assert "work-day, progress, movement, planning, or actual execution history" in base_js
     assert "#delete-reconstruction-task.danger" in css
 
 


### PR DESCRIPTION
## Purpose

Restore the Manager delete action needed while cleaning the reconstructed reusable Setup Catalog before 2026 planning.

Some duplicate/bad reusable definitions introduced during reconstruction have no annual historical record, so the UI must not require a `setup_session_task` row before Delete is available.

## Change

- show **Delete Task** for Managers whenever a reusable Catalog task is selected;
- remove the UI dependency on an annual reconstruction row / `setup_session_task_id`;
- use the existing governed reconstruction-delete API/database command;
- keep the database fail-closed guardrails for protected planning/execution history;
- return to the Reusable Task Catalog after successful deletion;
- add targeted contract coverage for catalog-only deletion.

No database schema change or Production mutation is included.

Based on accepted Production Setup SHA `5a8a317357ffa5d77c38bc4df63fe6c7b451dbaf`.

Related: #122.