### PR TITLE
Document post-catalog Setup reconstruction and migration history

### DIFF
--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/README.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/README.md
@@ -5,22 +5,37 @@
 | Document Type | Operator / User Portal |
 | System | Production Database — Setup and Deployment |
 | Audience | MSB volunteers, reviewers, managers, and Setup operators |
-| Status | CURRENT — Production runtime operational; Setup UI/workflow in live evaluation |
+| Status | CURRENT — Production reusable catalog rebuilt; 2025 review and live task development continue |
 | Owner | MSB Production Database / Setup administrator |
-| Last Reviewed | 2026-09-07 |
+| Last Reviewed | 2026-09-09 |
 | Keywords | Setup, 2025 review, training, 2026 plan, Setup procedures, deployment |
 
 Setup and Deployment covers the work of planning and carrying out the annual move from storage to the park, plus the information crews need while installing the show.
 
-The Setup application is now live at:
+The Setup application is live at:
 
 ```text
 https://my.sheboyganlights.org/setup/
 ```
 
-The current working session is **2025 — Historical Verification**. It uses real Production data so managers can reconstruct what happened in 2025, learn the workflow, improve reusable Setup knowledge, and identify UI/workflow problems before the 2026 Setup Session is created.
+The current working session is **2025 — Historical Verification**. It uses real Production data so managers can reconstruct what happened in 2025, improve reusable Setup knowledge, and identify workflow problems before the 2026 Setup Session is created.
 
-The application is operational, but the Setup/UI subsystem is still in **live evaluation**. The current review period is intended to generate questions, corrections, suggestions, and usability findings before final acceptance.
+## Current PostgreSQL Working Baseline
+
+The reusable task reconstruction was deployed to Production on 2026-09-09. The current working baseline in PostgreSQL is:
+
+```text
+active reusable tasks      = 185
+total reusable task rows   = 187
+reusable dependencies      = 0
+2026 Setup Sessions        = 0
+```
+
+The two additional reusable rows are retired identities preserved for history. The dependency set is intentionally empty pending the reviewed predecessor/readiness pass.
+
+The reviewed reconstruction workbook and historical schedules remain evidence for how this baseline was built, but they are **not the ongoing master task list**. From this point forward, continue building, correcting, organizing, and reviewing reusable Setup tasks against the **current Production PostgreSQL data**. New historical evidence may inform a task correction, but the current PostgreSQL catalog is the working source of truth.
+
+The application remains in live evaluation. Managers should continue to report missing tasks, incorrect scope/order, prerequisite/readiness needs, and UI/workflow problems rather than silently working around them.
 
 ## Start Here
 
@@ -82,14 +97,17 @@ Only an Administrator may create a new annual Setup Session or promote an annual
 
 ## Current Evaluation Boundary
 
-Production deployment is accepted, but final UI/workflow acceptance is intentionally open while managers use the 2025 session.
+The reconstructed reusable catalog is accepted in Production, but Issue #122 remains open because the broader Setup Session workflow is not finished.
 
 Current known boundaries:
 
 - no 2026 Setup Session has been created;
+- the current PostgreSQL reusable catalog is the working baseline and will continue to be corrected as real task knowledge is found;
+- the predecessor/readiness pass is still required before creating 2026; the current reusable dependency count is intentionally zero;
 - Pick List generation is not yet a live Production workflow;
-- Container/Display movement and scanning write commands remain outside this review boundary; and
-- the open Setup PRs remain the active engineering workstream until live-use findings are resolved.
+- Container/Display movement and scanning write commands remain outside the current live workflow;
+- known catalog corrections can still be found during live review, such as the missing physical Frosty setup task discovered immediately after deployment; and
+- Stage-level ↔ Scene drag/drop is tracked separately in Issue #133 and is not a blocker to continuing catalog work.
 
 ## Related Systems
 

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/README.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/README.md
@@ -5,11 +5,11 @@
 | Document Type | Engineering Handoff Portal |
 | System | Production Database — Setup and Deployment |
 | Audience | Greg, maintainers, database administrators, future engineering sessions |
-| Status | CURRENT HANDOFF — 2025 reconstruction active; correction/reconciliation package accepted in Production |
+| Status | CURRENT HANDOFF — reusable catalog reconstruction accepted in Production; live PostgreSQL catalog is now the working baseline |
 | Owner | MSB Production Database engineering |
 | Last Reviewed | 2026-09-09 |
 
-This is the engineering starting point for Setup Session architecture, database behavior, application contracts, Production state, reconstruction rules, planning behavior, Pick List direction, and resume information.
+This is the engineering starting point for Setup Session architecture, database behavior, application contracts, Production state, task development, planning behavior, Pick List direction, and resume information.
 
 The operator-facing instructions are separate under [`../operatorSOP/`](../operatorSOP/README.md).
 
@@ -23,37 +23,53 @@ https://my.sheboyganlights.org/setup/
 
 The 2025 Setup Session remains the real Production-backed Historical Review / Training environment. No 2026 Setup Session has been created.
 
-The operator-approved training/reconstruction correction package is now accepted in Production.
+The training/reconstruction correction package and the reviewed reusable-catalog reconstruction are accepted in Production.
 
 ```text
-accepted application/database target = aaf7de1c1d457b3dfaafe061f084a044cdf2abb7
-migrations 019-022                = Production accepted
-Production deployment result         = PASS
-Production governed Setup fingerprint = unchanged across deployment
+current deployed Setup SHA              = 5a8a317357ffa5d77c38bc4df63fe6c7b451dbaf
+migrations 019-022                      = Production accepted
+migrations 023-024                      = Production accepted
+active reusable tasks                   = 185
+total reusable task rows                = 187
+reusable dependencies                   = 0
+2026 Setup Sessions                     = 0
+Production governed Setup fingerprint   = f0b98ac75e297a08eabc3df040708c08
 ```
 
-Production corrections now include:
+The two non-active reusable rows are retired identities preserved for history. The zero dependency count is intentional: migration 024 reset the untrusted predecessor set so the next pass can rebuild hard predecessors separately from preferred order and readiness conditions.
+
+The current PostgreSQL data is now the authoritative **working task baseline**. The large one-list workbook and 2022/2025 schedules remain historical/reconstruction evidence, but future task development should not maintain another spreadsheet as a parallel master. Continue adding, correcting, moving, and enriching reusable tasks against the current Production catalog, using historical evidence only to support those changes.
+
+Known immediate catalog finding after deployment:
+
+- physical `Set Up Frosty` is missing; transport-only `Bring Frosty to park` was correctly excluded from reusable work, but the physical setup task was never created;
+- Frosty setup must precede the applicable Stars setup work;
+- this belongs in the live catalog correction + predecessor pass, not in another bulk reconstruction import.
+
+Production corrections already include:
 
 - reconstruction-safe deletion of mistaken provisional historical tasks;
 - Captain / Alternate / Advisor management using `ref.person` identity;
 - reusable-task match/reconciliation state for annual 2025 items;
 - active-person enforcement for new Captain/knowledge-owner assignments;
-- improved Catalog return navigation;
-- compact Material / Logistics summary with detailed dialog;
-- clarified reusable-task match wording; and
-- accepted Captain type-ahead behavior.
+- reusable Stage/Scene organization and catalog order controls;
+- compact Material / Logistics context;
+- Physical Effort metadata (`LIGHT`, `MODERATE`, `HEAVY`, or unreviewed);
+- the normalized 185-task reusable catalog;
+- normalized `Locate Power & Network` and `Layout Panels` naming; and
+- retirement of provisional reusable tasks 40 and 58 without fabricating 2025 annual rows.
 
-The broad Setup subsystem remains open for real 2025 evaluation. Production availability and this accepted package do not mean every 2026 planning, Pick List, movement, search, Scene-classification, or historical-reconstruction need is complete.
+The broader Setup subsystem remains open for real evaluation. Production availability and the accepted catalog do not mean 2026 planning, Pick List, movement, or predecessor/readiness work is complete.
 
 ## Start Here
 
-- [Setup Catalog Reconstruction Import — 2026-09-09](Setup_Catalog_Reconstruction_Import_2026-09-09.md) — current implementation candidate for converting the reviewed one-list reconstruction into a normalized reusable catalog before 2026 creation: effort metadata, current Stage/Scene identity, Locate/Layout normalization, logistics boundary, mixed-stage Container rule, dependency reset, and disposable acceptance gate.
-- [Setup Planning Operating Model — 2026-09-08](Setup_Planning_Operating_Model_2026-09-08.md) — operator-confirmed planning model: short planning horizon, preferred-order scheduling, Needs Scheduling queue, Sunday avoidance, weather constraints, grass-cutting dependency for cords, multi-day tasks, crew/hour interpretation, mixed-stage Container mobilization, and Rick spreadsheet evidence rules.
-- [Setup Planning Candidate Work View — 2026-09-09](Setup_Planning_Candidate_Work_View_2026-09-09.md) — operator-confirmed missing planning surface between reusable Stage-organized tasks and the short-range schedule: cross-Stage Available/Blocked/In-Progress candidates, operator choice of what can/should happen next, and Arch Trailer unload/access order.
+- [Setup Catalog Reconstruction Import — 2026-09-09](Setup_Catalog_Reconstruction_Import_2026-09-09.md) — accepted historical record of migrations 023/024 and the one-time normalized catalog reconstruction. Do not treat it as the ongoing task master after Production acceptance.
+- [Setup Planning Operating Model — 2026-09-08](Setup_Planning_Operating_Model_2026-09-08.md) — operator-confirmed planning model: short planning horizon, preferred-order scheduling, Needs Scheduling queue, Sunday avoidance, weather constraints, grass-cutting dependency for cords, multi-day tasks, crew/hour interpretation, mixed-stage Container mobilization, and historical evidence rules.
+- [Setup Planning Candidate Work View — 2026-09-09](Setup_Planning_Candidate_Work_View_2026-09-09.md) — operator-confirmed planning surface between reusable Stage-organized tasks and the short-range schedule: cross-Stage Available/Blocked/In-Progress candidates, operator choice of what can/should happen next, and Arch Trailer unload/access order.
 - [Setup Pick List Tablet Workflow — 2026-09-09](Setup_Pick_List_Tablet_Workflow_2026-09-09.md) — standalone Setup Pick List direction: tablet-first workflow, scan integration, task-to-Container resolver, mixed-stage Container behavior, and explicit statement that Pick List generation is not yet implemented.
-- [2025 Live Review Work Ledger — 2026-09-08](Setup_2025_Live_Review_Work_Ledger_2026-09-08.md) — reconstruction/reconciliation work ledger, Rick-note interpretation rules, candidate lineage, unresolved findings, and historical acceptance context. Some candidate/deployment status inside this dated ledger predates the accepted 019-022 Production promotion; use this README and current issue/PR evidence for latest Production state.
-- [Setup Training Browser Acceptance — 2026-09-08](Setup_Training_Browser_Acceptance_2026-09-08.md) — accepted browser-review evidence for the correction/reconciliation package.
-- [Setup Session Production Engineering Handoff — 2026-09-07](Setup_Session_Production_Engineering_Handoff_2026-09-07.md) — original Production foundation/runtime baseline and rollback context.
+- [2025 Live Review Work Ledger — 2026-09-08](Setup_2025_Live_Review_Work_Ledger_2026-09-08.md) — dated reconstruction/reconciliation evidence and decision history. Candidate/deployment status inside this dated ledger is historical; use this README and current Production data for current state.
+- [Setup Training Browser Acceptance — 2026-09-08](Setup_Training_Browser_Acceptance_2026-09-08.md) — accepted browser-review evidence for the earlier correction/reconciliation package.
+- [Setup Session Production Engineering Handoff — 2026-09-07](Setup_Session_Production_Engineering_Handoff_2026-09-07.md) — original Production foundation/runtime baseline and rollback context; retained as dated deployment history, not the latest runtime state.
 - [Setup Internal Analytics and Visible Update Contract — 2026-09-07](Setup_Internal_Analytics_and_Version_Contract_2026-09-07.md) — GA4/privacy and visible revision contract.
 - [Internal Web Backbone Handoff](Internal_Web_Backbone_Handoff.md) — source-subsystem contract for intranet navigation/search/application entry points.
 - [Setup Session Shared Review and Season-Year Guard](../Setup_Session_Shared_Review_and_Season_Year_Guard_2026-09-07.md) — annual-vs-reusable data boundary and session-year enforcement.
@@ -85,38 +101,42 @@ The Production Database repository owns Setup application/business/database beha
 Primary current work remains:
 
 ```text
-#122  Setup Session engineering / planning / Pick List / live reconstruction umbrella
-#125  Production foundation / application / correction lineage
-#130  global People / Capability / Qualification catalog exposed by Captain review
+#122  Setup Session engineering / planning / Pick List / movement umbrella
+#125  Production foundation / application lineage and eventual merge/closeout
+#133  reusable task drag/drop between Stage-level and Scene scopes
+#130  global People / Capability / Qualification catalog consumed by Setup
 #132  Captain work-report duration / multi-day effort capture
 #113  shared Scan application readiness / identity capture integration
 ```
 
 The People/Skills work belongs to **03 — People and Identity**. Setup consumes that global identity/capability model; Setup must not create a second person/skill catalog.
 
-## Current Reconstruction Source Rules
+## Current Task Development Source Rule
 
-Rick Hoffmann's 2025 spreadsheets are mixed evidence, not normalized task definitions.
-
-Current reconstruction review window:
-
-```text
-2025-09-30 through Thanksgiving 2025
-```
+The one-time large reconstruction import is complete.
 
 Use evidence in three buckets:
 
 ```text
-1. 2025 annual historical fact
+1. annual historical fact
 2. reusable Setup knowledge
 3. ambiguous/question — do not guess
 ```
 
+But the place where reusable tasks are now built and corrected is the current PostgreSQL catalog.
+
+```text
+current PostgreSQL reusable catalog
+    -> identify missing/wrong task
+    -> verify current Stage/Scene and practical task boundary
+    -> correct/add reusable task in Production through governed application commands
+    -> add reusable effort/resources/readiness/prerequisites when known
+    -> preserve annual historical facts separately
+```
+
+Rick Hoffmann's 2025 spreadsheets, the reviewed one-list workbook, and the recovered 2022 Project schedule remain evidence. They are not normalized task definitions and are no longer a parallel authoritative task store.
+
 Crew names do not automatically create Captains. Daily recorded hours do not automatically equal task duration. Multi-task work days require conservative interpretation.
-
-The 2022 Project schedule is also historical planning evidence for task decomposition, relative order, predecessors, rough duration, named crews, and equipment. It is not a rigid future schedule.
-
-See the [Setup Planning Operating Model](Setup_Planning_Operating_Model_2026-09-08.md) for the durable interpretation and planning rules.
 
 ## Current Planning Model
 
@@ -150,9 +170,7 @@ Important current rules:
 - generic `Staging to Park` is obsolete as a reusable task;
 - mixed-stage Containers/trailers must be detected from authoritative contents and mobilized when the first carried item is needed;
 - Container-specific post-arrival behavior may be full unload, park/mobile storage, special transformation, or ordered partial unload and must not be guessed; and
-- 2025/2022 historical evidence should improve reusable crew ranges, expected effort, prerequisites, readiness rules, and missing task steps only where evidence supports them.
-
-See [Setup Planning Candidate Work View](Setup_Planning_Candidate_Work_View_2026-09-09.md) for the missing planning layer and the operator-confirmed Arch Trailer unload/access order.
+- historical evidence should improve reusable crew ranges, expected effort, prerequisites, readiness rules, and missing task steps only where evidence supports them.
 
 ## Pick List Current Boundary
 
@@ -168,20 +186,27 @@ See [Setup Pick List Tablet Workflow](Setup_Pick_List_Tablet_Workflow_2026-09-09
 
 Still unresolved or intentionally separate:
 
-- controlled reassign/merge when a 2025 annual item belongs to a **different** reusable task;
-- many missing reusable task steps exposed by Rick's 2025 notes and the recovered 2022 schedule;
-- continued 2025 crew-size / expected-duration reconstruction;
-- task/Stage search;
+- live catalog completion/correction as additional real task knowledge is found, beginning with missing `Set Up Frosty`;
+- reviewed predecessor/readiness pass across the current reusable catalog; dependencies are intentionally zero until this is rebuilt;
+- classification of historical sequencing into **hard predecessor**, **preferred order**, or **readiness condition**;
 - cross-Stage candidate planning surface and candidate-to-work-day workflow;
-- classification of historical predecessors into hard predecessor versus preferred order versus readiness condition;
-- true Setup Scene versus LOR display-group classification using shared Folder Alignment classification;
+- work-day scheduling UX for Morning / Afternoon / All Day, parallel crews, and repeat scheduling of multi-day tasks;
+- controlled reassign/merge when a 2025 annual item belongs to a different reusable task;
 - authoritative Controller context in Material / Logistics from FieldWiring / Controller Inventory;
 - Pick List generation and tablet workflow;
 - mixed-stage Container annual mobilization/unload-group state and ordered-access rules;
-- Container/Display movement/scanning writes; and
+- Container/Display movement/scanning writes and park-location execution evidence; and
 - future People capability/qualification integration for crew suitability.
 
+Issue #133 separately tracks Stage-level ↔ Scene drag/drop. It is useful but not a blocker for live task correction because scope can already be changed through the existing governed task controls.
+
 Detailed KIT contents remain outside the current 2026 MVP, but an existing KIT Container can be a real physical Setup dependency.
+
+## 2026 Session Gate
+
+Do **not** create the 2026 Setup Session yet.
+
+Before 2026 creation, the current live catalog should be useful enough for planning and the predecessor/readiness pass should establish the dependency/readiness rules needed by the candidate planning view. Creating 2026 before that would copy an intentionally dependency-empty catalog into annual planning prematurely.
 
 ## Critical Runtime Permission Boundary
 
@@ -195,18 +220,18 @@ Before changing this subsystem:
 
 1. read the Production Database Project Rules;
 2. read this engineering portal;
-3. read the [Setup Catalog Reconstruction Import](Setup_Catalog_Reconstruction_Import_2026-09-09.md) while the reusable-catalog import candidate is active;
-4. read the [Setup Planning Operating Model](Setup_Planning_Operating_Model_2026-09-08.md);
-5. read the [Setup Planning Candidate Work View](Setup_Planning_Candidate_Work_View_2026-09-09.md) before implementing scheduling/planning UI;
-6. read the [Setup Pick List Tablet Workflow](Setup_Pick_List_Tablet_Workflow_2026-09-09.md) before implementing staging/logistics/pick behavior;
-7. review issue #122 and PR #125 for newest live-reconstruction findings;
-8. use the [2025 Live Review Work Ledger](Setup_2025_Live_Review_Work_Ledger_2026-09-08.md) for historical reconstruction rules and lineage, but do not treat its older candidate status as current Production state;
+3. inspect the current PostgreSQL reusable task catalog first; do not reconstruct the active task list from old spreadsheets or chat memory;
+4. use the [Setup Catalog Reconstruction Import](Setup_Catalog_Reconstruction_Import_2026-09-09.md) as the accepted import/deployment history, not as an ongoing task master;
+5. read the [Setup Planning Operating Model](Setup_Planning_Operating_Model_2026-09-08.md);
+6. read the [Setup Planning Candidate Work View](Setup_Planning_Candidate_Work_View_2026-09-09.md) before implementing scheduling/planning UI;
+7. read the [Setup Pick List Tablet Workflow](Setup_Pick_List_Tablet_Workflow_2026-09-09.md) before implementing logistics/pick behavior;
+8. review Issue #122 and PR #125 for newest live findings and merge/closeout state;
 9. preserve annual 2025 facts separately from reusable future knowledge;
 10. do not infer exact duration, Captain, crew, or completion from shorthand evidence;
-11. use issue #130 / 03 People and Identity for global skill/qualification work;
-12. use issue #113 / Labeling and Scanning for shared scan capture/resolution contracts rather than duplicating scanner-specific logic in Setup;
+11. use Issue #130 / 03 People and Identity for global skill/qualification work;
+12. use Issue #113 / Labeling and Scanning for shared scan capture/resolution contracts rather than duplicating scanner-specific logic in Setup;
 13. use `Gregovate/MSB-Server-Management` for runtime/deployment authority; and
-14. keep operator docs, engineering docs, and Internal Web Backbone navigation synchronized when accepted behavior changes.
+14. keep operator docs, engineering docs, PR/issue status, and Internal Web Backbone navigation synchronized when accepted behavior changes.
 
 ## Related Systems
 

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/README.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/README.md
@@ -67,6 +67,8 @@ The broader Setup subsystem remains open for real evaluation. Production availab
 
 ## Start Here
 
+- [Setup Task Material Resolver Contract — 2026-09-09](Setup_Task_Material_Resolver_Contract_2026-09-09.md) — **required before changing Material / Logistics**. Preserves the distinction between task scope, Display physical location, reusable task Display work-package ownership, and current Container storage. One Display may belong to zero or one reusable Setup task; one task may own zero, one, or many Displays. Stage/Scene membership is selection/context evidence, not automatic task material inheritance.
+- [Setup Predecessor and Readiness Contract — 2026-09-09](Setup_Predecessor_and_Readiness_Contract_2026-09-09.md) — **required before changing dependencies/readiness/scheduling**. Preserves hard predecessor vs preferred order vs readiness, area-specific grass/mulch readiness, the current free-form readiness-note limitation, and the Shift-drag predecessor direction.
 - [Setup Catalog Reconstruction Import — 2026-09-09](Setup_Catalog_Reconstruction_Import_2026-09-09.md) — accepted historical record of migrations 023/024 and the one-time normalized catalog reconstruction. Do not treat it as the ongoing task master after Production acceptance.
 - [Setup Reconstruction Migration and Acceptance History — 2026-09-07 to 2026-09-09](Setup_Reconstruction_Migration_and_Acceptance_History_2026-09-07_to_09.md) — durable record of the PL/pgSQL ambiguity defect class, migrations 013/015/018/020, disposable-only migration exclusion, browser/preview gate failures, reconstruction omissions, and Catalog-only delete cleanup finding. Read this before changing Setup migration or acceptance patterns.
 - [Setup Planning Operating Model — 2026-09-08](Setup_Planning_Operating_Model_2026-09-08.md) — operator-confirmed planning model: short planning horizon, preferred-order scheduling, Needs Scheduling queue, Sunday avoidance, weather constraints, grass-cutting dependency for cords, multi-day tasks, crew/hour interpretation, mixed-stage Container mobilization, and historical evidence rules.
@@ -146,6 +148,32 @@ Rick Hoffmann's 2025 spreadsheets, the reviewed one-list workbook, and the recov
 
 Crew names do not automatically create Captains. Daily recorded hours do not automatically equal task duration. Multi-task work days require conservative interpretation.
 
+## Task Scope vs Display Work Package vs Container
+
+Do not collapse these concepts.
+
+```text
+Task scope
+    -> where the reusable work belongs organizationally/physically
+
+Display work package
+    -> which Displays, if any, this reusable task owns for Setup planning/reporting
+
+Container
+    -> where those Displays are currently stored/transported
+```
+
+Current reusable Display ownership rule:
+
+```text
+one Display -> zero or one reusable Setup task
+one reusable Setup task -> zero, one, or many Displays
+```
+
+A real task may own **no Displays at all**. `Grease Gate bearings` is the canonical example. Conversely, a practical grouped task such as `Setup Panels`, Hwy 42 Traffic Signs, or Rotary MSB Signs may own many Displays. Do not create one task per panel and do not duplicate one Display across reusable tasks.
+
+Stage/Scene/LOR membership can help the Manager select the intended work package, but it is not automatic task ownership. The current Material / Logistics resolver violates this boundary by automatically expanding Scene membership while many Stage-level Display-bearing tasks have no explicit `ref.setup_task_display` rows yet. See the Task Material Resolver Contract before changing this behavior.
+
 ## Current Planning Model
 
 Setup is **not** a rigid season-long calendar scheduler.
@@ -169,7 +197,11 @@ Important current rules:
 
 - avoid Sunday work whenever reasonably possible;
 - avoid rain and high winds whenever reasonably possible;
-- do not lay cords until grass cutting has stopped;
+- distinguish **HARD PREDECESSOR**, **PREFERRED ORDER**, and **READINESS CONDITION** rather than recreating one rigid historical chain;
+- grass cutting/mulching completion for cord laying is **area-specific to the task/work area**, not one park-wide prerequisite and not a guessed calendar date;
+- the current `readiness_note` records reusable readiness knowledge but **does not currently gate task availability/scheduling**; structured annual readiness remains to be built;
+- Stage 00 can be ready for cord work while another park area is still being mowed/mulched;
+- for the reviewed Stage 00 `Lay Cords #67` example, Hwy 42 sign setup tasks are real hard predecessors while mowing/mulching completion in the Stage 00 cord-laying area is readiness, not another fake Setup task;
 - tasks may span several work days;
 - expected duration is a planning aid, not a one-day restriction;
 - preferred order and prerequisites matter more than false long-range date precision;
@@ -178,6 +210,7 @@ Important current rules:
 - normal Catalog drag already works for reordering within a Stage/Scene and for moving tasks between visible Stage areas; preserve that behavior;
 - predecessor entry needs a faster interaction for the large 2025 dependency pass: current operator direction is **Shift-drag the later/dependent task onto its predecessor** to create the dependency without moving either task; ordinary unmodified drag must retain its existing reorder/scope meaning;
 - modifier-drag dependency creation should use the existing governed `ref.set_setup_task_dependency(...)` write path and provide explicit success/failure feedback rather than silently creating an ambiguous relationship;
+- modifier-drag applies only to task dependencies; do not use it to encode readiness conditions;
 - generic `Staging to Park` is obsolete as a reusable task;
 - mixed-stage Containers/trailers must be detected from authoritative contents and mobilized when the first carried item is needed;
 - Container-specific post-arrival behavior may be full unload, park/mobile storage, special transformation, or ordered partial unload and must not be guessed; and
@@ -191,7 +224,17 @@ The intended direction is a standalone **Pick List** section inside Setup, usabl
 
 Setup owns the Pick List business workflow. Issue #113 / Scan owns identity capture/resolution and supported Zebra/camera/manual input behavior.
 
-See [Setup Pick List Tablet Workflow](Setup_Pick_List_Tablet_Workflow_2026-09-09.md).
+The material chain for Pick List work is task-level, not Stage-level:
+
+```text
+selected/scheduled reusable task
+    -> task-owned Displays, if any
+    -> current Display.container_id
+    -> deduplicated Containers
+    -> reviewed supplemental support/KIT Containers
+```
+
+See [Setup Pick List Tablet Workflow](Setup_Pick_List_Tablet_Workflow_2026-09-09.md) and [Setup Task Material Resolver Contract](Setup_Task_Material_Resolver_Contract_2026-09-09.md).
 
 ## Known Boundaries / Open Work
 
@@ -203,7 +246,10 @@ Still unresolved or intentionally separate:
 - reviewed predecessor/readiness pass across the current reusable catalog; dependencies are intentionally zero until this is rebuilt;
 - efficient predecessor-editing interaction for that pass, preserving existing normal drag/reorder/scope behavior while adding explicit Shift-drag dependency creation;
 - classification of historical sequencing into **hard predecessor**, **preferred order**, or **readiness condition**;
-- investigate and correct the Display/material/Container resolver so Scene membership does not overstate task ownership/material requirements and the future Pick List can trust the result;
+- structured annual readiness state so reusable `readiness_note` rules can actually gate/flag availability by task/work area rather than relying only on operator memory;
+- correct Manager-facing task-to-Display work-package ownership so one Display is assigned to zero or one reusable task, group tasks can own many Displays, and zero-Display tasks remain valid;
+- remove automatic Scene-wide material inheritance once explicit reviewed task ownership is sufficient; do **not** replace it with automatic Stage-wide inheritance;
+- reconcile any duplicate `ref.setup_task_display` ownership before enforcing a uniqueness rule on `display_id`;
 - cross-Stage candidate planning surface and candidate-to-work-day workflow;
 - work-day scheduling UX for Morning / Afternoon / All Day, parallel crews, and repeat scheduling of multi-day tasks;
 - controlled reassign/merge when a 2025 annual item belongs to a different reusable task;
@@ -226,7 +272,8 @@ Before 2026 creation, at minimum:
 - remove confirmed reconstruction duplicates/bad reusable definitions so they are not propagated;
 - correct missing real work such as `Set Up Frosty` and other omissions discovered during live review;
 - complete the reviewed predecessor/readiness pass, distinguishing hard predecessors from preferred order and area-specific readiness conditions;
-- resolve material/Display ownership sufficiently that the task-to-Display-to-Container result can support planning/Pick List work without known false relationships; and
+- preserve area-specific readiness such as grass/mulch completion separately from reusable task predecessors; do not fabricate one park-wide `Grass Cutting Complete` task;
+- resolve task Display ownership sufficiently that the task-to-Display-to-Container result can support planning/Pick List work without known false relationships, while preserving legitimate zero-Display tasks; and
 - finish the 2025 reusable planning model rather than copying a knowingly incomplete reconstruction into 2026.
 
 The 2025 Production-backed review remains the proving ground until that plan is complete.
@@ -244,18 +291,20 @@ Before changing this subsystem:
 1. read the Production Database Project Rules;
 2. read this engineering portal;
 3. inspect the current PostgreSQL reusable task catalog first; do not reconstruct the active task list from old spreadsheets or chat memory;
-4. use the [Setup Catalog Reconstruction Import](Setup_Catalog_Reconstruction_Import_2026-09-09.md) as the accepted import/deployment history, not as an ongoing task master;
-5. read the [Setup Reconstruction Migration and Acceptance History](Setup_Reconstruction_Migration_and_Acceptance_History_2026-09-07_to_09.md) before changing Setup migrations, disposable acceptance, or reconstruction-cleanup behavior;
-6. read the [Setup Planning Operating Model](Setup_Planning_Operating_Model_2026-09-08.md);
-7. read the [Setup Planning Candidate Work View](Setup_Planning_Candidate_Work_View_2026-09-09.md) before implementing scheduling/planning UI;
-8. read the [Setup Pick List Tablet Workflow](Setup_Pick_List_Tablet_Workflow_2026-09-09.md) before implementing logistics/pick behavior;
-9. review Issue #122, PR #125, and PR #139 for the newest live findings, Catalog cleanup gate, and deployment/merge state; use #136/#137 as source lineage for the combined cleanup candidate;
-10. preserve annual 2025 facts separately from reusable future knowledge;
-11. do not infer exact duration, Captain, crew, or completion from shorthand evidence;
-12. use Issue #130 / 03 People and Identity for global skill/qualification work;
-13. use Issue #113 / Labeling and Scanning for shared scan capture/resolution contracts rather than duplicating scanner-specific logic in Setup;
-14. use `Gregovate/MSB-Server-Management` for runtime/deployment authority; and
-15. keep operator docs, engineering docs, PR/issue status, and Internal Web Backbone navigation synchronized when accepted behavior changes.
+4. read the [Setup Task Material Resolver Contract](Setup_Task_Material_Resolver_Contract_2026-09-09.md) before touching Material / Logistics, task Display ownership, or Pick List material resolution;
+5. read the [Setup Predecessor and Readiness Contract](Setup_Predecessor_and_Readiness_Contract_2026-09-09.md) before touching dependencies, readiness, Shift-drag predecessor editing, or candidate availability;
+6. use the [Setup Catalog Reconstruction Import](Setup_Catalog_Reconstruction_Import_2026-09-09.md) as the accepted import/deployment history, not as an ongoing task master;
+7. read the [Setup Reconstruction Migration and Acceptance History](Setup_Reconstruction_Migration_and_Acceptance_History_2026-09-07_to_09.md) before changing Setup migrations, disposable acceptance, or reconstruction-cleanup behavior;
+8. read the [Setup Planning Operating Model](Setup_Planning_Operating_Model_2026-09-08.md);
+9. read the [Setup Planning Candidate Work View](Setup_Planning_Candidate_Work_View_2026-09-09.md) before implementing scheduling/planning UI;
+10. read the [Setup Pick List Tablet Workflow](Setup_Pick_List_Tablet_Workflow_2026-09-09.md) before implementing logistics/pick behavior;
+11. review Issue #122, PR #125, and PR #139 for the newest live findings, Catalog cleanup gate, and deployment/merge state; use #136/#137 as source lineage for the combined cleanup candidate;
+12. preserve annual 2025 facts separately from reusable future knowledge;
+13. do not infer exact duration, Captain, crew, completion, task material, or hard predecessor from shorthand evidence;
+14. use Issue #130 / 03 People and Identity for global skill/qualification work;
+15. use Issue #113 / Labeling and Scanning for shared scan capture/resolution contracts rather than duplicating scanner-specific logic in Setup;
+16. use `Gregovate/MSB-Server-Management` for runtime/deployment authority; and
+17. keep operator docs, engineering docs, PR/issue status, and Internal Web Backbone navigation synchronized when accepted behavior changes.
 
 ## Related Systems
 

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/README.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/README.md
@@ -45,7 +45,9 @@ Known immediate catalog findings after deployment:
 - physical `Set Up Frosty` is missing; transport-only `Bring Frosty to park` was correctly excluded from reusable work, but the physical setup task was never created;
 - Frosty setup must precede the applicable Stars setup work;
 - confirmed duplicate/bad reusable Catalog definitions from reconstruction/merge may have **no annual historical row** and must be removed before 2026 planning rather than propagated forward;
-- the governed database reconstruction-delete command already supports Catalog-only safe deletion and fails closed on protected planning/execution history, but the Manager UI currently hides Delete without annual-session context; PR #137 restores that UI path; and
+- the governed database reconstruction-delete command already supports Catalog-only safe deletion and fails closed on protected planning/execution history, but the Manager UI currently hides Delete without annual-session context; PR #137 restores that UI path;
+- PR #136 moves the separate `Save Effort` control beside the Physical Effort selector so Catalog cleanup is less error-prone;
+- PR #139 combines the #136 and #137 source-only fixes onto one forward-descendant deployment candidate from the accepted Production SHA; and
 - these findings belong in live Catalog correction + predecessor/readiness work, not in another bulk reconstruction import.
 
 Production corrections already include:
@@ -106,7 +108,9 @@ Primary current work remains:
 ```text
 #122  Setup Session engineering / planning / Pick List / movement umbrella
 #125  Production foundation / application lineage and eventual merge/closeout
-#137  restore Catalog-only reconstruction Delete Task UI before 2026 propagation
+#139  combined source-only cleanup deployment candidate: Save Effort placement + Catalog Delete
+#136  source lineage for Save Effort placement
+#137  source lineage for Catalog-only reconstruction Delete Task UI
 #133  reusable task drag/drop between Stage-level and Scene scopes
 #130  global People / Capability / Qualification catalog consumed by Setup
 #132  Captain work-report duration / multi-day effort capture
@@ -171,6 +175,9 @@ Important current rules:
 - preferred order and prerequisites matter more than false long-range date precision;
 - the reusable task catalog may be organized by Stage for visualization, but Stage completion is not a scheduling gate;
 - planning needs a separate cross-Stage candidate view showing Available / Blocked / In-Progress work before tasks receive dates;
+- normal Catalog drag already works for reordering within a Stage/Scene and for moving tasks between visible Stage areas; preserve that behavior;
+- predecessor entry needs a faster interaction for the large 2025 dependency pass: current operator direction is **Shift-drag the later/dependent task onto its predecessor** to create the dependency without moving either task; ordinary unmodified drag must retain its existing reorder/scope meaning;
+- modifier-drag dependency creation should use the existing governed `ref.set_setup_task_dependency(...)` write path and provide explicit success/failure feedback rather than silently creating an ambiguous relationship;
 - generic `Staging to Park` is obsolete as a reusable task;
 - mixed-stage Containers/trailers must be detected from authoritative contents and mobilized when the first carried item is needed;
 - Container-specific post-arrival behavior may be full unload, park/mobile storage, special transformation, or ordered partial unload and must not be guessed; and
@@ -190,10 +197,13 @@ See [Setup Pick List Tablet Workflow](Setup_Pick_List_Tablet_Workflow_2026-09-09
 
 Still unresolved or intentionally separate:
 
-- remove confirmed duplicate/bad reusable Catalog definitions introduced during reconstruction/merge before 2026 propagation; PR #137 must restore the Catalog-only Manager Delete UI while the database remains fail-closed on protected history;
+- deploy/accept PR #139 so `Save Effort` placement and Catalog-only `Delete Task` are available during 2025 cleanup;
+- remove confirmed duplicate/bad reusable Catalog definitions introduced during reconstruction/merge before 2026 propagation;
 - live catalog completion/correction as additional real task knowledge is found, including missing `Set Up Frosty`;
 - reviewed predecessor/readiness pass across the current reusable catalog; dependencies are intentionally zero until this is rebuilt;
+- efficient predecessor-editing interaction for that pass, preserving existing normal drag/reorder/scope behavior while adding explicit Shift-drag dependency creation;
 - classification of historical sequencing into **hard predecessor**, **preferred order**, or **readiness condition**;
+- investigate and correct the Display/material/Container resolver so Scene membership does not overstate task ownership/material requirements and the future Pick List can trust the result;
 - cross-Stage candidate planning surface and candidate-to-work-day workflow;
 - work-day scheduling UX for Morning / Afternoon / All Day, parallel crews, and repeat scheduling of multi-day tasks;
 - controlled reassign/merge when a 2025 annual item belongs to a different reusable task;
@@ -209,15 +219,17 @@ Detailed KIT contents remain outside the current 2026 MVP, but an existing KIT C
 
 ## 2026 Session Gate
 
-Do **not** create the 2026 Setup Session yet.
+**Operator decision: do not create the 2026 Setup Session until the reconstructed 2025 Setup plan is complete.**
 
-Before 2026 creation:
+Before 2026 creation, at minimum:
 
 - remove confirmed reconstruction duplicates/bad reusable definitions so they are not propagated;
-- correct missing real work such as `Set Up Frosty`; and
-- make the predecessor/readiness pass useful enough to establish the dependency/readiness rules needed by the candidate planning view.
+- correct missing real work such as `Set Up Frosty` and other omissions discovered during live review;
+- complete the reviewed predecessor/readiness pass, distinguishing hard predecessors from preferred order and area-specific readiness conditions;
+- resolve material/Display ownership sufficiently that the task-to-Display-to-Container result can support planning/Pick List work without known false relationships; and
+- finish the 2025 reusable planning model rather than copying a knowingly incomplete reconstruction into 2026.
 
-Creating 2026 before those corrections would copy known reconstruction mistakes and an intentionally dependency-empty Catalog into annual planning prematurely.
+The 2025 Production-backed review remains the proving ground until that plan is complete.
 
 ## Critical Runtime Permission Boundary
 
@@ -237,7 +249,7 @@ Before changing this subsystem:
 6. read the [Setup Planning Operating Model](Setup_Planning_Operating_Model_2026-09-08.md);
 7. read the [Setup Planning Candidate Work View](Setup_Planning_Candidate_Work_View_2026-09-09.md) before implementing scheduling/planning UI;
 8. read the [Setup Pick List Tablet Workflow](Setup_Pick_List_Tablet_Workflow_2026-09-09.md) before implementing logistics/pick behavior;
-9. review Issue #122, PR #125, and PR #137 for the newest live findings, Catalog cleanup gate, and merge/closeout state;
+9. review Issue #122, PR #125, and PR #139 for the newest live findings, Catalog cleanup gate, and deployment/merge state; use #136/#137 as source lineage for the combined cleanup candidate;
 10. preserve annual 2025 facts separately from reusable future knowledge;
 11. do not infer exact duration, Captain, crew, or completion from shorthand evidence;
 12. use Issue #130 / 03 People and Identity for global skill/qualification work;

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/README.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/README.md
@@ -40,15 +40,17 @@ The two non-active reusable rows are retired identities preserved for history. T
 
 The current PostgreSQL data is now the authoritative **working task baseline**. The large one-list workbook and 2022/2025 schedules remain historical/reconstruction evidence, but future task development should not maintain another spreadsheet as a parallel master. Continue adding, correcting, moving, and enriching reusable tasks against the current Production catalog, using historical evidence only to support those changes.
 
-Known immediate catalog finding after deployment:
+Known immediate catalog findings after deployment:
 
 - physical `Set Up Frosty` is missing; transport-only `Bring Frosty to park` was correctly excluded from reusable work, but the physical setup task was never created;
 - Frosty setup must precede the applicable Stars setup work;
-- this belongs in the live catalog correction + predecessor pass, not in another bulk reconstruction import.
+- confirmed duplicate/bad reusable Catalog definitions from reconstruction/merge may have **no annual historical row** and must be removed before 2026 planning rather than propagated forward;
+- the governed database reconstruction-delete command already supports Catalog-only safe deletion and fails closed on protected planning/execution history, but the Manager UI currently hides Delete without annual-session context; PR #137 restores that UI path; and
+- these findings belong in live Catalog correction + predecessor/readiness work, not in another bulk reconstruction import.
 
 Production corrections already include:
 
-- reconstruction-safe deletion of mistaken provisional historical tasks;
+- the governed reconstruction-safe database deletion command for mistaken provisional/Catalog tasks;
 - Captain / Alternate / Advisor management using `ref.person` identity;
 - reusable-task match/reconciliation state for annual 2025 items;
 - active-person enforcement for new Captain/knowledge-owner assignments;
@@ -59,11 +61,12 @@ Production corrections already include:
 - normalized `Locate Power & Network` and `Layout Panels` naming; and
 - retirement of provisional reusable tasks 40 and 58 without fabricating 2025 annual rows.
 
-The broader Setup subsystem remains open for real evaluation. Production availability and the accepted catalog do not mean 2026 planning, Pick List, movement, or predecessor/readiness work is complete.
+The broader Setup subsystem remains open for real evaluation. Production availability and the accepted catalog do not mean 2026 planning, Pick List, movement, predecessor/readiness, or Catalog cleanup is complete.
 
 ## Start Here
 
 - [Setup Catalog Reconstruction Import — 2026-09-09](Setup_Catalog_Reconstruction_Import_2026-09-09.md) — accepted historical record of migrations 023/024 and the one-time normalized catalog reconstruction. Do not treat it as the ongoing task master after Production acceptance.
+- [Setup Reconstruction Migration and Acceptance History — 2026-09-07 to 2026-09-09](Setup_Reconstruction_Migration_and_Acceptance_History_2026-09-07_to_09.md) — durable record of the PL/pgSQL ambiguity defect class, migrations 013/015/018/020, disposable-only migration exclusion, browser/preview gate failures, reconstruction omissions, and Catalog-only delete cleanup finding. Read this before changing Setup migration or acceptance patterns.
 - [Setup Planning Operating Model — 2026-09-08](Setup_Planning_Operating_Model_2026-09-08.md) — operator-confirmed planning model: short planning horizon, preferred-order scheduling, Needs Scheduling queue, Sunday avoidance, weather constraints, grass-cutting dependency for cords, multi-day tasks, crew/hour interpretation, mixed-stage Container mobilization, and historical evidence rules.
 - [Setup Planning Candidate Work View — 2026-09-09](Setup_Planning_Candidate_Work_View_2026-09-09.md) — operator-confirmed planning surface between reusable Stage-organized tasks and the short-range schedule: cross-Stage Available/Blocked/In-Progress candidates, operator choice of what can/should happen next, and Arch Trailer unload/access order.
 - [Setup Pick List Tablet Workflow — 2026-09-09](Setup_Pick_List_Tablet_Workflow_2026-09-09.md) — standalone Setup Pick List direction: tablet-first workflow, scan integration, task-to-Container resolver, mixed-stage Container behavior, and explicit statement that Pick List generation is not yet implemented.
@@ -103,6 +106,7 @@ Primary current work remains:
 ```text
 #122  Setup Session engineering / planning / Pick List / movement umbrella
 #125  Production foundation / application lineage and eventual merge/closeout
+#137  restore Catalog-only reconstruction Delete Task UI before 2026 propagation
 #133  reusable task drag/drop between Stage-level and Scene scopes
 #130  global People / Capability / Qualification catalog consumed by Setup
 #132  Captain work-report duration / multi-day effort capture
@@ -186,7 +190,8 @@ See [Setup Pick List Tablet Workflow](Setup_Pick_List_Tablet_Workflow_2026-09-09
 
 Still unresolved or intentionally separate:
 
-- live catalog completion/correction as additional real task knowledge is found, beginning with missing `Set Up Frosty`;
+- remove confirmed duplicate/bad reusable Catalog definitions introduced during reconstruction/merge before 2026 propagation; PR #137 must restore the Catalog-only Manager Delete UI while the database remains fail-closed on protected history;
+- live catalog completion/correction as additional real task knowledge is found, including missing `Set Up Frosty`;
 - reviewed predecessor/readiness pass across the current reusable catalog; dependencies are intentionally zero until this is rebuilt;
 - classification of historical sequencing into **hard predecessor**, **preferred order**, or **readiness condition**;
 - cross-Stage candidate planning surface and candidate-to-work-day workflow;
@@ -206,7 +211,13 @@ Detailed KIT contents remain outside the current 2026 MVP, but an existing KIT C
 
 Do **not** create the 2026 Setup Session yet.
 
-Before 2026 creation, the current live catalog should be useful enough for planning and the predecessor/readiness pass should establish the dependency/readiness rules needed by the candidate planning view. Creating 2026 before that would copy an intentionally dependency-empty catalog into annual planning prematurely.
+Before 2026 creation:
+
+- remove confirmed reconstruction duplicates/bad reusable definitions so they are not propagated;
+- correct missing real work such as `Set Up Frosty`; and
+- make the predecessor/readiness pass useful enough to establish the dependency/readiness rules needed by the candidate planning view.
+
+Creating 2026 before those corrections would copy known reconstruction mistakes and an intentionally dependency-empty Catalog into annual planning prematurely.
 
 ## Critical Runtime Permission Boundary
 
@@ -222,16 +233,17 @@ Before changing this subsystem:
 2. read this engineering portal;
 3. inspect the current PostgreSQL reusable task catalog first; do not reconstruct the active task list from old spreadsheets or chat memory;
 4. use the [Setup Catalog Reconstruction Import](Setup_Catalog_Reconstruction_Import_2026-09-09.md) as the accepted import/deployment history, not as an ongoing task master;
-5. read the [Setup Planning Operating Model](Setup_Planning_Operating_Model_2026-09-08.md);
-6. read the [Setup Planning Candidate Work View](Setup_Planning_Candidate_Work_View_2026-09-09.md) before implementing scheduling/planning UI;
-7. read the [Setup Pick List Tablet Workflow](Setup_Pick_List_Tablet_Workflow_2026-09-09.md) before implementing logistics/pick behavior;
-8. review Issue #122 and PR #125 for newest live findings and merge/closeout state;
-9. preserve annual 2025 facts separately from reusable future knowledge;
-10. do not infer exact duration, Captain, crew, or completion from shorthand evidence;
-11. use Issue #130 / 03 People and Identity for global skill/qualification work;
-12. use Issue #113 / Labeling and Scanning for shared scan capture/resolution contracts rather than duplicating scanner-specific logic in Setup;
-13. use `Gregovate/MSB-Server-Management` for runtime/deployment authority; and
-14. keep operator docs, engineering docs, PR/issue status, and Internal Web Backbone navigation synchronized when accepted behavior changes.
+5. read the [Setup Reconstruction Migration and Acceptance History](Setup_Reconstruction_Migration_and_Acceptance_History_2026-09-07_to_09.md) before changing Setup migrations, disposable acceptance, or reconstruction-cleanup behavior;
+6. read the [Setup Planning Operating Model](Setup_Planning_Operating_Model_2026-09-08.md);
+7. read the [Setup Planning Candidate Work View](Setup_Planning_Candidate_Work_View_2026-09-09.md) before implementing scheduling/planning UI;
+8. read the [Setup Pick List Tablet Workflow](Setup_Pick_List_Tablet_Workflow_2026-09-09.md) before implementing logistics/pick behavior;
+9. review Issue #122, PR #125, and PR #137 for the newest live findings, Catalog cleanup gate, and merge/closeout state;
+10. preserve annual 2025 facts separately from reusable future knowledge;
+11. do not infer exact duration, Captain, crew, or completion from shorthand evidence;
+12. use Issue #130 / 03 People and Identity for global skill/qualification work;
+13. use Issue #113 / Labeling and Scanning for shared scan capture/resolution contracts rather than duplicating scanner-specific logic in Setup;
+14. use `Gregovate/MSB-Server-Management` for runtime/deployment authority; and
+15. keep operator docs, engineering docs, PR/issue status, and Internal Web Backbone navigation synchronized when accepted behavior changes.
 
 ## Related Systems
 

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/README.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/README.md
@@ -7,7 +7,7 @@
 | Audience | Greg, maintainers, database administrators, future engineering sessions |
 | Status | CURRENT HANDOFF — reusable catalog reconstruction accepted in Production; live PostgreSQL catalog is now the working baseline |
 | Owner | MSB Production Database engineering |
-| Last Reviewed | 2026-09-09 |
+| Last Reviewed | 2026-09-10 |
 
 This is the engineering starting point for Setup Session architecture, database behavior, application contracts, Production state, task development, planning behavior, Pick List direction, and resume information.
 
@@ -67,6 +67,7 @@ The broader Setup subsystem remains open for real evaluation. Production availab
 
 ## Start Here
 
+- [Setup Data Consumption and Authorization Contract — 2026-09-10](Setup_Data_Consumption_and_Authorization_Contract_2026-09-10.md) — **required before changing Setup permissions, Directus authorization, PostgreSQL grants, or person/actor linkage**. Documents the complete current read/write table surface, Directus capability model, `fieldwiring_app` least-privilege boundary, `ref.person.directus_user_id` write prerequisite, and the 2026-09-10 finding that repeat Directus login does not repair established Manager mappings.
 - [Setup Task Material Resolver Contract — 2026-09-09](Setup_Task_Material_Resolver_Contract_2026-09-09.md) — **required before changing Material / Logistics**. Preserves the distinction between task scope, Display physical location, reusable task Display work-package ownership, and current Container storage. One Display may belong to zero or one reusable Setup task; one task may own zero, one, or many Displays. Stage/Scene membership is selection/context evidence, not automatic task material inheritance.
 - [Setup Predecessor and Readiness Contract — 2026-09-09](Setup_Predecessor_and_Readiness_Contract_2026-09-09.md) — **required before changing dependencies/readiness/scheduling**. Preserves hard predecessor vs preferred order vs readiness, area-specific grass/mulch readiness, the current free-form readiness-note limitation, and the Shift-drag predecessor direction.
 - [Setup Catalog Reconstruction Import — 2026-09-09](Setup_Catalog_Reconstruction_Import_2026-09-09.md) — accepted historical record of migrations 023/024 and the one-time normalized catalog reconstruction. Do not treat it as the ongoing task master after Production acceptance.
@@ -240,6 +241,7 @@ See [Setup Pick List Tablet Workflow](Setup_Pick_List_Tablet_Workflow_2026-09-09
 
 Still unresolved or intentionally separate:
 
+- repair the proven current Manager `ref.person.directus_user_id` linkage gaps through a governed People/Identity path, then add a durable onboarding/reconciliation mechanism that does not depend on a manual Directus UI visit; see the Setup Data Consumption and Authorization Contract;
 - deploy/accept PR #139 so `Save Effort` placement and Catalog-only `Delete Task` are available during 2025 cleanup;
 - remove confirmed duplicate/bad reusable Catalog definitions introduced during reconstruction/merge before 2026 propagation;
 - live catalog completion/correction as additional real task knowledge is found, including missing `Set Up Frosty`;
@@ -280,6 +282,8 @@ The 2025 Production-backed review remains the proving ground until that plan is 
 
 ## Critical Runtime Permission Boundary
 
+Setup human authorization, person/actor linkage, PostgreSQL read grants, and governed write-function permissions are separate layers. Read the [Setup Data Consumption and Authorization Contract](Setup_Data_Consumption_and_Authorization_Contract_2026-09-10.md) before changing any of them.
+
 `msbadmin` is the SSH administrator but runtime-path validation must use the `fieldwiring` service identity for paths and the shared Python environment that depend on runtime group permissions.
 
 Server-side detail and recovery procedure belong in `Gregovate/MSB-Server-Management`.
@@ -290,21 +294,22 @@ Before changing this subsystem:
 
 1. read the Production Database Project Rules;
 2. read this engineering portal;
-3. inspect the current PostgreSQL reusable task catalog first; do not reconstruct the active task list from old spreadsheets or chat memory;
-4. read the [Setup Task Material Resolver Contract](Setup_Task_Material_Resolver_Contract_2026-09-09.md) before touching Material / Logistics, task Display ownership, or Pick List material resolution;
-5. read the [Setup Predecessor and Readiness Contract](Setup_Predecessor_and_Readiness_Contract_2026-09-09.md) before touching dependencies, readiness, Shift-drag predecessor editing, or candidate availability;
-6. use the [Setup Catalog Reconstruction Import](Setup_Catalog_Reconstruction_Import_2026-09-09.md) as the accepted import/deployment history, not as an ongoing task master;
-7. read the [Setup Reconstruction Migration and Acceptance History](Setup_Reconstruction_Migration_and_Acceptance_History_2026-09-07_to_09.md) before changing Setup migrations, disposable acceptance, or reconstruction-cleanup behavior;
-8. read the [Setup Planning Operating Model](Setup_Planning_Operating_Model_2026-09-08.md);
-9. read the [Setup Planning Candidate Work View](Setup_Planning_Candidate_Work_View_2026-09-09.md) before implementing scheduling/planning UI;
-10. read the [Setup Pick List Tablet Workflow](Setup_Pick_List_Tablet_Workflow_2026-09-09.md) before implementing logistics/pick behavior;
-11. review Issue #122, PR #125, and PR #139 for the newest live findings, Catalog cleanup gate, and deployment/merge state; use #136/#137 as source lineage for the combined cleanup candidate;
-12. preserve annual 2025 facts separately from reusable future knowledge;
-13. do not infer exact duration, Captain, crew, completion, task material, or hard predecessor from shorthand evidence;
-14. use Issue #130 / 03 People and Identity for global skill/qualification work;
-15. use Issue #113 / Labeling and Scanning for shared scan capture/resolution contracts rather than duplicating scanner-specific logic in Setup;
-16. use `Gregovate/MSB-Server-Management` for runtime/deployment authority; and
-17. keep operator docs, engineering docs, PR/issue status, and Internal Web Backbone navigation synchronized when accepted behavior changes.
+3. read the [Setup Data Consumption and Authorization Contract](Setup_Data_Consumption_and_Authorization_Contract_2026-09-10.md) before changing permissions, Directus authorization, PostgreSQL grants, or person/actor linkage;
+4. inspect the current PostgreSQL reusable task catalog first; do not reconstruct the active task list from old spreadsheets or chat memory;
+5. read the [Setup Task Material Resolver Contract](Setup_Task_Material_Resolver_Contract_2026-09-09.md) before touching Material / Logistics, task Display ownership, or Pick List material resolution;
+6. read the [Setup Predecessor and Readiness Contract](Setup_Predecessor_and_Readiness_Contract_2026-09-09.md) before touching dependencies, readiness, Shift-drag predecessor editing, or candidate availability;
+7. use the [Setup Catalog Reconstruction Import](Setup_Catalog_Reconstruction_Import_2026-09-09.md) as the accepted import/deployment history, not as an ongoing task master;
+8. read the [Setup Reconstruction Migration and Acceptance History](Setup_Reconstruction_Migration_and_Acceptance_History_2026-09-07_to_09.md) before changing Setup migrations, disposable acceptance, or reconstruction-cleanup behavior;
+9. read the [Setup Planning Operating Model](Setup_Planning_Operating_Model_2026-09-08.md);
+10. read the [Setup Planning Candidate Work View](Setup_Planning_Candidate_Work_View_2026-09-09.md) before implementing scheduling/planning UI;
+11. read the [Setup Pick List Tablet Workflow](Setup_Pick_List_Tablet_Workflow_2026-09-09.md) before implementing logistics/pick behavior;
+12. review Issue #122, PR #125, and PR #139 for the newest live findings, Catalog cleanup gate, and deployment/merge state; use #136/#137 as source lineage for the combined cleanup candidate;
+13. preserve annual 2025 facts separately from reusable future knowledge;
+14. do not infer exact duration, Captain, crew, completion, task material, or hard predecessor from shorthand evidence;
+15. use Issue #130 / 03 People and Identity for global skill/qualification and durable user/person identity work;
+16. use Issue #113 / Labeling and Scanning for shared scan capture/resolution contracts rather than duplicating scanner-specific logic in Setup;
+17. use `Gregovate/MSB-Server-Management` for runtime/deployment authority; and
+18. keep operator docs, engineering docs, PR/issue status, and Internal Web Backbone navigation synchronized when accepted behavior changes.
 
 ## Related Systems
 

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Catalog_Reconstruction_Import_2026-09-09.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Catalog_Reconstruction_Import_2026-09-09.md
@@ -2,60 +2,78 @@
 
 | Document Control | Value |
 |---|---|
-| Document Type | Engineering Reconstruction / Import Contract |
+| Document Type | Engineering Reconstruction / Import Record |
 | System | Production Database — Setup Session |
-| Status | IMPLEMENTATION CANDIDATE — disposable Production-clone acceptance required before Production consideration |
+| Status | ACCEPTED IN PRODUCTION — one-time reconstruction complete; current PostgreSQL catalog is the ongoing working baseline |
 | Owner | MSB Production Database engineering |
 | Related Work | Issue #122; Setup Catalog Reconciliation Workflow; Setup Smart Scheduler Workflow |
 
 ## Purpose
 
-Define the controlled conversion of the reviewed 2022/2025 reconstruction workbook into the reusable Setup catalog that will become the basis for future Setup planning before a 2026 Setup Session is created.
+Record the controlled conversion of the reviewed 2022/2025 reconstruction workbook into the reusable Setup catalog that now serves as the current Production working baseline.
 
-This is the point where provisional historical reconstruction is intentionally normalized into current Production Stage/Scene identity and permanent reusable task knowledge.
+This was the point where provisional historical reconstruction was normalized into current Production Stage/Scene identity and permanent reusable task knowledge. It is now a **deployment/history record**, not the ongoing task master.
 
-## Source Authority
+## Current Authority After Import
 
-The candidate is based on:
+The one-time reconstruction import is complete.
+
+From this point forward:
+
+```text
+current Production PostgreSQL reusable catalog
+    = working task baseline
+
+reviewed one-list workbook / 2022 schedule / 2025 notes
+    = historical and reconstruction evidence
+```
+
+Do not maintain a second spreadsheet as a parallel authoritative task list. Continue building, correcting, organizing, and enriching reusable tasks against the current PostgreSQL data through the governed Setup application/database commands.
+
+## Source Authority Used For The Import
+
+The accepted import was based on:
 
 1. the operator-reviewed `MSB_Setup_ONE_LIST_Reconciliation_20260909_WITH_EFFORT` workbook;
-2. the current Production reusable-task snapshot containing 68 active reusable tasks before reconstruction;
-3. the current Production `ref.stage` / `ref.lor_scene` inventory exported 2026-09-09; and
+2. the Production reusable-task snapshot containing 68 active reusable tasks before reconstruction;
+3. the Production `ref.stage` / `ref.lor_scene` inventory exported 2026-09-09; and
 4. operator-confirmed mappings and task-boundary decisions made during the reconstruction review.
 
-Historical Stage numbers are not durable identity. Current Production Stage/Scene IDs control.
+Historical Stage numbers were not treated as durable identity. Current Production Stage/Scene IDs controlled the import.
 
-## Candidate Catalog Result
+## Accepted Catalog Result
 
-The controlled candidate targets:
+Production acceptance established:
 
 ```text
 active reusable tasks after reconstruction = 185
+total reusable task rows                    = 187
 existing reusable identities retained       = 66
 new reusable definitions                    = 119
 provisional task 40                         = retired/inactive
 provisional task 58 "light"                 = retired/inactive
 new 2025 annual rows                        = 0
 reusable dependency rows after import       = 0
+2026 Setup Sessions                         = 0
 ```
 
-Task 40 (`Deliver Command Center`) is the obsolete provisional duplicate. Existing task 51 (`Deliver and Set Up Command Center Trailer`) is retained as the reusable Command Center task.
+Task 40 (`Deliver Command Center`) was the obsolete provisional duplicate. Existing task 51 (`Deliver and Set Up Command Center Trailer`) was retained as the reusable Command Center task.
 
-Task 58 (`light`) is a junk provisional reconstruction row and is retired.
+Task 58 (`light`) was a junk provisional reconstruction row and was retired.
 
-Retirement preserves the historical shells rather than deleting history. Their 2025 annual occurrences are excluded from the historical session.
+Retirement preserved the historical shells rather than deleting history. Their 2025 annual occurrences were excluded from the historical session.
 
 ## 2025 Annual Boundary
 
-The reconstructed catalog is future reusable knowledge. Newly reconstructed reusable tasks must **not** be fabricated as 2025 annual occurrences simply because the catalog is being improved during 2025 review.
+The reconstructed catalog is reusable knowledge. Newly reconstructed reusable tasks were **not** fabricated as 2025 annual occurrences simply because the catalog was improved during 2025 review.
 
-Therefore migration 024 creates reusable tasks directly and does not call the normal browser creation command that automatically appends new tasks to open sessions.
+Migration 024 therefore created reusable tasks directly and did not use the normal browser creation behavior that appends new tasks to an open session.
 
-Existing 2025 historical rows remain historical evidence. The future 2026 Setup Session will be created only after the reusable catalog and predecessor/readiness model are accepted.
+Existing 2025 historical rows remain historical evidence. The future 2026 Setup Session will be created only after the live reusable catalog and predecessor/readiness model are useful enough for planning.
 
 ## Effort Metadata
 
-The only new reusable planning metadata introduced by this reconstruction is:
+The reusable planning metadata introduced by this reconstruction is:
 
 ```text
 ref.setup_task.effort_level
@@ -70,9 +88,9 @@ HEAVY
 NULL = not yet reviewed / unknown
 ```
 
-The reviewed workbook used `MEDIUM` in some rows; the database vocabulary normalizes those values to `MODERATE`.
+The reviewed workbook used `MEDIUM` in some rows; the database vocabulary normalized those values to `MODERATE`.
 
-Candidate reviewed counts:
+Accepted Production counts:
 
 ```text
 LIGHT       8
@@ -81,11 +99,11 @@ HEAVY       4
 NULL       161
 ```
 
-No `planning_role`, trailer-specific flag, or special Arch/Antenna classification is introduced.
+No `planning_role`, trailer-specific flag, or special Arch/Antenna classification was introduced.
 
-## Existing Ordering Model Is Reused
+## Existing Ordering Model Reused
 
-No new scheduler-order column is required for this import.
+No duplicate scheduler-order column was added.
 
 Existing model:
 
@@ -97,27 +115,27 @@ ops.setup_work_day_task.sort_order        order inside scheduled work
 ops.setup_work_day_task.crew_lane         parallel temporary crew lane
 ```
 
-The reviewed historical dates/order are used only to seed a practical reusable `baseline_plan_order`. They are evidence of sequencing, not future calendar dates.
+Historical dates/order were used only to seed a practical reusable `baseline_plan_order`. They remain sequencing evidence, not future calendar dates.
 
 ## Canonical Task Names
 
-Equivalent locating work is normalized to:
+Equivalent locating work was normalized to:
 
 ```text
 Locate Power & Network
 ```
 
-The candidate contains ten such reusable tasks in the appropriate current Stage/Scene scopes.
+The accepted import produced ten such reusable tasks in the reviewed current scopes.
 
-Equivalent panel-position marking is normalized to:
+Equivalent panel-position marking was normalized to:
 
 ```text
 Layout Panels
 ```
 
-The candidate contains four such reusable tasks.
+The accepted import produced four such reusable tasks.
 
-This normalization does **not** collapse physically different work such as:
+This normalization did **not** collapse physically different work such as:
 
 - `Layout Trees`;
 - `Layout New Trees`;
@@ -128,9 +146,9 @@ Those remain distinct reusable tasks where field practice supports them.
 
 ## OMW / Heat Mister Reconciliation
 
-Historical `OMW / Heat Mister` evidence resolves to current Global Warming Stage identity, with the relevant Global Warming Scene.
+Historical `OMW / Heat Mister` evidence resolved to current Global Warming Stage identity.
 
-The reusable sequence retains the core work:
+The reusable sequence retained the core work:
 
 ```text
 Locate Power & Network
@@ -151,11 +169,11 @@ remain evidence for those reusable tasks rather than becoming three additional r
 
 ## Pure Logistics Versus Real Setup Work
 
-The reconstruction deliberately distinguishes logistics from work that must itself be planned/reported.
+The reconstruction deliberately distinguished logistics from work that must itself be planned/reported.
 
 ### Pure logistics
 
-Ordinary transport-only evidence is not promoted to a reusable Setup task merely because the old schedule recorded a move. Examples removed from the reusable candidate include:
+Ordinary transport-only evidence was not promoted to a reusable Setup task merely because an old schedule recorded a move. Examples excluded from the reusable import included:
 
 ```text
 Deliver Horse & Sleigh to park
@@ -169,9 +187,25 @@ The future Pick List / movement workflow owns ordinary material mobilization.
 
 Moves that are actual work because they physically unlock access to stored Displays/material remain real reusable tasks.
 
-This captures the operational reason large items appeared at the beginning of the historical schedule: some large trailers/Displays must leave the workshop before crews can reach racks and other Setup material.
-
 These are modeled as ordinary reusable tasks, not with a separate planning-role field.
+
+## Known Post-Import Catalog Finding — Frosty
+
+The logistics distinction above exposed one omission after Production deployment.
+
+`Bring Frosty to park` was correctly excluded because transportation itself is logistics. However, no separate reusable physical task was created for the actual Frosty setup.
+
+Current correction required in the live PostgreSQL catalog:
+
+```text
+Stage 02 — Triangle
+    Frosty work
+        Set Up Frosty
+```
+
+The operator confirmed that Frosty must be set up before the applicable Stars setup work. Add the physical Frosty task to the current catalog, then establish that dependency during the reviewed predecessor pass.
+
+This is an example of the post-import operating rule: **correct the current PostgreSQL catalog directly rather than reopening the reconstruction workbook as a master list.**
 
 ## Mixed-Stage Containers and Trailers
 
@@ -191,11 +225,11 @@ shared Container / trailer
     -> required unload group becomes actionable when its Setup work needs it
 ```
 
-The current reusable `UNLOAD_CONTAINER` tasks remain valid where unloading is itself meaningful physical work. The future Pick List/movement layer must support the same model for Arch Trailer, Antenna Trailer, and future shared trailers without adding `is_arch_trailer`, `is_mixed_stage_trailer`, or equivalent special-case flags.
+The reusable `UNLOAD_CONTAINER` tasks remain valid where unloading is itself meaningful physical work. The future Pick List/movement layer must support the same model for Arch Trailer, Antenna Trailer, and future shared trailers without special-case flags.
 
 ## Aggregate Historical Evidence Is Not a Reusable Task
 
-Cross-area shorthand rows are retained as evidence but are not converted into one synthetic reusable task.
+Cross-area shorthand rows remain evidence but were not converted into synthetic reusable tasks.
 
 Examples:
 
@@ -209,25 +243,25 @@ Reusable work belongs in the actual current Stage/Scene scope where the work is 
 
 ## Santa's Station Name Normalization
 
-Historical `Quarry` evidence resolves to current Santa's Station Stage identity.
+Historical `Quarry` evidence resolved to current Santa's Station Stage identity.
 
-Reusable task names in the candidate use Santa's Station naming rather than perpetuating the old Quarry name.
+Reusable task names in the accepted catalog use Santa's Station naming rather than perpetuating the old Quarry name.
 
-Historical source documents can continue to show Quarry because that is what they were called at the time; the reusable current catalog does not.
+Historical source documents can continue to show Quarry because that is what they were called at the time.
 
 ## Dependency Reset and Next Pass
 
-The old dependency set is not trusted after the scope/identity reconstruction.
+The old dependency set was not trusted after the scope/identity reconstruction.
 
-Migration 024 intentionally clears:
+Migration 024 intentionally cleared:
 
 ```text
 ref.setup_task_dependency
 ```
 
-This is not the final scheduler state. It creates a clean dependency baseline for the separate reviewed predecessor/readiness pass.
+Production currently has zero reusable dependency rows by design.
 
-Before creating the 2026 Setup Session, that next pass must distinguish:
+The next reviewed pass must distinguish:
 
 ```text
 HARD PREDECESSOR
@@ -237,22 +271,26 @@ READINESS CONDITION
 
 Examples include:
 
+- Frosty setup before the applicable Stars work;
 - Locates before Layout where field practice requires it;
 - Layout before physical installation where locations must be marked;
 - grass cutting stopped before cord laying;
 - physical assembly before downstream power/network work;
-- genuine workshop-access tasks before work that cannot be physically reached.
+- genuine workshop-access tasks before work that cannot be physically reached; and
+- ordered Arch Trailer unload/access dependencies where the shared physical trailer constrains later work.
 
-## Disposable Acceptance Gate
+Do not create the 2026 Setup Session before this pass is useful enough for the planning workflow.
 
-Candidate migrations:
+## Acceptance Evidence
+
+Accepted migrations:
 
 ```text
 023_add_setup_task_effort.sql
 024_reconstruct_setup_catalog_from_reviewed_one_list.sql
 ```
 
-Migration 024 sources its reviewed catalog rows from:
+Migration 024 sourced its reviewed rows from:
 
 ```text
 Setup/Database/reconstruction/024_catalog_batch_01.sql
@@ -260,41 +298,28 @@ Setup/Database/reconstruction/024_catalog_batch_01.sql
 Setup/Database/reconstruction/024_catalog_batch_05.sql
 ```
 
-Acceptance tooling:
+Disposable Production-clone validation passed before Production mutation.
+
+Final accepted Production deployment:
 
 ```text
-Setup/Acceptance/run_setup_catalog_reconstruction_disposable_acceptance.ps1
-Setup/Acceptance/setup_catalog_reconstruction_disposable_acceptance_server.sh
-Setup/Acceptance/setup_catalog_reconstruction_disposable_validation.sql
+Setup runtime SHA                    = 5a8a317357ffa5d77c38bc4df63fe6c7b451dbaf
+active reusable tasks                = 185
+total reusable task rows             = 187
+dependencies                         = 0
+2026 Setup Sessions                  = 0
+Production Setup fingerprint         = f0b98ac75e297a08eabc3df040708c08
+rollback archive                     = /home/msbadmin/backups/setup-catalog/msb-pre-setup-catalog-20260909T184826.dump
+deployment report                    = /home/msbadmin/setup-acceptance-reports/Setup_Catalog_Reconstruction_Production_Deploy_20260909T184826.txt
+wrapper result                       = SETUP_CATALOG_RECONSTRUCTION_PRODUCTION_DEPLOYMENT_PASS
 ```
 
-The acceptance runner may read Production with `pg_dump` and `SELECT` only. All schema/data writes occur in a disposable PostgreSQL clone restored from current Production.
+The Production deployment completed with 134 application tests passing, protected negative-path HTTP 401 acceptance, public `/setup/` health PASS, and the final Production fingerprint matching the accepted post-catalog state.
 
-The disposable validation must prove at minimum:
+## Production Change Rule Going Forward
 
-- 185 active reusable tasks;
-- 66 existing identities retained and 119 new definitions created by the migration source;
-- tasks 40 and 58 inactive;
-- task 51 preserved;
-- 10 canonical `Locate Power & Network` tasks;
-- 4 canonical `Layout Panels` tasks;
-- accepted effort counts;
-- no new annual rows for task IDs created by reconstruction;
-- no 2026+ Setup Session;
-- zero reusable dependencies pending the predecessor pass;
-- valid current Stage/Scene foreign-key pairing; and
-- Production Setup fingerprint unchanged after disposable acceptance.
+This accepted import does not authorize future ad hoc Production changes.
 
-## Production Gate
+Future Production database/application mutations still require the current project rules and the governing Production Database deployment runbook from `Gregovate/MSB-Server-Management`.
 
-Passing disposable acceptance does not authorize Production mutation.
-
-Any Production application of migrations 023/024 requires:
-
-1. current candidate SHA identified;
-2. current Production preflight;
-3. retrieval and reading of the governing Production Database deployment runbook from `Gregovate/MSB-Server-Management` in that workstream;
-4. explicit operator approval for the Production mutation; and
-5. post-deployment catalog/browser acceptance before proceeding to the predecessor pass.
-
-No 2026 Setup Session should be created as part of this reconstruction deployment.
+Routine Manager task maintenance that is already exposed through governed application commands is normal Production use and should operate on the current PostgreSQL catalog rather than through another reconstruction migration.

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Data_Consumption_and_Authorization_Contract_2026-09-10.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Data_Consumption_and_Authorization_Contract_2026-09-10.md
@@ -1,0 +1,323 @@
+# Setup Data Consumption and Authorization Contract — 2026-09-10
+
+| Document Control | Value |
+|---|---|
+| Document Type | Engineering Contract / Production Troubleshooting Reference |
+| System | Production Database — Setup and Deployment |
+| Status | CURRENT — documents implemented authorization/data-access behavior and 2026-09-10 Production finding |
+| Owner | MSB Production Database engineering; People and Identity owns durable person/authentication linkage |
+| Last Reviewed | 2026-09-10 |
+
+## Purpose
+
+Define the current Production Setup application's database-consumption surface, human authorization model, PostgreSQL application-role permissions, actor-attribution requirements, and failure boundaries so future work does not have to reconstruct these relationships from SQL, application source, or chat history.
+
+This document does **not** authorize Production permission changes, person-link changes, Directus configuration changes, or Setup data mutation. Gather current Production evidence before changing any permission or identity record.
+
+## Critical Separation of Responsibilities
+
+Setup uses three separate layers that must not be confused:
+
+```text
+1. Browser authentication
+   Cloudflare Access supplies the authenticated email.
+
+2. Human application authorization
+   active Directus user + current Directus role/policy
+   -> ref.setup_browser_capabilities(email)
+   -> read / movement / Manager / Administrator capability
+
+3. Human write attribution
+   Directus user UUID must map to ref.person.directus_user_id
+   -> transaction-local app.directus_user_uuid
+   -> narrow SECURITY DEFINER command
+   -> existing actor/audit triggers
+```
+
+A user can therefore be an authorized Setup Manager and still be unable to save anything when the Directus UUID is not linked to `ref.person`.
+
+Changing Directus collection/table permissions does **not** repair that condition.
+
+## Human Capability Model
+
+`ref.setup_browser_capabilities(text)` is the current Setup authorization authority used by the protected application.
+
+| Human authority | Read Setup | Movement capability flag | Maintain reusable/annual Setup data | Create annual Setup Session | Promote annual order to reusable baseline |
+|---|---:|---:|---:|---:|---:|
+| Production Crew / Volunteer-equivalent accepted policy | Yes | Yes | No | No | No |
+| Manager | Yes | Yes | Yes | No | No |
+| Administrator / accepted admin access | Yes | Yes | Yes | Yes | Yes |
+
+Current capability evaluation uses active `public.directus_users` plus Directus role/policy membership. It recognizes the accepted role/policy names `Volunteer`, `Production Crew`, `Manager`, and `Administrator`, together with accepted Directus `admin_access` authority.
+
+The current Setup application does **not** use ordinary Directus collection permissions as the authorization check for its PostgreSQL reads/writes. The capability function reads Directus authorization metadata inside a `SECURITY DEFINER` boundary.
+
+### Captain / Alternate execution exception
+
+A mapped person who has Setup read access and is assigned as `CAPTAIN` or `ALTERNATE` for a reusable task may record task progress through the governed execution command even when that person is not a Manager.
+
+`ADVISOR` alone does not grant progress-write authority.
+
+The execution command still requires the authenticated Directus user to map to the correct `ref.person` row.
+
+## Write-Identity Requirement
+
+Manager and Administrator commands call `ref.setup_management_actor(text, boolean)`. Captain/Alternate progress commands call `ref.setup_execution_actor(text, bigint)`.
+
+Both resolve the authenticated Directus user and then require:
+
+```text
+ref.person.directus_user_id = public.directus_users.id
+```
+
+If no matching `ref.person` row exists, the governed write fails closed with:
+
+```text
+Authenticated Setup operator is not mapped to an MSB person
+```
+
+This is an actor/audit identity failure, not evidence that the Directus Manager/Administrator role is missing.
+
+## 2026-09-10 Production Finding
+
+A read-only Production audit established that several current Manager accounts resolve successfully through `ref.setup_browser_capabilities(...)` with `can_manage_setup = true` but their matching `ref.person` rows have `directus_user_id IS NULL`.
+
+Other current Manager/Administrator accounts are correctly mapped and can pass the actor boundary.
+
+A separate Administrator-authorized account uses an authenticated email for which no matching `ref.person.email` row exists. That is a different identity-reconciliation case and must not be auto-linked by name or guesswork.
+
+One affected established Manager explicitly authenticated again through the Directus/Google login path at `db.sheboyganlights.org`; a repeated read-only audit showed that `ref.person.directus_user_id` remained NULL. Therefore **repeat login is not a supported repair mechanism for an already-established Manager account**.
+
+## Directus Onboarding Dependency / Known Flaw
+
+The current documented Directus **User Onboarding** flow matches an existing `ref.person` by exact MSB email when the person's `directus_user_id` is NULL or already equals the triggering Directus user UUID. If no matching person is found, its missing-person branch can create a person.
+
+The observed onboarding branch is gated to an active Google-provider Directus user whose role is still NULL before the flow assigns the default role.
+
+That is adequate for the specific first-onboarding path but is **not a general reconciliation mechanism** for already-established Directus users whose role/policy is already populated.
+
+Operationally, Setup must not depend on a Manager remembering to visit `db.sheboyganlights.org` merely to establish the identity needed by another protected application. The current 2026-09-10 evidence also proves that a repeat visit does not repair the affected established Manager case.
+
+People and Identity owns the durable fix. The accepted direction is to preserve exact-email identity matching and Directus authorization authority while adding a governed reconciliation/provisioning path that is independent of a manual Directus UI visit. Any repair must fail closed on conflicting UUIDs or ambiguous identity and must not guess from a person's name.
+
+## PostgreSQL Application Role
+
+The protected Setup backend connects through the existing PostgreSQL login:
+
+```text
+fieldwiring_app
+```
+
+That login intentionally has `default_transaction_read_only = on` as a backstop inherited from the shared FieldWiring runtime contract.
+
+Setup ordinary reads remain read-only. Setup write repositories explicitly open a bounded read-write transaction only when invoking a narrow governed command.
+
+The application role is intentionally **not** granted broad INSERT/UPDATE/DELETE on Setup tables.
+
+Conceptually:
+
+```text
+fieldwiring_app
+    -> SELECT approved read surfaces
+    -> EXECUTE approved SECURITY DEFINER commands
+    -> no broad Setup-table DML
+```
+
+## Direct PostgreSQL Read Surface Used by Setup
+
+The following tables are directly read by the protected Setup application's PostgreSQL login.
+
+### Setup-owned reusable/reference data
+
+| Table | Current Setup use |
+|---|---|
+| `ref.season` | annual season selection/context |
+| `ref.stage` | Stage/Sub-stage scope, names, ordering, current-location context |
+| `ref.setup_task` | reusable task catalog and task definition |
+| `ref.setup_task_dependency` | reusable predecessor relationships |
+| `ref.setup_task_display` | explicit task-to-Display relationships |
+| `ref.setup_task_container_support` | supplemental/support/KIT Container relationships |
+| `ref.setup_task_captain` | Captain/Alternate/Advisor assignments |
+| `ref.setup_resource` | reusable equipment/resource catalog |
+| `ref.setup_task_resource` | reusable task-resource requirements |
+
+### Permanent/shared physical and LOR context consumed by Setup
+
+| Table | Owning/related subsystem | Current Setup use |
+|---|---|---|
+| `ref.display` | permanent Display identity/inventory | task/material context and current `container_id` |
+| `ref.container` | Containers and Storage | current storage/transport Container context |
+| `ref.lor_scene` | current LOR projection | explicit Scene scope/context |
+| `ref.lor_scene_display` | current LOR projection | current Scene Display membership |
+| `ref.person` | People and Identity | person names for execution/audit context; durable Directus-person identity link |
+
+`ref.person` SELECT access for `fieldwiring_app` predates Setup and is part of the shared FieldWiring least-privilege read contract. Setup nevertheless consumes it and therefore has a cross-subsystem dependency on People and Identity.
+
+### Annual Setup operational data
+
+| Table | Current Setup use |
+|---|---|
+| `ops.setup_session` | annual Setup Session identity/status |
+| `ops.setup_session_task` | annual inclusion/review/planning/execution state |
+| `ops.setup_work_day` | short-horizon work-day planning |
+| `ops.setup_work_day_task` | work-day/shift/crew-lane task assignment |
+| `ops.setup_task_progress` | multi-period progress/evidence |
+| `ops.setup_container_state` | annual Container position state/read context |
+| `ops.setup_display_state` | annual Display position state/read context |
+| `ops.setup_movement_event` | movement history/read context |
+| `ops.setup_movement_event_display` | movement-event Display relationships |
+
+Movement/scanning write commands remain outside the currently accepted Setup Production workflow even though current read models/capability flags include movement context.
+
+## Authorization Metadata Consumed Inside SECURITY DEFINER Functions
+
+The Setup application role does not receive ordinary direct SELECT access to these Directus system tables. Setup capability/actor functions consume them inside the governed function boundary:
+
+| Table | Purpose |
+|---|---|
+| `public.directus_users` | resolve active Directus user UUID/email/provider/role |
+| `public.directus_roles` | resolve current role name |
+| `public.directus_access` | resolve user/role policy assignments |
+| `public.directus_policies` | resolve policy names and `admin_access` |
+
+These are **authorization metadata**, not Setup business tables.
+
+## Governed Write Targets
+
+Do not grant direct table DML merely because one of these actions writes a table. The browser/backend calls the named narrow function and the function performs the table mutation as `SECURITY DEFINER` after authorization and actor resolution.
+
+| User action / command class | Principal table(s) mutated |
+|---|---|
+| Create reusable task | `ref.setup_task`; also adds `ops.setup_session_task` rows for still-open sessions |
+| Update reusable task | `ref.setup_task` |
+| Set Stage/Scene scope | `ref.setup_task` |
+| Set Physical Effort | `ref.setup_task` |
+| Add/remove predecessor | `ref.setup_task_dependency` |
+| Create reusable resource | `ref.setup_resource` |
+| Add/update/remove task resource | `ref.setup_task_resource` |
+| Add/update/remove Captain/Alternate/Advisor | `ref.setup_task_captain` |
+| Update annual historical review/actuals | `ops.setup_session_task` |
+| Change annual planned order | `ops.setup_session_task` |
+| Create/update work day | `ops.setup_work_day` |
+| Schedule/remove task on work day | `ops.setup_work_day_task`; may update `ops.setup_session_task` planned state/date |
+| Record progress | `ops.setup_task_progress`; updates `ops.setup_session_task`; may update `ops.setup_work_day_task` |
+| Administrator creates annual Setup Session | `ops.setup_session`, `ops.setup_session_task`, `ops.setup_display_state`, `ops.setup_container_state` |
+| Administrator promotes annual order to future baseline | `ref.setup_task.baseline_plan_order` |
+| Reconstruction-safe task delete | removes eligible rows from `ops.setup_session_task`, `ref.setup_task_dependency`, `ref.setup_task_display`, `ref.setup_task_container_support`, `ref.setup_task_captain`, `ref.setup_task_resource`, then `ref.setup_task` |
+
+The Session-creation command also reads `ref.season`, `ref.setup_task`, `ref.display`, `ref.display_status`, and `ref.container` inside its governed function to seed the annual Session state.
+
+## Where Permission Changes Actually Belong
+
+Before changing anything, identify which layer failed.
+
+### User cannot open/read Setup
+
+Inspect:
+
+```text
+Cloudflare authenticated email
+-> active public.directus_users row
+-> Directus role / directus_access / directus_policies
+-> ref.setup_browser_capabilities(email)
+```
+
+Do not change Setup table DML permissions to solve this.
+
+### User is recognized as Manager but write returns "not mapped to an MSB person"
+
+Inspect:
+
+```text
+public.directus_users.id
+<-> ref.person.directus_user_id
+```
+
+This is an identity-link problem owned by People and Identity. Do not grant broad Setup table DML and do not change the Manager policy to bypass it.
+
+### Setup backend receives PostgreSQL permission denied
+
+Inspect the `fieldwiring_app` grant contract:
+
+- schema USAGE;
+- direct SELECT on the approved read surface;
+- EXECUTE on the specific governed function being called;
+- no unexpected broad table DML.
+
+### UI button missing despite valid capability
+
+Inspect the Setup application/UI capability logic separately. A hidden/visible button is not the security boundary.
+
+## Production Preflight — Human Identity Mapping
+
+Before onboarding Managers/Captains or troubleshooting write failures, use a read-only audit that compares current Setup-authorized Directus identities to `ref.person.directus_user_id` and exact `ref.person.email` matches.
+
+Required classifications:
+
+```text
+OK - DIRECTUS USER IS MAPPED
+BROKEN - PERSON EXISTS BY EMAIL BUT DIRECTUS LINK IS NULL
+CONFLICT - EMAIL PERSON IS LINKED TO DIFFERENT DIRECTUS USER
+BROKEN - NO REF.PERSON WITH MATCHING MSB EMAIL
+```
+
+Never auto-repair a `CONFLICT` or no-match case by first/last name.
+
+## Production Preflight — PostgreSQL Grants
+
+Before altering database permissions, inspect actual current grants rather than assuming migration history still represents Production exactly.
+
+At minimum verify:
+
+- `fieldwiring_app` can CONNECT;
+- schema USAGE exists for required schemas;
+- every directly queried Setup table has SELECT;
+- every invoked governed Setup function has EXECUTE;
+- direct INSERT/UPDATE/DELETE remains absent from governed Setup tables.
+
+The current grant authorities include:
+
+- `FieldWiring/Application/grant_fieldwiring_app.sql` for the shared base read login and `ref.person`/LOR/shared reference reads;
+- `Setup/Database/006_grant_setup_app_read.sql` for Setup core read tables;
+- `Setup/Database/009_create_setup_scope_schedule_execution_commands.sql` for `ops.setup_task_progress` read and governed execution commands; and
+- `Setup/Database/014_grant_setup_scene_field_context_read.sql` for Display/Container/current Scene material-context reads.
+
+## Authoritative Implementation Sources
+
+- `Setup/Database/002_create_setup_browser_authorization_contract.sql`
+- `Setup/Database/003_create_setup_management_commands.sql`
+- `Setup/Database/006_grant_setup_app_read.sql`
+- `Setup/Database/008_create_setup_resource_management_commands.sql`
+- `Setup/Database/009_create_setup_scope_schedule_execution_commands.sql`
+- `Setup/Database/014_grant_setup_scene_field_context_read.sql`
+- `Setup/Database/017_enforce_setup_session_year_and_admin_promotion.sql`
+- `Setup/Database/019_add_reconstruction_safe_task_delete.sql`
+- `Setup/Database/020_add_setup_captain_management_commands.sql`
+- `Setup/Database/022_require_active_setup_captain_people.sql`
+- `Setup/Database/023_add_setup_task_effort.sql`
+- `Setup/Application/setup_api.py`
+- `Setup/Application/setup_repository.py`
+- `Setup/Application/setup_resource_repository.py`
+- `Setup/Application/setup_next_repository.py`
+- `Setup/Application/setup_training_api.py`
+- `FieldWiring/Application/grant_fieldwiring_app.sql`
+- `Docs/02_Production_Database/01_System_Architecture/03_People_and_Identity/engineering/Directus_User_Onboarding_Identity_Contract_2026-09-09.md`
+
+## Related Systems
+
+- [Setup engineering portal](README.md)
+- [People and Identity](../../03_People_and_Identity/README.md)
+- [Wiring System](../../09_Wiring_System/README.md)
+
+## Current Resume Point
+
+The immediate Production write blocker is **not** unresolved Manager authorization. Current evidence proves affected Managers already resolve `can_manage_setup = true`.
+
+The next identity work belongs to People and Identity:
+
+1. repair only proven exact-email `ref.person` / Directus UUID linkage cases through a governed, reviewed path;
+2. handle any no-person-match Administrator identity separately rather than guessing;
+3. define a durable onboarding/reconciliation mechanism that does not require a manual visit to the Directus UI and that can reconcile already-established users safely; and
+4. rerun the read-only Setup identity audit before testing Manager writes.
+
+Do not weaken `ref.setup_management_actor(...)`, bypass person attribution, or grant broad Setup table DML as a workaround.

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Data_Consumption_and_Authorization_Contract_2026-09-10.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Data_Consumption_and_Authorization_Contract_2026-09-10.md
@@ -78,15 +78,33 @@ Authenticated Setup operator is not mapped to an MSB person
 
 This is an actor/audit identity failure, not evidence that the Directus Manager/Administrator role is missing.
 
-## 2026-09-10 Production Finding
+## 2026-09-10 Production Finding and Immediate Repair
 
-A read-only Production audit established that several current Manager accounts resolve successfully through `ref.setup_browser_capabilities(...)` with `can_manage_setup = true` but their matching `ref.person` rows have `directus_user_id IS NULL`.
+A read-only Production audit established that several current Manager accounts resolved successfully through `ref.setup_browser_capabilities(...)` with `can_manage_setup = true` while their matching `ref.person` rows had `directus_user_id IS NULL`.
 
-Other current Manager/Administrator accounts are correctly mapped and can pass the actor boundary.
+The three proven exact-email/null-link cases were:
 
-A separate Administrator-authorized account uses an authenticated email for which no matching `ref.person.email` row exists. That is a different identity-reconciliation case and must not be auto-linked by name or guesswork.
+```text
+person_id 19  Randy Miller  rmiller@sheboyganlights.org
+person_id 29  Eric Sandvig  esandvig@sheboyganlights.org
+person_id 31  Tom Shircel    tshircel@sheboyganlights.org
+```
 
-One affected established Manager explicitly authenticated again through the Directus/Google login path at `db.sheboyganlights.org`; a repeated read-only audit showed that `ref.person.directus_user_id` remained NULL. Therefore **repeat login is not a supported repair mechanism for an already-established Manager account**.
+One affected established Manager, Randy Miller, explicitly authenticated again through the Directus/Google login path at `db.sheboyganlights.org`; a repeated read-only audit showed that `ref.person.directus_user_id` remained NULL. Therefore **repeat login is not a supported repair mechanism for an already-established Manager account**.
+
+A bounded Production preflight then proved for all three rows: active Person, exact email match, active Directus user with the same exact email, null existing Person link, expected Directus UUID, and no UUID conflict with another Person.
+
+A single bounded transaction updated only `ref.person.directus_user_id` for those three existing Person rows, leaving the normal `ref.person` audit trigger enabled. Post-update readback confirmed:
+
+```text
+person_id 19 -> 27b7a81c-103b-4bd4-b147-72d32fb83418
+person_id 29 -> 3875bfd3-86f6-4f7b-84fb-c06328b05005
+person_id 31 -> 28640462-2cc3-40b1-8a87-50e2a3b9074f
+```
+
+This was an immediate operational recovery. It does **not** fix the systemic onboarding/reconciliation flaw.
+
+The administrator performing normal MSB operations uses `gliebig@sheboyganlights.org`, which is correctly mapped to `ref.person` person_id 17. The separately authorized `greg@engrinnovations.com` account is an intentional backup/business engineering identity used for system design. It must not be treated as an ordinary missing-Person defect or auto-linked/auto-created merely because it appears in an authorization audit.
 
 ## Directus Onboarding Dependency / Known Flaw
 
@@ -261,7 +279,7 @@ CONFLICT - EMAIL PERSON IS LINKED TO DIFFERENT DIRECTUS USER
 BROKEN - NO REF.PERSON WITH MATCHING MSB EMAIL
 ```
 
-Never auto-repair a `CONFLICT` or no-match case by first/last name.
+An authorized account with no Person match may also be an intentionally separate engineering/service/backup identity rather than a defect. Confirm purpose before classifying or repairing it. Never auto-repair a `CONFLICT` or no-match case by first/last name.
 
 ## Production Preflight — PostgreSQL Grants
 
@@ -311,13 +329,13 @@ The current grant authorities include:
 
 ## Current Resume Point
 
-The immediate Production write blocker is **not** unresolved Manager authorization. Current evidence proves affected Managers already resolve `can_manage_setup = true`.
+The immediate three-Manager Production write blocker was repaired on 2026-09-10 by linking the three proven exact-email Person rows to their existing active Directus UUIDs. Manager role/policy permissions were not changed.
 
 The next identity work belongs to People and Identity:
 
-1. repair only proven exact-email `ref.person` / Directus UUID linkage cases through a governed, reviewed path;
-2. handle any no-person-match Administrator identity separately rather than guessing;
-3. define a durable onboarding/reconciliation mechanism that does not require a manual visit to the Directus UI and that can reconcile already-established users safely; and
-4. rerun the read-only Setup identity audit before testing Manager writes.
+1. validate Randy Miller's real Setup write path after the repair, then allow the assigned Manager review to continue if successful;
+2. define a durable onboarding/reconciliation mechanism that does not require a manual visit to the Directus UI and that can reconcile already-established users safely;
+3. add acceptance coverage for first-onboarding linkage, established-user reconciliation, conflict/no-match failure, and population-wide authorized-user audit; and
+4. treat intentionally separate engineering/backup identities according to their documented purpose rather than forcing them into the operational Person mapping model.
 
 Do not weaken `ref.setup_management_actor(...)`, bypass person attribution, or grant broad Setup table DML as a workaround.

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Predecessor_and_Readiness_Contract_2026-09-09.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Predecessor_and_Readiness_Contract_2026-09-09.md
@@ -10,17 +10,17 @@
 
 ## Purpose
 
-Preserve the operator-confirmed distinction between reusable task predecessors, preferred order, and annual/site readiness so future Setup work does not reconstruct these rules from chat or historical task order.
+Preserve the operator-confirmed distinction between reusable task predecessors, preferred order, and external/site readiness so future Setup work does not reconstruct these rules from chat or historical task order.
 
 The 2025 reconstruction intentionally reset reusable dependencies to zero because the imported predecessor set was not trustworthy. The next dependency pass must rebuild only reviewed relationships.
 
 ## Three Different Concepts
 
-### 1. Hard predecessor
+### Hard predecessor
 
 A hard predecessor is another reusable Setup task that must be complete before the dependent task can proceed.
 
-Example established during Stage 00 review:
+Stage 00 example:
 
 ```text
 Lay Cords #67
@@ -28,94 +28,95 @@ Lay Cords #67
     hard predecessor -> Setup HWY42 MSB and Rotary Signs #66
 ```
 
-These are real Setup tasks. They belong in the governed reusable dependency relationship and should be evaluated by task completion state.
+These are real Setup tasks and belong in the governed reusable dependency relationship.
 
-### 2. Preferred order
+### Preferred order
 
 Preferred order means one task is normally better to do before another, but field conditions may justify changing the sequence.
 
-Do not turn a historical sequence into a hard dependency merely because the work happened in that order once.
+Do not convert historical sequence into a hard dependency unless the earlier task is truly required.
 
-Preferred order belongs in reusable planning/order behavior, not in the hard dependency table unless the prerequisite is truly required.
+### Readiness condition
 
-### 3. Readiness condition
+A readiness condition is **not a Setup task**. It represents an external/site condition MSB does not perform or does not want to treat as Setup work.
 
-A readiness condition is not another Setup task. It is an external/site/operational condition that must be satisfied before the work is practical.
+Examples:
 
-Examples include:
-
-- mowing/mulching complete in the task's work area;
-- leaves cleared in the task's work area;
+- mowing/mulching complete in the applicable work area;
+- leaves cleared in the applicable work area;
+- outside construction/road work clear;
 - access available;
-- construction/road work clear;
-- weather appropriate for the work;
-- required site condition or external dependency satisfied.
+- another site condition controlled by an external party.
 
-Do not fabricate fake Setup tasks such as a single park-wide `Grass Cutting Complete` task merely to express readiness.
+Do not fabricate `Grass Cutting Complete` or similar Setup tasks merely to create a blocker. Such a fake task would create misleading completion/reporting history for work MSB did not perform.
+
+## Structured Readiness Is Required
+
+The current free-form `readiness_note` is not sufficient as the long-term control mechanism.
+
+It can describe a condition, but free text cannot reliably answer:
+
+- which tasks share the same condition;
+- whether that condition is currently satisfied;
+- which work is blocked by it; or
+- when one readiness change should release several tasks.
+
+The required design is a **structured reusable readiness condition** that can be linked to one or more reusable tasks, with separate annual/current readiness state.
+
+Conceptually:
+
+```text
+Reusable readiness condition
+    "Mowing/mulching complete — Stage 00 HWY42 work area"
+
+linked tasks
+    -> Lay Cords
+    -> Network hookup
+    -> Testing
+
+annual/current state
+    -> NOT READY / READY
+    -> optional actor/time/note as appropriate
+```
+
+This is a condition record, not a Setup task. It should not appear as completed Setup work, consume crew time, or appear in Setup task completion reports.
+
+Exact table/function names remain implementation design work; do not invent Production schema merely from this conceptual contract.
 
 ## Area-Specific Grass / Mulch Rule
 
-Grass cutting and mulching are **area-specific**, not a single park-wide prerequisite.
+Grass cutting and mulching readiness is **area-specific**, not park-wide.
 
-Stage 00 may be ready for cord work while another part of the park is still being cut or mulched.
+Stage 00 can be ready while another part of the park is still being cut or mulched.
 
-For `Lay Cords #67`, the reusable readiness rule is conceptually:
-
-```text
-mowing/mulching complete in the Stage 00 HWY 42 cord-laying area
-```
-
-The condition applies to the task/work area, not to the entire park and not to an arbitrary calendar date.
-
-This means the future planner must be capable of representing independent readiness by task/work area.
-
-## Current Production UI Boundary
-
-The current reusable task field `readiness_note` is free-form text.
-
-It is useful now for recording the reusable rule, but it **does not currently block a task from becoming available/schedulable**.
-
-Therefore the current operating workaround is:
+For the Stage 00 HWY42 area, the condition must be satisfied before the affected work proceeds, including:
 
 ```text
-reusable task
-    -> record normal readiness rule in readiness_note
-    -> operator must still apply judgment manually
+Lay Cords
+Network hookup
+Testing
 ```
 
-That is not the finished scheduling model.
+The condition is tied to that physical work area. Other Stage/Scene/Sub-stage areas need their own readiness state as applicable.
 
-The future annual Setup Session needs structured readiness state so the reusable task can say **what condition is normally required** and the annual session can say **whether that condition is satisfied this year / right now**.
-
-Conceptual direction:
-
-```text
-Reusable task knowledge
-    readiness requirement = mowing/mulching complete in this work area
-
-Annual Setup state
-    NOT READY / READY
-    actor / time / note as appropriate
-```
-
-Exact schema and UI controls remain implementation work. Do not invent an unreviewed global readiness table or boolean merely from this document.
+Do not use one global park-wide `Grass Cutting Complete` flag if areas can become ready independently.
 
 ## Relationship to Scheduling
 
-A task may have all hard predecessors complete and still be `NOT READY` because the site condition is not satisfied.
-
-Conversely, a readiness condition becoming true does not imply that all task predecessors are complete.
+A task can have all hard predecessors complete but remain unavailable because a readiness condition is not satisfied.
 
 Conceptually:
 
 ```text
 hard predecessors complete
-    + annual readiness satisfied
+    + linked readiness conditions READY
     + crew/equipment/weather practical
-    -> candidate work can be AVAILABLE / READY TO SCHEDULE
+    -> task can be AVAILABLE / READY TO SCHEDULE
 ```
 
-Preferred order influences which available work is normally chosen next but should not falsely block other valid work.
+Readiness does not imply predecessor completion, and predecessor completion does not imply readiness.
+
+Weather can influence day-to-day planning separately; do not automatically turn every weather note into a durable readiness condition without an accepted rule.
 
 ## Efficient Predecessor Editing
 
@@ -131,18 +132,16 @@ Shift-drag the later/dependent task onto its predecessor
 
 Requirements:
 
-- ordinary unmodified drag must preserve existing reorder and Stage/Scene movement behavior;
-- Shift-drag must be explicit and visually distinct from normal drag;
-- use the existing governed `ref.set_setup_task_dependency(...)` command path;
-- circular-dependency protection remains database-governed;
-- show explicit confirmation/result so an ambiguous drop never silently creates a dependency;
-- do not use modifier-drag for readiness conditions, because readiness is not another reusable task.
-
-Alt-drag was discussed as an alternative modifier, but Shift-drag is the current preferred direction.
+- ordinary unmodified drag preserves existing reorder and Stage/Scene movement behavior;
+- Shift-drag is visually distinct from normal drag;
+- use the existing governed `ref.set_setup_task_dependency(...)` write path;
+- database circular-dependency protection remains authoritative;
+- show explicit success/failure feedback; and
+- modifier-drag applies only to task predecessors, not readiness conditions.
 
 ## Reconstruction Rule
 
-When reviewing 2022/2025 evidence, classify each sequencing relationship as exactly one of:
+Classify sequencing evidence as one of:
 
 ```text
 HARD PREDECESSOR
@@ -150,39 +149,37 @@ PREFERRED ORDER
 READINESS CONDITION
 ```
 
-Do not force all three into the same dependency mechanism.
-
 Examples:
 
 ```text
-Signs physically must be installed before cords can be laid there
+HWY42 signs must be installed before affected cord work
     -> HARD PREDECESSOR
 
-Crew normally does one small job before another for efficiency
-    -> PREFERRED ORDER
-
-Mowing/mulching must be complete in the cord-laying area
+Mowing/mulching complete in the HWY42 work area
     -> READINESS CONDITION
+
+A task is normally done earlier for convenience but can safely move
+    -> PREFERRED ORDER
 ```
 
 ## 2026 Session Gate
 
-The operator decision remains: **do not create the 2026 Setup Session until the reconstructed 2025 plan is complete.**
+**Do not create the 2026 Setup Session until the reconstructed 2025 Setup plan is complete.**
 
-Before propagation, the predecessor/readiness pass must be useful enough that known required task dependencies and area-specific readiness are not lost or converted into a misleading rigid schedule.
+Before propagation, known hard predecessors and structured area-specific readiness must be represented well enough that the future planner does not rely on a free-text note and operator memory for critical blockers.
 
 ## Implementation Gate
 
-Before Production implementation of structured readiness or modifier-drag dependency editing:
+Before Production implementation:
 
 1. preserve current normal drag/reorder/scope behavior;
-2. inventory the reusable tasks being reviewed for hard predecessors;
-3. keep readiness conditions distinct from task dependencies;
-4. use representative cases including Stage 00 cord laying and at least one weather/access readiness case;
-5. prove circular dependency rejection remains intact;
-6. prove Shift-drag creates only the intended directed dependency and does not move either task;
-7. prove unmodified drag remains unchanged;
-8. design annual readiness state separately from the reusable readiness rule; and
+2. keep readiness conditions separate from reusable task dependencies;
+3. support one readiness condition gating multiple tasks;
+4. support independent readiness by work area;
+5. prove the Stage 00 HWY42 condition blocks Lay Cords, Network hookup, and Testing until READY;
+6. ensure readiness conditions do not appear as completed Setup work or crew/reporting tasks;
+7. prove Shift-drag creates only the intended directed task dependency and does not move either task;
+8. prove unmodified drag remains unchanged; and
 9. perform protected browser validation before Production acceptance.
 
 ## Related Durable Sources

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Predecessor_and_Readiness_Contract_2026-09-09.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Predecessor_and_Readiness_Contract_2026-09-09.md
@@ -1,0 +1,193 @@
+# Setup Predecessor and Readiness Contract — 2026-09-09
+
+| Document Control | Value |
+|---|---|
+| Document Type | Engineering Contract / Live Review Finding |
+| System | Production Database — Setup and Deployment |
+| Status | CURRENT DESIGN AUTHORITY — structured readiness implementation pending |
+| Owner | MSB Production Database engineering |
+| Related Work | Issue #122; PR #125; PR #138 |
+
+## Purpose
+
+Preserve the operator-confirmed distinction between reusable task predecessors, preferred order, and annual/site readiness so future Setup work does not reconstruct these rules from chat or historical task order.
+
+The 2025 reconstruction intentionally reset reusable dependencies to zero because the imported predecessor set was not trustworthy. The next dependency pass must rebuild only reviewed relationships.
+
+## Three Different Concepts
+
+### 1. Hard predecessor
+
+A hard predecessor is another reusable Setup task that must be complete before the dependent task can proceed.
+
+Example established during Stage 00 review:
+
+```text
+Lay Cords #67
+    hard predecessor -> Setup HWY42 Traffic Signs #195
+    hard predecessor -> Setup HWY42 MSB and Rotary Signs #66
+```
+
+These are real Setup tasks. They belong in the governed reusable dependency relationship and should be evaluated by task completion state.
+
+### 2. Preferred order
+
+Preferred order means one task is normally better to do before another, but field conditions may justify changing the sequence.
+
+Do not turn a historical sequence into a hard dependency merely because the work happened in that order once.
+
+Preferred order belongs in reusable planning/order behavior, not in the hard dependency table unless the prerequisite is truly required.
+
+### 3. Readiness condition
+
+A readiness condition is not another Setup task. It is an external/site/operational condition that must be satisfied before the work is practical.
+
+Examples include:
+
+- mowing/mulching complete in the task's work area;
+- leaves cleared in the task's work area;
+- access available;
+- construction/road work clear;
+- weather appropriate for the work;
+- required site condition or external dependency satisfied.
+
+Do not fabricate fake Setup tasks such as a single park-wide `Grass Cutting Complete` task merely to express readiness.
+
+## Area-Specific Grass / Mulch Rule
+
+Grass cutting and mulching are **area-specific**, not a single park-wide prerequisite.
+
+Stage 00 may be ready for cord work while another part of the park is still being cut or mulched.
+
+For `Lay Cords #67`, the reusable readiness rule is conceptually:
+
+```text
+mowing/mulching complete in the Stage 00 HWY 42 cord-laying area
+```
+
+The condition applies to the task/work area, not to the entire park and not to an arbitrary calendar date.
+
+This means the future planner must be capable of representing independent readiness by task/work area.
+
+## Current Production UI Boundary
+
+The current reusable task field `readiness_note` is free-form text.
+
+It is useful now for recording the reusable rule, but it **does not currently block a task from becoming available/schedulable**.
+
+Therefore the current operating workaround is:
+
+```text
+reusable task
+    -> record normal readiness rule in readiness_note
+    -> operator must still apply judgment manually
+```
+
+That is not the finished scheduling model.
+
+The future annual Setup Session needs structured readiness state so the reusable task can say **what condition is normally required** and the annual session can say **whether that condition is satisfied this year / right now**.
+
+Conceptual direction:
+
+```text
+Reusable task knowledge
+    readiness requirement = mowing/mulching complete in this work area
+
+Annual Setup state
+    NOT READY / READY
+    actor / time / note as appropriate
+```
+
+Exact schema and UI controls remain implementation work. Do not invent an unreviewed global readiness table or boolean merely from this document.
+
+## Relationship to Scheduling
+
+A task may have all hard predecessors complete and still be `NOT READY` because the site condition is not satisfied.
+
+Conversely, a readiness condition becoming true does not imply that all task predecessors are complete.
+
+Conceptually:
+
+```text
+hard predecessors complete
+    + annual readiness satisfied
+    + crew/equipment/weather practical
+    -> candidate work can be AVAILABLE / READY TO SCHEDULE
+```
+
+Preferred order influences which available work is normally chosen next but should not falsely block other valid work.
+
+## Efficient Predecessor Editing
+
+The current prerequisite selector/button is too cumbersome for the large 2025 review pass.
+
+Operator-confirmed desired interaction:
+
+```text
+Shift-drag the later/dependent task onto its predecessor
+    -> create dependency: dragged task depends on target task
+    -> neither task moves
+```
+
+Requirements:
+
+- ordinary unmodified drag must preserve existing reorder and Stage/Scene movement behavior;
+- Shift-drag must be explicit and visually distinct from normal drag;
+- use the existing governed `ref.set_setup_task_dependency(...)` command path;
+- circular-dependency protection remains database-governed;
+- show explicit confirmation/result so an ambiguous drop never silently creates a dependency;
+- do not use modifier-drag for readiness conditions, because readiness is not another reusable task.
+
+Alt-drag was discussed as an alternative modifier, but Shift-drag is the current preferred direction.
+
+## Reconstruction Rule
+
+When reviewing 2022/2025 evidence, classify each sequencing relationship as exactly one of:
+
+```text
+HARD PREDECESSOR
+PREFERRED ORDER
+READINESS CONDITION
+```
+
+Do not force all three into the same dependency mechanism.
+
+Examples:
+
+```text
+Signs physically must be installed before cords can be laid there
+    -> HARD PREDECESSOR
+
+Crew normally does one small job before another for efficiency
+    -> PREFERRED ORDER
+
+Mowing/mulching must be complete in the cord-laying area
+    -> READINESS CONDITION
+```
+
+## 2026 Session Gate
+
+The operator decision remains: **do not create the 2026 Setup Session until the reconstructed 2025 plan is complete.**
+
+Before propagation, the predecessor/readiness pass must be useful enough that known required task dependencies and area-specific readiness are not lost or converted into a misleading rigid schedule.
+
+## Implementation Gate
+
+Before Production implementation of structured readiness or modifier-drag dependency editing:
+
+1. preserve current normal drag/reorder/scope behavior;
+2. inventory the reusable tasks being reviewed for hard predecessors;
+3. keep readiness conditions distinct from task dependencies;
+4. use representative cases including Stage 00 cord laying and at least one weather/access readiness case;
+5. prove circular dependency rejection remains intact;
+6. prove Shift-drag creates only the intended directed dependency and does not move either task;
+7. prove unmodified drag remains unchanged;
+8. design annual readiness state separately from the reusable readiness rule; and
+9. perform protected browser validation before Production acceptance.
+
+## Related Durable Sources
+
+- [Setup Planning Operating Model](Setup_Planning_Operating_Model_2026-09-08.md)
+- [Setup Task Material Resolver Contract](Setup_Task_Material_Resolver_Contract_2026-09-09.md)
+- [Setup engineering portal](README.md)
+- GitHub Issue #122

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Reconstruction_Migration_and_Acceptance_History_2026-09-07_to_09.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Reconstruction_Migration_and_Acceptance_History_2026-09-07_to_09.md
@@ -1,0 +1,289 @@
+# Setup Reconstruction Migration and Acceptance History — 2026-09-07 to 2026-09-09
+
+| Document Control | Value |
+|---|---|
+| Document Type | Engineering Migration / Acceptance History |
+| System | Production Database — Setup Session |
+| Status | HISTORICAL ENGINEERING RECORD — preserves accepted reconstruction/deployment findings; not a current Production runbook |
+| Owner | MSB Production Database engineering |
+| Related Work | Issue #122; PR #125; PR #137; Setup Catalog Reconstruction Import |
+
+## Purpose
+
+Preserve the material migration, disposable-clone, browser-acceptance, and reconstruction-cleanup findings encountered while moving the Setup subsystem from the small 2025 Historical Verification foundation to the accepted reusable Catalog reconstruction.
+
+This record exists because several important failures were discovered only when the real governed Setup commands and Production-like disposable environment were exercised. Those findings must not be reconstructed from chat history or rediscovered by a later migration.
+
+For the current deployed state and resume point, use [`README.md`](README.md). For the final one-time Catalog import result, use [`Setup_Catalog_Reconstruction_Import_2026-09-09.md`](Setup_Catalog_Reconstruction_Import_2026-09-09.md).
+
+## Production Safety Boundary Used During Reconstruction
+
+The reconstruction work deliberately separated Production evidence from test writes.
+
+- Production could be inspected and fingerprinted.
+- Feature writes and migration probes were performed against disposable PostgreSQL clones before Production consideration.
+- A disposable failure stopped that acceptance attempt and required a corrected exact candidate to be rerun.
+- Production fingerprint / live-checkout checks were used to prove that failed disposable acceptance had not mutated Production.
+- Final Production mutation remained subject to the Production Database deployment runbook and rollback requirements.
+
+This boundary was important because the disposable gates found real SQL defects before the corresponding feature writes could reach Production.
+
+## Repeated PL/pgSQL Ambiguity Defect Class
+
+A major recurring defect was caused by the interaction between `RETURNS TABLE` output names and unqualified SQL identifiers inside PL/pgSQL.
+
+In PL/pgSQL, `RETURNS TABLE` output columns are also function variables. A bare column name can therefore become ambiguous when a table/CTE column uses the same name.
+
+The accepted correction pattern is:
+
+1. qualify table and CTE column references with relation aliases;
+2. prefer `ON CONFLICT ON CONSTRAINT <governed_constraint_name>` instead of a bare column-list conflict target when function variables can collide with column names; and
+3. exercise the actual governed command in a disposable database, not only migration syntax or static contract tests.
+
+### Migration 013 — reusable task creation
+
+[`013_fix_setup_task_creation_command.sql`](../../../../../Setup/Database/013_fix_setup_task_creation_command.sql) exists because Manager browser acceptance exposed:
+
+```text
+column reference "setup_task_id" is ambiguous
+```
+
+`ref.create_setup_task(...)` returns a column named `setup_task_id`. The original:
+
+```sql
+ON CONFLICT (setup_session_id, setup_task_id)
+```
+
+could collide with that PL/pgSQL output variable.
+
+The correction targets the existing governed unique constraint explicitly:
+
+```sql
+ON CONFLICT ON CONSTRAINT uq_setup_session_task DO NOTHING
+```
+
+No schema shape or authorization expansion was required.
+
+### Migration 015 — harden the remaining conflict targets
+
+[`015_harden_setup_command_conflict_targets.sql`](../../../../../Setup/Database/015_harden_setup_command_conflict_targets.sql) generalized the same finding instead of waiting for each command to fail independently.
+
+It replaced bare conflict targets with named constraints in:
+
+```text
+ref.set_setup_task_resource(...)
+ref.set_setup_task_dependency(...)
+ops.set_setup_work_day_task(...)
+```
+
+using:
+
+```text
+pk_setup_task_resource
+pk_setup_task_dependency
+pk_setup_work_day_task
+```
+
+Migration 013 remained the separate correction for reusable-task creation.
+
+This was an important migration-design correction: a command can parse, install, and still fail only when a specific write path executes.
+
+### Migration 018 — dependency cycle CTE still had an unqualified name
+
+[`018_fix_setup_dependency_cycle_reference.sql`](../../../../../Setup/Database/018_fix_setup_dependency_cycle_reference.sql) fixed the remaining ambiguity in `ref.set_setup_task_dependency(...)` after migration 015.
+
+The conflict target had already been hardened, but the recursive cycle-prevention query still referenced `setup_task_id` without a relation alias. Because the function also returns `setup_task_id`, PostgreSQL could interpret that identifier as either the recursive CTE column or the PL/pgSQL output variable.
+
+The correction explicitly uses the CTE alias:
+
+```sql
+FROM prerequisite_chain c
+WHERE c.setup_task_id = p_setup_task_id
+```
+
+The function signature, authorization, and cycle-prevention behavior remained unchanged. Live browser acceptance later passed when a real Mega Tree prerequisite was added, proving the corrected command path rather than only the migration installation.
+
+### Migration 020 — Captain assignment failed in disposable feature validation
+
+[`020_add_setup_captain_management_commands.sql`](../../../../../Setup/Database/020_add_setup_captain_management_commands.sql) exposed the same defect class during the 2026-09-08 training/reconstruction disposable gate.
+
+The candidate migrations reached 019/020/021 on a current Production clone, but feature validation failed inside `ref.set_setup_task_captain(...)` before the Captain assignment completed. The original column-list conflict target:
+
+```sql
+ON CONFLICT (setup_task_id, person_id)
+```
+
+was ambiguous because the function also returns `setup_task_id` and `person_id`.
+
+The correction pins the existing primary key:
+
+```sql
+ON CONFLICT ON CONSTRAINT pk_setup_task_captain
+```
+
+The failed run left the Production Setup fingerprint unchanged:
+
+```text
+a2a84fc3f162f2f30914c909710976cf
+```
+
+No Production mutation occurred. The corrected candidate then required a fresh disposable acceptance run.
+
+## Production Migration Path Had To Exclude Disposable-Only SQL
+
+During the earlier Production-foundation promotion, the durable migration path was explicitly separated from browser-preview/reset SQL.
+
+The reviewed durable sequence at that stage was:
+
+```text
+008 -> 009 -> 010 -> 011 -> 013 -> 014 -> 015 -> 016
+```
+
+Migration 012 was **not** a Production migration because it contained disposable browser-review execution resets. Migration 016 was the Production-safe Command Center / Park Infrastructure reconstruction seed.
+
+Later correction/training work added the subsequently accepted migrations through 022 before Catalog migrations 023/024 were deployed.
+
+The durable lesson is that migration numbering alone is not evidence that every SQL file belongs in the Production path. The Production sequence must be stated and reviewed explicitly.
+
+## Disposable / Browser Acceptance Harness Findings
+
+The Catalog reconstruction itself also exposed failures in the acceptance harness. These were important because a broken gate can either block a correct candidate or, worse, give misleading evidence about what was actually validated.
+
+### Function privilege mirror called a PROCEDURE as a function
+
+A Catalog browser-preview run failed before candidate migrations because the Production privilege-mirror query scanned `pg_proc` and called `has_function_privilege()` on `ref.apply_display_metadata_from_sheet()`, which is a PostgreSQL `PROCEDURE`.
+
+PostgreSQL correctly rejected that call as:
+
+```text
+is not a function
+```
+
+The correction restricted function-privilege mirroring to actual functions/window functions:
+
+```text
+p.prokind IN ('f','w')
+```
+
+The failure did not change the Production fingerprint or shared checkout.
+
+### Active Catalog count was correct but the effort API leaked retired rows
+
+Disposable Catalog validation correctly produced:
+
+```text
+185 active reusable tasks
+187 total reusable rows
+```
+
+But `/api/setup/task-efforts` returned 187 because the reader selected all `ref.setup_task` rows, including the two intentionally retired provisional identities 40 and 58.
+
+This was an application/API correctness defect, **not** a failed Catalog import.
+
+The correction added the active-row boundary:
+
+```sql
+WHERE active_flag
+```
+
+Because the application surface changed, the application/database candidate required re-acceptance rather than treating the Catalog count discrepancy as harmless.
+
+### Preview cleanup used the wrong process owner
+
+The same browser-preview cycle exposed a cleanup defect. Flask ran as the `fieldwiring` runtime identity, while the preview trap attempted plain `kill` as `msbadmin`.
+
+Result:
+
+- the preview listener could remain on port 8795;
+- cleanup could replace the original failure with exit 99; and
+- a stale listener could contaminate the next acceptance attempt.
+
+The harness was corrected to use privileged termination where required and to recognize the Catalog-preview process/container/worktree patterns during stale cleanup.
+
+This is why runtime-account ownership is part of acceptance design, not merely a server-administration detail.
+
+## One-Time Catalog Reconstruction Result
+
+After the correction and acceptance cycle, migrations 023/024 produced the accepted Production baseline:
+
+```text
+Setup runtime SHA                    = 5a8a317357ffa5d77c38bc4df63fe6c7b451dbaf
+active reusable tasks                = 185
+total reusable task rows             = 187
+reusable dependencies                = 0
+2026 Setup Sessions                  = 0
+Production Setup fingerprint         = f0b98ac75e297a08eabc3df040708c08
+```
+
+The reviewed workbook, 2025 notes, and recovered 2022 schedule are now reconstruction/historical evidence. They are not a second task master. Current PostgreSQL reusable tasks are the working Catalog baseline.
+
+## Reconstruction Correctness Findings After Deployment
+
+Production acceptance of the bulk import did not mean every reconstructed task boundary was permanently correct. The import deliberately depended on later live review to catch omissions, duplicate boundaries, and ambiguous historical shorthand before 2026 planning copied the Catalog forward.
+
+### Missing physical Frosty task
+
+Historical `Bring Frosty to park` evidence was correctly excluded as transport/logistics, but no separate reusable physical `Set Up Frosty` task was created.
+
+The required correction is to add the real physical setup work to the current Catalog and make it a predecessor of the applicable Stars setup work during the predecessor/readiness pass. Transport remains logistics.
+
+This is a concrete example of why historical filtering cannot merely remove logistics phrases; it must also verify that the physical work implied by the history still has a reusable task definition.
+
+### Reconstruction mistakes may have no annual historical row
+
+A later cleanup finding corrected an important assumption in the Manager UI.
+
+Some duplicate/bad reusable Catalog definitions introduced during reconstruction/merge have **no `ops.setup_session_task` annual row at all**. They are Catalog reconstruction mistakes, not historical annual records. Leaving them in the Catalog would propagate bad definitions into 2026.
+
+The existing governed database command:
+
+```text
+ref.delete_setup_reconstruction_task(...)
+```
+
+already supports Catalog-only deletion and fails closed when protected planning/execution history exists.
+
+The UI regression incorrectly hid Delete unless historical-session / annual-row context was present. PR #137 restores Manager **Delete Task** for a selected reusable Catalog task without requiring an annual historical record, while retaining the database guardrails.
+
+This refines the earlier reconstruction-delete rule:
+
+- if a mistaken reconstruction task has only its provisional annual inclusion, safe delete may remove that annual shell and reusable definition together;
+- if a mistaken reusable Catalog definition has no annual row, safe delete must still be available;
+- once protected planning, progress, work-day, movement, or execution history exists, destructive cleanup must fail closed and the normal retire/remove workflow applies instead.
+
+## Current Resume Point
+
+Do not create the 2026 Setup Session yet.
+
+Resume from the current Production PostgreSQL Catalog, not from the reconstruction workbook:
+
+1. disposable/browser-accept PR #137 against a Catalog-only mistaken/duplicate task and verify the governed fail-closed behavior;
+2. remove confirmed reconstruction duplicates/bad reusable definitions before they can be propagated into 2026;
+3. add/correct missing real reusable work such as `Set Up Frosty`;
+4. perform the reviewed predecessor/readiness pass, distinguishing **hard predecessor**, **preferred order**, and **area-specific readiness condition**; and
+5. only then proceed toward the short-horizon 2026 planning/session gate.
+
+## Engineering Rule Carried Forward
+
+For future Setup migrations, static SQL review and migration-install success are not sufficient acceptance for governed PL/pgSQL commands.
+
+At minimum, candidate acceptance should include:
+
+- exact-candidate pinning;
+- disposable PostgreSQL built from current Production state where feasible;
+- execution of the governed write paths the migration changes;
+- negative-path / authorization checks;
+- cleanup proof;
+- Production fingerprint/live-checkout proof around failed disposable attempts; and
+- explicit rerun from the corrected exact candidate after a failure.
+
+When a `RETURNS TABLE` PL/pgSQL function uses names that also exist in tables/CTEs, qualify the SQL references and prefer named constraints for conflict targets.
+
+## Related Evidence
+
+- [`Setup_Catalog_Reconstruction_Import_2026-09-09.md`](Setup_Catalog_Reconstruction_Import_2026-09-09.md)
+- [`Setup_Training_Browser_Acceptance_2026-09-08.md`](Setup_Training_Browser_Acceptance_2026-09-08.md)
+- [`Setup_2025_Live_Review_Work_Ledger_2026-09-08.md`](Setup_2025_Live_Review_Work_Ledger_2026-09-08.md)
+- Issue #122 — annual Setup Session engineering/reconstruction umbrella
+- PR #125 — Setup Production foundation / accepted Catalog lineage
+- PR #137 — restore Catalog-only reconstruction Delete Task UI

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Task_Material_Resolver_Contract_2026-09-09.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Task_Material_Resolver_Contract_2026-09-09.md
@@ -27,6 +27,8 @@ Examples:
 
 Both can remain Stage 02 tasks and be assigned to different crews.
 
+`Claymation Panels` is an MSB task/work-package name. It is not the name of one LOR Scene. The Claymation work package can aggregate several existing LOR Display groups.
+
 A task may also legitimately require no Display material at all. `Grease Gate bearings` is the canonical example.
 
 ### 2. Task physical/documentation scope
@@ -48,7 +50,7 @@ Therefore a task may be:
 
 ```text
 task/documentation scope = Stage 02
-material Display source  = a specific LOR Scene/group
+material Display source  = one or more specific LOR Scenes/groups
 ```
 
 The material group must not force the task into Scene scope.
@@ -59,7 +61,15 @@ LOR already maintains the Display grouping in `ref.lor_scene_display`. Setup sho
 
 This avoids the "forgotten Display" failure: if a Display is later added to the authoritative LOR group, Setup resolves it automatically without a separate Display-to-task maintenance step.
 
-A task may use no material group, one group, or—if actual field practice requires it—more than one group. Exact schema cardinality must be inventoried before implementation rather than assumed.
+A task may use:
+
+- no material group;
+- one LOR group; or
+- several LOR groups when one practical crew task spans several programming groups.
+
+The Stage 02 Claymation task proves that more-than-one material group is required. A single task may aggregate several LOR groups while the task itself remains Stage 02 scoped.
+
+A LOR group may also be relevant to more than one reusable task over the Setup lifecycle, for example physical setup, cord/network hookup, or testing. Therefore the task-to-LOR-material-group relationship must not be designed as one-to-one.
 
 For a true Scene, task scope and material group may be the same Scene. For a Stage-level/background grouping, they deliberately differ.
 
@@ -78,6 +88,22 @@ selected/scheduled task
 
 A Container may hold Displays from more than one Scene or Stage. That is normal. Container membership is downstream storage/transport evidence and must not be used to infer task scope or LOR material-group membership.
 
+## Read-Only Coverage Evidence — Stages 00, 01, 02, and 13
+
+The 2026-09-09 read-only material-group coverage review found:
+
+```text
+Stage 00 active Displays reviewed = 11
+Stage 01 active Displays reviewed = 14
+Stage 02 active Displays reviewed = 32
+Stage 13 active Displays reviewed = 38
+Total                            = 95
+```
+
+Every one of those 95 active Displays had `lor_group_count = 1` in the reviewed result. No active Display in those four Stages appeared ungrouped or multiply grouped in that evidence set.
+
+This strongly supports using current LOR group membership as the normal dynamic Display source rather than maintaining a second Setup Display list.
+
 ## Known-Good Reference: 13-Christmas Story
 
 `13-Christmas Story` is the reference case that currently behaves correctly in Production.
@@ -85,10 +111,11 @@ A Container may hold Displays from more than one Scene or Stage. That is normal.
 Observed live Material / Logistics result:
 
 ```text
-true task/physical scope = 13-Christmas Story Scene
-LOR material group       = 13-Christmas Story Scene
-Displays resolved        = 8
-Containers resolved      = 4
+true task/physical scope   = 13-Christmas Story Scene
+LOR material group         = 13-Christmas Story Scene
+Displays resolved          = 8
+Containers resolved        = 4
+current Container IDs      = 6, 131, 150, 171
 Displays without Container = 1
 ```
 
@@ -98,21 +125,61 @@ The Stage-level/background correction should reproduce this same material-resolu
 
 ## Stage-Level Material-Group Examples
 
+### Stage 00 — Hwy 42
+
 ```text
-02 Claymation Panels
-    task/documentation scope -> Stage 02
-    material Display source  -> Show Background Stage 02 Triangle Claymation
+Setup HWY42 Traffic Signs
+    task/documentation scope -> Stage 00
+    material LOR group       -> 275 HWY42 Traffic Signs
+    current result           -> 7 Displays -> Containers 1, 146
 
-02 Triangle Volunteer Path Setup
-    task/documentation scope -> Stage 02
-    material Display source  -> its corresponding LOR grouping
-
-Grease Gate bearings
-    task/documentation scope -> Stage 01 / Front Gate
-    material Display source  -> none
+Setup HWY42 MSB / Rotary Signs
+    task/documentation scope -> Stage 00
+    material LOR group       -> 289 HWY42 MSB and Rotary Signs
+    current result           -> 4 Displays -> Container 1
 ```
 
-This lets separate crews receive separate work packages inside the same Stage while all field Procedures/Wiring still resolve to the correct Stage unless a true Scene exists.
+### Stage 02 — Triangle
+
+```text
+02 Triangle Volunteer Path Setup
+    task/documentation scope -> Stage 02
+    material LOR group       -> 279 Volunteer Path Lights
+    current result           -> 2 Displays -> Container 72
+
+02 Claymation Panels
+    task/documentation scope -> Stage 02
+    material LOR groups      -> several current Stage 02 LOR groups
+```
+
+The operator-defined `Claymation Panels` work package includes displays commonly referred to by MSB as Claymation characters. Current reviewed Stage 02 evidence includes these LOR groups:
+
+```text
+280 Abominable      -> TR-Abominable      -> Container 2
+281 Narwhal         -> TR-Narwhal         -> Container 2
+282 CharlieInTheBox -> TR-CharlieInTheBox -> Container 2
+284 Frosty          -> TR-FrostyComeBack  -> Container 2
+```
+
+The operator also identifies Rudolph as part of the Claymation work package. No Rudolph-named active Display/LOR group appeared in the reviewed Stage 00/01/02/13 coverage output, so its current authoritative LOR identity must be located rather than guessed before finalizing the Claymation material mapping.
+
+Other Stage 02 groups such as Signage, US Flag, Volunteer Path Lights, Fred's Stars, and Mega Tree remain separate material groupings unless actual task practice says otherwise.
+
+### Stage 01 — Front Entrance
+
+Stage 01 currently includes Stage-fallback programming groups plus true Scenes. Current Stage-fallback groups include Goal Sign, Making Spirits Bright, Open-Close Sign, RotaryGear-01, and TuneRadio-2CH-01; true Scenes include `01-Entrance Arch` and `01-Front Gate`.
+
+A Stage 01 task may use one or more of those programming groups while continuing to resolve Procedures/Wiring to Stage 01 unless it is truly scoped to `01-Entrance Arch` or `01-Front Gate`.
+
+### Zero-material task
+
+```text
+Grease Gate bearings
+    task/documentation scope -> Stage 01 / Front Gate area
+    material LOR group       -> none
+```
+
+Zero material is valid when the task is real work but has no Display work package.
 
 ## Required Stage-Level Programming / Grouping Scenes
 
@@ -141,7 +208,7 @@ Their LOR membership can supply Setup material while Folder Alignment still reso
 - task Scene organization; and
 - automatic Display material expansion through `ref.lor_scene_display`.
 
-That works for the true Scene reference case `13-Christmas Story`, but fails for Stage-level tasks whose Display material is represented by a separate background/programming LOR Scene. Those tasks currently show zero Displays/Containers unless explicit `ref.setup_task_display` rows happen to exist.
+That works for the true Scene reference case `13-Christmas Story`, but fails for Stage-level tasks whose Display material is represented by one or more separate background/programming LOR Scenes. Those tasks currently show zero Displays/Containers unless explicit `ref.setup_task_display` rows happen to exist.
 
 Representative review areas include:
 
@@ -150,11 +217,11 @@ Representative review areas include:
 - Stage 01 Front Entrance grouping scenes;
 - Stage 02 Triangle Volunteer Path and Claymation as separate crew tasks;
 - Stage 16 Northern Lights; and
-- other Stage-level tasks with a distinct LOR grouping but no true `NN-Scene` folder.
+- other Stage-level tasks with distinct LOR grouping(s) but no true `NN-Scene` folder.
 
 The fix is **not** automatic expansion of every Display on the Stage and **not** manual maintenance of every Display-to-task row.
 
-The missing relationship is a way for a reusable task to reference its authoritative LOR material grouping independently of its Stage/Scene physical/documentation scope.
+The missing relationship is a way for a reusable task to reference zero, one, or several authoritative LOR material groups independently of its Stage/Scene physical/documentation scope.
 
 ## Existing `ref.setup_task_display`
 
@@ -172,14 +239,18 @@ The implementation should support:
 
 - task scope remaining Stage/Sub-stage/true Scene according to Folder Alignment;
 - zero material group for tasks such as bearing maintenance;
-- a Stage-level task referencing an LOR background/programming Scene solely as its Display/material source;
+- one or several LOR material groups for a Stage-level task;
 - separate tasks in one Stage referencing different LOR Display groups so parallel crews get the correct material;
+- several LOR groups being aggregated into one practical task, as with Stage 02 Claymation;
+- a LOR group being reusable by more than one task when different phases operate on the same Displays;
 - true Scene tasks such as Christmas Story using their Scene group naturally;
 - dynamic membership from current `ref.lor_scene_display`, so Displays are not forgotten in a second maintained list;
 - current Container derivation from the resolved Displays;
 - Container deduplication even when one Container carries several Scene/Stage groups;
 - explicit supplemental KIT/support Containers separately; and
-- clear UI language distinguishing **Task Scope** from **Material Group**.
+- clear UI language distinguishing **Task Scope** from **Material Group(s)**.
+
+The material-review UI should also distinguish an intentionally material-free task from a task whose material grouping has simply not yet been reviewed. Do not make an unexplained zero look the same as `NONE`.
 
 ## 2026 Session Gate
 

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Task_Material_Resolver_Contract_2026-09-09.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Task_Material_Resolver_Contract_2026-09-09.md
@@ -10,209 +10,161 @@
 
 ## Purpose
 
-Record the task/material distinction established during 2025 Setup Catalog review so future engineering does not reconstruct it from chat, screenshots, or individual task examples.
+Preserve the operator-confirmed distinction between reusable Setup task scope, LOR Display grouping, physical/documentation scope, and Container derivation so future work does not reconstruct this model from screenshots or chat.
 
-This contract governs how reusable Setup work should resolve required Displays/assets and, downstream, current Containers for planning and Pick List use.
+## Four Concepts Must Remain Separate
 
-## Three Concepts Must Not Be Collapsed
+### 1. Reusable Setup task
 
-### 1. Reusable task scope
-
-A reusable Setup task is the practical unit of work and has a Stage/Sub-stage/Scene/Park Infrastructure organizational home.
-
-Task scope answers **where the work belongs**. It does not prove that the task owns any Display.
-
-Example:
-
-```text
-Grease Gate bearings
-    -> belongs at the Front Gate / applicable Stage scope
-    -> is real reusable Setup work
-    -> may legitimately own zero Displays
-```
-
-Do not move a task to another Stage/Scene merely to make Material / Logistics appear populated.
-
-### 2. Display physical/documentation location
-
-A physical Display belongs to the existing current Stage/Sub-stage/Scene hierarchy.
-
-The authoritative hierarchy already exists through:
-
-- `ref.display.stage_id -> ref.stage`;
-- current `ref.lor_scene_display -> ref.lor_scene` membership where the Display belongs to a real Scene scope; and
-- the production-accepted shared field-context / Folder Alignment resolver.
-
-A Scene is a real field/documentation scope only when it is deliberately aligned. If there is no more-specific Scene/Sub-stage scope, the Display remains at the applicable Stage/Sub-stage scope.
-
-A Display has one physical Setup location in that hierarchy. It must not be assigned to two different physical Setup locations merely to satisfy task planning.
-
-### 3. Reusable task Display work-package ownership
-
-Display assignment is optional and separate from task scope.
-
-Current operating rule established during live 2025 review:
-
-```text
-one Display
-    -> zero or one reusable Setup task
-
-one reusable Setup task
-    -> zero, one, or many Displays
-```
-
-If a Display belongs to a reusable Setup work package, one reusable task owns that Display for Setup planning/reporting. Do not duplicate the same Display across reusable tasks.
-
-The practical task boundary controls the assignment. Do not create one task per panel merely to make Display ownership easy.
+A task is a practical unit of work that can be planned/staffed independently.
 
 Examples:
 
 ```text
+02 Triangle Volunteer Path Setup
+02 Claymation Panels
+```
+
+Both may belong to Stage 02 and be assigned to different crews.
+
+A task may also legitimately require no Display group at all. `Grease Gate bearings` is the canonical example.
+
+### 2. Task physical/documentation scope
+
+Task scope answers where the work belongs for Setup organization and shared Procedures/Wiring context.
+
+The existing Folder Alignment contract controls this scope:
+
+```text
+NN-Name-XY      -> Stage
+NNa-Name-XY     -> Sub-stage
+NN-Name         -> Scene under the owning Stage
+NNa-Name        -> Scene under the owning Sub-stage
+```
+
+If an LOR programming/grouping Scene does not correspond to a real `NN-Scene` / `NNa-Scene` structured folder, the physical/documentation scope remains the owning Stage/Sub-stage.
+
+Therefore a task may be:
+
+```text
+task scope     = Stage 02
+material group = an LOR Scene/group that gathers the Displays used by that task
+```
+
+The material group must not force the task into Scene scope.
+
+### 3. LOR Display/material group
+
+LOR already maintains useful Scene/group membership in `ref.lor_scene_display`. Setup should consume that authoritative grouping when a practical task corresponds to the group instead of copying every Display into a second manually-maintained task list.
+
+This avoids the "forgotten Display" failure: if a Display is later added to the authoritative LOR group, Setup can resolve it automatically without a separate Display-to-task maintenance step.
+
+A task may use zero, one, or, if real field practice requires it, more than one LOR material group. Exact schema cardinality must be confirmed before implementation; do not assume a single nullable column without inventory.
+
+For a true Scene such as `13-Christmas Story`, the task physical scope and the LOR material group may happen to be the same Scene.
+
+For a Stage-level/background grouping, they deliberately differ:
+
+```text
+02 Claymation Panels
+    task/documentation scope -> Stage 02
+    material Display source  -> Show Background Stage 02 Triangle Claymation
+
+02 Triangle Volunteer Path Setup
+    task/documentation scope -> Stage 02
+    material Display source  -> its corresponding LOR grouping
+
 Grease Gate bearings
-    -> zero Displays is valid
-
-Set Up Traffic Signs
-    -> one reusable task
-    -> may own the full reviewed Traffic Sign Display group
-
-Set Up MSB & Rotary Signs
-    -> one reusable task
-    -> may own the reviewed MSB / Rotary sign Display group
-
-Setup Panels
-    -> one practical crew/work-package task
-    -> may own many panel Displays
+    task/documentation scope -> Stage 01 / Front Gate
+    material Display source  -> none
 ```
 
-Known review areas include Hwy 42 Traffic Signs, Rotary MSB Signs, Front Entrance, Northern Lights, and other grouped physical work.
+### 4. Container derivation
 
-LOR Scene/display-group and Stage membership are useful **selection evidence** for establishing a task's work package, but they do not automatically make every Display in that scope belong to every task located there.
-
-## Required Resolver Flow
-
-The material resolver must follow:
+Once the required Display group is known, current Containers derive from the Displays' current `ref.display.container_id` values.
 
 ```text
-selected reusable Setup task
-    -> its assigned Display work package, if any
-        -> each Display's current ref.display.container_id
-            -> deduplicate current Containers / trailers
-                -> add reviewed supplemental support / KIT Containers
-                    -> explain why each item / Container is required
+selected/scheduled task
+    -> LOR material group(s), if any
+    -> current Displays in those group(s)
+    -> current Display.container_id
+    -> deduplicate Containers/trailers
+    -> add explicit supplemental KIT/support Containers when needed
 ```
 
-A task with no assigned Displays may correctly resolve zero Displays and zero derived Containers. That is not inherently a data defect.
+Do not maintain a second task-to-Container list where current Display storage already supplies the answer.
 
-Do **not** replace task-level ownership with automatic inheritance such as:
+## Required Stage-Level Programming / Grouping Scenes
+
+The following LOR Scenes are required show-programming/grouping constructs even though they resolve physically/documentationally to their owning Stage rather than to separate `NN-Scene` folders:
 
 ```text
-task Stage -> every Stage Display -> Containers
+Stage 00
+- Show Background Stage 00 HWY42 MSB-Rotary-Trees
+- Show Background Stage 00 HWY42 Traffic Signs
+
+Stage 01
+- Show Background Stage 01 FE Goal Sign
+- Show Background Stage 01 FE MSB Sign
+- Show Background Stage 01 FE Open-Close Sign
+- Show Background Stage 01 FE Outside Gate
 ```
 
-or:
+These six are required for programming the show and for authoritative Display grouping. Do not delete or normalize them away merely because they do not create separate Google Drive Scene folders.
 
-```text
-task Scene -> every Scene Display -> Containers
-```
-
-Stage/Scene/LOR groups may be offered as bulk-selection sources when the whole group truly is the practical work package. Bulk selection is an editing convenience that writes reviewed task-to-Display ownership; it is not silent inheritance.
+Their LOR Scene membership can be used as task material grouping while Folder Alignment still resolves Procedures/Wiring to Stage 00 or Stage 01.
 
 ## Current Production Defect
 
-`Setup/Application/setup_next_repository.py` currently builds `field_context()` Display scope from:
+`Setup/Application/setup_next_repository.py::field_context()` currently uses the task's `lor_scene_id` for both concepts at once:
 
-1. explicit `ref.setup_task_display` mappings; plus
-2. automatic expansion of every Display in `ref.lor_scene_display` for the task's `lor_scene_id`.
+- task Scene organization; and
+- automatic Display material expansion through `ref.lor_scene_display`.
 
-This violates the operating model in two different ways:
+That works for a true Scene such as Christmas Story, but fails for Stage-level tasks whose material is represented by a separate background/programming LOR Scene. Those tasks currently show zero Displays/Containers unless explicit `ref.setup_task_display` rows happen to exist.
 
-- Scene-organized tasks can appear to own every Scene Display even when no reviewed task-to-Display ownership exists;
-- many real Display-bearing Stage-level work packages have no populated `ref.setup_task_display` ownership yet and therefore show zero, while zero is also a legitimate result for non-Display tasks such as bearing maintenance.
+Representative review examples include:
 
-The application cannot safely distinguish those Stage-level cases merely from Stage membership. The missing piece is reviewed task-level Display ownership plus a practical Manager editing workflow.
+- Stage 01 `Claymation Panels` / Front Entrance groupings;
+- Stage 16 `Setup Northern Lights`;
+- Stage 16 `Layout RGB Locations (20' Spacing, 32P & 30D)`;
+- Stage 16 `Northern Lights Plug in Power & Network`;
+- Hwy 42 Traffic Signs;
+- Hwy 42 MSB / Rotary Signs; and
+- Stage 02 Volunteer Path versus Claymation Panels as separate crew tasks within the same Stage.
 
-Representative Production review evidence includes:
+The fix is **not** automatic expansion of every Display on the Stage and **not** manual maintenance of every Display-to-task row.
 
-- Stage 01 `Claymation Panels` currently shows 0 resolved Displays even though this is intended as Display-bearing work;
-- Stage 16 `Setup Northern Lights`, `Layout RGB Locations (20' Spacing, 32P & 30D)`, and `Northern Lights Plug in Power & Network` currently show 0;
-- Christmas Story Scene currently shows 8 Displays / 4 Containers because of automatic Scene expansion; this result may be physically plausible but the ownership must come from reviewed task material rather than implicit Scene inheritance;
-- additional operator-noted areas include Hwy 42 Traffic Signs, Rotary MSB Signs, and Front Entrance; and
-- `Grease Gate bearings` is the counterexample proving that Stage-level zero cannot automatically be treated as missing material.
+The missing relationship is a way for a task to reference its authoritative LOR material grouping independently of its Stage/Scene physical/documentation scope.
 
-The fix is **not** to add automatic Stage expansion. The fix is to make task-level Display work-package ownership reviewable and trustworthy, then have the resolver consume it.
+## Implementation Direction
 
-## Manager Editing Requirement
+Before choosing schema, inventory representative Production tasks and their LOR grouping candidates.
 
-The Catalog needs a practical way to maintain task material without forcing one Display at a time where a real work group already exists.
+The implementation should support:
 
-Required direction:
+- task scope remaining Stage/Sub-stage/true Scene according to Folder Alignment;
+- zero material group for tasks such as bearing maintenance;
+- a Stage-level task referencing an LOR background/programming Scene solely as its Display/material source;
+- separate tasks in one Stage referencing different LOR Display groups so parallel crews get the correct material;
+- true Scene tasks using their Scene group naturally;
+- dynamic membership from current `ref.lor_scene_display`, so Displays are not forgotten in a second maintained list;
+- current Container derivation from the resolved Displays;
+- explicit supplemental KIT/support Containers separately; and
+- clear UI language distinguishing **Task Scope** from **Material Group**.
 
-- show the Displays currently owned by the selected reusable task;
-- show enough Stage/Sub-stage/Scene context to understand where those Displays physically belong;
-- allow selecting a known Stage/Sub-stage/Scene/LOR group as a **bulk source** when that group truly matches the practical task;
-- write explicit task-to-Display ownership for the reviewed selected Displays rather than relying on future implicit inheritance;
-- allow explicit add/remove/reassign corrections;
-- prevent one Display from being assigned to more than one reusable Setup task;
-- preserve zero-Display tasks as valid;
-- surface each Display's current Container after ownership is established;
-- do not create a second maintained Container list when Container demand can be derived from current Display-to-Container relationships; and
-- keep supplemental support/KIT Container relationships explicit and separate because they are not always derivable from Display storage.
-
-When reassigning a Display from one reusable task to another, the UI should show the current owner and require an explicit move/reassign rather than silently duplicating the relationship.
-
-## Container Rules
-
-`ref.display.container_id` remains the current storage/transport relationship for a Display.
-
-The resolver should derive Container demand from the selected task's owned Displays and deduplicate it. This is necessary because one Container/trailer may carry Displays for several Stages even though each Display itself has only one reusable Setup task owner.
-
-Known examples:
-
-- Container 34 / Arch Trailer carries Displays for multiple Stages;
-- Antenna Trailer carries material for several unrelated Display groups; and
-- a KIT/support Container can be required even when no task Display currently points to it.
-
-Do not assign a Display to the wrong Container or wrong Stage merely to express a Setup dependency.
-
-## Planning Boundary
-
-Reusable task Display ownership is separate from:
-
-- Stage/Scene Catalog organization;
-- physical Display Stage/Scene location;
-- task predecessor/dependency relationships;
-- preferred execution order;
-- annual schedule/date assignment;
-- readiness conditions; and
-- current Container movement state.
-
-A task such as bearing lubrication can be real Setup work with no Display material. Conversely, a grouped panel-install task can own many Displays and derive several Containers.
+Existing `ref.setup_task_display` data must be inventoried before retirement/reinterpretation. Do not delete or migrate it blindly; determine whether any rows represent exceptions not captured by an LOR group.
 
 ## 2026 Session Gate
 
 The operator decision remains: **do not create the 2026 Setup Session until the reconstructed 2025 plan is complete.**
 
-Before propagation, task material must be trustworthy enough that planning/Pick List work does not inherit known false or missing Display/Container relationships.
-
-## Implementation Gate
-
-Before changing Production behavior:
-
-1. inventory current `ref.setup_task_display` ownership and representative tasks;
-2. identify tasks that legitimately require zero Displays;
-3. identify practical group tasks whose material can be bulk-selected from existing Stage/Scene/LOR grouping evidence;
-4. identify any Display currently mapped to more than one reusable task and reconcile it before enforcing uniqueness;
-5. confirm the editing workflow against representative areas including Front Entrance, Hwy 42 Traffic Signs, Rotary MSB Signs, Northern Lights, and one known-good Scene group;
-6. implement explicit add/remove/reassign behavior and preserve zero-Display tasks;
-7. only then remove implicit Scene-wide material ownership from the resolver;
-8. verify derived Container deduplication and shared-trailer behavior; and
-9. perform protected browser validation before Production acceptance.
+Material resolution must be trustworthy before 2026 propagation so near-term planning/Pick List work does not inherit known missing or false Display/Container relationships.
 
 ## Related Durable Sources
 
+- [Google Drive Path Resolution Contract](../../../../../00_Project_Overview/Google_Drive/engineering/Google_Drive_Path_Resolution_Contract.md)
 - [Setup Pick List Tablet Workflow](Setup_Pick_List_Tablet_Workflow_2026-09-09.md)
-- [Setup Planning Operating Model](Setup_Planning_Operating_Model_2026-09-08.md)
+- [Setup Predecessor and Readiness Contract](Setup_Predecessor_and_Readiness_Contract_2026-09-09.md)
 - [Setup engineering portal](README.md)
-- [Google Drive Stage/Sub-stage/Scene folder SOP](../../../../../00_Project_Overview/Google_Drive/operatorSOP/Create_Stage_Substage_Scene_Folder.md)
-- [Shared Field Context Database Layer Acceptance](../../07_Labeling_and_Scanning/Shared_Field_Context_Database_Layer_Acceptance_2026-08-23.md)
 - GitHub Issue #122

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Task_Material_Resolver_Contract_2026-09-09.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Task_Material_Resolver_Contract_2026-09-09.md
@@ -14,11 +14,26 @@ Record the task/material distinction established during 2025 Setup Catalog revie
 
 This contract governs how reusable Setup work should resolve required Displays/assets and, downstream, current Containers for planning and Pick List use.
 
-## Two Different Scopes Must Not Be Collapsed
+## Three Concepts Must Not Be Collapsed
 
-Setup has two related but different concepts:
+### 1. Reusable task scope
 
-### 1. Physical / documentation location scope
+A reusable Setup task is the practical unit of work and has a Stage/Sub-stage/Scene/Park Infrastructure organizational home.
+
+Task scope answers **where the work belongs**. It does not prove that the task owns any Display.
+
+Example:
+
+```text
+Grease Gate bearings
+    -> belongs at the Front Gate / applicable Stage scope
+    -> is real reusable Setup work
+    -> may legitimately own zero Displays
+```
+
+Do not move a task to another Stage/Scene merely to make Material / Logistics appear populated.
+
+### 2. Display physical/documentation location
 
 A physical Display belongs to the existing current Stage/Sub-stage/Scene hierarchy.
 
@@ -32,24 +47,46 @@ A Scene is a real field/documentation scope only when it is deliberately aligned
 
 A Display has one physical Setup location in that hierarchy. It must not be assigned to two different physical Setup locations merely to satisfy task planning.
 
-### 2. Reusable task material requirement
+### 3. Reusable task Display work-package ownership
 
-A reusable Setup task is a practical unit of work. Its material requirement is **not automatically equal to every Display in its Stage or Scene**.
+Display assignment is optional and separate from task scope.
 
-A task may require:
+Current operating rule established during live 2025 review:
 
-- zero Displays/assets;
-- one Display;
-- many Displays as a practical group; or
-- Displays plus reviewed supplemental support/KIT Containers.
+```text
+one Display
+    -> zero or one reusable Setup task
 
-Examples established during live review:
+one reusable Setup task
+    -> zero, one, or many Displays
+```
 
-- `Grease Gate bearings` can legitimately require **no Display rows**;
-- a `Setup Panels` task can intentionally require **a group of panel Displays**;
-- grouped work such as Hwy 42 Traffic Signs, Rotary MSB Signs, Front Entrance panels, Northern Lights, and similar areas must be reviewed as practical task material, not inferred from the whole Stage merely because the task is Stage-organized.
+If a Display belongs to a reusable Setup work package, one reusable task owns that Display for Setup planning/reporting. Do not duplicate the same Display across reusable tasks.
 
-The same physical Display/location may participate in more than one work task when the work itself requires that Display. Physical location ownership and task material participation are separate concepts.
+The practical task boundary controls the assignment. Do not create one task per panel merely to make Display ownership easy.
+
+Examples:
+
+```text
+Grease Gate bearings
+    -> zero Displays is valid
+
+Set Up Traffic Signs
+    -> one reusable task
+    -> may own the full reviewed Traffic Sign Display group
+
+Set Up MSB & Rotary Signs
+    -> one reusable task
+    -> may own the reviewed MSB / Rotary sign Display group
+
+Setup Panels
+    -> one practical crew/work-package task
+    -> may own many panel Displays
+```
+
+Known review areas include Hwy 42 Traffic Signs, Rotary MSB Signs, Front Entrance, Northern Lights, and other grouped physical work.
+
+LOR Scene/display-group and Stage membership are useful **selection evidence** for establishing a task's work package, but they do not automatically make every Display in that scope belong to every task located there.
 
 ## Required Resolver Flow
 
@@ -57,14 +94,16 @@ The material resolver must follow:
 
 ```text
 selected reusable Setup task
-    -> required Displays / durable assets for that task
+    -> its assigned Display work package, if any
         -> each Display's current ref.display.container_id
             -> deduplicate current Containers / trailers
                 -> add reviewed supplemental support / KIT Containers
                     -> explain why each item / Container is required
 ```
 
-Do **not** replace this with:
+A task with no assigned Displays may correctly resolve zero Displays and zero derived Containers. That is not inherently a data defect.
+
+Do **not** replace task-level ownership with automatic inheritance such as:
 
 ```text
 task Stage -> every Stage Display -> Containers
@@ -76,9 +115,7 @@ or:
 task Scene -> every Scene Display -> Containers
 ```
 
-unless that task's reviewed material requirement is in fact the entire Stage/Scene group.
-
-Stage/Scene organization is useful context and may provide a bulk-selection source for editing task material, but it is not itself sufficient proof that every Display in that scope is required by the task.
+Stage/Scene/LOR groups may be offered as bulk-selection sources when the whole group truly is the practical work package. Bulk selection is an editing convenience that writes reviewed task-to-Display ownership; it is not silent inheritance.
 
 ## Current Production Defect
 
@@ -87,66 +124,69 @@ Stage/Scene organization is useful context and may provide a bulk-selection sour
 1. explicit `ref.setup_task_display` mappings; plus
 2. automatic expansion of every Display in `ref.lor_scene_display` for the task's `lor_scene_id`.
 
-There is no Stage-level material branch.
+This violates the operating model in two different ways:
 
-This produces two failure classes:
+- Scene-organized tasks can appear to own every Scene Display even when no reviewed task-to-Display ownership exists;
+- many real Display-bearing Stage-level work packages have no populated `ref.setup_task_display` ownership yet and therefore show zero, while zero is also a legitimate result for non-Display tasks such as bearing maintenance.
 
-- Stage-organized tasks with no explicit task material can show **0 Displays / 0 Containers** even when the Stage contains the intended group;
-- Scene-organized tasks can appear to work while potentially overstating task material by automatically treating all Scene members as required.
+The application cannot safely distinguish those Stage-level cases merely from Stage membership. The missing piece is reviewed task-level Display ownership plus a practical Manager editing workflow.
 
-Representative Production review evidence:
+Representative Production review evidence includes:
 
-- Stage 01 `Claymation Panels` -> 0 resolved Displays although Stage 01 has active Displays;
-- Stage 16 `Setup Northern Lights` -> 0;
-- Stage 16 `Layout RGB Locations (20' Spacing, 32P & 30D)` -> 0;
-- Stage 16 `Northern Lights Plug in Power & Network` -> 0;
-- Christmas Story Scene currently resolves 8 Displays / 4 Containers because of automatic Scene expansion;
-- additional operator-noted areas include Hwy 42 Traffic Signs, Rotary MSB Signs, and Front Entrance.
+- Stage 01 `Claymation Panels` currently shows 0 resolved Displays even though this is intended as Display-bearing work;
+- Stage 16 `Setup Northern Lights`, `Layout RGB Locations (20' Spacing, 32P & 30D)`, and `Northern Lights Plug in Power & Network` currently show 0;
+- Christmas Story Scene currently shows 8 Displays / 4 Containers because of automatic Scene expansion; this result may be physically plausible but the ownership must come from reviewed task material rather than implicit Scene inheritance;
+- additional operator-noted areas include Hwy 42 Traffic Signs, Rotary MSB Signs, and Front Entrance; and
+- `Grease Gate bearings` is the counterexample proving that Stage-level zero cannot automatically be treated as missing material.
 
-The fix is **not** simply to add automatic Stage expansion. Task material must remain a task-level reviewed requirement.
+The fix is **not** to add automatic Stage expansion. The fix is to make task-level Display work-package ownership reviewable and trustworthy, then have the resolver consume it.
 
-## Editing Requirement
+## Manager Editing Requirement
 
 The Catalog needs a practical way to maintain task material without forcing one Display at a time where a real work group already exists.
 
 Required direction:
 
-- show current required Displays for the selected reusable task;
+- show the Displays currently owned by the selected reusable task;
+- show enough Stage/Sub-stage/Scene context to understand where those Displays physically belong;
 - allow selecting a known Stage/Sub-stage/Scene/LOR group as a **bulk source** when that group truly matches the practical task;
+- write explicit task-to-Display ownership for the reviewed selected Displays rather than relying on future implicit inheritance;
 - allow explicit add/remove/reassign corrections;
+- prevent one Display from being assigned to more than one reusable Setup task;
 - preserve zero-Display tasks as valid;
-- surface each Display's current Container after task material is selected;
-- do not create a second maintained Container list when Container demand can be derived from current Display-to-Container relationships;
+- surface each Display's current Container after ownership is established;
+- do not create a second maintained Container list when Container demand can be derived from current Display-to-Container relationships; and
 - keep supplemental support/KIT Container relationships explicit and separate because they are not always derivable from Display storage.
 
-Bulk selection is an editing convenience, not an automatic inheritance rule.
+When reassigning a Display from one reusable task to another, the UI should show the current owner and require an explicit move/reassign rather than silently duplicating the relationship.
 
 ## Container Rules
 
 `ref.display.container_id` remains the current storage/transport relationship for a Display.
 
-The resolver should derive Container demand from selected task Displays and deduplicate it. This is necessary because one Container/trailer may carry Displays for several Stages or tasks.
+The resolver should derive Container demand from the selected task's owned Displays and deduplicate it. This is necessary because one Container/trailer may carry Displays for several Stages even though each Display itself has only one reusable Setup task owner.
 
 Known examples:
 
 - Container 34 / Arch Trailer carries Displays for multiple Stages;
-- Antenna Trailer carries material for several unrelated Display groups;
+- Antenna Trailer carries material for several unrelated Display groups; and
 - a KIT/support Container can be required even when no task Display currently points to it.
 
 Do not assign a Display to the wrong Container or wrong Stage merely to express a Setup dependency.
 
 ## Planning Boundary
 
-Reusable task material is separate from:
+Reusable task Display ownership is separate from:
 
 - Stage/Scene Catalog organization;
+- physical Display Stage/Scene location;
 - task predecessor/dependency relationships;
 - preferred execution order;
 - annual schedule/date assignment;
-- readiness conditions;
+- readiness conditions; and
 - current Container movement state.
 
-A task such as bearing lubrication can be real Setup work with no Display material. Conversely, a grouped panel-install task can require many Displays and several Containers.
+A task such as bearing lubrication can be real Setup work with no Display material. Conversely, a grouped panel-install task can own many Displays and derive several Containers.
 
 ## 2026 Session Gate
 
@@ -158,14 +198,15 @@ Before propagation, task material must be trustworthy enough that planning/Pick 
 
 Before changing Production behavior:
 
-1. inventory current `ref.setup_task_display` mappings and representative tasks;
+1. inventory current `ref.setup_task_display` ownership and representative tasks;
 2. identify tasks that legitimately require zero Displays;
 3. identify practical group tasks whose material can be bulk-selected from existing Stage/Scene/LOR grouping evidence;
-4. confirm the editing workflow against representative areas including Front Entrance, Hwy 42 Traffic Signs, Rotary MSB Signs, Northern Lights, and one known-good Scene group;
-5. change the resolver only after the task-material editing/selection rule is explicit;
-6. test that zero-Display tasks remain valid and that bulk group selection does not become silent automatic inheritance;
-7. verify derived Container deduplication and shared-trailer behavior; and
-8. perform protected browser validation before Production acceptance.
+4. identify any Display currently mapped to more than one reusable task and reconcile it before enforcing uniqueness;
+5. confirm the editing workflow against representative areas including Front Entrance, Hwy 42 Traffic Signs, Rotary MSB Signs, Northern Lights, and one known-good Scene group;
+6. implement explicit add/remove/reassign behavior and preserve zero-Display tasks;
+7. only then remove implicit Scene-wide material ownership from the resolver;
+8. verify derived Container deduplication and shared-trailer behavior; and
+9. perform protected browser validation before Production acceptance.
 
 ## Related Durable Sources
 

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Task_Material_Resolver_Contract_2026-09-09.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Task_Material_Resolver_Contract_2026-09-09.md
@@ -1,0 +1,177 @@
+# Setup Task Material Resolver Contract — 2026-09-09
+
+| Document Control | Value |
+|---|---|
+| Document Type | Engineering Contract / Live Review Finding |
+| System | Production Database — Setup and Deployment |
+| Status | CURRENT DESIGN AUTHORITY — Production resolver correction pending |
+| Owner | MSB Production Database engineering |
+| Related Work | Issue #122; PR #125; PR #138 |
+
+## Purpose
+
+Record the task/material distinction established during 2025 Setup Catalog review so future engineering does not reconstruct it from chat, screenshots, or individual task examples.
+
+This contract governs how reusable Setup work should resolve required Displays/assets and, downstream, current Containers for planning and Pick List use.
+
+## Two Different Scopes Must Not Be Collapsed
+
+Setup has two related but different concepts:
+
+### 1. Physical / documentation location scope
+
+A physical Display belongs to the existing current Stage/Sub-stage/Scene hierarchy.
+
+The authoritative hierarchy already exists through:
+
+- `ref.display.stage_id -> ref.stage`;
+- current `ref.lor_scene_display -> ref.lor_scene` membership where the Display belongs to a real Scene scope; and
+- the production-accepted shared field-context / Folder Alignment resolver.
+
+A Scene is a real field/documentation scope only when it is deliberately aligned. If there is no more-specific Scene/Sub-stage scope, the Display remains at the applicable Stage/Sub-stage scope.
+
+A Display has one physical Setup location in that hierarchy. It must not be assigned to two different physical Setup locations merely to satisfy task planning.
+
+### 2. Reusable task material requirement
+
+A reusable Setup task is a practical unit of work. Its material requirement is **not automatically equal to every Display in its Stage or Scene**.
+
+A task may require:
+
+- zero Displays/assets;
+- one Display;
+- many Displays as a practical group; or
+- Displays plus reviewed supplemental support/KIT Containers.
+
+Examples established during live review:
+
+- `Grease Gate bearings` can legitimately require **no Display rows**;
+- a `Setup Panels` task can intentionally require **a group of panel Displays**;
+- grouped work such as Hwy 42 Traffic Signs, Rotary MSB Signs, Front Entrance panels, Northern Lights, and similar areas must be reviewed as practical task material, not inferred from the whole Stage merely because the task is Stage-organized.
+
+The same physical Display/location may participate in more than one work task when the work itself requires that Display. Physical location ownership and task material participation are separate concepts.
+
+## Required Resolver Flow
+
+The material resolver must follow:
+
+```text
+selected reusable Setup task
+    -> required Displays / durable assets for that task
+        -> each Display's current ref.display.container_id
+            -> deduplicate current Containers / trailers
+                -> add reviewed supplemental support / KIT Containers
+                    -> explain why each item / Container is required
+```
+
+Do **not** replace this with:
+
+```text
+task Stage -> every Stage Display -> Containers
+```
+
+or:
+
+```text
+task Scene -> every Scene Display -> Containers
+```
+
+unless that task's reviewed material requirement is in fact the entire Stage/Scene group.
+
+Stage/Scene organization is useful context and may provide a bulk-selection source for editing task material, but it is not itself sufficient proof that every Display in that scope is required by the task.
+
+## Current Production Defect
+
+`Setup/Application/setup_next_repository.py` currently builds `field_context()` Display scope from:
+
+1. explicit `ref.setup_task_display` mappings; plus
+2. automatic expansion of every Display in `ref.lor_scene_display` for the task's `lor_scene_id`.
+
+There is no Stage-level material branch.
+
+This produces two failure classes:
+
+- Stage-organized tasks with no explicit task material can show **0 Displays / 0 Containers** even when the Stage contains the intended group;
+- Scene-organized tasks can appear to work while potentially overstating task material by automatically treating all Scene members as required.
+
+Representative Production review evidence:
+
+- Stage 01 `Claymation Panels` -> 0 resolved Displays although Stage 01 has active Displays;
+- Stage 16 `Setup Northern Lights` -> 0;
+- Stage 16 `Layout RGB Locations (20' Spacing, 32P & 30D)` -> 0;
+- Stage 16 `Northern Lights Plug in Power & Network` -> 0;
+- Christmas Story Scene currently resolves 8 Displays / 4 Containers because of automatic Scene expansion;
+- additional operator-noted areas include Hwy 42 Traffic Signs, Rotary MSB Signs, and Front Entrance.
+
+The fix is **not** simply to add automatic Stage expansion. Task material must remain a task-level reviewed requirement.
+
+## Editing Requirement
+
+The Catalog needs a practical way to maintain task material without forcing one Display at a time where a real work group already exists.
+
+Required direction:
+
+- show current required Displays for the selected reusable task;
+- allow selecting a known Stage/Sub-stage/Scene/LOR group as a **bulk source** when that group truly matches the practical task;
+- allow explicit add/remove/reassign corrections;
+- preserve zero-Display tasks as valid;
+- surface each Display's current Container after task material is selected;
+- do not create a second maintained Container list when Container demand can be derived from current Display-to-Container relationships;
+- keep supplemental support/KIT Container relationships explicit and separate because they are not always derivable from Display storage.
+
+Bulk selection is an editing convenience, not an automatic inheritance rule.
+
+## Container Rules
+
+`ref.display.container_id` remains the current storage/transport relationship for a Display.
+
+The resolver should derive Container demand from selected task Displays and deduplicate it. This is necessary because one Container/trailer may carry Displays for several Stages or tasks.
+
+Known examples:
+
+- Container 34 / Arch Trailer carries Displays for multiple Stages;
+- Antenna Trailer carries material for several unrelated Display groups;
+- a KIT/support Container can be required even when no task Display currently points to it.
+
+Do not assign a Display to the wrong Container or wrong Stage merely to express a Setup dependency.
+
+## Planning Boundary
+
+Reusable task material is separate from:
+
+- Stage/Scene Catalog organization;
+- task predecessor/dependency relationships;
+- preferred execution order;
+- annual schedule/date assignment;
+- readiness conditions;
+- current Container movement state.
+
+A task such as bearing lubrication can be real Setup work with no Display material. Conversely, a grouped panel-install task can require many Displays and several Containers.
+
+## 2026 Session Gate
+
+The operator decision remains: **do not create the 2026 Setup Session until the reconstructed 2025 plan is complete.**
+
+Before propagation, task material must be trustworthy enough that planning/Pick List work does not inherit known false or missing Display/Container relationships.
+
+## Implementation Gate
+
+Before changing Production behavior:
+
+1. inventory current `ref.setup_task_display` mappings and representative tasks;
+2. identify tasks that legitimately require zero Displays;
+3. identify practical group tasks whose material can be bulk-selected from existing Stage/Scene/LOR grouping evidence;
+4. confirm the editing workflow against representative areas including Front Entrance, Hwy 42 Traffic Signs, Rotary MSB Signs, Northern Lights, and one known-good Scene group;
+5. change the resolver only after the task-material editing/selection rule is explicit;
+6. test that zero-Display tasks remain valid and that bulk group selection does not become silent automatic inheritance;
+7. verify derived Container deduplication and shared-trailer behavior; and
+8. perform protected browser validation before Production acceptance.
+
+## Related Durable Sources
+
+- [Setup Pick List Tablet Workflow](Setup_Pick_List_Tablet_Workflow_2026-09-09.md)
+- [Setup Planning Operating Model](Setup_Planning_Operating_Model_2026-09-08.md)
+- [Setup engineering portal](README.md)
+- [Google Drive Stage/Sub-stage/Scene folder SOP](../../../../../00_Project_Overview/Google_Drive/operatorSOP/Create_Stage_Substage_Scene_Folder.md)
+- [Shared Field Context Database Layer Acceptance](../../07_Labeling_and_Scanning/Shared_Field_Context_Database_Layer_Acceptance_2026-08-23.md)
+- GitHub Issue #122

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Task_Material_Resolver_Contract_2026-09-09.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Task_Material_Resolver_Contract_2026-09-09.md
@@ -149,19 +149,22 @@ Setup HWY42 MSB / Rotary Signs
 
 02 Claymation Panels
     task/documentation scope -> Stage 02
-    material LOR groups      -> several current Stage 02 LOR groups
+    material LOR groups      -> 280, 281, 282, 283, 284
 ```
 
-The operator-defined `Claymation Panels` work package includes displays commonly referred to by MSB as Claymation characters. Current reviewed Stage 02 evidence includes these LOR groups:
+The operator-defined `Claymation Panels` work package includes the character Displays commonly referred to by MSB as Claymation. Current reviewed Stage 02 evidence resolves the group as:
 
 ```text
-280 Abominable      -> TR-Abominable      -> Container 2
-281 Narwhal         -> TR-Narwhal         -> Container 2
-282 CharlieInTheBox -> TR-CharlieInTheBox -> Container 2
-284 Frosty          -> TR-FrostyComeBack  -> Container 2
+280 Abominable      -> TR-Abominable       -> Container 2
+281 Narwhal         -> TR-Narwhal          -> Container 2
+282 CharlieInTheBox -> TR-CharlieInTheBox  -> Container 2
+283 Headlights      -> FE-HeadlightsSign   -> Container 2   (Rudolph)
+284 Frosty          -> TR-FrostyComeBack   -> Container 2
 ```
 
-The operator also identifies Rudolph as part of the Claymation work package. No Rudolph-named active Display/LOR group appeared in the reviewed Stage 00/01/02/13 coverage output, so its current authoritative LOR identity must be located rather than guessed before finalizing the Claymation material mapping.
+`Rudolph` is the operator/common-name identity for the current `Headlights` LOR group / `FE-HeadlightsSign` Display in this work package. Do not create a separate Rudolph Display or Scene merely to make the Setup task name match the operator terminology.
+
+All five current Claymation groups resolve to Container 2, which makes the current transport result especially simple even though the work package spans five LOR groups.
 
 Other Stage 02 groups such as Signage, US Flag, Volunteer Path Lights, Fred's Stars, and Mega Tree remain separate material groupings unless actual task practice says otherwise.
 

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Task_Material_Resolver_Contract_2026-09-09.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Task_Material_Resolver_Contract_2026-09-09.md
@@ -41,6 +41,44 @@ Stage/Sub-stage task
 
 The resolver must use the accepted Folder Alignment/shared field-context rules for physical scope classification. Do not use a simple Scene-name regex as Production authority; regex classification used during read-only diagnostics was only a convenient inspection aid.
 
+## Operational Separation Rule — Promote the Material Boundary in LOR
+
+When a subset of a Stage is important enough that it needs to be scheduled, crewed, and resolved as an independent material work area, the preferred design is to make that subset a **real LOR Scene** rather than creating a second task-specific Display list in Setup.
+
+Example established during live review:
+
+```text
+02 Triangle Volunteer Path Setup
+```
+
+If Volunteer Path Lights remains a Stage-fallback LOR group, a Stage-level Setup task sees the broader Stage 02 fallback material context.
+
+If Volunteer Path Lights is promoted to a real Stage-02 Scene in LOR, then:
+
+```text
+02-Volunteer Path Lights  (illustrative name; exact accepted naming must follow LOR/Folder Alignment rules)
+    -> current LOR Scene membership owns the Volunteer Path Displays
+    -> Folder Alignment resolves that Scene as its own physical/documentation scope
+    -> the reusable Volunteer Path Setup task can live at that Scene
+    -> Material / Logistics resolves exactly that Scene's Displays/Containers
+```
+
+The remaining Stage-02 fallback task(s), such as a Stage-level Claymation Panels task, then naturally exclude the Volunteer Path Scene material because true child-Scene Displays do not belong to the parent Stage fallback set.
+
+This keeps the grouping in one place:
+
+```text
+LOR Scene membership = authoritative Display grouping
+Setup task scope      = where the work is planned/staffed
+Material resolver     = current Displays/Containers for that scope
+```
+
+Do not create a separate Setup Display-membership list merely to obtain this separation.
+
+A real Scene should only be created when the work/material boundary is operationally real. Do not manufacture Scenes for every task. Tasks such as `Grease Gate Bearings` can remain scoped to the applicable Stage/Scene while requiring no Display material.
+
+Creating a true LOR Scene also means it becomes a real Folder Alignment scope. If Procedures/Wiring are expected at that Scene level, the corresponding controlled Google Drive Scene structure must remain aligned with the accepted folder contract; do not create a LOR Scene that silently contradicts the documentation hierarchy.
+
 ## Why This Model
 
 The same LOR data already controls the physical show design. If a Display is moved in LOR and the accepted LOR ingest/reconciliation updates current Stage/Scene membership, Setup material context should update automatically.
@@ -79,13 +117,7 @@ Grease Gate Bearings
 
 The task still belongs to the Gate. Lack of Display material must never be interpreted as lack of physical task scope.
 
-Other Stage-level tasks such as `Claymation Panels` or `Triangle Volunteer Path Setup` can remain independent work items for separate crews even though their Material / Logistics panel may show the same broader Stage-level fallback context.
-
-That broader result is acceptable because Material / Logistics answers:
-
-> What Displays and Containers currently belong to the physical scope where this task lives?
-
-It does **not** claim every displayed item is exclusively owned by that one task.
+A Stage-level task can legitimately see the broader Stage fallback material context. When that result is too broad for an operationally distinct crew/work area, prefer promoting that physical/material subset to a true LOR Scene rather than maintaining task-specific Display membership in Setup.
 
 ## Optional Material-Applicability Review State
 
@@ -165,11 +197,11 @@ Stage 13 true Scene 13-Christmas Story
 `13-Christmas Story` is the current known-good Production reference.
 
 ```text
-task scope              = true Scene 13-Christmas Story
-Displays resolved       = 8
-Containers resolved     = 4
-Container IDs           = 6, 131, 150, 171
-Displays without Container = 1
+task scope                  = true Scene 13-Christmas Story
+Displays resolved           = 8
+Containers resolved         = 4
+Container IDs               = 6, 131, 150, 171
+Displays without Container  = 1
 ```
 
 This behavior is correct and must be preserved.
@@ -251,9 +283,9 @@ Stage 13
 - Die Hard
 ```
 
-Those groups provide Display membership evidence. Their physical/documentation scope still resolves according to Folder Alignment.
+Those groups provide Display membership evidence. Their physical/documentation scope still resolves according to Folder Alignment unless one is deliberately promoted to a real Scene because it represents a true independently planned material/work area.
 
-Do not delete or promote them merely to make Setup material resolution easier.
+Do not delete or promote them merely to make Setup material resolution easier. Promotion to a true Scene should reflect actual operational separation, as with the proposed Volunteer Path case.
 
 ## Current Production Defect
 
@@ -274,6 +306,8 @@ else if task is Stage/Sub-stage scoped:
 ```
 
 Then derive current Containers from those Displays.
+
+When a Stage-level material subset must be independently crewed/planned, prefer making that subset a true LOR Scene and moving the applicable reusable task into that Scene rather than creating another material relationship in Setup.
 
 ## Existing `ref.setup_task_display`
 
@@ -313,10 +347,11 @@ Before Production behavior changes:
 4. exclude true Scene Displays from the parent Stage fallback set;
 5. derive/deduplicate Containers from resolved Displays;
 6. keep supplemental KIT/support Containers separate;
-7. decide through browser review whether `UNREVIEWED / USES_SCOPE_DISPLAY_MATERIAL / NO_DISPLAY_MATERIAL` is useful;
-8. preserve legitimate no-material tasks such as `Grease Gate Bearings`;
-9. regression-test Stages 00, 01, 02, 13, and Northern Lights/Stage 16; and
-10. perform protected browser validation before Production acceptance.
+7. when a work/material subset needs independent scheduling and crew assignment, prefer a real LOR Scene plus matching Setup task scope rather than a new Setup material-group table;
+8. decide through browser review whether `UNREVIEWED / USES_SCOPE_DISPLAY_MATERIAL / NO_DISPLAY_MATERIAL` is useful;
+9. preserve legitimate no-material tasks such as `Grease Gate Bearings`;
+10. regression-test Stages 00, 01, 02, 13, Volunteer Path after any Scene promotion, and Northern Lights/Stage 16; and
+11. perform protected browser validation before Production acceptance.
 
 ## Related Durable Sources
 

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Task_Material_Resolver_Contract_2026-09-09.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Task_Material_Resolver_Contract_2026-09-09.md
@@ -16,7 +16,7 @@ Preserve the operator-confirmed distinction between reusable Setup task scope, L
 
 ### 1. Reusable Setup task
 
-A task is a practical unit of work that can be planned/staffed independently.
+A task is a practical unit of work that can be planned and staffed independently.
 
 Examples:
 
@@ -25,9 +25,9 @@ Examples:
 02 Claymation Panels
 ```
 
-Both may belong to Stage 02 and be assigned to different crews.
+Both can remain Stage 02 tasks and be assigned to different crews.
 
-A task may also legitimately require no Display group at all. `Grease Gate bearings` is the canonical example.
+A task may also legitimately require no Display material at all. `Grease Gate bearings` is the canonical example.
 
 ### 2. Task physical/documentation scope
 
@@ -47,23 +47,56 @@ If an LOR programming/grouping Scene does not correspond to a real `NN-Scene` / 
 Therefore a task may be:
 
 ```text
-task scope     = Stage 02
-material group = an LOR Scene/group that gathers the Displays used by that task
+task/documentation scope = Stage 02
+material Display source  = a specific LOR Scene/group
 ```
 
 The material group must not force the task into Scene scope.
 
 ### 3. LOR Display/material group
 
-LOR already maintains useful Scene/group membership in `ref.lor_scene_display`. Setup should consume that authoritative grouping when a practical task corresponds to the group instead of copying every Display into a second manually-maintained task list.
+LOR already maintains the Display grouping in `ref.lor_scene_display`. Setup should consume that authoritative grouping when a practical task corresponds to the group instead of copying every Display into a second manually maintained task list.
 
-This avoids the "forgotten Display" failure: if a Display is later added to the authoritative LOR group, Setup can resolve it automatically without a separate Display-to-task maintenance step.
+This avoids the "forgotten Display" failure: if a Display is later added to the authoritative LOR group, Setup resolves it automatically without a separate Display-to-task maintenance step.
 
-A task may use zero, one, or, if real field practice requires it, more than one LOR material group. Exact schema cardinality must be confirmed before implementation; do not assume a single nullable column without inventory.
+A task may use no material group, one group, or—if actual field practice requires it—more than one group. Exact schema cardinality must be inventoried before implementation rather than assumed.
 
-For a true Scene such as `13-Christmas Story`, the task physical scope and the LOR material group may happen to be the same Scene.
+For a true Scene, task scope and material group may be the same Scene. For a Stage-level/background grouping, they deliberately differ.
 
-For a Stage-level/background grouping, they deliberately differ:
+### 4. Container derivation
+
+Once required Displays are resolved from the selected LOR material group(s), current Containers derive from each Display's current `ref.display.container_id`.
+
+```text
+selected/scheduled task
+    -> LOR material group(s), if any
+    -> current Displays in those groups
+    -> current Display.container_id
+    -> deduplicate Containers/trailers
+    -> add explicit supplemental KIT/support Containers when needed
+```
+
+A Container may hold Displays from more than one Scene or Stage. That is normal. Container membership is downstream storage/transport evidence and must not be used to infer task scope or LOR material-group membership.
+
+## Known-Good Reference: 13-Christmas Story
+
+`13-Christmas Story` is the reference case that currently behaves correctly in Production.
+
+Observed live Material / Logistics result:
+
+```text
+true task/physical scope = 13-Christmas Story Scene
+LOR material group       = 13-Christmas Story Scene
+Displays resolved        = 8
+Containers resolved      = 4
+Displays without Container = 1
+```
+
+This behavior is correct and must be preserved. The LOR Scene gathers the intended Displays, and those Displays lead to their current Containers.
+
+The Stage-level/background correction should reproduce this same material-resolution pattern **without changing the task's physical/documentation scope to a Scene**.
+
+## Stage-Level Material-Group Examples
 
 ```text
 02 Claymation Panels
@@ -79,20 +112,7 @@ Grease Gate bearings
     material Display source  -> none
 ```
 
-### 4. Container derivation
-
-Once the required Display group is known, current Containers derive from the Displays' current `ref.display.container_id` values.
-
-```text
-selected/scheduled task
-    -> LOR material group(s), if any
-    -> current Displays in those group(s)
-    -> current Display.container_id
-    -> deduplicate Containers/trailers
-    -> add explicit supplemental KIT/support Containers when needed
-```
-
-Do not maintain a second task-to-Container list where current Display storage already supplies the answer.
+This lets separate crews receive separate work packages inside the same Stage while all field Procedures/Wiring still resolve to the correct Stage unless a true Scene exists.
 
 ## Required Stage-Level Programming / Grouping Scenes
 
@@ -110,32 +130,39 @@ Stage 01
 - Show Background Stage 01 FE Outside Gate
 ```
 
-These six are required for programming the show and for authoritative Display grouping. Do not delete or normalize them away merely because they do not create separate Google Drive Scene folders.
+These six are required for programming the show and for authoritative Display grouping. Do not delete, rename away, or promote them into separate physical Scene folders merely because they do not use `NN-Scene` naming.
 
-Their LOR Scene membership can be used as task material grouping while Folder Alignment still resolves Procedures/Wiring to Stage 00 or Stage 01.
+Their LOR membership can supply Setup material while Folder Alignment still resolves Procedures/Wiring to Stage 00 or Stage 01.
 
 ## Current Production Defect
 
-`Setup/Application/setup_next_repository.py::field_context()` currently uses the task's `lor_scene_id` for both concepts at once:
+`Setup/Application/setup_next_repository.py::field_context()` currently uses the task's `lor_scene_id` for two different concepts at once:
 
 - task Scene organization; and
 - automatic Display material expansion through `ref.lor_scene_display`.
 
-That works for a true Scene such as Christmas Story, but fails for Stage-level tasks whose material is represented by a separate background/programming LOR Scene. Those tasks currently show zero Displays/Containers unless explicit `ref.setup_task_display` rows happen to exist.
+That works for the true Scene reference case `13-Christmas Story`, but fails for Stage-level tasks whose Display material is represented by a separate background/programming LOR Scene. Those tasks currently show zero Displays/Containers unless explicit `ref.setup_task_display` rows happen to exist.
 
-Representative review examples include:
+Representative review areas include:
 
-- Stage 01 `Claymation Panels` / Front Entrance groupings;
-- Stage 16 `Setup Northern Lights`;
-- Stage 16 `Layout RGB Locations (20' Spacing, 32P & 30D)`;
-- Stage 16 `Northern Lights Plug in Power & Network`;
-- Hwy 42 Traffic Signs;
-- Hwy 42 MSB / Rotary Signs; and
-- Stage 02 Volunteer Path versus Claymation Panels as separate crew tasks within the same Stage.
+- Stage 00 Hwy 42 Traffic Signs;
+- Stage 00 Hwy 42 MSB / Rotary signs;
+- Stage 01 Front Entrance grouping scenes;
+- Stage 02 Triangle Volunteer Path and Claymation as separate crew tasks;
+- Stage 16 Northern Lights; and
+- other Stage-level tasks with a distinct LOR grouping but no true `NN-Scene` folder.
 
 The fix is **not** automatic expansion of every Display on the Stage and **not** manual maintenance of every Display-to-task row.
 
-The missing relationship is a way for a task to reference its authoritative LOR material grouping independently of its Stage/Scene physical/documentation scope.
+The missing relationship is a way for a reusable task to reference its authoritative LOR material grouping independently of its Stage/Scene physical/documentation scope.
+
+## Existing `ref.setup_task_display`
+
+Existing `ref.setup_task_display` data must be inventoried before retirement, reinterpretation, or migration.
+
+Do not enforce a new one-Display/one-task uniqueness rule. A Display can legitimately be involved in more than one reusable work task over the course of Setup—for example layout, physical setup, cord/network hookup, and testing—while remaining in one physical Stage/Scene location.
+
+Use existing explicit rows only where they represent real exceptions or deliberate material detail not already captured by an authoritative LOR grouping. Do not make them the primary maintenance mechanism for ordinary grouped Displays.
 
 ## Implementation Direction
 
@@ -147,19 +174,18 @@ The implementation should support:
 - zero material group for tasks such as bearing maintenance;
 - a Stage-level task referencing an LOR background/programming Scene solely as its Display/material source;
 - separate tasks in one Stage referencing different LOR Display groups so parallel crews get the correct material;
-- true Scene tasks using their Scene group naturally;
+- true Scene tasks such as Christmas Story using their Scene group naturally;
 - dynamic membership from current `ref.lor_scene_display`, so Displays are not forgotten in a second maintained list;
 - current Container derivation from the resolved Displays;
+- Container deduplication even when one Container carries several Scene/Stage groups;
 - explicit supplemental KIT/support Containers separately; and
 - clear UI language distinguishing **Task Scope** from **Material Group**.
 
-Existing `ref.setup_task_display` data must be inventoried before retirement/reinterpretation. Do not delete or migrate it blindly; determine whether any rows represent exceptions not captured by an LOR group.
-
 ## 2026 Session Gate
 
-The operator decision remains: **do not create the 2026 Setup Session until the reconstructed 2025 plan is complete.**
+**Do not create the 2026 Setup Session until the reconstructed 2025 Setup plan is complete.**
 
-Material resolution must be trustworthy before 2026 propagation so near-term planning/Pick List work does not inherit known missing or false Display/Container relationships.
+Material resolution must be trustworthy before 2026 propagation so planning/Pick List work does not inherit known missing or false Display/Container relationships.
 
 ## Related Durable Sources
 

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Task_Material_Resolver_Contract_2026-09-09.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Task_Material_Resolver_Contract_2026-09-09.md
@@ -18,14 +18,14 @@ The governing principle is:
 LOR owns current Display placement/grouping.
 Setup owns reusable work/tasks.
 Folder Alignment resolves LOR Scene evidence to physical Stage/Sub-stage/Scene scope.
-Material / Logistics reports the current Displays/Containers for the task's resolved physical scope.
+Material / Logistics reports the current Displays/Containers for the task's resolved physical scope when that task actually requires Display/container material.
 ```
 
 ## Core Rule
 
 Material / Logistics is a **scope-context resolver**, not a task-owned parts list.
 
-For a reusable Setup task:
+For a reusable Setup task whose Display/container material flag is enabled:
 
 ```text
 true Scene task
@@ -41,6 +41,65 @@ Stage/Sub-stage task
 
 The resolver must use the accepted Folder Alignment/shared field-context rules for physical scope classification. Do not use a simple Scene-name regex as Production authority; regex classification used during read-only diagnostics was only a convenient inspection aid.
 
+## Display / Container Material Applicability
+
+Live review clarified that Display/container material is **not relevant to every Setup task** even when the task belongs to a Stage/Scene that has many Displays.
+
+The normal stage workflow often contains several separate reusable tasks such as:
+
+```text
+Locate
+Layout
+Setup
+Cords
+Network
+Test
+```
+
+Not every task in that sequence needs the physical Displays/Containers presented as task material. In the common pattern, Display/container material becomes relevant primarily at the **Setup** step. Other steps may still use ordinary task resources, procedures, wiring context, prerequisites, readiness, and Stage/Scene scope without needing the Display/container material panel to represent required material.
+
+Current preferred design direction is therefore a narrow boolean on the reusable task, conceptually:
+
+```text
+requires_display_material boolean NOT NULL DEFAULT false
+```
+
+Semantics:
+
+```text
+false
+    -> task remains fully scoped to its Stage/Scene
+    -> no Display/container material is considered required for this task
+    -> prerequisites, readiness, procedures, resources, wiring, effort, etc. still apply
+
+true
+    -> resolve current Display/container material from the task's Stage/Scene scope
+```
+
+This flag must not be inferred solely from task name or action type because the operator stated the Locate/Layout/Setup/Cords/Network/Test pattern is common but not universal. Default false is deliberate; material should be enabled only where the reusable task truly needs it.
+
+Canonical examples:
+
+```text
+Grease Gate Bearings
+    scope                     = applicable Gate/Stage/Scene
+    requires_display_material = false
+
+Setup Northern Lights
+    scope                     = Stage 16
+    requires_display_material = true
+
+Layout RGB Locations
+    scope                     = Stage 16
+    requires_display_material = false unless operator review says otherwise
+
+Northern Lights Plug in Power & Network
+    scope                     = Stage 16
+    requires_display_material = false unless operator review says otherwise
+```
+
+The UI label should describe the business effect clearly (for example `Uses Display / Container Material`) rather than an ambiguous term such as `Task Only`.
+
 ## Operational Separation Rule — Promote the Material Boundary in LOR
 
 When a subset of a Stage is important enough that it needs to be scheduled, crewed, and resolved as an independent material work area, the preferred design is to make that subset a **real LOR Scene** rather than creating a second task-specific Display list in Setup.
@@ -51,7 +110,7 @@ Example established during live review:
 02 Triangle Volunteer Path Setup
 ```
 
-If Volunteer Path Lights remains a Stage-fallback LOR group, a Stage-level Setup task sees the broader Stage 02 fallback material context.
+If Volunteer Path Lights remains a Stage-fallback LOR group, a Stage-level Setup task sees the broader Stage 02 fallback material context when material is enabled.
 
 If Volunteer Path Lights is promoted to a real Stage-02 Scene in LOR, then:
 
@@ -70,7 +129,7 @@ This keeps the grouping in one place:
 ```text
 LOR Scene membership = authoritative Display grouping
 Setup task scope      = where the work is planned/staffed
-Material resolver     = current Displays/Containers for that scope
+Material resolver     = current Displays/Containers for that scope, when enabled
 ```
 
 Do not create a separate Setup Display-membership list merely to obtain this separation.
@@ -103,39 +162,7 @@ Display moved in LOR
 
 The reusable Setup task itself does not automatically move merely because one Display moved. Task scope remains a deliberate reusable work decision.
 
-## Task Scope and Material Context Are Separate
-
-A task may belong to a Stage/Scene even when no Display material is needed.
-
-Canonical example:
-
-```text
-Grease Gate Bearings
-    task scope       = applicable Front Gate / Stage scope
-    Display material = none required for the work
-```
-
-The task still belongs to the Gate. Lack of Display material must never be interpreted as lack of physical task scope.
-
-A Stage-level task can legitimately see the broader Stage fallback material context. When that result is too broad for an operationally distinct crew/work area, prefer promoting that physical/material subset to a true LOR Scene rather than maintaining task-specific Display membership in Setup.
-
-## Optional Material-Applicability Review State
-
-Operator discussion identified a possible useful control so material-free tasks do not present scope material as if it were required.
-
-Do not implement this as an unreviewed two-state checkbox that makes every existing unchecked task ambiguous. Preferred design direction is an explicit review state such as:
-
-```text
-UNREVIEWED
-USES_SCOPE_DISPLAY_MATERIAL
-NO_DISPLAY_MATERIAL
-```
-
-This state, if implemented, describes whether Display/Container scope context is relevant to the task. It does not alter task Stage/Scene scope and does not maintain individual Display ownership.
-
-Exact column name/UI wording remains subject to browser review.
-
-## Read-Only Coverage Evidence — Stages 00, 01, 02, and 13
+## Read-Only Coverage Evidence — Stages 00, 01, 02, 13, and 16
 
 The 2026-09-09 read-only material review found 95 active Displays across Stages 00, 01, 02, and 13, and every reviewed Display had exactly one current `ref.lor_scene_display` membership in that evidence set.
 
@@ -147,50 +174,22 @@ Stage 13 = 38 active Displays
 Total    = 95
 ```
 
-This strongly supports using LOR membership as the current Display source rather than copying Display membership into Setup.
-
-### Scope-level results from the same review
+Stage 16 was then reviewed separately and provides the strongest Stage-level defect case:
 
 ```text
-Stage 00 fallback
-    11 Displays
-    Containers 1, 146
-
-Stage 01 fallback
-    7 Displays
-    Container 1
-
-Stage 01 true Scene 01-Entrance Arch
-    3 Displays
-    Containers 151, 152, 153
-
-Stage 01 true Scene 01-Front Gate
-    4 Displays
-    Containers 31, 59
-
-Stage 02 fallback
-    12 Displays
-    Containers 1, 2, 14, 31, 72
-
-Stage 02 true Scene 02-Fred's Stars
-    16 Displays
-    Container 63
-
-Stage 02 true Scene 02-Mega Tree
-    4 Displays
-    Containers 157, 158
-    plus uncontainerized Displays
-
-Stage 13 fallback
-    9 Displays
-    Containers 6, 7, 37, 226
-    plus uncontainerized Displays
-
-Stage 13 true Scene 13-Christmas Story
-    8 Displays
-    Containers 6, 131, 150, 171
-    plus 1 Display without Container
+Stage 16 Northern Lights
+    lor_scene_id               = 298
+    scene_name                 = 16-Northern Lights-NL
+    active Displays            = 66
+    DS Displays                = 32
+    PS Displays                = 34
+    Containers                 = 16, 17, 18, 19
+    every reviewed Display     = exactly one LOR group
 ```
+
+The current Setup Stage-level tasks still resolve 0 Displays / 0 Containers because `SetupNextRepository.field_context()` has no Stage fallback path.
+
+This proves both that LOR is the correct authority and that Stage-level material resolution is a real code defect rather than missing LOR data.
 
 ## Known-Good Reference: 13-Christmas Story
 
@@ -214,6 +213,30 @@ resolved physical scope
     -> current Display.container_id
     -> deduplicated Containers
 ```
+
+## Stage 16 Acceptance Case
+
+Stage 16 currently has three Stage-level reusable tasks:
+
+```text
+Layout RGB Locations (20' Spacing, 32P & 30D)
+Setup Northern Lights
+Northern Lights Plug in Power & Network
+```
+
+The current LOR authority says the Stage contains 66 Displays, specifically 32 DS + 34 PS, across Containers 16, 17, 18, and 19.
+
+The task name's embedded `32P & 30D` count is stale and demonstrates why task names and Procedures must not be treated as authoritative material counts. Display counts and Container resolution must come from current LOR-derived database relationships.
+
+After the Stage fallback resolver exists, a Stage-16 task with `requires_display_material = true` must resolve:
+
+```text
+66 Displays
+4 Containers
+Container IDs 16, 17, 18, 19
+```
+
+A Stage-16 task with `requires_display_material = false` remains a valid Stage-16 task but must not present those 66 Displays/4 Containers as material required for that task.
 
 ## Preview UUID Is Not the Scope Boundary
 
@@ -276,7 +299,7 @@ Stage 02
 - Narwhal
 - Signage
 - US Flag
-- Volunteer Path Lights
+- Volunteer Path Lights (until the operator's new true Scene is ingested/reconciled)
 
 Stage 13
 - Root
@@ -285,7 +308,7 @@ Stage 13
 
 Those groups provide Display membership evidence. Their physical/documentation scope still resolves according to Folder Alignment unless one is deliberately promoted to a real Scene because it represents a true independently planned material/work area.
 
-Do not delete or promote them merely to make Setup material resolution easier. Promotion to a true Scene should reflect actual operational separation, as with the proposed Volunteer Path case.
+Do not delete or promote them merely to make Setup material resolution easier. Promotion to a true Scene should reflect actual operational separation, as with the Volunteer Path change.
 
 ## Current Production Defect
 
@@ -298,7 +321,9 @@ The required correction is **not** task-specific Display ownership and **not** t
 It is:
 
 ```text
-if task is true Scene scoped:
+if requires_display_material = false:
+    no Display/container material result
+else if task is true Scene scoped:
     resolve that Scene's Displays
 else if task is Stage/Sub-stage scoped:
     resolve all current LOR Displays whose accepted physical scope falls back
@@ -343,15 +368,16 @@ Before Production behavior changes:
 
 1. use the accepted Folder Alignment/shared field-context resolver as the scope authority;
 2. preserve the known-good `13-Christmas Story` behavior;
-3. implement Stage/Sub-stage fallback aggregation across all LOR Scene groups that resolve to that scope, regardless of Preview UUID;
-4. exclude true Scene Displays from the parent Stage fallback set;
-5. derive/deduplicate Containers from resolved Displays;
-6. keep supplemental KIT/support Containers separate;
-7. when a work/material subset needs independent scheduling and crew assignment, prefer a real LOR Scene plus matching Setup task scope rather than a new Setup material-group table;
-8. decide through browser review whether `UNREVIEWED / USES_SCOPE_DISPLAY_MATERIAL / NO_DISPLAY_MATERIAL` is useful;
+3. add a default-false reusable-task Display/container material applicability flag with explicit operator control;
+4. implement Stage/Sub-stage fallback aggregation across all LOR Scene groups that resolve to that scope, regardless of Preview UUID;
+5. exclude true Scene Displays from the parent Stage fallback set;
+6. derive/deduplicate Containers from resolved Displays;
+7. keep supplemental KIT/support Containers separate;
+8. when a work/material subset needs independent scheduling and crew assignment, prefer a real LOR Scene plus matching Setup task scope rather than a new Setup material-group table;
 9. preserve legitimate no-material tasks such as `Grease Gate Bearings`;
-10. regression-test Stages 00, 01, 02, 13, Volunteer Path after any Scene promotion, and Northern Lights/Stage 16; and
-11. perform protected browser validation before Production acceptance.
+10. validate the common Locate/Layout/Setup/Cords/Network/Test pattern without assuming it is universal;
+11. regression-test Stages 00, 01, 02, 13, Volunteer Path after its next LOR ingest/reconciliation, and Northern Lights/Stage 16; and
+12. perform protected browser validation before Production acceptance.
 
 ## Related Durable Sources
 

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Task_Material_Resolver_Contract_2026-09-09.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Task_Material_Resolver_Contract_2026-09-09.md
@@ -10,256 +10,313 @@
 
 ## Purpose
 
-Preserve the operator-confirmed distinction between reusable Setup task scope, LOR Display grouping, physical/documentation scope, and Container derivation so future work does not reconstruct this model from screenshots or chat.
+Preserve the operator-confirmed material-resolution model discovered during 2025 Setup review so future work does not create a second manually maintained Display grouping outside LOR.
 
-## Four Concepts Must Remain Separate
-
-### 1. Reusable Setup task
-
-A task is a practical unit of work that can be planned and staffed independently.
-
-Examples:
+The governing principle is:
 
 ```text
-02 Triangle Volunteer Path Setup
-02 Claymation Panels
+LOR owns current Display placement/grouping.
+Setup owns reusable work/tasks.
+Folder Alignment resolves LOR Scene evidence to physical Stage/Sub-stage/Scene scope.
+Material / Logistics reports the current Displays/Containers for the task's resolved physical scope.
 ```
 
-Both can remain Stage 02 tasks and be assigned to different crews.
+## Core Rule
 
-`Claymation Panels` is an MSB task/work-package name. It is not the name of one LOR Scene. The Claymation work package can aggregate several existing LOR Display groups.
+Material / Logistics is a **scope-context resolver**, not a task-owned parts list.
 
-A task may also legitimately require no Display material at all. `Grease Gate bearings` is the canonical example.
-
-### 2. Task physical/documentation scope
-
-Task scope answers where the work belongs for Setup organization and shared Procedures/Wiring context.
-
-The existing Folder Alignment contract controls this scope:
+For a reusable Setup task:
 
 ```text
-NN-Name-XY      -> Stage
-NNa-Name-XY     -> Sub-stage
-NN-Name         -> Scene under the owning Stage
-NNa-Name        -> Scene under the owning Sub-stage
+true Scene task
+    -> resolve Displays in that exact LOR Scene
+    -> derive current Containers from those Displays
+
+Stage/Sub-stage task
+    -> collect all LOR Scene memberships whose accepted physical/documentation
+       resolution falls back to that Stage/Sub-stage
+    -> exclude Displays whose LOR Scene resolves to a more-specific true Scene
+    -> derive current Containers from the resulting Displays
 ```
 
-If an LOR programming/grouping Scene does not correspond to a real `NN-Scene` / `NNa-Scene` structured folder, the physical/documentation scope remains the owning Stage/Sub-stage.
+The resolver must use the accepted Folder Alignment/shared field-context rules for physical scope classification. Do not use a simple Scene-name regex as Production authority; regex classification used during read-only diagnostics was only a convenient inspection aid.
 
-Therefore a task may be:
+## Why This Model
+
+The same LOR data already controls the physical show design. If a Display is moved in LOR and the accepted LOR ingest/reconciliation updates current Stage/Scene membership, Setup material context should update automatically.
+
+Setup must not require a second Display-to-task maintenance step merely to keep material location current.
+
+This avoids a predictable failure mode:
 
 ```text
-task/documentation scope = Stage 02
-material Display source  = one or more specific LOR Scenes/groups
+Display moved in LOR
+    + Setup copy not updated
+    -> stale Setup material list
 ```
 
-The material group must not force the task into Scene scope.
-
-### 3. LOR Display/material group
-
-LOR already maintains the Display grouping in `ref.lor_scene_display`. Setup should consume that authoritative grouping when a practical task corresponds to the group instead of copying every Display into a second manually maintained task list.
-
-This avoids the "forgotten Display" failure: if a Display is later added to the authoritative LOR group, Setup resolves it automatically without a separate Display-to-task maintenance step.
-
-A task may use:
-
-- no material group;
-- one LOR group; or
-- several LOR groups when one practical crew task spans several programming groups.
-
-The Stage 02 Claymation task proves that more-than-one material group is required. A single task may aggregate several LOR groups while the task itself remains Stage 02 scoped.
-
-A LOR group may also be relevant to more than one reusable task over the Setup lifecycle, for example physical setup, cord/network hookup, or testing. Therefore the task-to-LOR-material-group relationship must not be designed as one-to-one.
-
-For a true Scene, task scope and material group may be the same Scene. For a Stage-level/background grouping, they deliberately differ.
-
-### 4. Container derivation
-
-Once required Displays are resolved from the selected LOR material group(s), current Containers derive from each Display's current `ref.display.container_id`.
+Under the scope resolver:
 
 ```text
-selected/scheduled task
-    -> LOR material group(s), if any
-    -> current Displays in those groups
-    -> current Display.container_id
-    -> deduplicate Containers/trailers
-    -> add explicit supplemental KIT/support Containers when needed
+Display moved in LOR
+    -> current LOR Scene/Stage scope changes
+    -> next Setup material resolution follows the new scope automatically
 ```
 
-A Container may hold Displays from more than one Scene or Stage. That is normal. Container membership is downstream storage/transport evidence and must not be used to infer task scope or LOR material-group membership.
+The reusable Setup task itself does not automatically move merely because one Display moved. Task scope remains a deliberate reusable work decision.
+
+## Task Scope and Material Context Are Separate
+
+A task may belong to a Stage/Scene even when no Display material is needed.
+
+Canonical example:
+
+```text
+Grease Gate Bearings
+    task scope       = applicable Front Gate / Stage scope
+    Display material = none required for the work
+```
+
+The task still belongs to the Gate. Lack of Display material must never be interpreted as lack of physical task scope.
+
+Other Stage-level tasks such as `Claymation Panels` or `Triangle Volunteer Path Setup` can remain independent work items for separate crews even though their Material / Logistics panel may show the same broader Stage-level fallback context.
+
+That broader result is acceptable because Material / Logistics answers:
+
+> What Displays and Containers currently belong to the physical scope where this task lives?
+
+It does **not** claim every displayed item is exclusively owned by that one task.
+
+## Optional Material-Applicability Review State
+
+Operator discussion identified a possible useful control so material-free tasks do not present scope material as if it were required.
+
+Do not implement this as an unreviewed two-state checkbox that makes every existing unchecked task ambiguous. Preferred design direction is an explicit review state such as:
+
+```text
+UNREVIEWED
+USES_SCOPE_DISPLAY_MATERIAL
+NO_DISPLAY_MATERIAL
+```
+
+This state, if implemented, describes whether Display/Container scope context is relevant to the task. It does not alter task Stage/Scene scope and does not maintain individual Display ownership.
+
+Exact column name/UI wording remains subject to browser review.
 
 ## Read-Only Coverage Evidence — Stages 00, 01, 02, and 13
 
-The 2026-09-09 read-only material-group coverage review found:
+The 2026-09-09 read-only material review found 95 active Displays across Stages 00, 01, 02, and 13, and every reviewed Display had exactly one current `ref.lor_scene_display` membership in that evidence set.
 
 ```text
-Stage 00 active Displays reviewed = 11
-Stage 01 active Displays reviewed = 14
-Stage 02 active Displays reviewed = 32
-Stage 13 active Displays reviewed = 38
-Total                            = 95
+Stage 00 = 11 active Displays
+Stage 01 = 14 active Displays
+Stage 02 = 32 active Displays
+Stage 13 = 38 active Displays
+Total    = 95
 ```
 
-Every one of those 95 active Displays had `lor_group_count = 1` in the reviewed result. No active Display in those four Stages appeared ungrouped or multiply grouped in that evidence set.
+This strongly supports using LOR membership as the current Display source rather than copying Display membership into Setup.
 
-This strongly supports using current LOR group membership as the normal dynamic Display source rather than maintaining a second Setup Display list.
+### Scope-level results from the same review
+
+```text
+Stage 00 fallback
+    11 Displays
+    Containers 1, 146
+
+Stage 01 fallback
+    7 Displays
+    Container 1
+
+Stage 01 true Scene 01-Entrance Arch
+    3 Displays
+    Containers 151, 152, 153
+
+Stage 01 true Scene 01-Front Gate
+    4 Displays
+    Containers 31, 59
+
+Stage 02 fallback
+    12 Displays
+    Containers 1, 2, 14, 31, 72
+
+Stage 02 true Scene 02-Fred's Stars
+    16 Displays
+    Container 63
+
+Stage 02 true Scene 02-Mega Tree
+    4 Displays
+    Containers 157, 158
+    plus uncontainerized Displays
+
+Stage 13 fallback
+    9 Displays
+    Containers 6, 7, 37, 226
+    plus uncontainerized Displays
+
+Stage 13 true Scene 13-Christmas Story
+    8 Displays
+    Containers 6, 131, 150, 171
+    plus 1 Display without Container
+```
 
 ## Known-Good Reference: 13-Christmas Story
 
-`13-Christmas Story` is the reference case that currently behaves correctly in Production.
-
-Observed live Material / Logistics result:
+`13-Christmas Story` is the current known-good Production reference.
 
 ```text
-true task/physical scope   = 13-Christmas Story Scene
-LOR material group         = 13-Christmas Story Scene
-Displays resolved          = 8
-Containers resolved        = 4
-current Container IDs      = 6, 131, 150, 171
+task scope              = true Scene 13-Christmas Story
+Displays resolved       = 8
+Containers resolved     = 4
+Container IDs           = 6, 131, 150, 171
 Displays without Container = 1
 ```
 
-This behavior is correct and must be preserved. The LOR Scene gathers the intended Displays, and those Displays lead to their current Containers.
+This behavior is correct and must be preserved.
 
-The Stage-level/background correction should reproduce this same material-resolution pattern **without changing the task's physical/documentation scope to a Scene**.
-
-## Stage-Level Material-Group Examples
-
-### Stage 00 — Hwy 42
+The Stage/Sub-stage fallback fix should use the same downstream pattern:
 
 ```text
-Setup HWY42 Traffic Signs
-    task/documentation scope -> Stage 00
-    material LOR group       -> 275 HWY42 Traffic Signs
-    current result           -> 7 Displays -> Containers 1, 146
-
-Setup HWY42 MSB / Rotary Signs
-    task/documentation scope -> Stage 00
-    material LOR group       -> 289 HWY42 MSB and Rotary Signs
-    current result           -> 4 Displays -> Container 1
+resolved physical scope
+    -> current LOR Display memberships in that scope
+    -> current Display.container_id
+    -> deduplicated Containers
 ```
 
-### Stage 02 — Triangle
+## Preview UUID Is Not the Scope Boundary
 
-```text
-02 Triangle Volunteer Path Setup
-    task/documentation scope -> Stage 02
-    material LOR group       -> 279 Volunteer Path Lights
-    current result           -> 2 Displays -> Container 72
+A follow-up read-only inventory proved that `preview_uuid` cannot be used as the general Setup material boundary.
 
-02 Claymation Panels
-    task/documentation scope -> Stage 02
-    material LOR groups      -> 280, 281, 282, 283, 284
-```
-
-The operator-defined `Claymation Panels` work package includes the character Displays commonly referred to by MSB as Claymation. Current reviewed Stage 02 evidence resolves the group as:
-
-```text
-280 Abominable      -> TR-Abominable       -> Container 2
-281 Narwhal         -> TR-Narwhal          -> Container 2
-282 CharlieInTheBox -> TR-CharlieInTheBox  -> Container 2
-283 Headlights      -> FE-HeadlightsSign   -> Container 2   (Rudolph)
-284 Frosty          -> TR-FrostyComeBack   -> Container 2
-```
-
-`Rudolph` is the operator/common-name identity for the current `Headlights` LOR group / `FE-HeadlightsSign` Display in this work package. Do not create a separate Rudolph Display or Scene merely to make the Setup task name match the operator terminology.
-
-All five current Claymation groups resolve to Container 2, which makes the current transport result especially simple even though the work package spans five LOR groups.
-
-Other Stage 02 groups such as Signage, US Flag, Volunteer Path Lights, Fred's Stars, and Mega Tree remain separate material groupings unless actual task practice says otherwise.
-
-### Stage 01 — Front Entrance
-
-Stage 01 currently includes Stage-fallback programming groups plus true Scenes. Current Stage-fallback groups include Goal Sign, Making Spirits Bright, Open-Close Sign, RotaryGear-01, and TuneRadio-2CH-01; true Scenes include `01-Entrance Arch` and `01-Front Gate`.
-
-A Stage 01 task may use one or more of those programming groups while continuing to resolve Procedures/Wiring to Stage 01 unless it is truly scoped to `01-Entrance Arch` or `01-Front Gate`.
-
-### Zero-material task
-
-```text
-Grease Gate bearings
-    task/documentation scope -> Stage 01 / Front Gate area
-    material LOR group       -> none
-```
-
-Zero material is valid when the task is real work but has no Display work package.
-
-## Required Stage-Level Programming / Grouping Scenes
-
-The following LOR Scenes are required show-programming/grouping constructs even though they resolve physically/documentationally to their owning Stage rather than to separate `NN-Scene` folders:
+Observed examples:
 
 ```text
 Stage 00
-- Show Background Stage 00 HWY42 MSB-Rotary-Trees
-- Show Background Stage 00 HWY42 Traffic Signs
+    HWY42 MSB and Rotary Signs  -> one Preview UUID
+    HWY42 Traffic Signs         -> different Preview UUID
 
 Stage 01
-- Show Background Stage 01 FE Goal Sign
-- Show Background Stage 01 FE MSB Sign
-- Show Background Stage 01 FE Open-Close Sign
-- Show Background Stage 01 FE Outside Gate
+    one Preview UUID contains:
+        01-Entrance Arch        true Scene
+        01-Front Gate           true Scene
+        RotaryGear-01           Stage fallback
+        TuneRadio-2CH-01        Stage fallback
+    other Stage-fallback groups use other Preview UUIDs
+
+Stage 02
+    one Preview UUID contains the eight Stage-fallback groups
+    another Preview UUID contains 02-Fred's Stars and 02-Mega Tree
+
+Stage 13
+    one Preview UUID contains both:
+        true 13-... Scenes
+        Stage-fallback Root / Die Hard groups
 ```
 
-These six are required for programming the show and for authoritative Display grouping. Do not delete, rename away, or promote them into separate physical Scene folders merely because they do not use `NN-Scene` naming.
+Therefore:
 
-Their LOR membership can supply Setup material while Folder Alignment still resolves Procedures/Wiring to Stage 00 or Stage 01.
+- Preview identity remains valid LOR provenance/operating context;
+- Preview identity must **not** determine whether material belongs to a Setup Stage or Scene;
+- physical scope must be resolved per LOR Scene/group using the accepted Folder Alignment/shared field-context rules.
+
+## LOR Programming Groups Are Still Authoritative Inputs
+
+Stage-fallback LOR Scenes/groups remain important programming/grouping constructs even when they do not become separate physical/documentation Scene folders.
+
+Examples include:
+
+```text
+Stage 00
+- HWY42 MSB and Rotary Signs
+- HWY42 Traffic Signs
+
+Stage 01
+- Goal Sign
+- Making Spirits Bright
+- Open-Close Sign
+- RotaryGear-01
+- TuneRadio-2CH-01
+
+Stage 02
+- Abominable
+- CharlieInTheBox
+- Frosty
+- Headlights (Rudolph)
+- Narwhal
+- Signage
+- US Flag
+- Volunteer Path Lights
+
+Stage 13
+- Root
+- Die Hard
+```
+
+Those groups provide Display membership evidence. Their physical/documentation scope still resolves according to Folder Alignment.
+
+Do not delete or promote them merely to make Setup material resolution easier.
 
 ## Current Production Defect
 
-`Setup/Application/setup_next_repository.py::field_context()` currently uses the task's `lor_scene_id` for two different concepts at once:
+`Setup/Application/setup_next_repository.py::field_context()` currently expands Displays automatically only when the Setup task itself has `lor_scene_id`.
 
-- task Scene organization; and
-- automatic Display material expansion through `ref.lor_scene_display`.
+That works for true Scene tasks such as Christmas Story but leaves Stage-level tasks at zero unless explicit `ref.setup_task_display` rows exist.
 
-That works for the true Scene reference case `13-Christmas Story`, but fails for Stage-level tasks whose Display material is represented by one or more separate background/programming LOR Scenes. Those tasks currently show zero Displays/Containers unless explicit `ref.setup_task_display` rows happen to exist.
+The required correction is **not** task-specific Display ownership and **not** task-specific LOR-group ownership.
 
-Representative review areas include:
+It is:
 
-- Stage 00 Hwy 42 Traffic Signs;
-- Stage 00 Hwy 42 MSB / Rotary signs;
-- Stage 01 Front Entrance grouping scenes;
-- Stage 02 Triangle Volunteer Path and Claymation as separate crew tasks;
-- Stage 16 Northern Lights; and
-- other Stage-level tasks with distinct LOR grouping(s) but no true `NN-Scene` folder.
+```text
+if task is true Scene scoped:
+    resolve that Scene's Displays
+else if task is Stage/Sub-stage scoped:
+    resolve all current LOR Displays whose accepted physical scope falls back
+    to that same Stage/Sub-stage
+```
 
-The fix is **not** automatic expansion of every Display on the Stage and **not** manual maintenance of every Display-to-task row.
-
-The missing relationship is a way for a reusable task to reference zero, one, or several authoritative LOR material groups independently of its Stage/Scene physical/documentation scope.
+Then derive current Containers from those Displays.
 
 ## Existing `ref.setup_task_display`
 
-Existing `ref.setup_task_display` data must be inventoried before retirement, reinterpretation, or migration.
+Existing `ref.setup_task_display` data must be inventoried before retirement, reinterpretation, or deletion.
 
-Do not enforce a new one-Display/one-task uniqueness rule. A Display can legitimately be involved in more than one reusable work task over the course of Setup—for example layout, physical setup, cord/network hookup, and testing—while remaining in one physical Stage/Scene location.
+Do not make it the normal source for scope-level material context and do not add a uniqueness constraint merely to force a task-ownership model that the operator has not accepted.
 
-Use existing explicit rows only where they represent real exceptions or deliberate material detail not already captured by an authoritative LOR grouping. Do not make them the primary maintenance mechanism for ordinary grouped Displays.
+If explicit rows represent genuine exceptions or supplemental detail, preserve them only under a separately reviewed rule.
 
-## Implementation Direction
+## Container Rule
 
-Before choosing schema, inventory representative Production tasks and their LOR grouping candidates.
+Containers are downstream storage/transport evidence.
 
-The implementation should support:
+```text
+resolved Displays
+    -> each current ref.display.container_id
+    -> deduplicate Containers
+```
 
-- task scope remaining Stage/Sub-stage/true Scene according to Folder Alignment;
-- zero material group for tasks such as bearing maintenance;
-- one or several LOR material groups for a Stage-level task;
-- separate tasks in one Stage referencing different LOR Display groups so parallel crews get the correct material;
-- several LOR groups being aggregated into one practical task, as with Stage 02 Claymation;
-- a LOR group being reusable by more than one task when different phases operate on the same Displays;
-- true Scene tasks such as Christmas Story using their Scene group naturally;
-- dynamic membership from current `ref.lor_scene_display`, so Displays are not forgotten in a second maintained list;
-- current Container derivation from the resolved Displays;
-- Container deduplication even when one Container carries several Scene/Stage groups;
-- explicit supplemental KIT/support Containers separately; and
-- clear UI language distinguishing **Task Scope** from **Material Group(s)**.
+A Container may legitimately contain Displays belonging to several LOR groups, Scenes, or Stages. Container membership must not be used to infer task scope.
 
-The material-review UI should also distinguish an intentionally material-free task from a task whose material grouping has simply not yet been reviewed. Do not make an unexplained zero look the same as `NONE`.
+Supplemental KIT/support Containers that are not derivable from Display storage remain a separate explicit relationship.
 
 ## 2026 Session Gate
 
 **Do not create the 2026 Setup Session until the reconstructed 2025 Setup plan is complete.**
 
 Material resolution must be trustworthy before 2026 propagation so planning/Pick List work does not inherit known missing or false Display/Container relationships.
+
+## Implementation Gate
+
+Before Production behavior changes:
+
+1. use the accepted Folder Alignment/shared field-context resolver as the scope authority;
+2. preserve the known-good `13-Christmas Story` behavior;
+3. implement Stage/Sub-stage fallback aggregation across all LOR Scene groups that resolve to that scope, regardless of Preview UUID;
+4. exclude true Scene Displays from the parent Stage fallback set;
+5. derive/deduplicate Containers from resolved Displays;
+6. keep supplemental KIT/support Containers separate;
+7. decide through browser review whether `UNREVIEWED / USES_SCOPE_DISPLAY_MATERIAL / NO_DISPLAY_MATERIAL` is useful;
+8. preserve legitimate no-material tasks such as `Grease Gate Bearings`;
+9. regression-test Stages 00, 01, 02, 13, and Northern Lights/Stage 16; and
+10. perform protected browser validation before Production acceptance.
 
 ## Related Durable Sources
 

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/operatorSOP/README.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/operatorSOP/README.md
@@ -5,9 +5,9 @@
 | Document Type | Operator Portal |
 | System | Production Database — Setup and Deployment |
 | Audience | MSB reviewers, managers, and Setup operators |
-| Status | CURRENT — Production runtime operational; UI/workflow in live evaluation |
+| Status | CURRENT — Production reusable catalog rebuilt; live review/task development continues |
 | Owner | MSB Production Database / Setup administrator |
-| Last Reviewed | 2026-09-07 |
+| Last Reviewed | 2026-09-09 |
 | Keywords | Setup, 2025, historical review, training, reusable tasks, resources, 2026 baseline |
 
 Use this area for plain-English instructions for working in the Setup application. Engineering, database, service, permission, and deployment details belong in [`../engineering/`](../engineering/README.md).
@@ -26,22 +26,37 @@ The current shared working session is:
 2025 — Historical Verification
 ```
 
-The application uses real Production data. It is available for manager/reviewer use now, but the UI/workflow is still being evaluated through real 2025 review work.
+The application uses real Production data.
+
+The reusable catalog reconstruction was accepted in Production on 2026-09-09. Current working baseline:
+
+```text
+active reusable tasks    = 185
+total reusable rows      = 187
+reusable prerequisites   = 0
+2026 Setup Sessions      = 0
+```
+
+The prerequisite count is intentionally zero until the reviewed predecessor/readiness pass rebuilds the real dependency model.
+
+The current PostgreSQL catalog is now the working source for task development. The reconstruction workbook and historical schedules remain evidence, but operators/managers should continue adding and correcting real reusable tasks in the live Setup application rather than maintaining a separate spreadsheet master.
 
 ## What Do You Need To Do?
 
 - [Review and Correct the 2025 Setup History](Review_2025_Setup_History.md) — verify 2025 information, improve reusable Setup knowledge, add missing tasks/resources where appropriate, and record questions or suggestions.
 
-Additional task procedures will be added only when the corresponding workflow is actually production-operational.
+Additional task procedures will be added only when the corresponding workflow is actually Production-operational.
 
 ## Important Boundaries
 
 - The 2025 review area uses real Production data.
 - Annual 2025 corrections stay with the 2025 Setup Session.
 - Reusable Task changes are permanent Setup knowledge and may affect future seasons.
+- Continue reusable task development against the current PostgreSQL catalog; do not recreate a parallel spreadsheet master.
 - Operational dates entered for the selected Setup Session must be in that session's year.
 - Only an Administrator may create a new annual Setup Session or carry annual order forward as the future reusable baseline.
-- Pick Lists and Container/Display movement/scanning writes are not part of the current live-review workflow.
+- Do not create the 2026 Setup Session until the current catalog and predecessor/readiness pass are useful enough for planning.
+- Pick Lists and Container/Display movement/scanning writes are not part of the current live workflow.
 - Do not create fake records merely to test the UI. Use real review work and report workflow/UI findings instead.
 
 ## During Live Evaluation
@@ -49,13 +64,15 @@ Additional task procedures will be added only when the corresponding workflow is
 Managers and reviewers are encouraged to:
 
 - open tasks and compare annual 2025 information with reusable task information;
-- add genuinely missing reusable tasks;
+- add genuinely missing reusable tasks discovered during live review;
 - add/correct resources and prerequisites;
-- correct task scope, order, crew/time expectations, and notes where supported;
+- correct task scope, order, crew/time expectations, effort, and notes where supported;
 - verify records only when they have actually been reviewed;
 - leave uncertain information UNVERIFIED or mark it NEEDS CORRECTION;
 - ask questions and make suggestions about confusing, missing, or inefficient workflow; and
 - report UI problems instead of working around them silently.
+
+A current example is the missing physical `Set Up Frosty` task discovered after catalog deployment. The old transport entry `Bring Frosty to park` remains logistics evidence; the live catalog needs the reusable physical setup task and its Stars prerequisite relationship.
 
 ## Related Documents
 


### PR DESCRIPTION
## Purpose

Promote the September 7–9 Setup reconstruction/deployment findings into controlled Setup documentation so future work does not need chat history to reconstruct migration, acceptance, material-resolution, predecessor, or readiness decisions.

## Current engineering contracts

### Task Material Resolver

`Setup_Task_Material_Resolver_Contract_2026-09-09.md` now records the corrected operator-confirmed model:

- **task/documentation scope** and **LOR material group** are separate;
- a task can remain Stage/Sub-stage scoped while referencing a background/programming LOR Scene solely to gather the Displays used by that work;
- true Scenes such as `13-Christmas Story` can use the same Scene for both task scope and material grouping;
- `13-Christmas Story` is the known-good Production reference: 8 Displays -> 4 Containers, with current Scene membership gathering the Displays correctly;
- Stage 02 `Triangle Volunteer Path Setup` and `Claymation Panels` are examples of separate Stage-level tasks that can be assigned to different crews while each uses a different LOR Display grouping;
- `Grease Gate bearings` is a valid Stage-level task with no Display/material group;
- normal grouped Displays must come dynamically from authoritative `ref.lor_scene_display`, not a second manually maintained Display-to-task list that can forget later additions;
- current Containers derive downstream from each resolved Display's current `ref.display.container_id`, with deduplication and separate supplemental KIT/support relationships;
- a Container may legitimately contain Displays from several Scenes/Stages and therefore must not be used to infer task scope or material grouping.

Required show-programming/grouping LOR Scenes explicitly preserved even though their physical/documentation scope resolves to Stage 00/01:

```text
Show Background Stage 00 HWY42 MSB-Rotary-Trees
Show Background Stage 00 HWY42 Traffic Signs
Show Background Stage 01 FE Goal Sign
Show Background Stage 01 FE MSB Sign
Show Background Stage 01 FE Open-Close Sign
Show Background Stage 01 FE Outside Gate
```

These are required programming/grouping objects; they are not stray Scenes and must not be deleted merely because they do not create separate `NN-Scene` folders.

### Predecessor / Readiness

`Setup_Predecessor_and_Readiness_Contract_2026-09-09.md` records:

- HARD PREDECESSOR vs PREFERRED ORDER vs READINESS CONDITION;
- Stage 00 Lay Cords depends on the two Hwy 42 sign Setup tasks as real predecessors;
- mowing/mulching completion is an external, **area-specific readiness condition**, not a Setup task and not a park-wide completion record;
- the same readiness condition must be able to gate multiple affected tasks such as Lay Cords, Network hookup, and Testing;
- current free-form `readiness_note` is insufficient as the durable control mechanism because it cannot reliably link/share/gate conditions;
- future annual/current readiness state is separate from the reusable readiness definition; and
- Shift-drag remains the desired efficient predecessor-entry interaction while ordinary drag keeps its current reorder/scope behavior.

## Migration / acceptance history

The branch also preserves the PL/pgSQL ambiguity failures, disposable-only migration exclusion, preview privilege/process-owner defects, Frosty omission, Catalog-only delete finding, and related September 7–9 acceptance lessons.

## Boundary

Documentation only. No Production database, application, runtime, or service mutation is part of this PR.

Related: #122, #125, #134, #136, #137, #139.