### PR TITLE
Combine Setup cleanup UI tools for Production deployment

### DIFF
--- a/Setup/Application/production.html
+++ b/Setup/Application/production.html
@@ -231,7 +231,7 @@
 <script src="setup_live_review_fixes.js?v=2026-09-08.3"></script>
 <script src="setup_training_ux.js?v=2026-09-08.1"></script>
 <script src="setup_assigned_review.js?v=2026-09-08.2"></script>
-<script src="setup_training_review_refinement.js?v=2026-09-08.1"></script>
-<script src="setup_catalog_effort.js?v=2026-09-09.1"></script>
+<script src="setup_training_review_refinement.js?v=2026-09-09.2"></script>
+<script src="setup_catalog_effort.js?v=2026-09-09.2"></script>
 </body>
 </html>

--- a/Setup/Application/production.html
+++ b/Setup/Application/production.html
@@ -15,7 +15,7 @@
   <link rel="stylesheet" href="setup_session_year_guard.css?v=2026-09-07.1">
   <link rel="stylesheet" href="setup_live_review_fixes.css?v=2026-09-08.3">
   <link rel="stylesheet" href="setup_training_ux.css?v=2026-09-08.1">
-  <link rel="stylesheet" href="setup_training_review_refinement.css?v=2026-09-08.1">
+  <link rel="stylesheet" href="setup_training_review_refinement.css?v=2026-09-09.3">
 </head>
 <body>
 <header class="site-header">
@@ -118,7 +118,7 @@
               <label>Reusable notes<textarea id="edit-reusable-notes" rows="4"></textarea></label>
               <div id="reusable-manager-actions" class="action-row manager-only">
                 <button id="save-reusable-task" type="button">Save Reusable Task</button>
-                <button id="save-task-effort" type="button" class="secondary">Save Effort</button>
+                <button id="save-task-effort" type="button">Save Effort</button>
               </div>
             </fieldset>
 
@@ -231,7 +231,7 @@
 <script src="setup_live_review_fixes.js?v=2026-09-08.3"></script>
 <script src="setup_training_ux.js?v=2026-09-08.1"></script>
 <script src="setup_assigned_review.js?v=2026-09-08.2"></script>
-<script src="setup_training_review_refinement.js?v=2026-09-09.2"></script>
-<script src="setup_catalog_effort.js?v=2026-09-09.2"></script>
+<script src="setup_training_review_refinement.js?v=2026-09-09.3"></script>
+<script src="setup_catalog_effort.js?v=2026-09-09.3"></script>
 </body>
 </html>

--- a/Setup/Application/setup_catalog_effort.js
+++ b/Setup/Application/setup_catalog_effort.js
@@ -20,13 +20,11 @@ function placeSetupEffortSaveControl() {
 
   const actions = document.createElement('div');
   actions.className = 'action-row manager-only setup-effort-save-actions';
-  const note = document.createElement('span');
-  note.className = 'muted';
-  note.textContent = 'Effort saves separately from Save Reusable Task.';
 
+  button.classList.remove('secondary');
   label.parentElement.insertBefore(row, label);
   row.appendChild(label);
-  actions.append(button, note);
+  actions.appendChild(button);
   row.appendChild(actions);
 }
 

--- a/Setup/Application/setup_catalog_effort.js
+++ b/Setup/Application/setup_catalog_effort.js
@@ -7,6 +7,29 @@ function setupEffortLabel(value) {
   return normalized || 'Not reviewed';
 }
 
+function placeSetupEffortSaveControl() {
+  const select = el('edit-effort-level');
+  const button = el('save-task-effort');
+  const label = select?.closest('label');
+  if (!select || !button || !label) return;
+  if (el('setup-effort-editor-row')) return;
+
+  const row = document.createElement('div');
+  row.id = 'setup-effort-editor-row';
+  row.className = 'compact-grid';
+
+  const actions = document.createElement('div');
+  actions.className = 'action-row manager-only setup-effort-save-actions';
+  const note = document.createElement('span');
+  note.className = 'muted';
+  note.textContent = 'Effort saves separately from Save Reusable Task.';
+
+  label.parentElement.insertBefore(row, label);
+  row.appendChild(label);
+  actions.append(button, note);
+  row.appendChild(actions);
+}
+
 function applySetupEffortToTasks() {
   for (const task of appState.tasks || []) {
     task.effort_level = setupEffortState.get(Number(task.setup_task_id)) ?? null;
@@ -105,9 +128,11 @@ if (typeof reloadTasks === 'function') {
   };
 }
 
+placeSetupEffortSaveControl();
 el('save-task-effort')?.addEventListener('click', saveSelectedSetupEffort);
 
 window.addEventListener('load', () => {
+  placeSetupEffortSaveControl();
   applySetupEffortAccess();
   loadSetupEfforts().catch((error) => {
     console.error('Setup effort metadata could not be loaded', error);

--- a/Setup/Application/setup_training_review_refinement.css
+++ b/Setup/Application/setup_training_review_refinement.css
@@ -32,6 +32,20 @@
   border-color: var(--accent);
 }
 
+#setup-effort-editor-row {
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
+}
+
+#setup-effort-editor-row .setup-effort-save-actions {
+  align-items: end;
+  padding-top: 0;
+}
+
+#setup-effort-editor-row #save-task-effort {
+  white-space: nowrap;
+}
+
 .setup-reusable-match-target {
   margin: 10px 0 8px;
   padding: 10px 12px;
@@ -147,6 +161,17 @@
   padding: 16px;
   max-height: calc(86vh - 82px);
   overflow: auto;
+}
+
+@media (max-width: 900px) {
+  #setup-effort-editor-row {
+    grid-template-columns: 1fr;
+    align-items: stretch;
+  }
+
+  #setup-effort-editor-row .setup-effort-save-actions {
+    justify-content: flex-start;
+  }
 }
 
 @media (max-width: 760px) {

--- a/Setup/Application/setup_training_review_refinement.js
+++ b/Setup/Application/setup_training_review_refinement.js
@@ -25,9 +25,10 @@
       appState.access?.can_manage_setup
       && task?.setup_task_id != null
     );
+    const deleteTitle = 'Delete a mistaken reusable task while cleaning the reconstructed Catalog. The database refuses deletion when protected planning or execution history exists.';
 
-    button.textContent = 'Delete Task';
-    button.title = 'Delete a mistaken reusable task while cleaning the reconstructed Catalog. The database refuses deletion when protected planning or execution history exists.';
+    if (button.textContent !== 'Delete Task') button.textContent = 'Delete Task';
+    if (button.title !== deleteTitle) button.title = deleteTitle;
     if (button.hidden !== shouldHide) button.hidden = shouldHide;
   }
 

--- a/Setup/Application/setup_training_review_refinement.js
+++ b/Setup/Application/setup_training_review_refinement.js
@@ -17,6 +17,73 @@
     }
   }
 
+  function syncReconstructionDeleteControl() {
+    const button = document.getElementById('delete-reconstruction-task');
+    if (!button) return;
+    const task = typeof taskById === 'function' ? taskById(appState.selectedTaskId) : null;
+    const shouldHide = !(
+      appState.access?.can_manage_setup
+      && task?.setup_task_id != null
+    );
+
+    button.textContent = 'Delete Task';
+    button.title = 'Delete a mistaken reusable task while cleaning the reconstructed Catalog. The database refuses deletion when protected planning or execution history exists.';
+    if (button.hidden !== shouldHide) button.hidden = shouldHide;
+  }
+
+  function ensureReconstructionDeleteObserver() {
+    const button = document.getElementById('delete-reconstruction-task');
+    if (!button || button.dataset.catalogDeleteVisibilityObserver === '1') return;
+    button.dataset.catalogDeleteVisibilityObserver = '1';
+    new MutationObserver(() => syncReconstructionDeleteControl()).observe(
+      button,
+      { attributes: true, attributeFilter: ['hidden'] }
+    );
+    syncReconstructionDeleteControl();
+  }
+
+  async function deleteSelectedCatalogTask(event) {
+    const button = event.target.closest('#delete-reconstruction-task');
+    if (!button) return;
+
+    event.preventDefault();
+    event.stopImmediatePropagation();
+
+    const task = typeof taskById === 'function' ? taskById(appState.selectedTaskId) : null;
+    if (!task || !appState.access?.can_manage_setup) return;
+
+    const confirmed = window.confirm(
+      `Delete "${task.task_name}" completely from the Reusable Task Catalog?\n\n`
+      + 'Use this for reconstruction mistakes, duplicates, and bad task definitions that must not be propagated into 2026. '
+      + 'The database will refuse deletion if the task has protected planning or execution history.\n\n'
+      + 'This cannot be undone.'
+    );
+    if (!confirmed) return;
+
+    try {
+      setBusy(true);
+      const result = await api(
+        `api/setup/tasks/${task.setup_task_id}/reconstruction-delete`,
+        commandOptions('DELETE', {})
+      );
+      const deleted = result.deleted_task || {};
+      appState.selectedTaskId = null;
+      await reloadTasks(null);
+      if (typeof renderLibrary === 'function') renderLibrary();
+      showView('library');
+      setAlert(
+        `Deleted task ${deleted.setup_task_id || task.setup_task_id}. `
+        + `${deleted.deleted_annual_rows ?? 0} annual reconstruction row(s) were also removed.`,
+        'ok'
+      );
+    } catch (error) {
+      setAlert(error.message || error, 'error');
+      window.alert(error.message || error);
+    } finally {
+      setBusy(false);
+    }
+  }
+
   function ensureCaptainTypeahead() {
     const search = document.getElementById('setup-captain-search');
     const select = document.getElementById('setup-captain-person');
@@ -183,6 +250,8 @@
 
   function initializeRefinements() {
     relocateCatalogReturnControl();
+    ensureReconstructionDeleteObserver();
+    syncReconstructionDeleteControl();
     ensureCaptainTypeahead();
     observeMaterialContext();
   }
@@ -194,5 +263,7 @@
     { childList: true, subtree: true }
   );
 
+  document.addEventListener('click', deleteSelectedCatalogTask, true);
   document.addEventListener('click', () => requestAnimationFrame(initializeRefinements), true);
+  document.addEventListener('change', () => requestAnimationFrame(initializeRefinements), true);
 })();

--- a/Setup/Application/setup_training_review_refinement.js
+++ b/Setup/Application/setup_training_review_refinement.js
@@ -53,6 +53,10 @@
     const task = typeof taskById === 'function' ? taskById(appState.selectedTaskId) : null;
     if (!task || !appState.access?.can_manage_setup) return;
 
+    const returnButton = document.getElementById('setup-return-library');
+    const returnWrap = document.getElementById('setup-return-library-wrap');
+    const returnThroughCatalogOrigin = Boolean(returnButton && returnWrap && !returnWrap.hidden);
+
     const confirmed = window.confirm(
       `Delete "${task.task_name}" completely from the Reusable Task Catalog?\n\n`
       + 'Use this for reconstruction mistakes, duplicates, and bad task definitions that must not be propagated into 2026. '
@@ -70,8 +74,14 @@
       const deleted = result.deleted_task || {};
       appState.selectedTaskId = null;
       await reloadTasks(null);
-      if (typeof renderLibrary === 'function') renderLibrary();
-      showView('library');
+
+      if (returnThroughCatalogOrigin && returnButton) {
+        returnButton.click();
+      } else {
+        if (typeof renderLibrary === 'function') renderLibrary();
+        showView('library');
+      }
+
       setAlert(
         `Deleted task ${deleted.setup_task_id || task.setup_task_id}. `
         + `${deleted.deleted_annual_rows ?? 0} annual reconstruction row(s) were also removed.`,

--- a/Setup/Application/test_setup_catalog_delete_restore_contract.py
+++ b/Setup/Application/test_setup_catalog_delete_restore_contract.py
@@ -6,6 +6,7 @@ ROOT = Path(__file__).resolve().parent
 
 def test_catalog_delete_is_manager_visible_without_annual_reconstruction_row():
     js = (ROOT / "setup_training_review_refinement.js").read_text(encoding="utf-8")
+    assert "button.textContent !== 'Delete Task'" in js
     assert "button.textContent = 'Delete Task'" in js
     assert "appState.access?.can_manage_setup" in js
     assert "task?.setup_task_id != null" in js
@@ -22,3 +23,17 @@ def test_catalog_delete_uses_existing_governed_fail_closed_command():
     assert "protected planning or execution history" in js
     assert "event.stopImmediatePropagation()" in js
     assert "showView('library')" in js
+
+
+def test_catalog_delete_sync_is_idempotent_under_mutation_observers():
+    js = (ROOT / "setup_training_review_refinement.js").read_text(encoding="utf-8")
+    assert "if (button.textContent !== 'Delete Task') button.textContent = 'Delete Task';" in js
+    assert "if (button.title !== deleteTitle) button.title = deleteTitle;" in js
+    assert "if (button.hidden !== shouldHide) button.hidden = shouldHide;" in js
+    assert "attributeFilter: ['hidden']" in js
+
+
+def test_cleanup_js_assets_are_cache_busted_together():
+    html = (ROOT / "production.html").read_text(encoding="utf-8")
+    assert 'setup_training_review_refinement.js?v=2026-09-09.2' in html
+    assert 'setup_catalog_effort.js?v=2026-09-09.2' in html

--- a/Setup/Application/test_setup_catalog_delete_restore_contract.py
+++ b/Setup/Application/test_setup_catalog_delete_restore_contract.py
@@ -33,7 +33,16 @@ def test_catalog_delete_sync_is_idempotent_under_mutation_observers():
     assert "attributeFilter: ['hidden']" in js
 
 
-def test_cleanup_js_assets_are_cache_busted_together():
+def test_catalog_delete_returns_through_existing_catalog_origin_control():
+    js = (ROOT / "setup_training_review_refinement.js").read_text(encoding="utf-8")
+    assert "const returnButton = document.getElementById('setup-return-library');" in js
+    assert "const returnWrap = document.getElementById('setup-return-library-wrap');" in js
+    assert "returnThroughCatalogOrigin" in js
+    assert "returnButton.click();" in js
+
+
+def test_cleanup_assets_are_cache_busted_together():
     html = (ROOT / "production.html").read_text(encoding="utf-8")
-    assert 'setup_training_review_refinement.js?v=2026-09-09.2' in html
-    assert 'setup_catalog_effort.js?v=2026-09-09.2' in html
+    assert 'setup_training_review_refinement.css?v=2026-09-09.3' in html
+    assert 'setup_training_review_refinement.js?v=2026-09-09.3' in html
+    assert 'setup_catalog_effort.js?v=2026-09-09.3' in html

--- a/Setup/Application/test_setup_catalog_delete_restore_contract.py
+++ b/Setup/Application/test_setup_catalog_delete_restore_contract.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+
+
+def test_catalog_delete_is_manager_visible_without_annual_reconstruction_row():
+    js = (ROOT / "setup_training_review_refinement.js").read_text(encoding="utf-8")
+    assert "button.textContent = 'Delete Task'" in js
+    assert "appState.access?.can_manage_setup" in js
+    assert "task?.setup_task_id != null" in js
+    assert "setup_session_task_id" not in js
+    assert "season?.session_status" not in js
+    assert "reconstruction mistakes, duplicates, and bad task definitions" in js
+
+
+def test_catalog_delete_uses_existing_governed_fail_closed_command():
+    js = (ROOT / "setup_training_review_refinement.js").read_text(encoding="utf-8")
+    assert "deleteSelectedCatalogTask" in js
+    assert "reconstruction-delete" in js
+    assert "commandOptions('DELETE', {})" in js
+    assert "protected planning or execution history" in js
+    assert "event.stopImmediatePropagation()" in js
+    assert "showView('library')" in js

--- a/Setup/Application/test_setup_catalog_effort_contract.py
+++ b/Setup/Application/test_setup_catalog_effort_contract.py
@@ -47,11 +47,17 @@ def test_effort_editor_and_catalog_badge_are_present():
     assert "setup-effort-badge" in js
 
 
-def test_effort_save_control_is_moved_beside_effort_editor_and_explains_separate_save():
+def test_effort_save_control_is_primary_inline_and_has_no_extra_explanation():
+    html = text(BASE / "production.html")
     js = text(BASE / "setup_catalog_effort.js")
+    css = text(BASE / "setup_training_review_refinement.css")
+    assert 'id="save-task-effort" type="button">Save Effort</button>' in html
     assert "function placeSetupEffortSaveControl()" in js
     assert "setup-effort-editor-row" in js
-    assert "row.className = 'compact-grid'" in js
-    assert "actions.append(button, note)" in js
-    assert "Effort saves separately from Save Reusable Task." in js
+    assert "actions.appendChild(button)" in js
+    assert "button.classList.remove('secondary')" in js
+    assert "Effort saves separately from Save Reusable Task." not in js
+    assert "#setup-effort-editor-row" in css
+    assert "align-items: end" in css
+    assert "padding-top: 0" in css
     assert "placeSetupEffortSaveControl();" in js

--- a/Setup/Application/test_setup_catalog_effort_contract.py
+++ b/Setup/Application/test_setup_catalog_effort_contract.py
@@ -45,3 +45,13 @@ def test_effort_editor_and_catalog_badge_are_present():
     assert "can_manage_setup" in js
     assert "setup_effort_badge" not in js  # class stays hyphenated for CSS/DOM consistency
     assert "setup-effort-badge" in js
+
+
+def test_effort_save_control_is_moved_beside_effort_editor_and_explains_separate_save():
+    js = text(BASE / "setup_catalog_effort.js")
+    assert "function placeSetupEffortSaveControl()" in js
+    assert "setup-effort-editor-row" in js
+    assert "row.className = 'compact-grid'" in js
+    assert "actions.append(button, note)" in js
+    assert "Effort saves separately from Save Reusable Task." in js
+    assert "placeSetupEffortSaveControl();" in js

--- a/Setup/Application/test_setup_training_ux_contract.py
+++ b/Setup/Application/test_setup_training_ux_contract.py
@@ -19,7 +19,7 @@ def test_training_ux_assets_are_loaded_after_live_review_fixes():
     live_index = html.index("setup_live_review_fixes.js?v=2026-09-08.3")
     training_index = html.index("setup_training_ux.js?v=2026-09-08.1")
     assigned_index = html.index("setup_assigned_review.js?v=2026-09-08.2")
-    refinement_index = html.index("setup_training_review_refinement.js?v=2026-09-08.1")
+    refinement_index = html.index("setup_training_review_refinement.js?v=2026-09-09.2")
     assert "setup_training_ux.css?v=2026-09-08.1" in html
     assert "setup_training_review_refinement.css?v=2026-09-08.1" in html
     assert training_index > live_index

--- a/Setup/Application/test_setup_training_ux_contract.py
+++ b/Setup/Application/test_setup_training_ux_contract.py
@@ -66,6 +66,26 @@ def test_return_control_has_distinct_theme_safe_navigation_treatment():
     assert "color: #ffffff" in css
 
 
+def test_effort_save_alignment_uses_primary_button_and_field_baseline():
+    html = read("production.html")
+    js = read("setup_catalog_effort.js")
+    css = read("setup_training_review_refinement.css")
+    assert 'id="save-task-effort" type="button">Save Effort</button>' in html
+    assert "button.classList.remove('secondary')" in js
+    assert "#setup-effort-editor-row" in css
+    assert "grid-template-columns: minmax(0, 1fr) auto" in css
+    assert "align-items: end" in css
+    assert "Effort saves separately from Save Reusable Task." not in js
+
+
+def test_catalog_delete_reuses_existing_back_control_position():
+    js = read("setup_training_review_refinement.js")
+    assert "const returnButton = document.getElementById('setup-return-library');" in js
+    assert "const returnWrap = document.getElementById('setup-return-library-wrap');" in js
+    assert "returnThroughCatalogOrigin" in js
+    assert "returnButton.click();" in js
+
+
 def test_catalog_detail_adds_database_resolved_material_logistics_section():
     js = read("setup_training_ux.js")
     assert "4. Material / Logistics Context" in js

--- a/Setup/Application/test_setup_training_ux_contract.py
+++ b/Setup/Application/test_setup_training_ux_contract.py
@@ -19,9 +19,9 @@ def test_training_ux_assets_are_loaded_after_live_review_fixes():
     live_index = html.index("setup_live_review_fixes.js?v=2026-09-08.3")
     training_index = html.index("setup_training_ux.js?v=2026-09-08.1")
     assigned_index = html.index("setup_assigned_review.js?v=2026-09-08.2")
-    refinement_index = html.index("setup_training_review_refinement.js?v=2026-09-09.2")
+    refinement_index = html.index("setup_training_review_refinement.js?v=2026-09-09.3")
     assert "setup_training_ux.css?v=2026-09-08.1" in html
-    assert "setup_training_review_refinement.css?v=2026-09-08.1" in html
+    assert "setup_training_review_refinement.css?v=2026-09-09.3" in html
     assert training_index > live_index
     assert refinement_index > assigned_index > training_index
 

--- a/Setup/Application/test_setup_training_ux_contract.py
+++ b/Setup/Application/test_setup_training_ux_contract.py
@@ -180,15 +180,21 @@ def test_reusable_task_match_action_is_explicit_about_target_and_scope():
     assert "MATCH CONFIRMED" in js
 
 
-def test_reconstruction_delete_is_visible_only_in_historical_manager_context():
-    js = read("setup_training_ux.js")
+def test_reconstruction_delete_is_visible_for_catalog_only_tasks_in_historical_manager_context():
+    base_js = read("setup_training_ux.js")
+    refinement_js = read("setup_training_review_refinement.js")
     css = read("setup_training_ux.css")
-    assert "Delete Reconstruction Task" in js
-    assert "HISTORICAL_VERIFICATION" in js
-    assert "setup_session_task_id != null" in js
-    assert "reconstruction-delete" in js
-    assert "commandOptions('DELETE', {})" in js
-    assert "work-day, progress, movement, planning, or actual execution history" in js
+    combined = base_js + "\n" + refinement_js
+    assert "Delete Reconstruction Task" in base_js
+    assert "button.textContent = 'Delete Task'" in refinement_js
+    assert "HISTORICAL_VERIFICATION" in combined
+    assert "appState.access?.can_manage_setup" in refinement_js
+    assert "task?.setup_task_id != null" in refinement_js
+    assert "catalogDeleteVisibilityObserver" in refinement_js
+    assert "attributeFilter: ['hidden']" in refinement_js
+    assert "reconstruction-delete" in base_js
+    assert "commandOptions('DELETE', {})" in base_js
+    assert "work-day, progress, movement, planning, or actual execution history" in base_js
     assert "#delete-reconstruction-task.danger" in css
 
 


### PR DESCRIPTION
## Purpose

Bundle the source-only cleanup UI fixes needed to continue the 2025 Setup plan cleanup before any 2026 Setup Session is created.

## Included

- Save `Physical Effort` directly beside the effort selector using the normal primary blue save-button treatment; no extra explanatory sentence.
- Restore Manager `Delete Task` for reusable Catalog-only reconstruction mistakes even when no annual `setup_session_task` row exists, while continuing to use the governed fail-closed database delete command.
- After a Catalog task is deleted, return through the same existing `Back to Reusable Task Catalog` origin behavior so the Catalog position is preserved instead of jumping to the top.
- Cache-bust every modified Setup UI asset used by this refinement.

## Scope

Source-only Setup application/test changes. No database migration, environment, service, proxy, firewall, or runtime-shape change.

The branch is a forward descendant of the current accepted Production Setup baseline SHA:

`5a8a317357ffa5d77c38bc4df63fe6c7b451dbaf`

The first Production attempt at `d28610b9f6685989e0b7ae5d95babd4cf3db72f5` failed protected-route validation because cache-busting was omitted and a MutationObserver feedback loop could make the page unresponsive. Production was rolled back cleanly. The corrected deployment at `76de1502a403c231367fe8ea05276747974f2171` passed health, focused regression, unchanged fingerprint, and browser responsiveness/visibility checks. Additional operator UX refinements are now being applied on this same branch and require a new exact-target regression before any further Production deployment.

Related: #122, #125, #136, #137.