### PR TITLE
Clarify staged material limitation in Setup operator docs

### DIFF
--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/README.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/README.md
@@ -109,6 +109,29 @@ There is no operator-facing LOR Preview/programming-group/material-source select
 
 The UI color marker is presentation only. `requires_display_material` is authoritative.
 
+### Important boundary — not yet task-specific staged material
+
+The accepted resolver is intentionally a **Stage/real-Scene material-context resolver**, not a complete task-specific pick/release model.
+
+When one Stage has several separate physical Setup tasks, multiple material-enabled Stage-level tasks can resolve the same Stage-level Displays/Containers even if only part of that material should leave storage for the current step.
+
+Magic Igloo is the representative case:
+
+```text
+frame work
+    -> may need frame material first
+
+skin installation
+    -> skins/bungees may need to remain warm in the workshop until later
+
+lighting/camera/finish work
+    -> later material may not be needed at the first step
+```
+
+The current checkbox answers whether the task uses Stage/Scene Display material and exposes that current context. It does not subdivide the Stage material by physical task step or release time.
+
+Do not claim that resolved material means `pick this now`. Task-specific material subdivision, component/KIT representation, and staged Pick List timing remain open engineering work in Issue #141.
+
 See [Setup Stage / Scene Material Resolution Contract — 2026-09-10](Setup_Stage_Scene_Material_Resolution_Contract_2026-09-10.md).
 
 ## Current Accepted Planning / Execution Presentation
@@ -175,13 +198,14 @@ Primary active work now is issue-driven rather than continuing the old nested PR
 
 ```text
 #122  Setup Session engineering / planning / Pick List / live reconstruction umbrella
+#141  task-specific staged material subdivision and Pick List release timing
 #145  reusable Catalog cleanup gate before creating the 2026 Setup Session
 #130  global People / Capability / Qualification work consumed by Setup
 #132  Captain work-report duration / multi-day effort capture
 #113  shared Scan application readiness / identity capture integration
 ```
 
-Earlier Setup PRs #123/#124/#125/#134/#136/#137/#138/#139 are historical/superseded lineages and should not be treated as the current development authority once their unique accepted content is preserved in `main` and their closeout comments are recorded.
+Earlier Setup PRs #123/#124/#125/#134/#136/#137/#138/#139 are historical/superseded lineages and are not the current development authority.
 
 ## Reusable Catalog / Annual Session Boundary
 
@@ -264,11 +288,14 @@ The intended direction remains:
 
 ```text
 selected Setup work
-    -> resolved Displays
-    -> current Containers
+    -> required material at the correct task/release step
+    -> resolved Displays / other governed material units
+    -> current Containers/storage
     -> deduplicate
-    -> explain why each Container is required
+    -> explain why each item/Container is required
 ```
+
+The existing Stage/Scene material resolver provides useful context but does not yet provide the task-specific release step in the first arrow above. Issue #141 owns that unresolved material-subdivision/timing problem.
 
 Do not infer task scope from Container storage. Shared/mixed-stage Containers are normal.
 
@@ -294,6 +321,7 @@ Current significant remaining work includes:
 
 - reusable Catalog cleanup before 2026 propagation;
 - continued correction of task boundaries exposed by live review;
+- task-specific staged material subdivision / release timing for multi-step Stage work (Issue #141);
 - structured readiness and efficient predecessor entry;
 - cross-Stage candidate planning surface / short-horizon scheduler workflow;
 - authoritative Controller context from FieldWiring / Controller Inventory;
@@ -309,14 +337,15 @@ Before changing this subsystem:
 1. read the Production Database Project Rules;
 2. read this engineering portal;
 3. read the Stage/Scene material-resolution contract before changing material or Scene classification;
-4. review Issue #145 before creating or simulating 2026 annual state;
-5. preserve annual 2025 facts separately from reusable future knowledge;
-6. use the predecessor/readiness contract before rebuilding dependencies;
-7. use the Pick List contract before implementing logistics/pick behavior;
-8. use issue #130 / People and Identity for global capability/qualification work;
-9. use issue #113 / Labeling and Scanning for shared scan capture/resolution behavior;
-10. use `Gregovate/MSB-Server-Management` for current runtime/deployment authority; and
-11. update controlled docs and this README handoff whenever accepted behavior or the next resume point changes.
+4. review Issue #141 before designing task-specific material groups, components/KITs, or Pick List release timing;
+5. review Issue #145 before creating or simulating 2026 annual state;
+6. preserve annual 2025 facts separately from reusable future knowledge;
+7. use the predecessor/readiness contract before rebuilding dependencies;
+8. use the Pick List contract before implementing logistics/pick behavior;
+9. use issue #130 / People and Identity for global capability/qualification work;
+10. use issue #113 / Labeling and Scanning for shared scan capture/resolution behavior;
+11. use `Gregovate/MSB-Server-Management` for current runtime/deployment authority; and
+12. update controlled docs and this README handoff whenever accepted behavior or the next resume point changes.
 
 ## Related Systems
 

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/operatorSOP/README.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/operatorSOP/README.md
@@ -53,6 +53,16 @@ A colored task marker/highlight is only a visual cue that the material checkbox 
 
 It is normal for tasks such as locating, layout, network/power preparation, greasing, or other non-Display work to leave this box unchecked.
 
+### Important current limitation
+
+The current material result is **Stage/Scene material context**, not yet a task-specific pick/release list inside one Stage.
+
+If one Stage has several separate physical Setup tasks, more than one material-enabled Stage-level task can resolve the same Stage-level Displays/Containers even when only part of that material should be brought to the park for the current step.
+
+Example: Magic Igloo may need frame material first while skins should remain warm in the workshop until a later task. The current checkbox does not yet subdivide that Stage material by step or decide when each subset should leave storage.
+
+Do **not** treat every resolved item as "pick this now" merely because it appears in the Material / Logistics context. Task-specific staged material and pick-list timing remain separate future work tracked in Issue #141.
+
 ## Important Boundaries
 
 - The 2025 review area uses real Production data.
@@ -72,6 +82,7 @@ Managers and reviewers are encouraged to:
 - add genuinely missing reusable tasks;
 - mark **Uses Display / Container Material** only when that task really needs the current Display/Container material for its Stage/Scene work;
 - leave the material checkbox off for valid non-material tasks;
+- treat resolved material as context, not an automatic instruction to pick every item immediately;
 - add/correct resources and prerequisites;
 - correct task scope, order, crew/time expectations, and notes where supported;
 - verify records only when they have actually been reviewed;

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/operatorSOP/Review_2025_Setup_History.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/operatorSOP/Review_2025_Setup_History.md
@@ -139,6 +139,22 @@ The operator does **not** choose:
 
 If the task's Stage/Scene scope is wrong, correct the task scope. Do not choose a different material source to compensate.
 
+### Current staged-material limitation
+
+The current resolver answers:
+
+> What current Stage/Scene Displays and Containers are associated with this material-enabled task scope?
+
+It does **not** yet answer:
+
+> Which subset of that material should be picked or delivered for this exact work step today?
+
+If several Stage-level tasks exist under one Stage, multiple material-enabled tasks can resolve the same Stage-level material. That is expected with the current model and does not mean all of the resolved material should be transported at the first step.
+
+Magic Igloo is the key example: frame work may happen first while skins deliberately stay warm in the workshop until the later skin-install task. The current material checkbox does not yet subdivide those Stage materials by task step or release time.
+
+Treat Material / Logistics as **resolved context**, not as a complete pick/release instruction. Task-specific staged material and timing remain future engineering work tracked in Issue #141.
+
 ### Color coding
 
 Tasks with material enabled receive a colored marker/highlight in supported views. That is only a visual cue.
@@ -200,6 +216,7 @@ The application remains under real-use evaluation. Report things such as:
 - awkward or repetitive steps;
 - task organization that does not match real work;
 - unexpected Display/Container material resolution;
+- a Stage where material must be staged/released differently between separate tasks;
 - resources or prerequisites that are difficult to represent;
 - missing readiness behavior;
 - search/filter/navigation problems; and
@@ -226,6 +243,7 @@ A useful review leaves:
 - reusable task boundaries corrected at practical crew/work-package level;
 - material enabled only for tasks that actually require LOR-derived Displays/Containers;
 - non-material tasks left valid with material disabled;
+- current material context reviewed without assuming it is a complete pick/release plan;
 - correct Stage/real-Scene scope;
 - resources, effort, predecessors/readiness, order, and normal expectations improved where supported;
 - no fake records created merely for testing or UI workarounds; and

--- a/Docs/02_Production_Database/02_Operational_SOPs/Setup/Setup_Session_Manager_Review_Guide.md
+++ b/Docs/02_Production_Database/02_Operational_SOPs/Setup/Setup_Session_Manager_Review_Guide.md
@@ -136,6 +136,27 @@ A colored marker/highlight identifies material-enabled tasks in supported views.
 
 The task detail may show the resolved Displays/Containers as Material / Logistics context. This is for verification and downstream planning. Ordinary material membership comes from current LOR membership and current Display-to-Container assignment rather than a second manually maintained Setup list.
 
+### Current limitation: material context is not yet task-specific release timing
+
+The current resolver can still be too broad when one Stage has several separate physical Setup steps.
+
+Example:
+
+```text
+Magic Igloo
+    -> frame work
+    -> skin installation
+    -> later lighting/camera/finish work
+```
+
+The skins may need to stay warm in the workshop until the skin-install task. If more than one of those Stage-level tasks has the material checkbox enabled, the current resolver can show the same Stage-level Displays/Containers for each task because all of them share the same Stage scope.
+
+That does **not** mean every resolved item should be picked, loaded, or delivered for the first task.
+
+The current checkbox answers whether the task uses Stage/Scene Display material and shows that current context. It does not yet subdivide a Stage's material into task-specific release groups or determine when each subset should leave storage.
+
+Task-specific staged material and pick-list timing are tracked in Issue #141 and remain future engineering work.
+
 ## Stage View and Planned Order
 
 **Plan / Schedule** and **Perform Work** support Stage-oriented presentation.
@@ -221,7 +242,7 @@ Production-operational now includes:
 - Production-backed 2025 review/training;
 - reusable task create/copy/update/delete where governed safeguards allow it;
 - Stage/real-Scene scope organization;
-- automatic Display/Container material applicability and resolution;
+- automatic Display/Container material applicability and Stage/Scene context resolution;
 - Stage-oriented Plan / Schedule and Perform Work presentation;
 - search across Catalog, Plan / Schedule, and Perform Work;
 - resource/effort/prerequisite maintenance;
@@ -231,6 +252,7 @@ Production-operational now includes:
 Still incomplete/separate work includes:
 
 - final reusable Catalog cleanup before 2026 creation;
+- task-specific staged material subdivision / release timing (#141);
 - structured readiness gating;
 - improved predecessor-entry interaction;
 - Pick List generation/tablet workflow;


### PR DESCRIPTION
## Purpose

Correct the closeout documentation so the new `Uses Display / Container Material` checkbox is not mistaken for a complete task-specific pick/release model.

## Clarification

The accepted Production resolver provides Stage/real-Scene material context. It can still show the same Stage-level material for several sequential Stage tasks when those tasks share one Stage scope.

Magic Igloo is the representative case: frame work may happen before skins are released from the warm workshop. The current material context must not be interpreted as `pick everything now`.

## Updates

- add the current limitation to the plain-English operator portal;
- add it to the 2025 review procedure;
- add it to the Manager Review Guide;
- add Issue #141 and the staged-material boundary to the engineering handoff.

No application/database/runtime change is included. This is documentation-only closeout after the accepted V0.3.5 deployment.