### PR TITLE
Close out working Setup Stage/Scene scope drag/drop

### DIFF
--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/operatorSOP/README.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/operatorSOP/README.md
@@ -63,6 +63,14 @@ Example: Magic Igloo may need frame material first while skins should remain war
 
 Do **not** treat every resolved item as "pick this now" merely because it appears in the Material / Logistics context. Task-specific staged material and pick-list timing remain separate future work tracked in Issue #141.
 
+## Moving Tasks Between Stage-level and Scene
+
+Managers can drag a reusable task between **Stage-level / General** and a real **Scene** within the Stage. A task can also be dragged to another valid Stage/Scene destination.
+
+This is a real reusable-scope change, not only a visual reorder. The application saves the new Stage/Scene scope through the governed Setup command and keeps the existing Stage/Scene validity checks.
+
+Use this when the task was organized under the wrong Stage-level/Scene location. Do not create a fake Scene or use a programming-only LOR group as a Setup Scene merely to obtain a different material result.
+
 ## Important Boundaries
 
 - The 2025 review area uses real Production data.


### PR DESCRIPTION
## Purpose

Close Issue #133 after operator confirmation that reusable Setup task drag/drop now works between Stage-level / General and real Scene scopes.

## Evidence

Current `Setup/Application/setup_next_pass.js` uses scope drop zones and persists the destination through the governed `api/setup/tasks/{taskId}/scope` command. Existing contract coverage includes Stage/Scene drag behavior and the governed scope endpoint.

Operator acceptance on 2026-09-10 confirmed the originally reported Stage-level ↔ Scene limitation now works in Production.

## Documentation

Updates the plain-English Setup operator portal to state that Managers can drag reusable tasks between Stage-level / General and real Scene locations and that this is a persisted reusable-scope change, not only a visual reorder.

Closes #133.