### PR TITLE
Fix Setup dirty-edit loss before annual verification

### DIFF
--- a/Setup/Acceptance/run_setup_catalog_dirty_edit_browser_preview.ps1
+++ b/Setup/Acceptance/run_setup_catalog_dirty_edit_browser_preview.ps1
@@ -1,0 +1,72 @@
+param(
+    [string]$Server = 'msbadmin@192.168.5.9',
+    [Parameter(Mandatory=$true)]
+    [int]$PreviewPort,
+    [string]$PreviewEmail = 'gliebig@sheboyganlights.org'
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Exact application candidate for Issue #154. Later commits on this branch may
+# harden acceptance tooling, but browser approval remains pinned to this app SHA.
+$AcceptedCandidateSha = '89012d5e40a26323db78dce50d9e58dd27580169'
+$AcceptedBranch = 'agent/setup-catalog-dirty-edit-safety-154'
+$BaseWrapper = Join-Path $PSScriptRoot 'run_setup_source_only_browser_preview.ps1'
+
+if (-not (Test-Path -LiteralPath $BaseWrapper)) {
+    throw "Setup source-only preview base wrapper is missing: $BaseWrapper"
+}
+
+function Replace-Required {
+    param(
+        [Parameter(Mandatory=$true)][string]$Source,
+        [Parameter(Mandatory=$true)][string]$Needle,
+        [Parameter(Mandatory=$true)][string]$Replacement,
+        [Parameter(Mandatory=$true)][string]$Description
+    )
+
+    if (-not $Source.Contains($Needle)) {
+        throw "Setup dirty-edit preview could not find expected $Description."
+    }
+    return $Source.Replace($Needle, $Replacement)
+}
+
+# Reuse the hardened source-only current-Production-clone preview. Override only
+# the exact application candidate/ref and focused regression list for #154.
+$text = [System.IO.File]::ReadAllText($BaseWrapper)
+$text = $text.Replace("`r`n", "`n").Replace("`r", "`n")
+
+$text = Replace-Required -Source $text -Needle "`$CandidateSha = '51c739bd85115c9f5d2853763e8e1450ac381407'" -Replacement "`$CandidateSha = '$AcceptedCandidateSha'" -Description 'source-only candidate SHA assignment'
+$text = Replace-Required -Source $text -Needle "`$ExpectedBranch = 'agent/setup-session-production-foundation'" -Replacement "`$ExpectedBranch = '$AcceptedBranch'" -Description 'source-only expected branch assignment'
+
+# A dynamically compiled wrapper has no reliable MyInvocation path. Pin the
+# real Acceptance directory so the base wrapper resolves its server/entry files.
+$scriptDirLiteral = $PSScriptRoot.Replace("'", "''")
+$text = Replace-Required -Source $text -Needle '$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path' -Replacement "`$ScriptDir = '$scriptDirLiteral'" -Description 'base wrapper ScriptDir initialization'
+
+# Add the new #154 contract to the focused detached regression. Keep the
+# existing accepted regression files and add the version-bearing Stage-order
+# contract because the candidate health version changed from V0.3.5 to V0.3.6.
+$regressionNeedle = "        '      Setup/Application/test_setup_next_pass_contract.py'"
+$regressionReplacement = @(
+    "        '      Setup/Application/test_setup_next_pass_contract.py \\',",
+    "        '      Setup/Application/test_setup_stage_order_contract.py \\',",
+    "        '      Setup/Application/test_setup_dirty_edit_guard_contract.py'"
+) -join "`n"
+$text = Replace-Required -Source $text -Needle $regressionNeedle -Replacement $regressionReplacement -Description 'focused regression tail'
+
+$text = $text.Replace('SETUP SOURCE-ONLY BROWSER PREVIEW', 'SETUP CATALOG DIRTY-EDIT BROWSER PREVIEW')
+$text = $text.Replace('SETUP SOURCE-ONLY BROWSER REVIEW READY', 'SETUP CATALOG DIRTY-EDIT BROWSER REVIEW READY')
+
+Write-Host 'Issue #154 browser acceptance checklist:'
+Write-Host '  1. Open an annual 2025 task and change a reusable field without saving.'
+Write-Host '  2. Click Mark Verified; prove the reusable edit persists and annual state becomes VERIFIED.'
+Write-Host '  3. Force a reusable save failure (for example a duplicate/invalid task name) and click Mark Verified; prove verification does NOT change.'
+Write-Host '  4. With dirty edits, switch tasks and exercise Save + continue, Discard + continue, and Stay.'
+Write-Host '  5. Make an annual-note draft, click Save Reusable Task, and prove the annual draft remains present.'
+Write-Host '  6. Exercise one independent Effort or Material save and confirm it remains separately governed.'
+Write-Host '  7. Return to the Catalog / change tabs with dirty edits and confirm no silent loss.'
+Write-Host
+
+$script = [scriptblock]::Create($text)
+& $script -Server $Server -PreviewPort $PreviewPort -PreviewEmail $PreviewEmail

--- a/Setup/Acceptance/run_setup_catalog_dirty_edit_browser_preview.ps1
+++ b/Setup/Acceptance/run_setup_catalog_dirty_edit_browser_preview.ps1
@@ -49,8 +49,8 @@ $text = Replace-Required -Source $text -Needle '$ScriptDir = Split-Path -Parent 
 # contract because the candidate health version changed from V0.3.5 to V0.3.6.
 $regressionNeedle = "        '      Setup/Application/test_setup_next_pass_contract.py'"
 $regressionReplacement = @(
-    "        '      Setup/Application/test_setup_next_pass_contract.py \\',",
-    "        '      Setup/Application/test_setup_stage_order_contract.py \\',",
+    "        '      Setup/Application/test_setup_next_pass_contract.py \',",
+    "        '      Setup/Application/test_setup_stage_order_contract.py \',",
     "        '      Setup/Application/test_setup_dirty_edit_guard_contract.py'"
 ) -join "`n"
 $text = Replace-Required -Source $text -Needle $regressionNeedle -Replacement $regressionReplacement -Description 'focused regression tail'

--- a/Setup/Acceptance/run_setup_source_only_browser_preview.ps1
+++ b/Setup/Acceptance/run_setup_source_only_browser_preview.ps1
@@ -8,6 +8,7 @@ param(
 $ErrorActionPreference = 'Stop'
 $CandidateSha = '51c739bd85115c9f5d2853763e8e1450ac381407'
 $ExpectedBranch = 'agent/setup-session-production-foundation'
+$ApprovedRef = $ExpectedBranch
 
 if ($PreviewPort -lt 1024 -or $PreviewPort -gt 65535) {
     throw 'PreviewPort must be between 1024 and 65535.'
@@ -195,6 +196,7 @@ echo "Disposable PostgreSQL final server ready: PASS"
 
     Write-Host '========== SETUP SOURCE-ONLY BROWSER PREVIEW =========='
     Write-Host "Candidate SHA: $CandidateSha"
+    Write-Host "Approved ref:  $ApprovedRef"
     Write-Host "Preview URL:   http://127.0.0.1:$PreviewPort/"
     Write-Host "Preview user:  $PreviewEmail"
     Write-Host
@@ -210,7 +212,7 @@ echo "Disposable PostgreSQL final server ready: PASS"
 
     $remoteServer = "/tmp/$remoteServerName"
     $remoteEntry = "/tmp/$remoteEntryName"
-    $remoteCommand = "chmod 700 '$remoteServer'; cd /tmp; cp '$remoteEntry' ./setup_session_browser_preview_entry.py; bash -n '$remoteServer'; rc=`$?; if [ `$rc -eq 0 ]; then bash '$remoteServer' '$CandidateSha' '$PreviewPort' '$PreviewEmail'; rc=`$?; fi; rm -f '$remoteServer' '$remoteEntry' ./setup_session_browser_preview_entry.py; exit `$rc"
+    $remoteCommand = "chmod 700 '$remoteServer'; cd /tmp; cp '$remoteEntry' ./setup_session_browser_preview_entry.py; bash -n '$remoteServer'; rc=`$?; if [ `$rc -eq 0 ]; then bash '$remoteServer' '$CandidateSha' '$PreviewPort' '$PreviewEmail' '$ApprovedRef'; rc=`$?; fi; rm -f '$remoteServer' '$remoteEntry' ./setup_session_browser_preview_entry.py; exit `$rc"
 
     Write-Host 'Keep this PowerShell window open during browser review.'
     Write-Host 'When the server reports SETUP SOURCE-ONLY BROWSER REVIEW READY, open the Preview URL.'

--- a/Setup/Acceptance/setup_source_only_browser_preview_server.sh
+++ b/Setup/Acceptance/setup_source_only_browser_preview_server.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 CANDIDATE_SHA="${1:?candidate SHA required}"
 PREVIEW_PORT="${2:?preview port required}"
 PREVIEW_EMAIL="${3:?preview email required}"
+APPROVED_REF="${4:?approved Git ref required}"
 
 PROD_CONTAINER="msb-postgres"
 PROD_DB="msb"
@@ -31,6 +32,7 @@ exec > >(tee "$REPORT") 2>&1
 
 echo "========== SETUP SOURCE-ONLY BROWSER PREVIEW =========="
 echo "Candidate SHA: $CANDIDATE_SHA"
+echo "Approved ref:  $APPROVED_REF"
 echo "Preview port:  $PREVIEW_PORT"
 echo "Preview user:  $PREVIEW_EMAIL"
 echo "Production DB: pg_dump + SELECT only"
@@ -113,6 +115,10 @@ if [[ ! "$PREVIEW_EMAIL" =~ ^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+$ ]]; then
     echo "FAIL: preview email is invalid"
     exit 4
 fi
+if [[ -z "$APPROVED_REF" ]]; then
+    echo "FAIL: approved Git ref is required"
+    exit 5
+fi
 if [[ ! -s "$ENTRY_SCRIPT" ]]; then
     echo "FAIL: preview entry script is missing: $ENTRY_SCRIPT"
     exit 5
@@ -142,7 +148,7 @@ echo "Production Setup fingerprint: $PROD_BEFORE"
 
 echo
 echo "--- Fetch exact candidate and run detached regression ---"
-sudo git -C "$REPO_ROOT" fetch origin agent/setup-session-production-foundation
+sudo git -C "$REPO_ROOT" fetch origin "$APPROVED_REF"
 sudo git -C "$REPO_ROOT" cat-file -e "$CANDIDATE_SHA^{commit}"
 if ! sudo git -C "$REPO_ROOT" merge-base --is-ancestor "$LIVE_HEAD" "$CANDIDATE_SHA"; then
     echo "FAIL: candidate is not a forward descendant of live Setup"
@@ -218,6 +224,12 @@ REVOKE ALL ON FUNCTION ops.set_setup_work_day_task(text,bigint,bigint,text,text,
 REVOKE ALL ON FUNCTION ops.record_setup_task_progress(text,bigint,bigint,text,integer,integer,text,text,boolean) FROM PUBLIC;
 REVOKE ALL ON FUNCTION ops.set_setup_session_task_planned_order(text,bigint,integer,text) FROM PUBLIC;
 REVOKE ALL ON FUNCTION ops.promote_setup_session_order_to_baseline(text,integer) FROM PUBLIC;
+REVOKE ALL ON FUNCTION ref.delete_setup_reconstruction_task(text,bigint) FROM PUBLIC;
+REVOKE ALL ON FUNCTION ref.setup_task_captain_list(bigint) FROM PUBLIC;
+REVOKE ALL ON FUNCTION ref.setup_captain_person_list() FROM PUBLIC;
+REVOKE ALL ON FUNCTION ref.set_setup_task_captain(text,bigint,integer,text,integer,text,boolean) FROM PUBLIC;
+REVOKE ALL ON FUNCTION ref.set_setup_task_effort(text,bigint,text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION ref.set_setup_task_display_material_requirement(text,bigint,boolean) FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION ref.setup_browser_capabilities(text) TO fieldwiring_app;
 GRANT EXECUTE ON FUNCTION ops.create_setup_session(text,integer,text) TO fieldwiring_app;
@@ -233,6 +245,12 @@ GRANT EXECUTE ON FUNCTION ops.set_setup_work_day_task(text,bigint,bigint,text,te
 GRANT EXECUTE ON FUNCTION ops.record_setup_task_progress(text,bigint,bigint,text,integer,integer,text,text,boolean) TO fieldwiring_app;
 GRANT EXECUTE ON FUNCTION ops.set_setup_session_task_planned_order(text,bigint,integer,text) TO fieldwiring_app;
 GRANT EXECUTE ON FUNCTION ops.promote_setup_session_order_to_baseline(text,integer) TO fieldwiring_app;
+GRANT EXECUTE ON FUNCTION ref.delete_setup_reconstruction_task(text,bigint) TO fieldwiring_app;
+GRANT EXECUTE ON FUNCTION ref.setup_task_captain_list(bigint) TO fieldwiring_app;
+GRANT EXECUTE ON FUNCTION ref.setup_captain_person_list() TO fieldwiring_app;
+GRANT EXECUTE ON FUNCTION ref.set_setup_task_captain(text,bigint,integer,text,integer,text,boolean) TO fieldwiring_app;
+GRANT EXECUTE ON FUNCTION ref.set_setup_task_effort(text,bigint,text) TO fieldwiring_app;
+GRANT EXECUTE ON FUNCTION ref.set_setup_task_display_material_requirement(text,bigint,boolean) TO fieldwiring_app;
 SQL
 
 TEST_IP="$(sudo docker inspect "$TEST_CONTAINER" --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')"
@@ -333,6 +351,7 @@ echo
 echo "SETUP SOURCE-ONLY BROWSER REVIEW READY"
 echo "Open in your browser through the SSH tunnel: http://127.0.0.1:$PREVIEW_PORT/"
 echo "Candidate SHA: $CANDIDATE_SHA"
+echo "Approved ref: $APPROVED_REF"
 echo "Preview identity: $PREVIEW_EMAIL"
 echo "The row named '[PREVIEW ONLY] Setup write transaction probe' exists only in the disposable clone."
 echo "Exercise real Manager workflows here. Production remains unchanged."

--- a/Setup/Application/production.html
+++ b/Setup/Application/production.html
@@ -236,5 +236,6 @@
 <script src="setup_assigned_review.js?v=2026-09-08.2"></script>
 <script src="setup_training_review_refinement.js?v=2026-09-09.3"></script>
 <script src="setup_catalog_effort.js?v=2026-09-09.3"></script>
+<script src="setup_catalog_dirty_guard.js?v=2026-09-10.1"></script>
 </body>
 </html>

--- a/Setup/Application/production_backend.py
+++ b/Setup/Application/production_backend.py
@@ -20,7 +20,7 @@ from setup_effort_api import setup_effort_api
 from setup_material_api import setup_material_api
 from setup_material_resolution import install_setup_material_resolution
 
-PRODUCTION_VERSION = "V0.3.5-stage-scene-material-review"
+PRODUCTION_VERSION = "V0.3.6-catalog-dirty-edit-safety"
 PRODUCTION_ASSETS = frozenset(
     {
         "setup.css",
@@ -51,6 +51,7 @@ PRODUCTION_ASSETS = frozenset(
         "setup_training_review_refinement.css",
         "setup_training_review_refinement.js",
         "setup_catalog_effort.js",
+        "setup_catalog_dirty_guard.js",
     }
 )
 

--- a/Setup/Application/setup_catalog_dirty_guard.js
+++ b/Setup/Application/setup_catalog_dirty_guard.js
@@ -1,0 +1,473 @@
+/* Setup reusable/annual review dirty-edit protection.
+ *
+ * Issue #154: a Manager must never lose pending task edits merely because an
+ * annual verification action, prerequisite change, task switch, or season/view
+ * navigation reloads the selected task.
+ *
+ * This guard deliberately tracks only the fields owned by the existing
+ * "Save Reusable Task" and "Save Annual Review" commands. Physical Effort,
+ * Display/Container Material, resources, and Captains remain independent
+ * governed save surfaces and are not folded into either payload here.
+ */
+
+(() => {
+  'use strict';
+
+  const reusableFieldIds = new Set([
+    'edit-task-name',
+    'edit-stage-id',
+    'edit-action-type',
+    'edit-display-order',
+    'edit-active-flag',
+    'edit-crew-min',
+    'edit-crew-max',
+    'edit-duration-minutes',
+    'edit-completion',
+    'edit-readiness',
+    'edit-weather',
+    'edit-reusable-notes'
+  ]);
+
+  const annualFieldIds = new Set([
+    'edit-actual-crew',
+    'edit-actual-duration',
+    'edit-annual-notes'
+  ]);
+
+  let baseline = null;
+  let replayDepth = 0;
+  let installed = false;
+
+  function controlValue(id) {
+    const node = document.getElementById(id);
+    if (!node) return null;
+    return node.type === 'checkbox' ? Boolean(node.checked) : String(node.value ?? '');
+  }
+
+  function snapshot(fieldIds) {
+    const values = {};
+    fieldIds.forEach((id) => {
+      values[id] = controlValue(id);
+    });
+    return values;
+  }
+
+  function sameSnapshot(left, right) {
+    return JSON.stringify(left || {}) === JSON.stringify(right || {});
+  }
+
+  function captureBaseline(taskId = appState.selectedTaskId) {
+    if (taskId == null || Number(taskId) !== Number(appState.selectedTaskId)) {
+      baseline = null;
+      syncDirtyIndicators();
+      return;
+    }
+
+    baseline = {
+      taskId: Number(taskId),
+      reusable: snapshot(reusableFieldIds),
+      annual: snapshot(annualFieldIds)
+    };
+    syncDirtyIndicators();
+  }
+
+  function baselineMatchesSelection() {
+    return baseline && Number(baseline.taskId) === Number(appState.selectedTaskId);
+  }
+
+  function reusableDirty() {
+    return Boolean(
+      baselineMatchesSelection()
+      && !sameSnapshot(baseline.reusable, snapshot(reusableFieldIds))
+    );
+  }
+
+  function annualDirty() {
+    return Boolean(
+      baselineMatchesSelection()
+      && !sameSnapshot(baseline.annual, snapshot(annualFieldIds))
+    );
+  }
+
+  function anyDirty() {
+    return reusableDirty() || annualDirty();
+  }
+
+  function dirtyDescription() {
+    const parts = [];
+    if (reusableDirty()) parts.push('reusable task');
+    if (annualDirty()) parts.push(`${appState.seasonYear || 'annual'} review`);
+    return parts.join(' and ') || 'task';
+  }
+
+  function syncButtonLabel(id, cleanLabel, dirtyLabel, dirty) {
+    const button = document.getElementById(id);
+    if (!button) return;
+    button.textContent = dirty ? dirtyLabel : cleanLabel;
+    button.dataset.unsaved = dirty ? '1' : '0';
+  }
+
+  function syncDirtyIndicators() {
+    syncButtonLabel(
+      'save-reusable-task',
+      'Save Reusable Task',
+      'Save Reusable Task • Unsaved',
+      reusableDirty()
+    );
+    syncButtonLabel(
+      'save-annual-review',
+      'Save Annual Review',
+      'Save Annual Review • Unsaved',
+      annualDirty()
+    );
+  }
+
+  function reusablePayload() {
+    return {
+      task_name: el('edit-task-name').value.trim(),
+      stage_id: nullableInteger(el('edit-stage-id').value),
+      task_action_type: el('edit-action-type').value,
+      display_order: nullableInteger(el('edit-display-order').value) ?? 100,
+      active_flag: el('edit-active-flag').checked,
+      normal_crew_min: nullableInteger(el('edit-crew-min').value),
+      normal_crew_max: nullableInteger(el('edit-crew-max').value),
+      expected_duration_minutes: nullableInteger(el('edit-duration-minutes').value),
+      completion_point: el('edit-completion').value.trim(),
+      readiness_note: el('edit-readiness').value.trim(),
+      weather_note: el('edit-weather').value.trim(),
+      reusable_notes: el('edit-reusable-notes').value.trim()
+    };
+  }
+
+  function annualDraft() {
+    return snapshot(annualFieldIds);
+  }
+
+  function restoreSnapshot(values) {
+    Object.entries(values || {}).forEach(([id, value]) => {
+      const node = document.getElementById(id);
+      if (!node) return;
+      if (node.type === 'checkbox') node.checked = Boolean(value);
+      else node.value = value == null ? '' : String(value);
+    });
+    syncDirtyIndicators();
+  }
+
+  function annualPayload(verificationOverride = null) {
+    const task = taskById(appState.selectedTaskId);
+    return {
+      verification_state: verificationOverride || task?.verification_state || 'UNVERIFIED',
+      actual_started_at: task?.actual_started_at || null,
+      actual_completed_at: task?.actual_completed_at || null,
+      actual_crew_count: nullableInteger(el('edit-actual-crew').value),
+      actual_duration_minutes: nullableInteger(el('edit-actual-duration').value),
+      annual_notes: el('edit-annual-notes').value.trim()
+    };
+  }
+
+  async function persistReusableEdits({ announce = true, preserveAnnualDraft = true } = {}) {
+    const task = taskById(appState.selectedTaskId);
+    if (!task || !appState.access?.can_manage_setup) return false;
+
+    const preservedAnnual = preserveAnnualDraft ? annualDraft() : null;
+    try {
+      setBusy(true);
+      await api(
+        `api/setup/tasks/${task.setup_task_id}`,
+        commandOptions('PATCH', reusablePayload())
+      );
+      await reloadTasks(task.setup_task_id);
+      if (preservedAnnual && Number(appState.selectedTaskId) === Number(task.setup_task_id)) {
+        restoreSnapshot(preservedAnnual);
+      }
+      if (announce) {
+        setAlert(`Reusable task ${task.setup_task_id} saved to Production.`, 'ok');
+      }
+      return true;
+    } catch (error) {
+      setAlert(error.message || error, 'error');
+      window.alert(error.message || error);
+      return false;
+    } finally {
+      setBusy(false);
+      syncDirtyIndicators();
+    }
+  }
+
+  async function persistAnnualReview(verificationOverride = null, { announce = true } = {}) {
+    const task = taskById(appState.selectedTaskId);
+    if (!task || task.setup_session_task_id == null || !appState.access?.can_manage_setup) {
+      return false;
+    }
+
+    try {
+      setBusy(true);
+      await api(
+        `api/setup/session-tasks/${task.setup_session_task_id}/review`,
+        commandOptions('PATCH', annualPayload(verificationOverride))
+      );
+      await reloadTasks(task.setup_task_id);
+      if (announce) {
+        const state = verificationOverride
+          ? String(verificationOverride).replaceAll('_', ' ').toLocaleLowerCase()
+          : 'saved';
+        setAlert(`${appState.seasonYear} annual review ${state}.`, 'ok');
+      }
+      return true;
+    } catch (error) {
+      setAlert(error.message || error, 'error');
+      window.alert(error.message || error);
+      return false;
+    } finally {
+      setBusy(false);
+      syncDirtyIndicators();
+    }
+  }
+
+  async function saveDirtySurfaces() {
+    if (reusableDirty()) {
+      const reusableSaved = await persistReusableEdits({ announce: false, preserveAnnualDraft: true });
+      if (!reusableSaved) return false;
+    }
+
+    if (annualDirty()) {
+      const annualSaved = await persistAnnualReview(null, { announce: false });
+      if (!annualSaved) return false;
+    }
+
+    setAlert('Unsaved Setup task edits saved before continuing.', 'ok');
+    return true;
+  }
+
+  function discardCurrentDrafts() {
+    const taskId = appState.selectedTaskId;
+    if (taskId == null || !taskById(taskId)) {
+      baseline = null;
+      syncDirtyIndicators();
+      return;
+    }
+    selectTask(Number(taskId));
+  }
+
+  async function resolveDirtyBeforeNavigation(actionLabel) {
+    if (!anyDirty()) return true;
+
+    const saveFirst = window.confirm(
+      `You have unsaved ${dirtyDescription()} edits.\n\n`
+      + `Save them before ${actionLabel}?\n\n`
+      + 'OK = Save and continue\nCancel = choose whether to discard or stay here'
+    );
+
+    if (saveFirst) {
+      return saveDirtySurfaces();
+    }
+
+    const discard = window.confirm(
+      `Discard the unsaved ${dirtyDescription()} edits and ${actionLabel}?\n\n`
+      + 'OK = Discard and continue\nCancel = Stay on this task'
+    );
+    if (!discard) return false;
+
+    discardCurrentDrafts();
+    return true;
+  }
+
+  async function resolveDirtyBeforeDelete() {
+    if (!anyDirty()) return true;
+    const discard = window.confirm(
+      `This task has unsaved ${dirtyDescription()} edits.\n\n`
+      + 'Deleting the task cannot preserve those drafts. Discard them and continue to the delete confirmation?'
+    );
+    if (!discard) return false;
+    discardCurrentDrafts();
+    return true;
+  }
+
+  function replayClick(target) {
+    replayDepth += 1;
+    try {
+      target.click();
+    } finally {
+      replayDepth -= 1;
+    }
+  }
+
+  async function handleAnnualAction(buttonId) {
+    const overrides = {
+      'save-annual-review': null,
+      'mark-verified': 'VERIFIED',
+      'mark-correction': 'NEEDS_CORRECTION',
+      'mark-unverified': 'UNVERIFIED'
+    };
+
+    if (reusableDirty()) {
+      const reusableSaved = await persistReusableEdits({ announce: false, preserveAnnualDraft: true });
+      if (!reusableSaved) return;
+    }
+
+    await persistAnnualReview(overrides[buttonId]);
+  }
+
+  function taskIdFromClickTarget(target) {
+    const row = target.closest('#review-list .task-row, #library-view .open-task');
+    if (!row) return null;
+    return Number(row.dataset.taskId || 0) || null;
+  }
+
+  function installSelectionBaselineWrapper() {
+    if (typeof selectTask !== 'function' || selectTask.__dirtyGuardWrapped) return;
+    const priorSelectTask = selectTask;
+    const wrapped = function selectTaskWithDirtyBaseline(taskId) {
+      const result = priorSelectTask(taskId);
+      captureBaseline(taskId);
+      return result;
+    };
+    wrapped.__dirtyGuardWrapped = true;
+    selectTask = wrapped;
+  }
+
+  function installInputTracking() {
+    window.addEventListener('input', (event) => {
+      const id = event.target?.id;
+      if (reusableFieldIds.has(id) || annualFieldIds.has(id)) syncDirtyIndicators();
+    }, true);
+
+    window.addEventListener('change', (event) => {
+      const id = event.target?.id;
+      if (reusableFieldIds.has(id) || annualFieldIds.has(id)) syncDirtyIndicators();
+    }, true);
+  }
+
+  function installSeasonGuard() {
+    window.addEventListener('change', (event) => {
+      if (replayDepth || event.target?.id !== 'season-select' || !anyDirty()) return;
+
+      const select = event.target;
+      const requestedYear = select.value;
+      const currentYear = String(appState.seasonYear ?? '');
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      select.value = currentYear;
+
+      void (async () => {
+        const proceed = await resolveDirtyBeforeNavigation('changing Setup seasons');
+        if (!proceed) {
+          select.value = currentYear;
+          return;
+        }
+        select.value = requestedYear;
+        baseline = null;
+        syncDirtyIndicators();
+        await loadSeason(requestedYear);
+      })();
+    }, true);
+  }
+
+  function installClickGuard() {
+    window.addEventListener('click', (event) => {
+      if (replayDepth) return;
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+
+      const saveReusable = target.closest('#save-reusable-task');
+      if (saveReusable) {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        void persistReusableEdits();
+        return;
+      }
+
+      const annualButton = target.closest(
+        '#save-annual-review, #mark-verified, #mark-correction, #mark-unverified'
+      );
+      if (annualButton) {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        void handleAnnualAction(annualButton.id);
+        return;
+      }
+
+      const deleteButton = target.closest('#delete-reconstruction-task');
+      if (deleteButton && anyDirty()) {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        void (async () => {
+          if (await resolveDirtyBeforeDelete()) replayClick(deleteButton);
+        })();
+        return;
+      }
+
+      const dependencyAction = target.closest('#next-dependency-add-button, .next-dependency-remove');
+      if (dependencyAction && anyDirty()) {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        void (async () => {
+          if (await resolveDirtyBeforeNavigation('changing task prerequisites')) {
+            replayClick(dependencyAction);
+          }
+        })();
+        return;
+      }
+
+      const requestedTaskId = taskIdFromClickTarget(target);
+      if (
+        requestedTaskId != null
+        && Number(requestedTaskId) !== Number(appState.selectedTaskId)
+        && anyDirty()
+      ) {
+        const replayTarget = target.closest('#library-view .open-task')
+          || target.closest('#review-list .task-row');
+        if (!replayTarget) return;
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        void (async () => {
+          if (await resolveDirtyBeforeNavigation('opening another task')) replayClick(replayTarget);
+        })();
+        return;
+      }
+
+      const returnToCatalog = target.closest('#setup-return-library');
+      if (returnToCatalog && anyDirty()) {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        void (async () => {
+          if (await resolveDirtyBeforeNavigation('returning to the Reusable Task Catalog')) {
+            replayClick(returnToCatalog);
+          }
+        })();
+        return;
+      }
+
+      const tab = target.closest('.tabs .tab');
+      if (tab && !tab.classList.contains('active') && anyDirty()) {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        void (async () => {
+          if (await resolveDirtyBeforeNavigation(`opening ${tab.textContent.trim()}`)) replayClick(tab);
+        })();
+      }
+    }, true);
+  }
+
+  function installUnloadGuard() {
+    window.addEventListener('beforeunload', (event) => {
+      if (!anyDirty()) return;
+      event.preventDefault();
+      event.returnValue = '';
+    });
+  }
+
+  function initializeDirtyGuard() {
+    if (installed) return;
+    installed = true;
+    installSelectionBaselineWrapper();
+    installInputTracking();
+    installSeasonGuard();
+    installClickGuard();
+    installUnloadGuard();
+    syncDirtyIndicators();
+  }
+
+  if (document.readyState === 'complete') initializeDirtyGuard();
+  else window.addEventListener('load', initializeDirtyGuard, { once: true });
+})();

--- a/Setup/Application/setup_review_usability.js
+++ b/Setup/Application/setup_review_usability.js
@@ -1,353 +1,473 @@
-/* Manager review guidance and reusable-task ordering helpers. */
+/* Setup reusable/annual review dirty-edit protection.
+ *
+ * Issue #154: a Manager must never lose pending task edits merely because an
+ * annual verification action, prerequisite change, task switch, or season/view
+ * navigation reloads the selected task.
+ *
+ * This guard deliberately tracks only the fields owned by the existing
+ * "Save Reusable Task" and "Save Annual Review" commands. Physical Effort,
+ * Display/Container Material, resources, and Captains remain independent
+ * governed save surfaces and are not folded into either payload here.
+ */
 
-const setupReviewUsability = {
-  draggedTaskId: null
-};
+(() => {
+  'use strict';
 
-function setupReviewIsLocalPreview() {
-  return ['127.0.0.1', 'localhost', '::1'].includes(window.location.hostname);
-}
+  const reusableFieldIds = new Set([
+    'edit-task-name',
+    'edit-stage-id',
+    'edit-action-type',
+    'edit-display-order',
+    'edit-active-flag',
+    'edit-crew-min',
+    'edit-crew-max',
+    'edit-duration-minutes',
+    'edit-completion',
+    'edit-readiness',
+    'edit-weather',
+    'edit-reusable-notes'
+  ]);
 
-function setupTaskUpdatePayload(task, overrides = {}) {
-  return {
-    task_name: task.task_name,
-    stage_id: task.stage_id == null ? null : Number(task.stage_id),
-    task_action_type: task.task_action_type || 'WORK',
-    display_order: Number(task.display_order) || 100,
-    active_flag: Boolean(task.active_flag),
-    normal_crew_min: task.normal_crew_min == null ? null : Number(task.normal_crew_min),
-    normal_crew_max: task.normal_crew_max == null ? null : Number(task.normal_crew_max),
-    expected_duration_minutes: task.expected_duration_minutes == null ? null : Number(task.expected_duration_minutes),
-    completion_point: task.completion_point || null,
-    readiness_note: task.readiness_note || null,
-    weather_note: task.weather_note || null,
-    reusable_notes: task.reusable_notes || null,
-    ...overrides
-  };
-}
+  const annualFieldIds = new Set([
+    'edit-actual-crew',
+    'edit-actual-duration',
+    'edit-annual-notes'
+  ]);
 
-function setupTasksForStage(task) {
-  return sortedTasks().filter((candidate) => (
-    String(candidate.stage_key ?? '—') === String(task.stage_key ?? '—')
-  ));
-}
+  let baseline = null;
+  let replayDepth = 0;
+  let installed = false;
 
-async function persistSetupStageOrder(orderedIds) {
-  if (!appState.access?.can_manage_setup || !orderedIds.length) return;
-  const selected = appState.selectedTaskId;
-  const firstTask = taskById(orderedIds[0]);
-  const stageLabel = firstTask?.stage_key || 'General';
+  function controlValue(id) {
+    const node = document.getElementById(id);
+    if (!node) return null;
+    return node.type === 'checkbox' ? Boolean(node.checked) : String(node.value ?? '');
+  }
 
-  try {
-    setBusy(true);
-    for (let index = 0; index < orderedIds.length; index += 1) {
-      const task = taskById(orderedIds[index]);
-      if (!task) continue;
-      const newOrder = (index + 1) * 10;
-      if (Number(task.display_order) === newOrder) continue;
+  function snapshot(fieldIds) {
+    const values = {};
+    fieldIds.forEach((id) => {
+      values[id] = controlValue(id);
+    });
+    return values;
+  }
+
+  function sameSnapshot(left, right) {
+    return JSON.stringify(left || {}) === JSON.stringify(right || {});
+  }
+
+  function captureBaseline(taskId = appState.selectedTaskId) {
+    if (taskId == null || Number(taskId) !== Number(appState.selectedTaskId)) {
+      baseline = null;
+      syncDirtyIndicators();
+      return;
+    }
+
+    baseline = {
+      taskId: Number(taskId),
+      reusable: snapshot(reusableFieldIds),
+      annual: snapshot(annualFieldIds)
+    };
+    syncDirtyIndicators();
+  }
+
+  function baselineMatchesSelection() {
+    return baseline && Number(baseline.taskId) === Number(appState.selectedTaskId);
+  }
+
+  function reusableDirty() {
+    return Boolean(
+      baselineMatchesSelection()
+      && !sameSnapshot(baseline.reusable, snapshot(reusableFieldIds))
+    );
+  }
+
+  function annualDirty() {
+    return Boolean(
+      baselineMatchesSelection()
+      && !sameSnapshot(baseline.annual, snapshot(annualFieldIds))
+    );
+  }
+
+  function anyDirty() {
+    return reusableDirty() || annualDirty();
+  }
+
+  function dirtyDescription() {
+    const parts = [];
+    if (reusableDirty()) parts.push('reusable task');
+    if (annualDirty()) parts.push(`${appState.seasonYear || 'annual'} review`);
+    return parts.join(' and ') || 'task';
+  }
+
+  function syncButtonLabel(id, cleanLabel, dirtyLabel, dirty) {
+    const button = document.getElementById(id);
+    if (!button) return;
+    button.textContent = dirty ? dirtyLabel : cleanLabel;
+    button.dataset.unsaved = dirty ? '1' : '0';
+  }
+
+  function syncDirtyIndicators() {
+    syncButtonLabel(
+      'save-reusable-task',
+      'Save Reusable Task',
+      'Save Reusable Task • Unsaved',
+      reusableDirty()
+    );
+    syncButtonLabel(
+      'save-annual-review',
+      'Save Annual Review',
+      'Save Annual Review • Unsaved',
+      annualDirty()
+    );
+  }
+
+  function reusablePayload() {
+    return {
+      task_name: el('edit-task-name').value.trim(),
+      stage_id: nullableInteger(el('edit-stage-id').value),
+      task_action_type: el('edit-action-type').value,
+      display_order: nullableInteger(el('edit-display-order').value) ?? 100,
+      active_flag: el('edit-active-flag').checked,
+      normal_crew_min: nullableInteger(el('edit-crew-min').value),
+      normal_crew_max: nullableInteger(el('edit-crew-max').value),
+      expected_duration_minutes: nullableInteger(el('edit-duration-minutes').value),
+      completion_point: el('edit-completion').value.trim(),
+      readiness_note: el('edit-readiness').value.trim(),
+      weather_note: el('edit-weather').value.trim(),
+      reusable_notes: el('edit-reusable-notes').value.trim()
+    };
+  }
+
+  function annualDraft() {
+    return snapshot(annualFieldIds);
+  }
+
+  function restoreSnapshot(values) {
+    Object.entries(values || {}).forEach(([id, value]) => {
+      const node = document.getElementById(id);
+      if (!node) return;
+      if (node.type === 'checkbox') node.checked = Boolean(value);
+      else node.value = value == null ? '' : String(value);
+    });
+    syncDirtyIndicators();
+  }
+
+  function annualPayload(verificationOverride = null) {
+    const task = taskById(appState.selectedTaskId);
+    return {
+      verification_state: verificationOverride || task?.verification_state || 'UNVERIFIED',
+      actual_started_at: task?.actual_started_at || null,
+      actual_completed_at: task?.actual_completed_at || null,
+      actual_crew_count: nullableInteger(el('edit-actual-crew').value),
+      actual_duration_minutes: nullableInteger(el('edit-actual-duration').value),
+      annual_notes: el('edit-annual-notes').value.trim()
+    };
+  }
+
+  async function persistReusableEdits({ announce = true, preserveAnnualDraft = true } = {}) {
+    const task = taskById(appState.selectedTaskId);
+    if (!task || !appState.access?.can_manage_setup) return false;
+
+    const preservedAnnual = preserveAnnualDraft ? annualDraft() : null;
+    try {
+      setBusy(true);
       await api(
         `api/setup/tasks/${task.setup_task_id}`,
-        commandOptions('PATCH', setupTaskUpdatePayload(task, { display_order: newOrder }))
+        commandOptions('PATCH', reusablePayload())
       );
+      await reloadTasks(task.setup_task_id);
+      if (preservedAnnual && Number(appState.selectedTaskId) === Number(task.setup_task_id)) {
+        restoreSnapshot(preservedAnnual);
+      }
+      if (announce) {
+        setAlert(`Reusable task ${task.setup_task_id} saved to Production.`, 'ok');
+      }
+      return true;
+    } catch (error) {
+      setAlert(error.message || error, 'error');
+      window.alert(error.message || error);
+      return false;
+    } finally {
+      setBusy(false);
+      syncDirtyIndicators();
     }
-    setAlert(`Stage ${stageLabel} reusable task sequence updated.`, 'ok');
-    await reloadTasks(selected || null);
-    showView('library');
-  } catch (error) {
-    setAlert(error.message || error, 'error');
-    window.alert(error.message || error);
-  } finally {
-    setBusy(false);
   }
-}
 
-async function moveSetupLibraryTask(taskId, direction) {
-  const task = taskById(taskId);
-  if (!task || !appState.access?.can_manage_setup) return;
-  const sameStage = setupTasksForStage(task);
-  const index = sameStage.findIndex((item) => Number(item.setup_task_id) === Number(taskId));
-  const swapIndex = index + direction;
-  if (index < 0 || swapIndex < 0 || swapIndex >= sameStage.length) return;
-  const ids = sameStage.map((item) => Number(item.setup_task_id));
-  [ids[index], ids[swapIndex]] = [ids[swapIndex], ids[index]];
-  await persistSetupStageOrder(ids);
-}
+  async function persistAnnualReview(verificationOverride = null, { announce = true } = {}) {
+    const task = taskById(appState.selectedTaskId);
+    if (!task || task.setup_session_task_id == null || !appState.access?.can_manage_setup) {
+      return false;
+    }
 
-async function copySetupReusableTask(taskId) {
-  const source = taskById(taskId);
-  if (!source || !appState.access?.can_manage_setup) return;
+    try {
+      setBusy(true);
+      await api(
+        `api/setup/session-tasks/${task.setup_session_task_id}/review`,
+        commandOptions('PATCH', annualPayload(verificationOverride))
+      );
+      await reloadTasks(task.setup_task_id);
+      if (announce) {
+        const state = verificationOverride
+          ? String(verificationOverride).replaceAll('_', ' ').toLocaleLowerCase()
+          : 'saved';
+        setAlert(`${appState.seasonYear} annual review ${state}.`, 'ok');
+      }
+      return true;
+    } catch (error) {
+      setAlert(error.message || error, 'error');
+      window.alert(error.message || error);
+      return false;
+    } finally {
+      setBusy(false);
+      syncDirtyIndicators();
+    }
+  }
 
-  const proposedName = `${source.task_name} Copy`;
-  const newName = window.prompt('Name for the copied reusable task:', proposedName);
-  if (newName == null || !newName.trim()) return;
+  async function saveDirtySurfaces() {
+    if (reusableDirty()) {
+      const reusableSaved = await persistReusableEdits({ announce: false, preserveAnnualDraft: true });
+      if (!reusableSaved) return false;
+    }
 
-  if (!window.confirm(
-    'Copy this reusable task definition and its equipment/resources?\n\n' +
-    'Prerequisites and annual history will NOT be copied.'
-  )) return;
+    if (annualDirty()) {
+      const annualSaved = await persistAnnualReview(null, { announce: false });
+      if (!annualSaved) return false;
+    }
 
-  try {
-    setBusy(true);
-    const resourcePayload = await api(`api/setup/tasks/${source.setup_task_id}/resources`);
-    const resources = resourcePayload.resources || [];
-    const createPayload = {
-      task_name: newName.trim(),
-      stage_id: source.stage_id == null ? null : Number(source.stage_id),
-      task_action_type: source.task_action_type || 'WORK',
-      display_order: (Number(source.display_order) || 100) + 5,
-      normal_crew_min: source.normal_crew_min == null ? null : Number(source.normal_crew_min),
-      normal_crew_max: source.normal_crew_max == null ? null : Number(source.normal_crew_max),
-      expected_duration_minutes: source.expected_duration_minutes == null ? null : Number(source.expected_duration_minutes),
-      completion_point: source.completion_point || null,
-      readiness_note: source.readiness_note || null,
-      weather_note: source.weather_note || null,
-      reusable_notes: [
-        source.reusable_notes || '',
-        `[Copied from reusable task ${source.setup_task_id}; review task-specific details before use.]`
-      ].filter(Boolean).join('\n')
+    setAlert('Unsaved Setup task edits saved before continuing.', 'ok');
+    return true;
+  }
+
+  function discardCurrentDrafts() {
+    const taskId = appState.selectedTaskId;
+    if (taskId == null || !taskById(taskId)) {
+      baseline = null;
+      syncDirtyIndicators();
+      return;
+    }
+    selectTask(Number(taskId));
+  }
+
+  async function resolveDirtyBeforeNavigation(actionLabel) {
+    if (!anyDirty()) return true;
+
+    const saveFirst = window.confirm(
+      `You have unsaved ${dirtyDescription()} edits.\n\n`
+      + `Save them before ${actionLabel}?\n\n`
+      + 'OK = Save and continue\nCancel = choose whether to discard or stay here'
+    );
+
+    if (saveFirst) {
+      return saveDirtySurfaces();
+    }
+
+    const discard = window.confirm(
+      `Discard the unsaved ${dirtyDescription()} edits and ${actionLabel}?\n\n`
+      + 'OK = Discard and continue\nCancel = Stay on this task'
+    );
+    if (!discard) return false;
+
+    discardCurrentDrafts();
+    return true;
+  }
+
+  async function resolveDirtyBeforeDelete() {
+    if (!anyDirty()) return true;
+    const discard = window.confirm(
+      `This task has unsaved ${dirtyDescription()} edits.\n\n`
+      + 'Deleting the task cannot preserve those drafts. Discard them and continue to the delete confirmation?'
+    );
+    if (!discard) return false;
+    discardCurrentDrafts();
+    return true;
+  }
+
+  function replayClick(target) {
+    replayDepth += 1;
+    try {
+      target.click();
+    } finally {
+      replayDepth -= 1;
+    }
+  }
+
+  async function handleAnnualAction(buttonId) {
+    const overrides = {
+      'save-annual-review': null,
+      'mark-verified': 'VERIFIED',
+      'mark-correction': 'NEEDS_CORRECTION',
+      'mark-unverified': 'UNVERIFIED'
     };
 
-    const created = await api('api/setup/tasks', commandOptions('POST', createPayload));
-    const newId = created.setup_task?.setup_task_id;
-    if (!newId) throw new Error('Copied reusable task did not return a new task ID.');
-
-    for (const resource of resources) {
-      await api(
-        `api/setup/tasks/${newId}/resources/${resource.setup_resource_id}`,
-        commandOptions('PATCH', {
-          quantity_required: Number(resource.quantity_required) || 1,
-          requirement_type: resource.requirement_type || 'REQUIRED',
-          notes: resource.notes || null,
-          active_flag: true
-        })
-      );
+    if (reusableDirty()) {
+      const reusableSaved = await persistReusableEdits({ announce: false, preserveAnnualDraft: true });
+      if (!reusableSaved) return;
     }
 
-    setAlert(
-      `Reusable task ${source.setup_task_id} copied to task ${newId} with ${resources.length} equipment/resource assignment${resources.length === 1 ? '' : 's'}. Prerequisites and annual history were not copied.`,
-      'ok'
-    );
-    await reloadTasks(null);
-    showView('library');
-  } catch (error) {
-    setAlert(error.message || error, 'error');
-    window.alert(error.message || error);
-  } finally {
-    setBusy(false);
+    await persistAnnualReview(overrides[buttonId]);
   }
-}
 
-function enhanceSetupLibrary() {
-  const canManage = Boolean(appState.access?.can_manage_setup);
-  const rows = [...document.querySelectorAll('#library-list .library-task')];
+  function taskIdFromClickTarget(target) {
+    const row = target.closest('#review-list .task-row, #library-view .open-task');
+    if (!row) return null;
+    return Number(row.dataset.taskId || 0) || null;
+  }
 
-  rows.forEach((row) => {
-    const openButton = row.querySelector('.open-task');
-    if (!openButton) return;
-    const taskId = Number(openButton.dataset.taskId);
-    const task = taskById(taskId);
-    if (!task) return;
-    const sameStage = setupTasksForStage(task);
-    const index = sameStage.findIndex((item) => Number(item.setup_task_id) === taskId);
+  function installSelectionBaselineWrapper() {
+    if (typeof selectTask !== 'function' || selectTask.__dirtyGuardWrapped) return;
+    const priorSelectTask = selectTask;
+    const wrapped = function selectTaskWithDirtyBaseline(taskId) {
+      const result = priorSelectTask(taskId);
+      captureBaseline(taskId);
+      return result;
+    };
+    wrapped.__dirtyGuardWrapped = true;
+    selectTask = wrapped;
+  }
 
-    row.dataset.taskId = String(taskId);
-    row.dataset.stageKey = String(task.stage_key ?? '—');
-    row.draggable = canManage;
+  function installInputTracking() {
+    window.addEventListener('input', (event) => {
+      const id = event.target?.id;
+      if (reusableFieldIds.has(id) || annualFieldIds.has(id)) syncDirtyIndicators();
+    }, true);
 
-    if (canManage) {
-      const actions = row.querySelector('.library-actions');
-      if (actions) {
-        const up = document.createElement('button');
-        up.type = 'button';
-        up.className = 'small secondary stage-move-up';
-        up.textContent = '↑';
-        up.title = 'Move earlier in this Stage';
-        up.disabled = index <= 0;
-        up.addEventListener('click', (event) => {
-          event.stopPropagation();
-          moveSetupLibraryTask(taskId, -1);
-        });
+    window.addEventListener('change', (event) => {
+      const id = event.target?.id;
+      if (reusableFieldIds.has(id) || annualFieldIds.has(id)) syncDirtyIndicators();
+    }, true);
+  }
 
-        const down = document.createElement('button');
-        down.type = 'button';
-        down.className = 'small secondary stage-move-down';
-        down.textContent = '↓';
-        down.title = 'Move later in this Stage';
-        down.disabled = index < 0 || index >= sameStage.length - 1;
-        down.addEventListener('click', (event) => {
-          event.stopPropagation();
-          moveSetupLibraryTask(taskId, 1);
-        });
+  function installSeasonGuard() {
+    window.addEventListener('change', (event) => {
+      if (replayDepth || event.target?.id !== 'season-select' || !anyDirty()) return;
 
-        const copy = document.createElement('button');
-        copy.type = 'button';
-        copy.className = 'small secondary copy-task';
-        copy.textContent = 'Copy';
-        copy.title = 'Copy reusable definition and equipment/resources';
-        copy.addEventListener('click', (event) => {
-          event.stopPropagation();
-          copySetupReusableTask(taskId);
-        });
+      const select = event.target;
+      const requestedYear = select.value;
+      const currentYear = String(appState.seasonYear ?? '');
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      select.value = currentYear;
 
-        actions.insertBefore(up, openButton);
-        actions.insertBefore(down, openButton);
-        actions.insertBefore(copy, openButton);
+      void (async () => {
+        const proceed = await resolveDirtyBeforeNavigation('changing Setup seasons');
+        if (!proceed) {
+          select.value = currentYear;
+          return;
+        }
+        select.value = requestedYear;
+        baseline = null;
+        syncDirtyIndicators();
+        await loadSeason(requestedYear);
+      })();
+    }, true);
+  }
+
+  function installClickGuard() {
+    window.addEventListener('click', (event) => {
+      if (replayDepth) return;
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+
+      const saveReusable = target.closest('#save-reusable-task');
+      if (saveReusable) {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        void persistReusableEdits();
+        return;
       }
 
-      row.addEventListener('dragstart', (event) => {
-        setupReviewUsability.draggedTaskId = taskId;
-        row.classList.add('dragging');
-        event.dataTransfer.effectAllowed = 'move';
-        event.dataTransfer.setData('text/plain', String(taskId));
-      });
-
-      row.addEventListener('dragover', (event) => {
-        const dragged = taskById(setupReviewUsability.draggedTaskId);
-        if (!dragged || String(dragged.stage_key ?? '—') !== String(task.stage_key ?? '—')) return;
+      const annualButton = target.closest(
+        '#save-annual-review, #mark-verified, #mark-correction, #mark-unverified'
+      );
+      if (annualButton) {
         event.preventDefault();
-        event.dataTransfer.dropEffect = 'move';
-        row.classList.add('drop-target');
-      });
+        event.stopImmediatePropagation();
+        void handleAnnualAction(annualButton.id);
+        return;
+      }
 
-      row.addEventListener('dragleave', () => row.classList.remove('drop-target'));
-      row.addEventListener('drop', async (event) => {
+      const deleteButton = target.closest('#delete-reconstruction-task');
+      if (deleteButton && anyDirty()) {
         event.preventDefault();
-        row.classList.remove('drop-target');
-        const sourceId = Number(event.dataTransfer.getData('text/plain') || setupReviewUsability.draggedTaskId || 0);
-        if (!sourceId || sourceId === taskId) return;
-        const source = taskById(sourceId);
-        if (!source || String(source.stage_key ?? '—') !== String(task.stage_key ?? '—')) return;
+        event.stopImmediatePropagation();
+        void (async () => {
+          if (await resolveDirtyBeforeDelete()) replayClick(deleteButton);
+        })();
+        return;
+      }
 
-        const ids = setupTasksForStage(task).map((item) => Number(item.setup_task_id));
-        const sourceIndex = ids.indexOf(sourceId);
-        let targetIndex = ids.indexOf(taskId);
-        if (sourceIndex < 0 || targetIndex < 0) return;
-        ids.splice(sourceIndex, 1);
-        if (sourceIndex < targetIndex) targetIndex -= 1;
-        ids.splice(targetIndex, 0, sourceId);
-        await persistSetupStageOrder(ids);
-      });
+      const dependencyAction = target.closest('#next-dependency-add-button, .next-dependency-remove');
+      if (dependencyAction && anyDirty()) {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        void (async () => {
+          if (await resolveDirtyBeforeNavigation('changing task prerequisites')) {
+            replayClick(dependencyAction);
+          }
+        })();
+        return;
+      }
 
-      row.addEventListener('dragend', () => {
-        setupReviewUsability.draggedTaskId = null;
-        document.querySelectorAll('.library-task').forEach((item) => {
-          item.classList.remove('dragging', 'drop-target');
-        });
-      });
-    }
-  });
-}
+      const requestedTaskId = taskIdFromClickTarget(target);
+      if (
+        requestedTaskId != null
+        && Number(requestedTaskId) !== Number(appState.selectedTaskId)
+        && anyDirty()
+      ) {
+        const replayTarget = target.closest('#library-view .open-task')
+          || target.closest('#review-list .task-row');
+        if (!replayTarget) return;
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        void (async () => {
+          if (await resolveDirtyBeforeNavigation('opening another task')) replayClick(replayTarget);
+        })();
+        return;
+      }
 
-function installSetupHowItWorks() {
-  const tabs = document.querySelector('.tabs');
-  if (!tabs || document.getElementById('help-view')) return;
+      const returnToCatalog = target.closest('#setup-return-library');
+      if (returnToCatalog && anyDirty()) {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        void (async () => {
+          if (await resolveDirtyBeforeNavigation('returning to the Reusable Task Catalog')) {
+            replayClick(returnToCatalog);
+          }
+        })();
+        return;
+      }
 
-  const helpButton = document.createElement('button');
-  helpButton.className = 'tab';
-  helpButton.dataset.view = 'help';
-  helpButton.type = 'button';
-  helpButton.textContent = 'How Setup Works';
-  helpButton.addEventListener('click', () => showView('help'));
-  tabs.appendChild(helpButton);
-
-  const helpView = document.createElement('section');
-  helpView.id = 'help-view';
-  helpView.className = 'view';
-  helpView.innerHTML = `
-    <div class="card setup-help-card">
-      <div class="eyebrow">Plain-English Manager guide</div>
-      <h2>How Setup Session Works</h2>
-      <p>This browser review is validating the reusable Setup plan and the 2025 reconstruction. Scheduling, Pick Lists, and field movement/scanning are the next operational layer and are not active in this candidate yet.</p>
-      <div class="setup-help-grid">
-        <section class="setup-help-section">
-          <h3>1. Verify 2025</h3>
-          <p><strong>Reusable Task Definition</strong> is the normal job we expect to do again. <strong>2025 Annual Historical Actual</strong> is what happened in 2025.</p>
-          <ul>
-            <li><strong>Verified</strong>: the reusable task and 2025 information are reasonable.</li>
-            <li><strong>Needs Correction</strong>: something needs to be fixed before accepting it.</li>
-            <li><strong>Unverified</strong>: nobody has accepted it yet.</li>
-          </ul>
-        </section>
-        <section class="setup-help-section">
-          <h3>2. Reusable tasks and Stage sequence</h3>
-          <p>A reusable task is practical work worth planning each season. Sequence numbers 10, 20, 30, etc. mean the normal precedence <strong>within that Stage</strong>. They do not mean the entire Setup day runs as one serial queue.</p>
-          <p>Managers can drag tasks within a Stage or use ↑ / ↓. Use <strong>Copy</strong> for a similar task; equipment/resources copy, but prerequisites and annual history do not.</p>
-        </section>
-        <section class="setup-help-section">
-          <h3>3. Prerequisites and readiness</h3>
-          <p>A prerequisite means the next task cannot practically proceed until another task is complete. Dependencies may cross Stages, such as the Arch Trailer unload route.</p>
-          <p>Readiness is different: a task such as Festive Trees can remain NOT_READY until an outside condition is satisfied, such as leaves falling from the trees.</p>
-          <p>Dependency editing is not exposed yet. During this review, flag missing or wrong prerequisites.</p>
-        </section>
-        <section class="setup-help-section">
-          <h3>4. Scheduling model coming next</h3>
-          <p>One task can span multiple days. One day can have parallel crews. Scheduled work is grouped by <strong>Morning</strong>, <strong>Afternoon</strong>, or <strong>All Day</strong>.</p>
-          <p>The reusable Stage sequence is a planning starting point; the actual work-day plan can intentionally run Stow Storm, Elf Choir, and other work in parallel.</p>
-        </section>
-        <section class="setup-help-section">
-          <h3>5. Pick Lists</h3>
-          <p>The Pick List will be derived from the tasks scheduled for a work day/shift: required Displays → their current Containers + supplemental support/KIT Containers → deduplicated physical pull list.</p>
-          <p>A Pick List replaces manual material bookkeeping, not real labor. A true Prepare/Load task remains a task if people actually spend meaningful time doing that work.</p>
-        </section>
-        <section class="setup-help-section">
-          <h3>6. Movement and scanning</h3>
-          <p>Scanning identifies the physical Display, Container, or Location. Setup Session owns what that scan means operationally. The audited movement command layer is not active in this browser candidate.</p>
-        </section>
-      </div>
-    </div>
-  `;
-  document.querySelector('main')?.appendChild(helpView);
-}
-
-function clarifySetupOrderLabels() {
-  const editOrder = document.getElementById('edit-display-order');
-  if (editOrder?.closest('label')) {
-    editOrder.closest('label').childNodes[0].nodeValue = 'Stage sequence';
-  }
-  const addOrder = document.getElementById('add-display-order');
-  if (addOrder?.closest('label')) {
-    addOrder.closest('label').childNodes[0].nodeValue = 'Stage sequence';
+      const tab = target.closest('.tabs .tab');
+      if (tab && !tab.classList.contains('active') && anyDirty()) {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        void (async () => {
+          if (await resolveDirtyBeforeNavigation(`opening ${tab.textContent.trim()}`)) replayClick(tab);
+        })();
+      }
+    }, true);
   }
 
-  const libraryHint = document.querySelector('#library-view .hint');
-  if (libraryHint && !document.querySelector('.sequence-explainer')) {
-    const note = document.createElement('div');
-    note.className = 'hint sequence-explainer';
-    note.textContent = 'Stage sequence (10, 20, 30...) expresses normal precedence within a Stage. Drag tasks or use ↑ / ↓ to reorder. Daily scheduling will separately support shifts, parallel crews, and multi-day work.';
-    libraryHint.insertAdjacentElement('afterend', note);
+  function installUnloadGuard() {
+    window.addEventListener('beforeunload', (event) => {
+      if (!anyDirty()) return;
+      event.preventDefault();
+      event.returnValue = '';
+    });
   }
-}
 
-function installPreviewReviewNotice() {
-  if (!setupReviewIsLocalPreview() || document.querySelector('.preview-review-notice')) return;
-  const notice = document.createElement('section');
-  notice.className = 'notice preview-review-notice';
-  notice.innerHTML = '<strong>Browser Review — disposable clone.</strong> Changes in this preview are shared only inside the disposable review database and are discarded during cleanup. Production is not being edited.';
-  const appAlert = document.getElementById('app-alert');
-  appAlert?.insertAdjacentElement('beforebegin', notice);
-}
-
-const baseSetupReviewSetAlert = setAlert;
-setAlert = function setupReviewAwareAlert(message, state = 'ok') {
-  let adjusted = String(message ?? '');
-  if (setupReviewIsLocalPreview()) {
-    adjusted = adjusted
-      .replaceAll(' saved to Production.', ' saved to the disposable review clone.')
-      .replaceAll(' created in Production.', ' created in the disposable review clone.')
-      .replaceAll(' loaded from Production.', ' loaded from the disposable review clone.')
-      .replaceAll('shared immediately.', 'shared inside this disposable review clone.');
+  function initializeDirtyGuard() {
+    if (installed) return;
+    installed = true;
+    installSelectionBaselineWrapper();
+    installInputTracking();
+    installSeasonGuard();
+    installClickGuard();
+    installUnloadGuard();
+    syncDirtyIndicators();
   }
-  return baseSetupReviewSetAlert(adjusted, state);
-};
 
-const baseSetupReviewRenderLibrary = renderLibrary;
-renderLibrary = function renderLibraryWithReviewUsability() {
-  baseSetupReviewRenderLibrary();
-  enhanceSetupLibrary();
-  clarifySetupOrderLabels();
-};
-
-installSetupHowItWorks();
-installPreviewReviewNotice();
-clarifySetupOrderLabels();
-if (appState.tasks?.length) renderLibrary();
+  if (document.readyState === 'complete') initializeDirtyGuard();
+  else window.addEventListener('load', initializeDirtyGuard, { once: true });
+})();

--- a/Setup/Application/setup_review_usability.js
+++ b/Setup/Application/setup_review_usability.js
@@ -1,473 +1,353 @@
-/* Setup reusable/annual review dirty-edit protection.
- *
- * Issue #154: a Manager must never lose pending task edits merely because an
- * annual verification action, prerequisite change, task switch, or season/view
- * navigation reloads the selected task.
- *
- * This guard deliberately tracks only the fields owned by the existing
- * "Save Reusable Task" and "Save Annual Review" commands. Physical Effort,
- * Display/Container Material, resources, and Captains remain independent
- * governed save surfaces and are not folded into either payload here.
- */
+/* Manager review guidance and reusable-task ordering helpers. */
 
-(() => {
-  'use strict';
+const setupReviewUsability = {
+  draggedTaskId: null
+};
 
-  const reusableFieldIds = new Set([
-    'edit-task-name',
-    'edit-stage-id',
-    'edit-action-type',
-    'edit-display-order',
-    'edit-active-flag',
-    'edit-crew-min',
-    'edit-crew-max',
-    'edit-duration-minutes',
-    'edit-completion',
-    'edit-readiness',
-    'edit-weather',
-    'edit-reusable-notes'
-  ]);
+function setupReviewIsLocalPreview() {
+  return ['127.0.0.1', 'localhost', '::1'].includes(window.location.hostname);
+}
 
-  const annualFieldIds = new Set([
-    'edit-actual-crew',
-    'edit-actual-duration',
-    'edit-annual-notes'
-  ]);
+function setupTaskUpdatePayload(task, overrides = {}) {
+  return {
+    task_name: task.task_name,
+    stage_id: task.stage_id == null ? null : Number(task.stage_id),
+    task_action_type: task.task_action_type || 'WORK',
+    display_order: Number(task.display_order) || 100,
+    active_flag: Boolean(task.active_flag),
+    normal_crew_min: task.normal_crew_min == null ? null : Number(task.normal_crew_min),
+    normal_crew_max: task.normal_crew_max == null ? null : Number(task.normal_crew_max),
+    expected_duration_minutes: task.expected_duration_minutes == null ? null : Number(task.expected_duration_minutes),
+    completion_point: task.completion_point || null,
+    readiness_note: task.readiness_note || null,
+    weather_note: task.weather_note || null,
+    reusable_notes: task.reusable_notes || null,
+    ...overrides
+  };
+}
 
-  let baseline = null;
-  let replayDepth = 0;
-  let installed = false;
+function setupTasksForStage(task) {
+  return sortedTasks().filter((candidate) => (
+    String(candidate.stage_key ?? '—') === String(task.stage_key ?? '—')
+  ));
+}
 
-  function controlValue(id) {
-    const node = document.getElementById(id);
-    if (!node) return null;
-    return node.type === 'checkbox' ? Boolean(node.checked) : String(node.value ?? '');
-  }
+async function persistSetupStageOrder(orderedIds) {
+  if (!appState.access?.can_manage_setup || !orderedIds.length) return;
+  const selected = appState.selectedTaskId;
+  const firstTask = taskById(orderedIds[0]);
+  const stageLabel = firstTask?.stage_key || 'General';
 
-  function snapshot(fieldIds) {
-    const values = {};
-    fieldIds.forEach((id) => {
-      values[id] = controlValue(id);
-    });
-    return values;
-  }
-
-  function sameSnapshot(left, right) {
-    return JSON.stringify(left || {}) === JSON.stringify(right || {});
-  }
-
-  function captureBaseline(taskId = appState.selectedTaskId) {
-    if (taskId == null || Number(taskId) !== Number(appState.selectedTaskId)) {
-      baseline = null;
-      syncDirtyIndicators();
-      return;
-    }
-
-    baseline = {
-      taskId: Number(taskId),
-      reusable: snapshot(reusableFieldIds),
-      annual: snapshot(annualFieldIds)
-    };
-    syncDirtyIndicators();
-  }
-
-  function baselineMatchesSelection() {
-    return baseline && Number(baseline.taskId) === Number(appState.selectedTaskId);
-  }
-
-  function reusableDirty() {
-    return Boolean(
-      baselineMatchesSelection()
-      && !sameSnapshot(baseline.reusable, snapshot(reusableFieldIds))
-    );
-  }
-
-  function annualDirty() {
-    return Boolean(
-      baselineMatchesSelection()
-      && !sameSnapshot(baseline.annual, snapshot(annualFieldIds))
-    );
-  }
-
-  function anyDirty() {
-    return reusableDirty() || annualDirty();
-  }
-
-  function dirtyDescription() {
-    const parts = [];
-    if (reusableDirty()) parts.push('reusable task');
-    if (annualDirty()) parts.push(`${appState.seasonYear || 'annual'} review`);
-    return parts.join(' and ') || 'task';
-  }
-
-  function syncButtonLabel(id, cleanLabel, dirtyLabel, dirty) {
-    const button = document.getElementById(id);
-    if (!button) return;
-    button.textContent = dirty ? dirtyLabel : cleanLabel;
-    button.dataset.unsaved = dirty ? '1' : '0';
-  }
-
-  function syncDirtyIndicators() {
-    syncButtonLabel(
-      'save-reusable-task',
-      'Save Reusable Task',
-      'Save Reusable Task • Unsaved',
-      reusableDirty()
-    );
-    syncButtonLabel(
-      'save-annual-review',
-      'Save Annual Review',
-      'Save Annual Review • Unsaved',
-      annualDirty()
-    );
-  }
-
-  function reusablePayload() {
-    return {
-      task_name: el('edit-task-name').value.trim(),
-      stage_id: nullableInteger(el('edit-stage-id').value),
-      task_action_type: el('edit-action-type').value,
-      display_order: nullableInteger(el('edit-display-order').value) ?? 100,
-      active_flag: el('edit-active-flag').checked,
-      normal_crew_min: nullableInteger(el('edit-crew-min').value),
-      normal_crew_max: nullableInteger(el('edit-crew-max').value),
-      expected_duration_minutes: nullableInteger(el('edit-duration-minutes').value),
-      completion_point: el('edit-completion').value.trim(),
-      readiness_note: el('edit-readiness').value.trim(),
-      weather_note: el('edit-weather').value.trim(),
-      reusable_notes: el('edit-reusable-notes').value.trim()
-    };
-  }
-
-  function annualDraft() {
-    return snapshot(annualFieldIds);
-  }
-
-  function restoreSnapshot(values) {
-    Object.entries(values || {}).forEach(([id, value]) => {
-      const node = document.getElementById(id);
-      if (!node) return;
-      if (node.type === 'checkbox') node.checked = Boolean(value);
-      else node.value = value == null ? '' : String(value);
-    });
-    syncDirtyIndicators();
-  }
-
-  function annualPayload(verificationOverride = null) {
-    const task = taskById(appState.selectedTaskId);
-    return {
-      verification_state: verificationOverride || task?.verification_state || 'UNVERIFIED',
-      actual_started_at: task?.actual_started_at || null,
-      actual_completed_at: task?.actual_completed_at || null,
-      actual_crew_count: nullableInteger(el('edit-actual-crew').value),
-      actual_duration_minutes: nullableInteger(el('edit-actual-duration').value),
-      annual_notes: el('edit-annual-notes').value.trim()
-    };
-  }
-
-  async function persistReusableEdits({ announce = true, preserveAnnualDraft = true } = {}) {
-    const task = taskById(appState.selectedTaskId);
-    if (!task || !appState.access?.can_manage_setup) return false;
-
-    const preservedAnnual = preserveAnnualDraft ? annualDraft() : null;
-    try {
-      setBusy(true);
+  try {
+    setBusy(true);
+    for (let index = 0; index < orderedIds.length; index += 1) {
+      const task = taskById(orderedIds[index]);
+      if (!task) continue;
+      const newOrder = (index + 1) * 10;
+      if (Number(task.display_order) === newOrder) continue;
       await api(
         `api/setup/tasks/${task.setup_task_id}`,
-        commandOptions('PATCH', reusablePayload())
+        commandOptions('PATCH', setupTaskUpdatePayload(task, { display_order: newOrder }))
       );
-      await reloadTasks(task.setup_task_id);
-      if (preservedAnnual && Number(appState.selectedTaskId) === Number(task.setup_task_id)) {
-        restoreSnapshot(preservedAnnual);
-      }
-      if (announce) {
-        setAlert(`Reusable task ${task.setup_task_id} saved to Production.`, 'ok');
-      }
-      return true;
-    } catch (error) {
-      setAlert(error.message || error, 'error');
-      window.alert(error.message || error);
-      return false;
-    } finally {
-      setBusy(false);
-      syncDirtyIndicators();
     }
+    setAlert(`Stage ${stageLabel} reusable task sequence updated.`, 'ok');
+    await reloadTasks(selected || null);
+    showView('library');
+  } catch (error) {
+    setAlert(error.message || error, 'error');
+    window.alert(error.message || error);
+  } finally {
+    setBusy(false);
   }
+}
 
-  async function persistAnnualReview(verificationOverride = null, { announce = true } = {}) {
-    const task = taskById(appState.selectedTaskId);
-    if (!task || task.setup_session_task_id == null || !appState.access?.can_manage_setup) {
-      return false;
-    }
+async function moveSetupLibraryTask(taskId, direction) {
+  const task = taskById(taskId);
+  if (!task || !appState.access?.can_manage_setup) return;
+  const sameStage = setupTasksForStage(task);
+  const index = sameStage.findIndex((item) => Number(item.setup_task_id) === Number(taskId));
+  const swapIndex = index + direction;
+  if (index < 0 || swapIndex < 0 || swapIndex >= sameStage.length) return;
+  const ids = sameStage.map((item) => Number(item.setup_task_id));
+  [ids[index], ids[swapIndex]] = [ids[swapIndex], ids[index]];
+  await persistSetupStageOrder(ids);
+}
 
-    try {
-      setBusy(true);
+async function copySetupReusableTask(taskId) {
+  const source = taskById(taskId);
+  if (!source || !appState.access?.can_manage_setup) return;
+
+  const proposedName = `${source.task_name} Copy`;
+  const newName = window.prompt('Name for the copied reusable task:', proposedName);
+  if (newName == null || !newName.trim()) return;
+
+  if (!window.confirm(
+    'Copy this reusable task definition and its equipment/resources?\n\n' +
+    'Prerequisites and annual history will NOT be copied.'
+  )) return;
+
+  try {
+    setBusy(true);
+    const resourcePayload = await api(`api/setup/tasks/${source.setup_task_id}/resources`);
+    const resources = resourcePayload.resources || [];
+    const createPayload = {
+      task_name: newName.trim(),
+      stage_id: source.stage_id == null ? null : Number(source.stage_id),
+      task_action_type: source.task_action_type || 'WORK',
+      display_order: (Number(source.display_order) || 100) + 5,
+      normal_crew_min: source.normal_crew_min == null ? null : Number(source.normal_crew_min),
+      normal_crew_max: source.normal_crew_max == null ? null : Number(source.normal_crew_max),
+      expected_duration_minutes: source.expected_duration_minutes == null ? null : Number(source.expected_duration_minutes),
+      completion_point: source.completion_point || null,
+      readiness_note: source.readiness_note || null,
+      weather_note: source.weather_note || null,
+      reusable_notes: [
+        source.reusable_notes || '',
+        `[Copied from reusable task ${source.setup_task_id}; review task-specific details before use.]`
+      ].filter(Boolean).join('\n')
+    };
+
+    const created = await api('api/setup/tasks', commandOptions('POST', createPayload));
+    const newId = created.setup_task?.setup_task_id;
+    if (!newId) throw new Error('Copied reusable task did not return a new task ID.');
+
+    for (const resource of resources) {
       await api(
-        `api/setup/session-tasks/${task.setup_session_task_id}/review`,
-        commandOptions('PATCH', annualPayload(verificationOverride))
+        `api/setup/tasks/${newId}/resources/${resource.setup_resource_id}`,
+        commandOptions('PATCH', {
+          quantity_required: Number(resource.quantity_required) || 1,
+          requirement_type: resource.requirement_type || 'REQUIRED',
+          notes: resource.notes || null,
+          active_flag: true
+        })
       );
-      await reloadTasks(task.setup_task_id);
-      if (announce) {
-        const state = verificationOverride
-          ? String(verificationOverride).replaceAll('_', ' ').toLocaleLowerCase()
-          : 'saved';
-        setAlert(`${appState.seasonYear} annual review ${state}.`, 'ok');
-      }
-      return true;
-    } catch (error) {
-      setAlert(error.message || error, 'error');
-      window.alert(error.message || error);
-      return false;
-    } finally {
-      setBusy(false);
-      syncDirtyIndicators();
-    }
-  }
-
-  async function saveDirtySurfaces() {
-    if (reusableDirty()) {
-      const reusableSaved = await persistReusableEdits({ announce: false, preserveAnnualDraft: true });
-      if (!reusableSaved) return false;
     }
 
-    if (annualDirty()) {
-      const annualSaved = await persistAnnualReview(null, { announce: false });
-      if (!annualSaved) return false;
-    }
-
-    setAlert('Unsaved Setup task edits saved before continuing.', 'ok');
-    return true;
-  }
-
-  function discardCurrentDrafts() {
-    const taskId = appState.selectedTaskId;
-    if (taskId == null || !taskById(taskId)) {
-      baseline = null;
-      syncDirtyIndicators();
-      return;
-    }
-    selectTask(Number(taskId));
-  }
-
-  async function resolveDirtyBeforeNavigation(actionLabel) {
-    if (!anyDirty()) return true;
-
-    const saveFirst = window.confirm(
-      `You have unsaved ${dirtyDescription()} edits.\n\n`
-      + `Save them before ${actionLabel}?\n\n`
-      + 'OK = Save and continue\nCancel = choose whether to discard or stay here'
+    setAlert(
+      `Reusable task ${source.setup_task_id} copied to task ${newId} with ${resources.length} equipment/resource assignment${resources.length === 1 ? '' : 's'}. Prerequisites and annual history were not copied.`,
+      'ok'
     );
+    await reloadTasks(null);
+    showView('library');
+  } catch (error) {
+    setAlert(error.message || error, 'error');
+    window.alert(error.message || error);
+  } finally {
+    setBusy(false);
+  }
+}
 
-    if (saveFirst) {
-      return saveDirtySurfaces();
+function enhanceSetupLibrary() {
+  const canManage = Boolean(appState.access?.can_manage_setup);
+  const rows = [...document.querySelectorAll('#library-list .library-task')];
+
+  rows.forEach((row) => {
+    const openButton = row.querySelector('.open-task');
+    if (!openButton) return;
+    const taskId = Number(openButton.dataset.taskId);
+    const task = taskById(taskId);
+    if (!task) return;
+    const sameStage = setupTasksForStage(task);
+    const index = sameStage.findIndex((item) => Number(item.setup_task_id) === taskId);
+
+    row.dataset.taskId = String(taskId);
+    row.dataset.stageKey = String(task.stage_key ?? '—');
+    row.draggable = canManage;
+
+    if (canManage) {
+      const actions = row.querySelector('.library-actions');
+      if (actions) {
+        const up = document.createElement('button');
+        up.type = 'button';
+        up.className = 'small secondary stage-move-up';
+        up.textContent = '↑';
+        up.title = 'Move earlier in this Stage';
+        up.disabled = index <= 0;
+        up.addEventListener('click', (event) => {
+          event.stopPropagation();
+          moveSetupLibraryTask(taskId, -1);
+        });
+
+        const down = document.createElement('button');
+        down.type = 'button';
+        down.className = 'small secondary stage-move-down';
+        down.textContent = '↓';
+        down.title = 'Move later in this Stage';
+        down.disabled = index < 0 || index >= sameStage.length - 1;
+        down.addEventListener('click', (event) => {
+          event.stopPropagation();
+          moveSetupLibraryTask(taskId, 1);
+        });
+
+        const copy = document.createElement('button');
+        copy.type = 'button';
+        copy.className = 'small secondary copy-task';
+        copy.textContent = 'Copy';
+        copy.title = 'Copy reusable definition and equipment/resources';
+        copy.addEventListener('click', (event) => {
+          event.stopPropagation();
+          copySetupReusableTask(taskId);
+        });
+
+        actions.insertBefore(up, openButton);
+        actions.insertBefore(down, openButton);
+        actions.insertBefore(copy, openButton);
+      }
+
+      row.addEventListener('dragstart', (event) => {
+        setupReviewUsability.draggedTaskId = taskId;
+        row.classList.add('dragging');
+        event.dataTransfer.effectAllowed = 'move';
+        event.dataTransfer.setData('text/plain', String(taskId));
+      });
+
+      row.addEventListener('dragover', (event) => {
+        const dragged = taskById(setupReviewUsability.draggedTaskId);
+        if (!dragged || String(dragged.stage_key ?? '—') !== String(task.stage_key ?? '—')) return;
+        event.preventDefault();
+        event.dataTransfer.dropEffect = 'move';
+        row.classList.add('drop-target');
+      });
+
+      row.addEventListener('dragleave', () => row.classList.remove('drop-target'));
+      row.addEventListener('drop', async (event) => {
+        event.preventDefault();
+        row.classList.remove('drop-target');
+        const sourceId = Number(event.dataTransfer.getData('text/plain') || setupReviewUsability.draggedTaskId || 0);
+        if (!sourceId || sourceId === taskId) return;
+        const source = taskById(sourceId);
+        if (!source || String(source.stage_key ?? '—') !== String(task.stage_key ?? '—')) return;
+
+        const ids = setupTasksForStage(task).map((item) => Number(item.setup_task_id));
+        const sourceIndex = ids.indexOf(sourceId);
+        let targetIndex = ids.indexOf(taskId);
+        if (sourceIndex < 0 || targetIndex < 0) return;
+        ids.splice(sourceIndex, 1);
+        if (sourceIndex < targetIndex) targetIndex -= 1;
+        ids.splice(targetIndex, 0, sourceId);
+        await persistSetupStageOrder(ids);
+      });
+
+      row.addEventListener('dragend', () => {
+        setupReviewUsability.draggedTaskId = null;
+        document.querySelectorAll('.library-task').forEach((item) => {
+          item.classList.remove('dragging', 'drop-target');
+        });
+      });
     }
+  });
+}
 
-    const discard = window.confirm(
-      `Discard the unsaved ${dirtyDescription()} edits and ${actionLabel}?\n\n`
-      + 'OK = Discard and continue\nCancel = Stay on this task'
-    );
-    if (!discard) return false;
+function installSetupHowItWorks() {
+  const tabs = document.querySelector('.tabs');
+  if (!tabs || document.getElementById('help-view')) return;
 
-    discardCurrentDrafts();
-    return true;
+  const helpButton = document.createElement('button');
+  helpButton.className = 'tab';
+  helpButton.dataset.view = 'help';
+  helpButton.type = 'button';
+  helpButton.textContent = 'How Setup Works';
+  helpButton.addEventListener('click', () => showView('help'));
+  tabs.appendChild(helpButton);
+
+  const helpView = document.createElement('section');
+  helpView.id = 'help-view';
+  helpView.className = 'view';
+  helpView.innerHTML = `
+    <div class="card setup-help-card">
+      <div class="eyebrow">Plain-English Manager guide</div>
+      <h2>How Setup Session Works</h2>
+      <p>This browser review is validating the reusable Setup plan and the 2025 reconstruction. Scheduling, Pick Lists, and field movement/scanning are the next operational layer and are not active in this candidate yet.</p>
+      <div class="setup-help-grid">
+        <section class="setup-help-section">
+          <h3>1. Verify 2025</h3>
+          <p><strong>Reusable Task Definition</strong> is the normal job we expect to do again. <strong>2025 Annual Historical Actual</strong> is what happened in 2025.</p>
+          <ul>
+            <li><strong>Verified</strong>: the reusable task and 2025 information are reasonable.</li>
+            <li><strong>Needs Correction</strong>: something needs to be fixed before accepting it.</li>
+            <li><strong>Unverified</strong>: nobody has accepted it yet.</li>
+          </ul>
+        </section>
+        <section class="setup-help-section">
+          <h3>2. Reusable tasks and Stage sequence</h3>
+          <p>A reusable task is practical work worth planning each season. Sequence numbers 10, 20, 30, etc. mean the normal precedence <strong>within that Stage</strong>. They do not mean the entire Setup day runs as one serial queue.</p>
+          <p>Managers can drag tasks within a Stage or use ↑ / ↓. Use <strong>Copy</strong> for a similar task; equipment/resources copy, but prerequisites and annual history do not.</p>
+        </section>
+        <section class="setup-help-section">
+          <h3>3. Prerequisites and readiness</h3>
+          <p>A prerequisite means the next task cannot practically proceed until another task is complete. Dependencies may cross Stages, such as the Arch Trailer unload route.</p>
+          <p>Readiness is different: a task such as Festive Trees can remain NOT_READY until an outside condition is satisfied, such as leaves falling from the trees.</p>
+          <p>Dependency editing is not exposed yet. During this review, flag missing or wrong prerequisites.</p>
+        </section>
+        <section class="setup-help-section">
+          <h3>4. Scheduling model coming next</h3>
+          <p>One task can span multiple days. One day can have parallel crews. Scheduled work is grouped by <strong>Morning</strong>, <strong>Afternoon</strong>, or <strong>All Day</strong>.</p>
+          <p>The reusable Stage sequence is a planning starting point; the actual work-day plan can intentionally run Stow Storm, Elf Choir, and other work in parallel.</p>
+        </section>
+        <section class="setup-help-section">
+          <h3>5. Pick Lists</h3>
+          <p>The Pick List will be derived from the tasks scheduled for a work day/shift: required Displays → their current Containers + supplemental support/KIT Containers → deduplicated physical pull list.</p>
+          <p>A Pick List replaces manual material bookkeeping, not real labor. A true Prepare/Load task remains a task if people actually spend meaningful time doing that work.</p>
+        </section>
+        <section class="setup-help-section">
+          <h3>6. Movement and scanning</h3>
+          <p>Scanning identifies the physical Display, Container, or Location. Setup Session owns what that scan means operationally. The audited movement command layer is not active in this browser candidate.</p>
+        </section>
+      </div>
+    </div>
+  `;
+  document.querySelector('main')?.appendChild(helpView);
+}
+
+function clarifySetupOrderLabels() {
+  const editOrder = document.getElementById('edit-display-order');
+  if (editOrder?.closest('label')) {
+    editOrder.closest('label').childNodes[0].nodeValue = 'Stage sequence';
+  }
+  const addOrder = document.getElementById('add-display-order');
+  if (addOrder?.closest('label')) {
+    addOrder.closest('label').childNodes[0].nodeValue = 'Stage sequence';
   }
 
-  async function resolveDirtyBeforeDelete() {
-    if (!anyDirty()) return true;
-    const discard = window.confirm(
-      `This task has unsaved ${dirtyDescription()} edits.\n\n`
-      + 'Deleting the task cannot preserve those drafts. Discard them and continue to the delete confirmation?'
-    );
-    if (!discard) return false;
-    discardCurrentDrafts();
-    return true;
+  const libraryHint = document.querySelector('#library-view .hint');
+  if (libraryHint && !document.querySelector('.sequence-explainer')) {
+    const note = document.createElement('div');
+    note.className = 'hint sequence-explainer';
+    note.textContent = 'Stage sequence (10, 20, 30...) expresses normal precedence within a Stage. Drag tasks or use ↑ / ↓ to reorder. Daily scheduling will separately support shifts, parallel crews, and multi-day work.';
+    libraryHint.insertAdjacentElement('afterend', note);
   }
+}
 
-  function replayClick(target) {
-    replayDepth += 1;
-    try {
-      target.click();
-    } finally {
-      replayDepth -= 1;
-    }
+function installPreviewReviewNotice() {
+  if (!setupReviewIsLocalPreview() || document.querySelector('.preview-review-notice')) return;
+  const notice = document.createElement('section');
+  notice.className = 'notice preview-review-notice';
+  notice.innerHTML = '<strong>Browser Review — disposable clone.</strong> Changes in this preview are shared only inside the disposable review database and are discarded during cleanup. Production is not being edited.';
+  const appAlert = document.getElementById('app-alert');
+  appAlert?.insertAdjacentElement('beforebegin', notice);
+}
+
+const baseSetupReviewSetAlert = setAlert;
+setAlert = function setupReviewAwareAlert(message, state = 'ok') {
+  let adjusted = String(message ?? '');
+  if (setupReviewIsLocalPreview()) {
+    adjusted = adjusted
+      .replaceAll(' saved to Production.', ' saved to the disposable review clone.')
+      .replaceAll(' created in Production.', ' created in the disposable review clone.')
+      .replaceAll(' loaded from Production.', ' loaded from the disposable review clone.')
+      .replaceAll('shared immediately.', 'shared inside this disposable review clone.');
   }
+  return baseSetupReviewSetAlert(adjusted, state);
+};
 
-  async function handleAnnualAction(buttonId) {
-    const overrides = {
-      'save-annual-review': null,
-      'mark-verified': 'VERIFIED',
-      'mark-correction': 'NEEDS_CORRECTION',
-      'mark-unverified': 'UNVERIFIED'
-    };
+const baseSetupReviewRenderLibrary = renderLibrary;
+renderLibrary = function renderLibraryWithReviewUsability() {
+  baseSetupReviewRenderLibrary();
+  enhanceSetupLibrary();
+  clarifySetupOrderLabels();
+};
 
-    if (reusableDirty()) {
-      const reusableSaved = await persistReusableEdits({ announce: false, preserveAnnualDraft: true });
-      if (!reusableSaved) return;
-    }
-
-    await persistAnnualReview(overrides[buttonId]);
-  }
-
-  function taskIdFromClickTarget(target) {
-    const row = target.closest('#review-list .task-row, #library-view .open-task');
-    if (!row) return null;
-    return Number(row.dataset.taskId || 0) || null;
-  }
-
-  function installSelectionBaselineWrapper() {
-    if (typeof selectTask !== 'function' || selectTask.__dirtyGuardWrapped) return;
-    const priorSelectTask = selectTask;
-    const wrapped = function selectTaskWithDirtyBaseline(taskId) {
-      const result = priorSelectTask(taskId);
-      captureBaseline(taskId);
-      return result;
-    };
-    wrapped.__dirtyGuardWrapped = true;
-    selectTask = wrapped;
-  }
-
-  function installInputTracking() {
-    window.addEventListener('input', (event) => {
-      const id = event.target?.id;
-      if (reusableFieldIds.has(id) || annualFieldIds.has(id)) syncDirtyIndicators();
-    }, true);
-
-    window.addEventListener('change', (event) => {
-      const id = event.target?.id;
-      if (reusableFieldIds.has(id) || annualFieldIds.has(id)) syncDirtyIndicators();
-    }, true);
-  }
-
-  function installSeasonGuard() {
-    window.addEventListener('change', (event) => {
-      if (replayDepth || event.target?.id !== 'season-select' || !anyDirty()) return;
-
-      const select = event.target;
-      const requestedYear = select.value;
-      const currentYear = String(appState.seasonYear ?? '');
-      event.preventDefault();
-      event.stopImmediatePropagation();
-      select.value = currentYear;
-
-      void (async () => {
-        const proceed = await resolveDirtyBeforeNavigation('changing Setup seasons');
-        if (!proceed) {
-          select.value = currentYear;
-          return;
-        }
-        select.value = requestedYear;
-        baseline = null;
-        syncDirtyIndicators();
-        await loadSeason(requestedYear);
-      })();
-    }, true);
-  }
-
-  function installClickGuard() {
-    window.addEventListener('click', (event) => {
-      if (replayDepth) return;
-      const target = event.target;
-      if (!(target instanceof Element)) return;
-
-      const saveReusable = target.closest('#save-reusable-task');
-      if (saveReusable) {
-        event.preventDefault();
-        event.stopImmediatePropagation();
-        void persistReusableEdits();
-        return;
-      }
-
-      const annualButton = target.closest(
-        '#save-annual-review, #mark-verified, #mark-correction, #mark-unverified'
-      );
-      if (annualButton) {
-        event.preventDefault();
-        event.stopImmediatePropagation();
-        void handleAnnualAction(annualButton.id);
-        return;
-      }
-
-      const deleteButton = target.closest('#delete-reconstruction-task');
-      if (deleteButton && anyDirty()) {
-        event.preventDefault();
-        event.stopImmediatePropagation();
-        void (async () => {
-          if (await resolveDirtyBeforeDelete()) replayClick(deleteButton);
-        })();
-        return;
-      }
-
-      const dependencyAction = target.closest('#next-dependency-add-button, .next-dependency-remove');
-      if (dependencyAction && anyDirty()) {
-        event.preventDefault();
-        event.stopImmediatePropagation();
-        void (async () => {
-          if (await resolveDirtyBeforeNavigation('changing task prerequisites')) {
-            replayClick(dependencyAction);
-          }
-        })();
-        return;
-      }
-
-      const requestedTaskId = taskIdFromClickTarget(target);
-      if (
-        requestedTaskId != null
-        && Number(requestedTaskId) !== Number(appState.selectedTaskId)
-        && anyDirty()
-      ) {
-        const replayTarget = target.closest('#library-view .open-task')
-          || target.closest('#review-list .task-row');
-        if (!replayTarget) return;
-        event.preventDefault();
-        event.stopImmediatePropagation();
-        void (async () => {
-          if (await resolveDirtyBeforeNavigation('opening another task')) replayClick(replayTarget);
-        })();
-        return;
-      }
-
-      const returnToCatalog = target.closest('#setup-return-library');
-      if (returnToCatalog && anyDirty()) {
-        event.preventDefault();
-        event.stopImmediatePropagation();
-        void (async () => {
-          if (await resolveDirtyBeforeNavigation('returning to the Reusable Task Catalog')) {
-            replayClick(returnToCatalog);
-          }
-        })();
-        return;
-      }
-
-      const tab = target.closest('.tabs .tab');
-      if (tab && !tab.classList.contains('active') && anyDirty()) {
-        event.preventDefault();
-        event.stopImmediatePropagation();
-        void (async () => {
-          if (await resolveDirtyBeforeNavigation(`opening ${tab.textContent.trim()}`)) replayClick(tab);
-        })();
-      }
-    }, true);
-  }
-
-  function installUnloadGuard() {
-    window.addEventListener('beforeunload', (event) => {
-      if (!anyDirty()) return;
-      event.preventDefault();
-      event.returnValue = '';
-    });
-  }
-
-  function initializeDirtyGuard() {
-    if (installed) return;
-    installed = true;
-    installSelectionBaselineWrapper();
-    installInputTracking();
-    installSeasonGuard();
-    installClickGuard();
-    installUnloadGuard();
-    syncDirtyIndicators();
-  }
-
-  if (document.readyState === 'complete') initializeDirtyGuard();
-  else window.addEventListener('load', initializeDirtyGuard, { once: true });
-})();
+installSetupHowItWorks();
+installPreviewReviewNotice();
+clarifySetupOrderLabels();
+if (appState.tasks?.length) renderLibrary();

--- a/Setup/Application/test_setup_dirty_edit_browser_preview_contract.py
+++ b/Setup/Application/test_setup_dirty_edit_browser_preview_contract.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+
+
+APP_DIR = Path(__file__).resolve().parent
+ACCEPTANCE = APP_DIR.parent / "Acceptance"
+CANDIDATE_SHA = "89012d5e40a26323db78dce50d9e58dd27580169"
+CANDIDATE_REF = "agent/setup-catalog-dirty-edit-safety-154"
+
+
+def read_acceptance(name: str) -> str:
+    return (ACCEPTANCE / name).read_text(encoding="utf-8")
+
+
+def test_dirty_edit_preview_pins_exact_candidate_and_ref() -> None:
+    launcher = read_acceptance("run_setup_catalog_dirty_edit_browser_preview.ps1")
+    server = read_acceptance("setup_source_only_browser_preview_server.sh")
+
+    assert f"$AcceptedCandidateSha = '{CANDIDATE_SHA}'" in launcher
+    assert f"$AcceptedBranch = '{CANDIDATE_REF}'" in launcher
+    assert "run_setup_source_only_browser_preview.ps1" in launcher
+    assert 'APPROVED_REF="${4:?approved Git ref required}"' in server
+    assert 'fetch origin "$APPROVED_REF"' in server
+    assert "agent/setup-session-production-foundation" not in server
+
+
+def test_source_only_preview_recreates_current_setup_write_boundary() -> None:
+    server = read_acceptance("setup_source_only_browser_preview_server.sh")
+
+    for signature in (
+        "ref.delete_setup_reconstruction_task(text,bigint)",
+        "ref.setup_task_captain_list(bigint)",
+        "ref.setup_captain_person_list()",
+        "ref.set_setup_task_captain(text,bigint,integer,text,integer,text,boolean)",
+        "ref.set_setup_task_effort(text,bigint,text)",
+        "ref.set_setup_task_display_material_requirement(text,bigint,boolean)",
+    ):
+        assert f"GRANT EXECUTE ON FUNCTION {signature} TO fieldwiring_app;" in server
+
+    assert "GRANT SELECT ON ALL TABLES IN SCHEMA ref, ops, lor_snap TO fieldwiring_app;" in server
+    assert "Preview role default_transaction_read_only=on: PASS" in server
+    assert "Preview least-privilege table boundary: PASS" in server
+
+
+def test_dirty_edit_preview_runs_focused_contract_and_prints_manual_matrix() -> None:
+    launcher = read_acceptance("run_setup_catalog_dirty_edit_browser_preview.ps1")
+
+    assert "test_setup_dirty_edit_guard_contract.py" in launcher
+    assert "test_setup_stage_order_contract.py" in launcher
+    assert "Mark Verified" in launcher
+    assert "verification does NOT change" in launcher
+    assert "Save + continue, Discard + continue, and Stay" in launcher
+    assert "annual draft remains present" in launcher
+    assert "independent Effort or Material save" in launcher
+
+
+def test_base_source_only_launcher_passes_explicit_ref_to_server() -> None:
+    base = read_acceptance("run_setup_source_only_browser_preview.ps1")
+    assert "$ApprovedRef = $ExpectedBranch" in base
+    assert "Approved ref:  $ApprovedRef" in base
+    assert "'$CandidateSha' '$PreviewPort' '$PreviewEmail' '$ApprovedRef'" in base

--- a/Setup/Application/test_setup_dirty_edit_guard_contract.py
+++ b/Setup/Application/test_setup_dirty_edit_guard_contract.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+
+
+def read(name: str) -> str:
+    return (ROOT / name).read_text(encoding="utf-8")
+
+
+def test_dirty_guard_asset_is_already_part_of_protected_setup_surface():
+    html = read("production.html")
+    host = read("production_backend.py")
+    assert 'setup_review_usability.js?v=2026-09-07.2' in html
+    assert '"setup_review_usability.js"' in host
+
+
+def test_dirty_guard_tracks_only_main_reusable_and_annual_save_surfaces():
+    js = read("setup_review_usability.js")
+    for field_id in (
+        "edit-task-name",
+        "edit-stage-id",
+        "edit-action-type",
+        "edit-display-order",
+        "edit-active-flag",
+        "edit-crew-min",
+        "edit-crew-max",
+        "edit-duration-minutes",
+        "edit-completion",
+        "edit-readiness",
+        "edit-weather",
+        "edit-reusable-notes",
+        "edit-actual-crew",
+        "edit-actual-duration",
+        "edit-annual-notes",
+    ):
+        assert field_id in js
+
+    # These have their own governed commands and must not be silently folded
+    # into Save Reusable Task merely to implement Issue #154.
+    assert "edit-effort-level" not in js
+    assert "edit-requires-display-material" not in js
+    assert "setup-resource-select" not in js
+    assert "setup-captain-person" not in js
+
+
+def test_mark_verified_saves_dirty_reusable_definition_before_annual_review():
+    js = read("setup_review_usability.js")
+    assert "'mark-verified': 'VERIFIED'" in js
+    assert "if (reusableDirty())" in js
+    assert "persistReusableEdits({ announce: false, preserveAnnualDraft: true })" in js
+    assert "if (!reusableSaved) return;" in js
+    assert "await persistAnnualReview(overrides[buttonId]);" in js
+    assert "api/setup/tasks/${task.setup_task_id}" in js
+    assert "api/setup/session-tasks/${task.setup_session_task_id}/review" in js
+
+
+def test_reusable_save_preserves_pending_annual_fields_across_task_reload():
+    js = read("setup_review_usability.js")
+    assert "const preservedAnnual = preserveAnnualDraft ? annualDraft() : null;" in js
+    assert "await reloadTasks(task.setup_task_id);" in js
+    assert "restoreSnapshot(preservedAnnual);" in js
+
+
+def test_navigation_uses_explicit_save_discard_cancel_decision():
+    js = read("setup_review_usability.js")
+    assert "Save and continue" in js
+    assert "Discard and continue" in js
+    assert "Stay on this task" in js
+    assert "resolveDirtyBeforeNavigation('opening another task')" in js
+    assert "resolveDirtyBeforeNavigation('returning to the Reusable Task Catalog')" in js
+    assert "changing Setup seasons" in js
+    assert "beforeunload" in js
+
+
+def test_prerequisite_reload_path_is_guarded_too():
+    js = read("setup_review_usability.js")
+    assert "#next-dependency-add-button, .next-dependency-remove" in js
+    assert "resolveDirtyBeforeNavigation('changing task prerequisites')" in js
+
+
+def test_existing_save_handlers_are_preempted_at_window_capture_boundary():
+    js = read("setup_review_usability.js")
+    assert "window.addEventListener('click'" in js
+    assert "window.addEventListener('change'" in js
+    assert "event.stopImmediatePropagation();" in js
+    assert "replayDepth" in js
+    assert "installSelectionBaselineWrapper" in js

--- a/Setup/Application/test_setup_dirty_edit_guard_contract.py
+++ b/Setup/Application/test_setup_dirty_edit_guard_contract.py
@@ -8,15 +8,21 @@ def read(name: str) -> str:
     return (ROOT / name).read_text(encoding="utf-8")
 
 
-def test_dirty_guard_asset_is_already_part_of_protected_setup_surface():
+def guard_source() -> str:
+    return read("setup_catalog_dirty_guard.js")
+
+
+def test_dirty_guard_asset_is_loaded_last_and_protected():
     html = read("production.html")
     host = read("production_backend.py")
-    assert 'setup_review_usability.js?v=2026-09-07.2' in html
-    assert '"setup_review_usability.js"' in host
+    guard_index = html.index("setup_catalog_dirty_guard.js?v=2026-09-10.1")
+    effort_index = html.index("setup_catalog_effort.js?v=2026-09-09.3")
+    assert guard_index > effort_index
+    assert '"setup_catalog_dirty_guard.js"' in host
 
 
 def test_dirty_guard_tracks_only_main_reusable_and_annual_save_surfaces():
-    js = read("setup_review_usability.js")
+    js = guard_source()
     for field_id in (
         "edit-task-name",
         "edit-stage-id",
@@ -45,7 +51,7 @@ def test_dirty_guard_tracks_only_main_reusable_and_annual_save_surfaces():
 
 
 def test_mark_verified_saves_dirty_reusable_definition_before_annual_review():
-    js = read("setup_review_usability.js")
+    js = guard_source()
     assert "'mark-verified': 'VERIFIED'" in js
     assert "if (reusableDirty())" in js
     assert "persistReusableEdits({ announce: false, preserveAnnualDraft: true })" in js
@@ -56,14 +62,14 @@ def test_mark_verified_saves_dirty_reusable_definition_before_annual_review():
 
 
 def test_reusable_save_preserves_pending_annual_fields_across_task_reload():
-    js = read("setup_review_usability.js")
+    js = guard_source()
     assert "const preservedAnnual = preserveAnnualDraft ? annualDraft() : null;" in js
     assert "await reloadTasks(task.setup_task_id);" in js
     assert "restoreSnapshot(preservedAnnual);" in js
 
 
 def test_navigation_uses_explicit_save_discard_cancel_decision():
-    js = read("setup_review_usability.js")
+    js = guard_source()
     assert "Save and continue" in js
     assert "Discard and continue" in js
     assert "Stay on this task" in js
@@ -74,13 +80,13 @@ def test_navigation_uses_explicit_save_discard_cancel_decision():
 
 
 def test_prerequisite_reload_path_is_guarded_too():
-    js = read("setup_review_usability.js")
+    js = guard_source()
     assert "#next-dependency-add-button, .next-dependency-remove" in js
     assert "resolveDirtyBeforeNavigation('changing task prerequisites')" in js
 
 
 def test_existing_save_handlers_are_preempted_at_window_capture_boundary():
-    js = read("setup_review_usability.js")
+    js = guard_source()
     assert "window.addEventListener('click'" in js
     assert "window.addEventListener('change'" in js
     assert "event.stopImmediatePropagation();" in js

--- a/Setup/Application/test_setup_production_contract.py
+++ b/Setup/Application/test_setup_production_contract.py
@@ -25,6 +25,7 @@ def test_production_html_uses_database_client_only() -> None:
     assert "setup_acceptance_fixes.css" in text
     assert "setup_session_year_guard.js" in text
     assert "setup_session_year_guard.css" in text
+    assert "setup_catalog_dirty_guard.js" in text
     assert "setup.js" not in text
     assert "setup_review_extensions.js" not in text
     assert "setup_instruction_live.js" not in text
@@ -39,12 +40,14 @@ def test_production_client_has_no_browser_local_prototype_state() -> None:
     stage_order_text = (APP_DIR / "setup_stage_order.js").read_text(encoding="utf-8")
     acceptance_text = (APP_DIR / "setup_acceptance_fixes.js").read_text(encoding="utf-8")
     guard_text = (APP_DIR / "setup_session_year_guard.js").read_text(encoding="utf-8")
+    dirty_guard_text = (APP_DIR / "setup_catalog_dirty_guard.js").read_text(encoding="utf-8")
     assert "localStorage." not in text
     assert "localStorage." not in resource_text
     assert "localStorage." not in next_text
     assert "localStorage." not in stage_order_text
     assert "localStorage." not in acceptance_text
     assert "localStorage." not in guard_text
+    assert "localStorage." not in dirty_guard_text
     assert "initialTasks" not in text
     assert "msb.setup.prototype" not in text
     assert "X-MSB-Setup-Command" in text
@@ -77,7 +80,7 @@ def test_production_entry_point_serves_shared_ui_and_blocks_prototype_routes() -
     assert health.status_code == 200
     payload = health.get_json()
     assert payload["status"] == "ok"
-    assert payload["version"] == "V0.3.5-stage-scene-material-review"
+    assert payload["version"] == "V0.3.6-catalog-dirty-edit-safety"
 
     for asset in (
         "/setup.css",
@@ -98,6 +101,7 @@ def test_production_entry_point_serves_shared_ui_and_blocks_prototype_routes() -
         "/setup_acceptance_fixes.js",
         "/setup_session_year_guard.css",
         "/setup_session_year_guard.js",
+        "/setup_catalog_dirty_guard.js",
     ):
         assert client.get(asset).status_code == 200
 

--- a/Setup/Application/test_setup_stage_order_contract.py
+++ b/Setup/Application/test_setup_stage_order_contract.py
@@ -39,4 +39,4 @@ def test_production_loads_stage_order_assets() -> None:
     assert "setup_stage_order.js" in html
     assert "setup_stage_order.css" in backend
     assert "setup_stage_order.js" in backend
-    assert "V0.3.5-stage-scene-material-review" in backend
+    assert "V0.3.6-catalog-dirty-edit-safety" in backend


### PR DESCRIPTION
## Scope

Implements Issue #154 only. This is the first Catalog-review safety pass before #153/#151/#152.

## Behavior

- tracks unsaved reusable-task fields owned by `Save Reusable Task`;
- tracks unsaved annual-review fields owned by `Save Annual Review`;
- `Mark Verified`, `Needs Correction`, `Back to Unverified`, and `Save Annual Review` save pending reusable edits first;
- a failed reusable save prevents the annual state change from proceeding;
- `Save Reusable Task` preserves pending annual-review draft fields across its task reload;
- task switching, season/view navigation, and prerequisite changes use explicit Save / Discard / Stay protection;
- browser unload warns while tracked edits remain dirty;
- reconstruction delete requires explicit discard of unsaved drafts before continuing;
- Physical Effort, Display/Container Material, resources, and Captains remain separate governed save surfaces.

## Implementation boundary

Adds a dedicated final-loaded `setup_catalog_dirty_guard.js` browser layer rather than rewriting the existing stacked Setup wrappers. Existing `setup_review_usability.js` remains unchanged from current `main`.

Candidate health:

`V0.3.6-catalog-dirty-edit-safety`

## Validation so far

- branch refreshed from current `main` `1e60827be4f090b8e3b9648161400f81693d7294`;
- final branch is not behind `main`;
- changed-file diff reviewed; existing Setup usability code restored byte-for-byte after a connector read inconsistency was caught before PR creation;
- new guard passes JavaScript syntax check;
- focused static regression contracts added.

## Still required before merge / Production

- full Setup regression suite;
- disposable current-Production-clone browser acceptance;
- specifically prove edit reusable field -> Mark Verified persists edit then verifies;
- prove failed reusable save blocks verification;
- prove Save / Discard / Stay on task switching/navigation;
- prove existing Effort/material/resource/Captain behavior remains unchanged;
- normal Production deployment/runbook gate.

Closes #154 only after protected browser and Production acceptance are complete.