### PR TITLE
Harden Setup dirty-edit protection after failed Production acceptance

### DIFF
--- a/Setup/Acceptance/run_setup_catalog_dirty_edit_browser_preview.ps1
+++ b/Setup/Acceptance/run_setup_catalog_dirty_edit_browser_preview.ps1
@@ -7,9 +7,11 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-# Exact V0.3.7 application candidate for the Issue #154 follow-up. Later
-# acceptance-only commits may follow, but browser approval remains pinned here.
-$AcceptedCandidateSha = '7480fdae852ca7de70a8cdb65f1f26c7c6aaa40b'
+# Exact V0.3.7 candidate for the Issue #154 follow-up. This SHA includes the
+# hardened application plus the corrected regression contract. Later
+# acceptance-only commits may follow, but browser/deployment approval remains
+# pinned here so the exact candidate does not move recursively.
+$AcceptedCandidateSha = '9d0c31421ce7cbd1b1cbcf733b06198ace418e9d'
 $AcceptedBranch = 'agent/setup-dirty-edit-followup-154'
 $BaseWrapper = Join-Path $PSScriptRoot 'run_setup_source_only_browser_preview.ps1'
 

--- a/Setup/Acceptance/run_setup_catalog_dirty_edit_browser_preview.ps1
+++ b/Setup/Acceptance/run_setup_catalog_dirty_edit_browser_preview.ps1
@@ -7,10 +7,10 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-# Exact application candidate for Issue #154. Later commits on this branch may
-# harden acceptance tooling, but browser approval remains pinned to this app SHA.
-$AcceptedCandidateSha = '89012d5e40a26323db78dce50d9e58dd27580169'
-$AcceptedBranch = 'agent/setup-catalog-dirty-edit-safety-154'
+# Exact V0.3.7 application candidate for the Issue #154 follow-up. Later
+# acceptance-only commits may follow, but browser approval remains pinned here.
+$AcceptedCandidateSha = '7480fdae852ca7de70a8cdb65f1f26c7c6aaa40b'
+$AcceptedBranch = 'agent/setup-dirty-edit-followup-154'
 $BaseWrapper = Join-Path $PSScriptRoot 'run_setup_source_only_browser_preview.ps1'
 
 if (-not (Test-Path -LiteralPath $BaseWrapper)) {
@@ -44,9 +44,8 @@ $text = Replace-Required -Source $text -Needle "`$ExpectedBranch = 'agent/setup-
 $scriptDirLiteral = $PSScriptRoot.Replace("'", "''")
 $text = Replace-Required -Source $text -Needle '$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path' -Replacement "`$ScriptDir = '$scriptDirLiteral'" -Description 'base wrapper ScriptDir initialization'
 
-# Add the new #154 contract to the focused detached regression. Keep the
-# existing accepted regression files and add the version-bearing Stage-order
-# contract because the candidate health version changed from V0.3.5 to V0.3.6.
+# Add the #154 contracts to the focused detached regression. The Stage-order
+# contract carries the current V0.3.7 health-version assertion.
 $regressionNeedle = "        '      Setup/Application/test_setup_next_pass_contract.py'"
 $regressionReplacement = @(
     "        '      Setup/Application/test_setup_next_pass_contract.py \',",
@@ -55,12 +54,13 @@ $regressionReplacement = @(
 ) -join "`n"
 $text = Replace-Required -Source $text -Needle $regressionNeedle -Replacement $regressionReplacement -Description 'focused regression tail'
 
-$text = $text.Replace('SETUP SOURCE-ONLY BROWSER PREVIEW', 'SETUP CATALOG DIRTY-EDIT BROWSER PREVIEW')
-$text = $text.Replace('SETUP SOURCE-ONLY BROWSER REVIEW READY', 'SETUP CATALOG DIRTY-EDIT BROWSER REVIEW READY')
+$text = $text.Replace('SETUP SOURCE-ONLY BROWSER PREVIEW', 'SETUP CATALOG DIRTY-EDIT V0.3.7 BROWSER PREVIEW')
+$text = $text.Replace('SETUP SOURCE-ONLY BROWSER REVIEW READY', 'SETUP CATALOG DIRTY-EDIT V0.3.7 BROWSER REVIEW READY')
 
-Write-Host 'Issue #154 browser acceptance checklist:'
-Write-Host '  1. Open an annual 2025 task and change a reusable field without saving.'
-Write-Host '  2. Click Mark Verified; prove the reusable edit persists and annual state becomes VERIFIED.'
+Write-Host 'Issue #154 V0.3.7 browser acceptance checklist:'
+Write-Host '  0. Before any edit, confirm the header visibly shows Client V0.3.7. If not, stop and refresh; do not write.'
+Write-Host '  1. Open an annual 2025 task and change reusable fields without saving.'
+Write-Host '  2. Click Mark Verified; prove every reusable edit persists and annual state becomes VERIFIED.'
 Write-Host '  3. Force a reusable save failure (for example a duplicate/invalid task name) and click Mark Verified; prove verification does NOT change.'
 Write-Host '  4. With dirty edits, switch tasks and exercise Save + continue, Discard + continue, and Stay.'
 Write-Host '  5. Make an annual-note draft, click Save Reusable Task, and prove the annual draft remains present.'

--- a/Setup/Application/production_backend.py
+++ b/Setup/Application/production_backend.py
@@ -20,7 +20,7 @@ from setup_effort_api import setup_effort_api
 from setup_material_api import setup_material_api
 from setup_material_resolution import install_setup_material_resolution
 
-PRODUCTION_VERSION = "V0.3.6-catalog-dirty-edit-safety"
+PRODUCTION_VERSION = "V0.3.7-catalog-dirty-edit-followup"
 PRODUCTION_ASSETS = frozenset(
     {
         "setup.css",
@@ -69,9 +69,17 @@ app.register_blueprint(setup_effort_api)
 app.register_blueprint(setup_material_api)
 
 
+def _no_store(response):
+    """Never let an old Setup page/asset survive an application deployment."""
+    response.headers["Cache-Control"] = "no-store, max-age=0"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "0"
+    return response
+
+
 @app.get("/")
 def production_index():
-    return send_from_directory(BASE_DIR, "production.html")
+    return _no_store(send_from_directory(BASE_DIR, "production.html"))
 
 
 @app.get("/api/health")
@@ -80,7 +88,7 @@ def production_health():
         os.environ.get(name, "").strip()
         for name in ("SETUP_DATABASE_DSN", "FIELDWIRING_DATABASE_DSN", "PROCEDURE_DATABASE_DSN")
     ) else "unconfigured"
-    return jsonify(status="ok", version=PRODUCTION_VERSION, data_mode=mode)
+    return _no_store(jsonify(status="ok", version=PRODUCTION_VERSION, data_mode=mode))
 
 
 @app.get("/<path:name>")
@@ -88,7 +96,7 @@ def production_asset(name: str):
     if name not in PRODUCTION_ASSETS:
         abort(404)
     mimetype = "application/javascript" if name.casefold().endswith(".js") else None
-    return send_from_directory(BASE_DIR, name, mimetype=mimetype)
+    return _no_store(send_from_directory(BASE_DIR, name, mimetype=mimetype))
 
 
 if __name__ == "__main__":

--- a/Setup/Application/setup_catalog_dirty_guard.js
+++ b/Setup/Application/setup_catalog_dirty_guard.js
@@ -1,18 +1,18 @@
 /* Setup reusable/annual review dirty-edit protection.
  *
- * Issue #154: a Manager must never lose pending task edits merely because an
- * annual verification action, prerequisite change, task switch, or season/view
- * navigation reloads the selected task.
+ * Issue #154 follow-up after failed Production acceptance on 2026-09-10.
  *
- * This guard deliberately tracks only the fields owned by the existing
- * "Save Reusable Task" and "Save Annual Review" commands. Physical Effort,
- * Display/Container Material, resources, and Captains remain independent
- * governed save surfaces and are not folded into either payload here.
+ * The critical change from the first candidate is that dirty detection no longer
+ * depends on an initialization baseline. The live form is compared directly to
+ * the currently selected server-backed task object every time an action occurs.
+ * Reusable edits must save successfully before an annual verification command
+ * is allowed to run.
  */
 
 (() => {
   'use strict';
 
+  const CLIENT_BUILD = 'V0.3.7-catalog-dirty-edit-followup';
   const reusableFieldIds = new Set([
     'edit-task-name',
     'edit-stage-id',
@@ -27,66 +27,91 @@
     'edit-weather',
     'edit-reusable-notes'
   ]);
-
   const annualFieldIds = new Set([
     'edit-actual-crew',
     'edit-actual-duration',
     'edit-annual-notes'
   ]);
 
-  let baseline = null;
   let replayDepth = 0;
-  let installed = false;
+  window.msbSetupClientBuild = CLIENT_BUILD;
 
-  function controlValue(id) {
-    const node = document.getElementById(id);
-    if (!node) return null;
-    return node.type === 'checkbox' ? Boolean(node.checked) : String(node.value ?? '');
+  function normalizeText(value) {
+    return String(value ?? '').trim();
   }
 
-  function snapshot(fieldIds) {
-    const values = {};
-    fieldIds.forEach((id) => {
-      values[id] = controlValue(id);
-    });
-    return values;
+  function normalizeNullableInteger(value) {
+    if (value == null || value === '') return null;
+    const parsed = Number.parseInt(String(value), 10);
+    return Number.isFinite(parsed) ? parsed : null;
   }
 
-  function sameSnapshot(left, right) {
-    return JSON.stringify(left || {}) === JSON.stringify(right || {});
-  }
-
-  function captureBaseline(taskId = appState.selectedTaskId) {
-    if (taskId == null || Number(taskId) !== Number(appState.selectedTaskId)) {
-      baseline = null;
-      syncDirtyIndicators();
-      return;
-    }
-
-    baseline = {
-      taskId: Number(taskId),
-      reusable: snapshot(reusableFieldIds),
-      annual: snapshot(annualFieldIds)
+  function reusableFormState() {
+    return {
+      task_name: normalizeText(el('edit-task-name').value),
+      stage_id: normalizeNullableInteger(el('edit-stage-id').value),
+      task_action_type: el('edit-action-type').value || 'WORK',
+      display_order: normalizeNullableInteger(el('edit-display-order').value) ?? 100,
+      active_flag: Boolean(el('edit-active-flag').checked),
+      normal_crew_min: normalizeNullableInteger(el('edit-crew-min').value),
+      normal_crew_max: normalizeNullableInteger(el('edit-crew-max').value),
+      expected_duration_minutes: normalizeNullableInteger(el('edit-duration-minutes').value),
+      completion_point: normalizeText(el('edit-completion').value),
+      readiness_note: normalizeText(el('edit-readiness').value),
+      weather_note: normalizeText(el('edit-weather').value),
+      reusable_notes: normalizeText(el('edit-reusable-notes').value)
     };
-    syncDirtyIndicators();
   }
 
-  function baselineMatchesSelection() {
-    return baseline && Number(baseline.taskId) === Number(appState.selectedTaskId);
+  function reusableTaskState(task) {
+    return {
+      task_name: normalizeText(task?.task_name),
+      stage_id: task?.stage_id == null ? null : Number(task.stage_id),
+      task_action_type: task?.task_action_type || 'WORK',
+      display_order: normalizeNullableInteger(task?.display_order) ?? 100,
+      active_flag: Boolean(task?.active_flag),
+      normal_crew_min: normalizeNullableInteger(task?.normal_crew_min),
+      normal_crew_max: normalizeNullableInteger(task?.normal_crew_max),
+      expected_duration_minutes: normalizeNullableInteger(task?.expected_duration_minutes),
+      completion_point: normalizeText(task?.completion_point),
+      readiness_note: normalizeText(task?.readiness_note),
+      weather_note: normalizeText(task?.weather_note),
+      reusable_notes: normalizeText(task?.reusable_notes)
+    };
+  }
+
+  function annualFormState() {
+    return {
+      actual_crew_count: normalizeNullableInteger(el('edit-actual-crew').value),
+      actual_duration_minutes: normalizeNullableInteger(el('edit-actual-duration').value),
+      annual_notes: normalizeText(el('edit-annual-notes').value)
+    };
+  }
+
+  function annualTaskState(task) {
+    return {
+      actual_crew_count: normalizeNullableInteger(task?.actual_crew_count),
+      actual_duration_minutes: normalizeNullableInteger(task?.actual_duration_minutes),
+      annual_notes: normalizeText(task?.annual_notes)
+    };
+  }
+
+  function sameState(left, right) {
+    return JSON.stringify(left) === JSON.stringify(right);
+  }
+
+  function selectedTask() {
+    return taskById(appState.selectedTaskId);
   }
 
   function reusableDirty() {
-    return Boolean(
-      baselineMatchesSelection()
-      && !sameSnapshot(baseline.reusable, snapshot(reusableFieldIds))
-    );
+    const task = selectedTask();
+    return Boolean(task && !sameState(reusableFormState(), reusableTaskState(task)));
   }
 
   function annualDirty() {
-    return Boolean(
-      baselineMatchesSelection()
-      && !sameSnapshot(baseline.annual, snapshot(annualFieldIds))
-    );
+    const task = selectedTask();
+    return Boolean(task && !sameState(annualFormState(), annualTaskState(task)));
   }
 
   function anyDirty() {
@@ -100,6 +125,46 @@
     return parts.join(' and ') || 'task';
   }
 
+  function installBuildBadge() {
+    if (document.getElementById('setup-client-build-badge')) return;
+    const access = document.getElementById('access-badge');
+    if (!access) return;
+    const badge = document.createElement('span');
+    badge.id = 'setup-client-build-badge';
+    badge.className = 'pill';
+    badge.textContent = 'Client V0.3.7';
+    badge.title = CLIENT_BUILD;
+    access.insertAdjacentElement('afterend', badge);
+  }
+
+  function setBuildBadgeState(serverVersion, ok) {
+    const badge = document.getElementById('setup-client-build-badge');
+    if (!badge) return;
+    badge.textContent = ok ? 'Client V0.3.7' : 'CLIENT / SERVER MISMATCH';
+    badge.title = `Client ${CLIENT_BUILD}; server ${serverVersion || 'unknown'}`;
+    badge.dataset.state = ok ? 'ok' : 'error';
+  }
+
+  async function ensureServerBuild() {
+    try {
+      const health = await api('api/health');
+      const serverVersion = String(health?.version || '');
+      const ok = serverVersion === CLIENT_BUILD;
+      setBuildBadgeState(serverVersion, ok);
+      if (!ok) {
+        const message = `Setup client/server version mismatch. Client ${CLIENT_BUILD}; server ${serverVersion || 'unknown'}. Refresh the page before making changes.`;
+        setAlert(message, 'error');
+        window.alert(message);
+      }
+      return ok;
+    } catch (error) {
+      setBuildBadgeState('unavailable', false);
+      setAlert(error.message || error, 'error');
+      window.alert(error.message || error);
+      return false;
+    }
+  }
+
   function syncButtonLabel(id, cleanLabel, dirtyLabel, dirty) {
     const button = document.getElementById(id);
     if (!button) return;
@@ -108,81 +173,36 @@
   }
 
   function syncDirtyIndicators() {
-    syncButtonLabel(
-      'save-reusable-task',
-      'Save Reusable Task',
-      'Save Reusable Task • Unsaved',
-      reusableDirty()
-    );
-    syncButtonLabel(
-      'save-annual-review',
-      'Save Annual Review',
-      'Save Annual Review • Unsaved',
-      annualDirty()
-    );
-  }
-
-  function reusablePayload() {
-    return {
-      task_name: el('edit-task-name').value.trim(),
-      stage_id: nullableInteger(el('edit-stage-id').value),
-      task_action_type: el('edit-action-type').value,
-      display_order: nullableInteger(el('edit-display-order').value) ?? 100,
-      active_flag: el('edit-active-flag').checked,
-      normal_crew_min: nullableInteger(el('edit-crew-min').value),
-      normal_crew_max: nullableInteger(el('edit-crew-max').value),
-      expected_duration_minutes: nullableInteger(el('edit-duration-minutes').value),
-      completion_point: el('edit-completion').value.trim(),
-      readiness_note: el('edit-readiness').value.trim(),
-      weather_note: el('edit-weather').value.trim(),
-      reusable_notes: el('edit-reusable-notes').value.trim()
-    };
+    syncButtonLabel('save-reusable-task', 'Save Reusable Task', 'Save Reusable Task • Unsaved', reusableDirty());
+    syncButtonLabel('save-annual-review', 'Save Annual Review', 'Save Annual Review • Unsaved', annualDirty());
   }
 
   function annualDraft() {
-    return snapshot(annualFieldIds);
+    return annualFormState();
   }
 
-  function restoreSnapshot(values) {
-    Object.entries(values || {}).forEach(([id, value]) => {
-      const node = document.getElementById(id);
-      if (!node) return;
-      if (node.type === 'checkbox') node.checked = Boolean(value);
-      else node.value = value == null ? '' : String(value);
-    });
+  function restoreAnnualDraft(values) {
+    if (!values) return;
+    el('edit-actual-crew').value = values.actual_crew_count ?? '';
+    el('edit-actual-duration').value = values.actual_duration_minutes ?? '';
+    el('edit-annual-notes').value = values.annual_notes ?? '';
     syncDirtyIndicators();
   }
 
-  function annualPayload(verificationOverride = null) {
-    const task = taskById(appState.selectedTaskId);
-    return {
-      verification_state: verificationOverride || task?.verification_state || 'UNVERIFIED',
-      actual_started_at: task?.actual_started_at || null,
-      actual_completed_at: task?.actual_completed_at || null,
-      actual_crew_count: nullableInteger(el('edit-actual-crew').value),
-      actual_duration_minutes: nullableInteger(el('edit-actual-duration').value),
-      annual_notes: el('edit-annual-notes').value.trim()
-    };
-  }
-
   async function persistReusableEdits({ announce = true, preserveAnnualDraft = true } = {}) {
-    const task = taskById(appState.selectedTaskId);
+    const task = selectedTask();
     if (!task || !appState.access?.can_manage_setup) return false;
+    if (!await ensureServerBuild()) return false;
 
     const preservedAnnual = preserveAnnualDraft ? annualDraft() : null;
     try {
       setBusy(true);
-      await api(
-        `api/setup/tasks/${task.setup_task_id}`,
-        commandOptions('PATCH', reusablePayload())
-      );
+      await api(`api/setup/tasks/${task.setup_task_id}`, commandOptions('PATCH', reusableFormState()));
       await reloadTasks(task.setup_task_id);
       if (preservedAnnual && Number(appState.selectedTaskId) === Number(task.setup_task_id)) {
-        restoreSnapshot(preservedAnnual);
+        restoreAnnualDraft(preservedAnnual);
       }
-      if (announce) {
-        setAlert(`Reusable task ${task.setup_task_id} saved to Production.`, 'ok');
-      }
+      if (announce) setAlert(`Reusable task ${task.setup_task_id} saved to Production.`, 'ok');
       return true;
     } catch (error) {
       setAlert(error.message || error, 'error');
@@ -195,24 +215,28 @@
   }
 
   async function persistAnnualReview(verificationOverride = null, { announce = true } = {}) {
-    const task = taskById(appState.selectedTaskId);
-    if (!task || task.setup_session_task_id == null || !appState.access?.can_manage_setup) {
-      return false;
-    }
+    const task = selectedTask();
+    if (!task || task.setup_session_task_id == null || !appState.access?.can_manage_setup) return false;
+    if (!await ensureServerBuild()) return false;
+
+    const annual = annualFormState();
+    const payload = {
+      verification_state: verificationOverride || task.verification_state || 'UNVERIFIED',
+      actual_started_at: task.actual_started_at || null,
+      actual_completed_at: task.actual_completed_at || null,
+      actual_crew_count: annual.actual_crew_count,
+      actual_duration_minutes: annual.actual_duration_minutes,
+      annual_notes: annual.annual_notes
+    };
 
     try {
       setBusy(true);
       await api(
         `api/setup/session-tasks/${task.setup_session_task_id}/review`,
-        commandOptions('PATCH', annualPayload(verificationOverride))
+        commandOptions('PATCH', payload)
       );
       await reloadTasks(task.setup_task_id);
-      if (announce) {
-        const state = verificationOverride
-          ? String(verificationOverride).replaceAll('_', ' ').toLocaleLowerCase()
-          : 'saved';
-        setAlert(`${appState.seasonYear} annual review ${state}.`, 'ok');
-      }
+      if (announce) setAlert(`${appState.seasonYear} annual review saved to Production.`, 'ok');
       return true;
     } catch (error) {
       setAlert(error.message || error, 'error');
@@ -221,74 +245,6 @@
     } finally {
       setBusy(false);
       syncDirtyIndicators();
-    }
-  }
-
-  async function saveDirtySurfaces() {
-    if (reusableDirty()) {
-      const reusableSaved = await persistReusableEdits({ announce: false, preserveAnnualDraft: true });
-      if (!reusableSaved) return false;
-    }
-
-    if (annualDirty()) {
-      const annualSaved = await persistAnnualReview(null, { announce: false });
-      if (!annualSaved) return false;
-    }
-
-    setAlert('Unsaved Setup task edits saved before continuing.', 'ok');
-    return true;
-  }
-
-  function discardCurrentDrafts() {
-    const taskId = appState.selectedTaskId;
-    if (taskId == null || !taskById(taskId)) {
-      baseline = null;
-      syncDirtyIndicators();
-      return;
-    }
-    selectTask(Number(taskId));
-  }
-
-  async function resolveDirtyBeforeNavigation(actionLabel) {
-    if (!anyDirty()) return true;
-
-    const saveFirst = window.confirm(
-      `You have unsaved ${dirtyDescription()} edits.\n\n`
-      + `Save them before ${actionLabel}?\n\n`
-      + 'OK = Save and continue\nCancel = choose whether to discard or stay here'
-    );
-
-    if (saveFirst) {
-      return saveDirtySurfaces();
-    }
-
-    const discard = window.confirm(
-      `Discard the unsaved ${dirtyDescription()} edits and ${actionLabel}?\n\n`
-      + 'OK = Discard and continue\nCancel = Stay on this task'
-    );
-    if (!discard) return false;
-
-    discardCurrentDrafts();
-    return true;
-  }
-
-  async function resolveDirtyBeforeDelete() {
-    if (!anyDirty()) return true;
-    const discard = window.confirm(
-      `This task has unsaved ${dirtyDescription()} edits.\n\n`
-      + 'Deleting the task cannot preserve those drafts. Discard them and continue to the delete confirmation?'
-    );
-    if (!discard) return false;
-    discardCurrentDrafts();
-    return true;
-  }
-
-  function replayClick(target) {
-    replayDepth += 1;
-    try {
-      target.click();
-    } finally {
-      replayDepth -= 1;
     }
   }
 
@@ -304,8 +260,59 @@
       const reusableSaved = await persistReusableEdits({ announce: false, preserveAnnualDraft: true });
       if (!reusableSaved) return;
     }
-
     await persistAnnualReview(overrides[buttonId]);
+  }
+
+  async function saveDirtySurfaces() {
+    if (reusableDirty()) {
+      const reusableSaved = await persistReusableEdits({ announce: false, preserveAnnualDraft: true });
+      if (!reusableSaved) return false;
+    }
+    if (annualDirty()) {
+      const annualSaved = await persistAnnualReview(null, { announce: false });
+      if (!annualSaved) return false;
+    }
+    setAlert('Unsaved Setup task edits saved before continuing.', 'ok');
+    return true;
+  }
+
+  function discardCurrentDrafts() {
+    const task = selectedTask();
+    if (task) selectTask(task.setup_task_id);
+  }
+
+  async function resolveDirtyBeforeNavigation(actionLabel) {
+    if (!anyDirty()) return true;
+    const saveFirst = window.confirm(
+      `You have unsaved ${dirtyDescription()} edits.\n\nSave them before ${actionLabel}?\n\nOK = Save and continue\nCancel = choose whether to discard or stay here`
+    );
+    if (saveFirst) return saveDirtySurfaces();
+
+    const discard = window.confirm(
+      `Discard the unsaved ${dirtyDescription()} edits and ${actionLabel}?\n\nOK = Discard and continue\nCancel = Stay on this task`
+    );
+    if (!discard) return false;
+    discardCurrentDrafts();
+    return true;
+  }
+
+  async function resolveDirtyBeforeDelete() {
+    if (!anyDirty()) return true;
+    const discard = window.confirm(
+      `This task has unsaved ${dirtyDescription()} edits.\n\nDeleting the task cannot preserve those drafts. Discard them and continue to the delete confirmation?`
+    );
+    if (!discard) return false;
+    discardCurrentDrafts();
+    return true;
+  }
+
+  function replayClick(target) {
+    replayDepth += 1;
+    try {
+      target.click();
+    } finally {
+      replayDepth -= 1;
+    }
   }
 
   function taskIdFromClickTarget(target) {
@@ -314,15 +321,15 @@
     return Number(row.dataset.taskId || 0) || null;
   }
 
-  function installSelectionBaselineWrapper() {
-    if (typeof selectTask !== 'function' || selectTask.__dirtyGuardWrapped) return;
+  function installSelectionRefreshWrapper() {
+    if (typeof selectTask !== 'function' || selectTask.__dirtyGuardV2Wrapped) return;
     const priorSelectTask = selectTask;
-    const wrapped = function selectTaskWithDirtyBaseline(taskId) {
+    const wrapped = function selectTaskWithDirtyRefresh(taskId) {
       const result = priorSelectTask(taskId);
-      captureBaseline(taskId);
+      syncDirtyIndicators();
       return result;
     };
-    wrapped.__dirtyGuardWrapped = true;
+    wrapped.__dirtyGuardV2Wrapped = true;
     selectTask = wrapped;
   }
 
@@ -331,7 +338,6 @@
       const id = event.target?.id;
       if (reusableFieldIds.has(id) || annualFieldIds.has(id)) syncDirtyIndicators();
     }, true);
-
     window.addEventListener('change', (event) => {
       const id = event.target?.id;
       if (reusableFieldIds.has(id) || annualFieldIds.has(id)) syncDirtyIndicators();
@@ -341,24 +347,17 @@
   function installSeasonGuard() {
     window.addEventListener('change', (event) => {
       if (replayDepth || event.target?.id !== 'season-select' || !anyDirty()) return;
-
       const select = event.target;
       const requestedYear = select.value;
       const currentYear = String(appState.seasonYear ?? '');
       event.preventDefault();
       event.stopImmediatePropagation();
       select.value = currentYear;
-
       void (async () => {
-        const proceed = await resolveDirtyBeforeNavigation('changing Setup seasons');
-        if (!proceed) {
-          select.value = currentYear;
-          return;
-        }
+        if (!await resolveDirtyBeforeNavigation('changing Setup seasons')) return;
         select.value = requestedYear;
-        baseline = null;
-        syncDirtyIndicators();
         await loadSeason(requestedYear);
+        syncDirtyIndicators();
       })();
     }, true);
   }
@@ -377,9 +376,7 @@
         return;
       }
 
-      const annualButton = target.closest(
-        '#save-annual-review, #mark-verified, #mark-correction, #mark-unverified'
-      );
+      const annualButton = target.closest('#save-annual-review, #mark-verified, #mark-correction, #mark-unverified');
       if (annualButton) {
         event.preventDefault();
         event.stopImmediatePropagation();
@@ -402,21 +399,14 @@
         event.preventDefault();
         event.stopImmediatePropagation();
         void (async () => {
-          if (await resolveDirtyBeforeNavigation('changing task prerequisites')) {
-            replayClick(dependencyAction);
-          }
+          if (await resolveDirtyBeforeNavigation('changing task prerequisites')) replayClick(dependencyAction);
         })();
         return;
       }
 
       const requestedTaskId = taskIdFromClickTarget(target);
-      if (
-        requestedTaskId != null
-        && Number(requestedTaskId) !== Number(appState.selectedTaskId)
-        && anyDirty()
-      ) {
-        const replayTarget = target.closest('#library-view .open-task')
-          || target.closest('#review-list .task-row');
+      if (requestedTaskId != null && requestedTaskId !== Number(appState.selectedTaskId) && anyDirty()) {
+        const replayTarget = target.closest('#library-view .open-task') || target.closest('#review-list .task-row');
         if (!replayTarget) return;
         event.preventDefault();
         event.stopImmediatePropagation();
@@ -431,9 +421,7 @@
         event.preventDefault();
         event.stopImmediatePropagation();
         void (async () => {
-          if (await resolveDirtyBeforeNavigation('returning to the Reusable Task Catalog')) {
-            replayClick(returnToCatalog);
-          }
+          if (await resolveDirtyBeforeNavigation('returning to the Reusable Task Catalog')) replayClick(returnToCatalog);
         })();
         return;
       }
@@ -457,17 +445,12 @@
     });
   }
 
-  function initializeDirtyGuard() {
-    if (installed) return;
-    installed = true;
-    installSelectionBaselineWrapper();
-    installInputTracking();
-    installSeasonGuard();
-    installClickGuard();
-    installUnloadGuard();
-    syncDirtyIndicators();
-  }
-
-  if (document.readyState === 'complete') initializeDirtyGuard();
-  else window.addEventListener('load', initializeDirtyGuard, { once: true });
+  installBuildBadge();
+  installSelectionRefreshWrapper();
+  installInputTracking();
+  installSeasonGuard();
+  installClickGuard();
+  installUnloadGuard();
+  syncDirtyIndicators();
+  void ensureServerBuild();
 })();

--- a/Setup/Application/test_setup_dirty_edit_browser_preview_contract.py
+++ b/Setup/Application/test_setup_dirty_edit_browser_preview_contract.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 APP_DIR = Path(__file__).resolve().parent
 ACCEPTANCE = APP_DIR.parent / "Acceptance"
-CANDIDATE_SHA = "7480fdae852ca7de70a8cdb65f1f26c7c6aaa40b"
+CANDIDATE_SHA = "9d0c31421ce7cbd1b1cbcf733b06198ace418e9d"
 CANDIDATE_REF = "agent/setup-dirty-edit-followup-154"
 
 

--- a/Setup/Application/test_setup_dirty_edit_browser_preview_contract.py
+++ b/Setup/Application/test_setup_dirty_edit_browser_preview_contract.py
@@ -3,8 +3,8 @@ from pathlib import Path
 
 APP_DIR = Path(__file__).resolve().parent
 ACCEPTANCE = APP_DIR.parent / "Acceptance"
-CANDIDATE_SHA = "89012d5e40a26323db78dce50d9e58dd27580169"
-CANDIDATE_REF = "agent/setup-catalog-dirty-edit-safety-154"
+CANDIDATE_SHA = "7480fdae852ca7de70a8cdb65f1f26c7c6aaa40b"
+CANDIDATE_REF = "agent/setup-dirty-edit-followup-154"
 
 
 def read_acceptance(name: str) -> str:
@@ -46,6 +46,8 @@ def test_dirty_edit_preview_runs_focused_contract_and_prints_manual_matrix() -> 
 
     assert "test_setup_dirty_edit_guard_contract.py" in launcher
     assert "test_setup_stage_order_contract.py" in launcher
+    assert "confirm the header visibly shows Client V0.3.7" in launcher
+    assert "do not write" in launcher
     assert "Mark Verified" in launcher
     assert "verification does NOT change" in launcher
     assert "Save + continue, Discard + continue, and Stay" in launcher

--- a/Setup/Application/test_setup_dirty_edit_guard_contract.py
+++ b/Setup/Application/test_setup_dirty_edit_guard_contract.py
@@ -29,7 +29,12 @@ def test_dirty_guard_compares_live_form_directly_to_selected_task():
     assert "function annualTaskState(task)" in js
     assert "!sameState(reusableFormState(), reusableTaskState(task))" in js
     assert "!sameState(annualFormState(), annualTaskState(task))" in js
-    assert "baseline" not in js
+
+    # Reject the old implementation mechanism, not an explanatory use of the
+    # English word "baseline" in comments.
+    assert "let baseline" not in js
+    assert "captureBaseline" not in js
+    assert "baselineMatchesSelection" not in js
 
 
 def test_dirty_guard_tracks_only_main_reusable_and_annual_save_surfaces():

--- a/Setup/Application/test_setup_dirty_edit_guard_contract.py
+++ b/Setup/Application/test_setup_dirty_edit_guard_contract.py
@@ -21,6 +21,17 @@ def test_dirty_guard_asset_is_loaded_last_and_protected():
     assert '"setup_catalog_dirty_guard.js"' in host
 
 
+def test_dirty_guard_compares_live_form_directly_to_selected_task():
+    js = guard_source()
+    assert "function reusableFormState()" in js
+    assert "function reusableTaskState(task)" in js
+    assert "function annualFormState()" in js
+    assert "function annualTaskState(task)" in js
+    assert "!sameState(reusableFormState(), reusableTaskState(task))" in js
+    assert "!sameState(annualFormState(), annualTaskState(task))" in js
+    assert "baseline" not in js
+
+
 def test_dirty_guard_tracks_only_main_reusable_and_annual_save_surfaces():
     js = guard_source()
     for field_id in (
@@ -42,15 +53,13 @@ def test_dirty_guard_tracks_only_main_reusable_and_annual_save_surfaces():
     ):
         assert field_id in js
 
-    # These have their own governed commands and must not be silently folded
-    # into Save Reusable Task merely to implement Issue #154.
     assert "edit-effort-level" not in js
     assert "edit-requires-display-material" not in js
     assert "setup-resource-select" not in js
     assert "setup-captain-person" not in js
 
 
-def test_mark_verified_saves_dirty_reusable_definition_before_annual_review():
+def test_mark_verified_saves_reusable_definition_before_annual_review():
     js = guard_source()
     assert "'mark-verified': 'VERIFIED'" in js
     assert "if (reusableDirty())" in js
@@ -61,11 +70,22 @@ def test_mark_verified_saves_dirty_reusable_definition_before_annual_review():
     assert "api/setup/session-tasks/${task.setup_session_task_id}/review" in js
 
 
-def test_reusable_save_preserves_pending_annual_fields_across_task_reload():
+def test_reusable_save_preserves_pending_annual_fields_across_reload():
     js = guard_source()
     assert "const preservedAnnual = preserveAnnualDraft ? annualDraft() : null;" in js
     assert "await reloadTasks(task.setup_task_id);" in js
-    assert "restoreSnapshot(preservedAnnual);" in js
+    assert "restoreAnnualDraft(preservedAnnual);" in js
+
+
+def test_client_build_is_visible_and_write_paths_fail_closed_on_mismatch():
+    js = guard_source()
+    assert "V0.3.7-catalog-dirty-edit-followup" in js
+    assert "setup-client-build-badge" in js
+    assert "window.msbSetupClientBuild = CLIENT_BUILD" in js
+    assert "async function ensureServerBuild()" in js
+    assert "serverVersion === CLIENT_BUILD" in js
+    assert "Refresh the page before making changes" in js
+    assert "if (!await ensureServerBuild()) return false;" in js
 
 
 def test_navigation_uses_explicit_save_discard_cancel_decision():
@@ -91,4 +111,4 @@ def test_existing_save_handlers_are_preempted_at_window_capture_boundary():
     assert "window.addEventListener('change'" in js
     assert "event.stopImmediatePropagation();" in js
     assert "replayDepth" in js
-    assert "installSelectionBaselineWrapper" in js
+    assert "installSelectionRefreshWrapper" in js

--- a/Setup/Application/test_setup_production_contract.py
+++ b/Setup/Application/test_setup_production_contract.py
@@ -75,12 +75,15 @@ def test_production_entry_point_serves_shared_ui_and_blocks_prototype_routes() -
     root = client.get("/")
     assert root.status_code == 200
     assert b"Shared Setup planning and verification" in root.data
+    assert root.headers["Cache-Control"] == "no-store, max-age=0"
+    assert root.headers["Pragma"] == "no-cache"
 
     health = client.get("/api/health")
     assert health.status_code == 200
     payload = health.get_json()
     assert payload["status"] == "ok"
-    assert payload["version"] == "V0.3.6-catalog-dirty-edit-safety"
+    assert payload["version"] == "V0.3.7-catalog-dirty-edit-followup"
+    assert health.headers["Cache-Control"] == "no-store, max-age=0"
 
     for asset in (
         "/setup.css",
@@ -103,7 +106,9 @@ def test_production_entry_point_serves_shared_ui_and_blocks_prototype_routes() -
         "/setup_session_year_guard.js",
         "/setup_catalog_dirty_guard.js",
     ):
-        assert client.get(asset).status_code == 200
+        response = client.get(asset)
+        assert response.status_code == 200
+        assert response.headers["Cache-Control"] == "no-store, max-age=0"
 
     for forbidden in (
         "/production.html",

--- a/Setup/Application/test_setup_stage_order_contract.py
+++ b/Setup/Application/test_setup_stage_order_contract.py
@@ -39,4 +39,4 @@ def test_production_loads_stage_order_assets() -> None:
     assert "setup_stage_order.js" in html
     assert "setup_stage_order.css" in backend
     assert "setup_stage_order.js" in backend
-    assert "V0.3.6-catalog-dirty-edit-safety" in backend
+    assert "V0.3.7-catalog-dirty-edit-followup" in backend


### PR DESCRIPTION
## Scope

Follow-up for Issue #154 after the V0.3.6 Production acceptance failed even though disposable-browser acceptance and live regression had passed.

## Production failure reproduced

On real Production task `setup_task_id=200` / annual task `81`, the operator entered reusable crew min `4`, crew max `6`, and completion text `Complete when panels are installed and leveld`, then clicked **Mark Verified**. The annual task became VERIFIED but the reusable edits disappeared after reload.

Production was immediately rolled back from `89012d5e40a26323db78dce50d9e58dd27580169` to the prior accepted `9791a6b5a9739c1107746ecbe3cf3ebb558f38bd`; V0.3.5 health returned PASS.

## V0.3.7 hardening

Exact browser/deployment candidate: `9d0c31421ce7cbd1b1cbcf733b06198ace418e9d`.

- dirty detection compares the live reusable/annual form directly against the selected server-backed task every time; it no longer depends on a captured baseline;
- annual verification saves reusable edits first and aborts the annual write if that save fails;
- pending annual drafts are preserved across a reusable-task save/reload;
- task/season/tab/prerequisite navigation remains Save / Discard / Stay guarded;
- the browser header visibly shows **Client V0.3.7** when the new guard is loaded;
- governed writes verify `/api/health` reports the matching V0.3.7 server build and fail closed on a client/server mismatch;
- Production HTML/assets/health return `Cache-Control: no-store, max-age=0` so refreshed pages cannot quietly reuse an old Setup bundle.

## Acceptance harness correction

The first two V0.3.7 preview attempts failed before browser startup because the launcher was still pinned to the earlier application SHA `7480fdae...`; that exact checkout still contained the superseded broad `assert "baseline" not in js` regression assertion. Production and the live Setup checkout remained unchanged during both failed attempts.

The preview is now pinned to `9d0c3142...`, which contains both the V0.3.7 application and the corrected regression contract. Later commits only update the launcher pointer/self-check and are intentionally not part of the pinned runtime candidate.

## Acceptance rule

Before any preview or Production write, the operator must visibly confirm **Client V0.3.7** in the header. If it is absent, stop and refresh rather than testing with a stale tab.

## Boundaries

No schema migration. No Plan/Schedule redesign. No changes to Effort, Material, resource, or Captain command ownership. Production remains rolled back on accepted V0.3.5 until this follow-up passes disposable browser review and a new gated deployment.