### PR TITLE
Document Setup SourceDocs Google Doc migration

### DIFF
--- a/Docs/00_Project_Overview/Google_Drive/operatorSOP/Align_Legacy_Setup_Documents.md
+++ b/Docs/00_Project_Overview/Google_Drive/operatorSOP/Align_Legacy_Setup_Documents.md
@@ -8,8 +8,8 @@
 | Audience | Production documentation maintainers and Folder Alignment reviewers |
 | Status | CURRENT |
 | Owner | Production documentation owner / administrator |
-| Last Reviewed | 2026-08-24 |
-| Keywords | legacy Setup, Google Drive, Archive, Folder Alignment, Stage, Scene |
+| Last Reviewed | 2026-09-10 |
+| Keywords | legacy Setup, Google Drive, Archive, SourceDocs, Folder Alignment, Stage, Scene |
 
 [↑ Google Drive / Display Folder Operations](../README.md)
 
@@ -18,6 +18,8 @@
 Use this procedure when reviewing an older Setup document from the central legacy Setup collection and assigning it to the correct current Stage, Sub-stage, or Scene.
 
 This task records **where the old document belongs**. It does not make the old document the current field instruction.
+
+During the 2026 migration, the reviewed legacy document is preserved in `Archive`. If it is still useful as the basis for current editing, a new Google-native working copy is then created in `SourceDocs` using Google Docs **File → Make a copy**. The archived original remains historical and is not the file edited going forward.
 
 ## Before You Start
 
@@ -48,6 +50,8 @@ Example:
 
 Putting the old document in `Archive` records the reviewed ownership while keeping it out of the current field instructions.
 
+`Archive` remains the location of the historical original. Do not later move that same original into `SourceDocs` and do not edit it after a new SourceDocs copy has been created.
+
 ## Procedure
 
 1. Open the current Folder Alignment worklist.
@@ -62,6 +66,7 @@ Putting the old document in `Archive` records the reviewed ownership while keepi
 10. If the old filename contains an obsolete Stage number, correct the filename only when the correct current Stage number is known.
 11. Leave uncertain documents in the central legacy source and flag them for review.
 12. Re-run Folder Alignment when you want the worklist to show the updated migration progress.
+13. If the archived Google Doc is still useful for current editing, continue with the SourceDocs migration workflow in [Publish a Current Setup Instruction](Publish_Current_Setup_Instruction.md): open the archived document in Google Docs, use **File → Make a copy**, and save the new Google-native working copy in `Procedures\Setup\SourceDocs`.
 
 ## Stage Number Example
 
@@ -85,6 +90,8 @@ Do not:
 
 - move a legacy document based only on a fuzzy filename match;
 - place an old `.gdoc` directly in `Procedures\Setup` and treat it as current;
+- copy/paste an archived `.gdoc` shortcut file into `SourceDocs` and treat that as a migrated Google Doc;
+- edit the archived original after a new SourceDocs copy has been created;
 - delete the old source after moving it to `Archive`;
 - duplicate one shared Stage/Scene instruction under every Display;
 - reorganize unrelated loose files while doing this task; or
@@ -97,7 +104,9 @@ A reviewed legacy Setup document is either:
 - safely moved into the correct Stage/Sub-stage/Scene `Procedures\Setup\Archive` folder; or
 - left in the legacy source and clearly identified as still needing review.
 
-The archived document is historical/source evidence, not current field authority.
+When a reviewed archived document is carried forward for current editing, a separate Google-native copy is created in `Procedures\Setup\SourceDocs` and all subsequent edits occur there.
+
+The archived document remains historical/source evidence, not current editable or field authority.
 
 ## Next Step
 
@@ -105,11 +114,14 @@ When the archived procedure contains information that is still useful for curren
 
 - [Publish a Current Setup Instruction](Publish_Current_Setup_Instruction.md)
 
+That procedure contains the required Google Docs **File → Make a copy** migration into `SourceDocs`, along with publication of the current field PDF.
+
 ## If Something Is Wrong
 
 - **Two Stages seem plausible:** do not move the file; flag it for review.
 - **The expected Stage/Scene folder does not exist:** do not create a folder just to receive the legacy document. Review Folder Alignment first.
 - **The correct destination exists but lacks the standard Procedure structure:** repair the Stage/Scene structure before publishing current material.
+- **A `.gdoc` was copied into SourceDocs using Explorer:** do not treat that as the migrated editable source. Open the archived document in Google Docs and use **File → Make a copy** into `SourceDocs`.
 
 ## Related Engineering
 

--- a/Docs/00_Project_Overview/Google_Drive/operatorSOP/Publish_Current_Setup_Instruction.md
+++ b/Docs/00_Project_Overview/Google_Drive/operatorSOP/Publish_Current_Setup_Instruction.md
@@ -8,7 +8,7 @@
 | Audience | Production documentation maintainers and Setup-document contributors |
 | Status | CURRENT |
 | Owner | Production documentation owner / administrator |
-| Last Reviewed | 2026-08-23 |
+| Last Reviewed | 2026-09-10 |
 | Keywords | Setup, publish PDF, Procedures, Google Drive, Stage Setup, SourceDocs, Archive |
 
 [↑ Google Drive / Display Folder Operations](../README.md)
@@ -18,6 +18,8 @@
 Use this procedure after a Setup instruction has been reviewed and is ready for field use.
 
 The current field document must be placed where the **Procedures** system expects current Setup material. Working files and older source material stay separate.
+
+During the 2026 migration, legacy Google-native Setup documents are being moved from historical `Archive` use into a new authoritative editable copy in `SourceDocs`. The archived original remains historical evidence; the `SourceDocs` copy becomes the file that is edited going forward.
 
 ## Before You Start
 
@@ -35,7 +37,7 @@ Current published Setup document:
 <Stage, Sub-stage, or Scene>\Procedures\Setup\<current instruction>.pdf
 ```
 
-Editable working/source files:
+Authoritative editable working/source file after migration:
 
 ```text
 <Stage, Sub-stage, or Scene>\Procedures\Setup\SourceDocs\
@@ -64,37 +66,54 @@ Historical or superseded material:
         ├── images\
         │   └── Front-Arch-Anchor-Detail.jpg
         ├── SourceDocs\
-        │   └── Front Entrance Setup.docx
+        │   └── Front Entrance Setup.gdoc
         └── Front Entrance Setup.pdf
 ```
 
 The PDF directly in `Procedures\Setup` is the current field instruction.
 
-The document in `SourceDocs` is editable working material and should not be expected to appear as the current field instruction.
+The Google-native document in `SourceDocs` is the authoritative editable working copy after migration and should not be expected to appear as the current field instruction.
 
-The document in `Archive` is historical/superseded material and should not be expected to appear as current.
+The document in `Archive` is the historical/original source and should not be edited after a SourceDocs copy has been created.
+
+## Migrating a Legacy Google Doc into SourceDocs
+
+When the only editable Setup procedure is a legacy `.gdoc` in `Procedures\Setup\Archive`, do **not** migrate it by copying or moving the `.gdoc` shortcut file in Windows Explorer. A `.gdoc` file is only a Google Drive shortcut/metadata file; copying it does not create the new Google-native document that is required for the new editable source.
+
+Use this workflow instead:
+
+1. Open the archived `.gdoc` in Google Docs.
+2. In Google Docs, choose **File → Make a copy**.
+3. Save the new Google-native copy into the same Stage/Sub-stage/Scene `Procedures\Setup\SourceDocs` folder.
+4. Give the new copy the intended current working filename if a rename is needed.
+5. Leave the archived original in `Archive` as historical evidence.
+6. From that point forward, make all edits in the `SourceDocs` copy only.
+7. When the edited procedure is approved for field use, publish/export the approved PDF directly into `Procedures\Setup`.
+
+The Setup Manager application follows the same migration rule: it prefers an editable Google-native source in `SourceDocs`; only when no editable SourceDocs `.gdoc` exists does it fall back to the legacy `Archive` source.
 
 ## Procedure
 
 1. Open the correct Stage, Sub-stage, or Scene folder.
 2. Open `Procedures\Setup`.
 3. Confirm the `Procedures` root has the required MSB marker file.
-4. Keep editable working/source files in `Setup\SourceDocs`.
-5. Keep Setup-specific instruction images in `Setup\images`.
-6. Keep older/superseded source material in `Setup\Archive`.
-7. Place the approved current field PDF directly in `Procedures\Setup`.
-8. Remove or archive any superseded current PDF that would otherwise look like another current instruction, unless more than one current Setup instruction is intentionally required for that scope.
-9. Open the **Procedures** system:
+4. If the current editable source exists only in `Setup\Archive`, use the **Migrating a Legacy Google Doc into SourceDocs** procedure above before editing.
+5. Keep the authoritative editable working/source file in `Setup\SourceDocs`.
+6. Keep Setup-specific instruction images in `Setup\images`.
+7. Keep older/superseded source material in `Setup\Archive`.
+8. Place the approved current field PDF directly in `Procedures\Setup`.
+9. Remove or archive any superseded current PDF that would otherwise look like another current instruction, unless more than one current Setup instruction is intentionally required for that scope.
+10. Open the **Procedures** system:
 
 ```text
 https://my.sheboyganlights.org/procedures/
 ```
 
-10. Search/browse to the intended Stage/Scene.
-11. Select **Setup**.
-12. Confirm the newly published PDF appears.
-13. Open it and verify the correct current document is displayed.
-14. Confirm no archived/source file appears as a current instruction.
+11. Search/browse to the intended Stage/Scene.
+12. Select **Setup**.
+13. Confirm the newly published PDF appears.
+14. Open it and verify the correct current document is displayed.
+15. Confirm no archived/source file appears as a current instruction.
 
 ## More Than One Current Setup Instruction
 
@@ -106,6 +125,8 @@ Do not leave old versions beside the current one merely because deleting or arch
 
 ## Important Warnings
 
+- **Do not edit the archived Google Doc after a SourceDocs copy exists.** `SourceDocs` is the authoritative editable location after migration.
+- **Do not migrate a `.gdoc` by Explorer copy/paste.** Open it in Google Docs and use **File → Make a copy** so a new Google-native document is created in `SourceDocs`.
 - **Do not put the current PDF in `Archive`.** It will not be treated as the current field instruction.
 - **Do not put the current PDF in `SourceDocs`.** That folder is for working/source material.
 - **Do not put Setup instruction images in the general Stage `Photos` folder.** Use `Procedures\Setup\images`.
@@ -113,12 +134,13 @@ Do not leave old versions beside the current one merely because deleting or arch
 
 ## Expected Result
 
-The approved current Setup PDF is directly in the correct Stage/Sub-stage/Scene `Procedures\Setup` folder and appears in the Procedures system for that same scope.
+The authoritative editable Setup source is in `Procedures\Setup\SourceDocs`, the historical original remains in `Procedures\Setup\Archive`, and the approved current field PDF is directly in the correct Stage/Sub-stage/Scene `Procedures\Setup` folder and appears in the Procedures system for that same scope.
 
-Source, image, and historical material remain separated into their correct support folders.
+Source, image, historical material, and the published field document remain separated into their correct locations.
 
 ## If Something Is Wrong
 
+- **Setup Manager still opens the Archive source:** verify that the new document was actually created as a Google-native document in `Procedures\Setup\SourceDocs`, not merely copied as a `.gdoc` shortcut file.
 - **PDF does not appear in Procedures:** first verify it is directly in `Procedures\Setup`, not `SourceDocs` or `Archive`; then verify the required root and `Procedures` markers.
 - **Wrong Stage/Scene appears:** do not move folders by guesswork. Review Folder Alignment and ownership first.
 - **An old PDF also appears as current:** move the superseded copy to `Archive` after confirming it is no longer current.


### PR DESCRIPTION
Closes #161.

Documents the already-implemented SourceDocs-first / Archive-fallback Setup editable-source behavior and the required Google-native migration workflow:

- preserve the legacy original in `Procedures\Setup\Archive`;
- open the archived `.gdoc` in Google Docs;
- use **File → Make a copy**;
- save the new Google-native document into `Procedures\Setup\SourceDocs`;
- edit only the SourceDocs copy going forward;
- continue publishing the approved field PDF directly in `Procedures\Setup`.

Also makes explicit that copying the `.gdoc` shortcut file in Windows Explorer is not the migration method.

Docs only; no application/runtime/schema changes.