### PR TITLE
Close out Setup V0.3.8 engineering documentation

### DIFF
--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/README.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/README.md
@@ -5,7 +5,7 @@
 | Document Type | Engineering Handoff Portal |
 | System | Production Database — Setup and Deployment |
 | Audience | Greg, maintainers, database administrators, future engineering sessions |
-| Status | CURRENT HANDOFF — Stage/Scene material and presentation accepted in Production; broader Setup work remains active |
+| Status | CURRENT HANDOFF — V0.3.8 accepted in Production; broader Setup work remains active |
 | Owner | MSB Production Database engineering |
 | Last Reviewed | 2026-09-11 |
 
@@ -21,23 +21,24 @@ Protected application:
 https://my.sheboyganlights.org/setup/
 ```
 
-Current accepted application/database target:
+Current exact accepted/deployed application target:
 
 ```text
-9791a6b5a9739c1107746ecbe3cf3ebb558f38bd
+2eee967b6c5359c0e2e2d876a2fe44af8359315c
 ```
 
-Repository normalization merge:
+Implementation repository lineage:
 
 ```text
-PR #144
-main merge commit = 96613aae4e5084dab2f735bc3dbcc8e13433109e
+Issue #153
+PR #160
+main merge commit = d882bb33785321de9a6a880347521adf9518502e
 ```
 
 Current Setup health:
 
 ```text
-V0.3.5-stage-scene-material-review
+V0.3.8-task-detail-compact
 ```
 
 Current annual context:
@@ -49,27 +50,46 @@ Current annual context:
 
 The current PostgreSQL reusable Catalog is the working task baseline. Do not use older fixed counts such as 57 or the earlier 185-task reconstruction snapshot as current authority; live Catalog cleanup and task development continued after those dated baselines.
 
-Production acceptance on 2026-09-11 proved:
+V0.3.8 source-only Production acceptance on 2026-09-11 proved:
 
 ```text
-exact candidate Setup/Application regression = 154 passed
-migration 025                                = applied / least-privilege PASS
-protected direct no-identity path            = HTTP 401 PASS
-Production business fingerprint              = 798e59ae47a5e313d45cd23e9fdc3c4a
-business fingerprint changed by deployment   = NO
+exact detached candidate regression          = 53 passed
+live deployed focused regression              = 53 passed
+Production fingerprint before deployment      = 9510360aa7de2da59d1ed8a9ad9d69f7
+Production fingerprint after deployment       = 9510360aa7de2da59d1ed8a9ad9d69f7
+business/source fingerprint changed by deploy = NO
+protected health                              = V0.3.8-task-detail-compact
+final protected laptop browser acceptance     = PASS
 ```
 
-Rollback archive:
+V0.3.8 did not apply a database migration or change Setup authorization. The accepted Stage/Scene material database baseline from V0.3.5 remains in force.
+
+The immediately prior accepted runtime was:
 
 ```text
-/home/msbadmin/backups/setup-stage-scene-material/msb_pre_setup_stage_scene_material_20260911T000157.dump
+9d0c31421ce7cbd1b1cbcf733b06198ace418e9d
+V0.3.7-catalog-dirty-edit-followup
 ```
 
-Deployment report:
+V0.3.7 fixed the dirty reusable-edit / `Mark Verified` data-loss path after the first V0.3.6 Production candidate failed real protected-route acceptance and was rolled back. V0.3.8 preserves those dirty-edit, client-build badge, cache, and client/server build-match protections.
+
+See the current [Setup Session Production Engineering Handoff — 2026-09-11](Setup_Session_Production_Engineering_Handoff_2026-09-11.md) and [V0.3.8 Production Acceptance](../../../../../Setup/Acceptance/Setup_Task_Detail_Production_Acceptance_2026-09-11.md).
+
+## Current Accepted Task-Detail Presentation
+
+At laptop/desktop width the accepted task-detail layout is:
 
 ```text
-/home/msbadmin/setup-acceptance-reports/Setup_Stage_Scene_Production_Deployment_20260911T000157.txt
+LEFT                               RIGHT
+Reusable Task Definition            Annual Historical Actual
+Material / Logistics                Captains / Knowledge Owners
 ```
+
+The reusable definition itself uses a compact two-column desktop grid. Material / Logistics retains all four essential counts and the existing full detail dialog. Prerequisites and Equipment / Resources remain below the rail block and are reachable with materially less scrolling.
+
+Physical mobile-device acceptance was not performed for V0.3.8; responsive stacking is contract-covered and was checked using a narrowed desktop browser proxy only.
+
+Cross-application palette and dark-mode white-logo consistency remain separate work in Issue #159.
 
 ## Current Accepted Material Model
 
@@ -136,7 +156,7 @@ See [Setup Stage / Scene Material Resolution Contract — 2026-09-10](Setup_Stag
 
 ## Current Accepted Planning / Execution Presentation
 
-**Plan / Schedule** and **Perform Work** now support Stage-oriented presentation:
+**Plan / Schedule** and **Perform Work** support Stage-oriented presentation:
 
 ```text
 Stage
@@ -148,23 +168,40 @@ Stage view is presentation only; it does not rewrite annual planned order.
 
 Switching to **Planned order** returns to the existing annual planning sequence/reorder behavior.
 
-The shared **Find task or Stage** search now applies to:
+The shared **Find task or Stage** search applies to:
 
 - Reusable Task Catalog;
 - Plan / Schedule; and
 - Perform Work.
 
+## Current Editable Procedure Source Rule
+
+Authorized Manager editable-source resolution is:
+
+```text
+Procedures\Setup\SourceDocs first
+-> Procedures\Setup\Archive only if no editable SourceDocs .gdoc exists
+```
+
+During the 2026 migration, the archived Google Doc remains the historical original. Open it in Google Docs, use **File -> Make a copy**, save the new Google-native working copy into `SourceDocs`, and edit only the SourceDocs copy going forward. Do not treat copying the Windows `.gdoc` shortcut file as document migration.
+
+The approved field PDF remains directly in `Procedures\Setup`.
+
+This workflow is controlled in the Google Drive operator SOPs and was closed through Issue #161 / PR #162.
+
 ## Start Here
 
+- [Setup Session Production Engineering Handoff — 2026-09-11](Setup_Session_Production_Engineering_Handoff_2026-09-11.md) — current deployed SHA/version, recent V0.3.6/V0.3.7/V0.3.8 lineage, fingerprint evidence, current boundaries, and resume point.
+- [Setup V0.3.8 Task Detail Production Acceptance — 2026-09-11](../../../../../Setup/Acceptance/Setup_Task_Detail_Production_Acceptance_2026-09-11.md) — exact source-only deployment, regression, fingerprint, protected-route, and browser evidence.
 - [Setup Stage / Scene Material Resolution Contract — 2026-09-10](Setup_Stage_Scene_Material_Resolution_Contract_2026-09-10.md) — current accepted material/source-classification authority.
-- [Setup Stage / Scene Production Acceptance — 2026-09-11](../../../../../Setup/Acceptance/Setup_Stage_Scene_Production_Acceptance_2026-09-11.md) — exact Production deployment, browser review, rollback, regression, and fingerprint evidence.
+- [Setup Stage / Scene Production Acceptance — 2026-09-11](../../../../../Setup/Acceptance/Setup_Stage_Scene_Production_Acceptance_2026-09-11.md) — V0.3.5 material/presentation database migration and acceptance history.
 - [Setup Data Consumption and Authorization Contract — 2026-09-10](Setup_Data_Consumption_and_Authorization_Contract_2026-09-10.md) — Setup capability, Person mapping, application-role, governed write, and grant boundaries.
 - [Setup Predecessor and Readiness Contract — 2026-09-09](Setup_Predecessor_and_Readiness_Contract_2026-09-09.md) — hard predecessor vs preferred order vs external/site readiness.
 - [Setup Reconstruction Migration and Acceptance History — 2026-09-07 to 09](Setup_Reconstruction_Migration_and_Acceptance_History_2026-09-07_to_09.md) — historical migration/disposable/browser lessons and reconstruction findings.
 - [Setup Planning Operating Model — 2026-09-08](Setup_Planning_Operating_Model_2026-09-08.md) — rolling-horizon planning direction.
 - [Setup Planning Candidate Work View — 2026-09-09](Setup_Planning_Candidate_Work_View_2026-09-09.md) — cross-Stage candidate planning direction.
 - [Setup Pick List Tablet Workflow — 2026-09-09](Setup_Pick_List_Tablet_Workflow_2026-09-09.md) — Pick List direction; not yet Production-operational.
-- [Setup Session Production Engineering Handoff — 2026-09-07](Setup_Session_Production_Engineering_Handoff_2026-09-07.md) — original foundation/runtime baseline; historical for current deployment SHA/version.
+- [Setup Session Production Engineering Handoff — 2026-09-07](Setup_Session_Production_Engineering_Handoff_2026-09-07.md) — historical V0.3.4 foundation/runtime baseline; not current deployment authority.
 
 ## Authoritative Implementation Sources
 
@@ -192,14 +229,23 @@ The Production Database repository owns Setup application/business/database beha
 
 ## Current Repository / Issue Structure
 
-The accepted Stage/Scene material/presentation implementation is merged through PR #144.
+Recent completed acceptance:
 
-Primary active work now is issue-driven rather than continuing the old nested PR stack:
+```text
+#154  dirty-edit / Mark Verified safety             CLOSED / V0.3.7 accepted
+#153  compact task-detail / Material layout         CLOSED / V0.3.8 accepted
+#161  Archive -> SourceDocs Google Doc documentation CLOSED / completed
+```
+
+Primary active work remains issue-driven:
 
 ```text
 #122  Setup Session engineering / planning / Pick List / live reconstruction umbrella
-#141  task-specific staged material subdivision and Pick List release timing
 #145  reusable Catalog cleanup gate before creating the 2026 Setup Session
+#151  Shift+left-drag predecessor creation
+#152  resource catalog sort order / existing-resource editing
+#159  shared light/dark palette and dark-mode white-logo consistency
+#141  task-specific staged material subdivision and Pick List release timing
 #130  global People / Capability / Qualification work consumed by Setup
 #132  Captain work-report duration / multi-day effort capture
 #113  shared Scan application readiness / identity capture integration
@@ -327,25 +373,28 @@ Current significant remaining work includes:
 - authoritative Controller context from FieldWiring / Controller Inventory;
 - Pick List generation and tablet workflow;
 - mixed-stage Container annual mobilization/unload-group state and ordered-access rules;
-- Container/Display movement/scanning writes; and
-- park-location execution evidence.
+- Container/Display movement/scanning writes;
+- park-location execution evidence; and
+- cross-app palette/dark-mode logo normalization (Issue #159).
 
 ## Resume Development
 
 Before changing this subsystem:
 
 1. read the Production Database Project Rules;
-2. read this engineering portal;
-3. read the Stage/Scene material-resolution contract before changing material or Scene classification;
-4. review Issue #141 before designing task-specific material groups, components/KITs, or Pick List release timing;
-5. review Issue #145 before creating or simulating 2026 annual state;
-6. preserve annual 2025 facts separately from reusable future knowledge;
-7. use the predecessor/readiness contract before rebuilding dependencies;
-8. use the Pick List contract before implementing logistics/pick behavior;
-9. use issue #130 / People and Identity for global capability/qualification work;
-10. use issue #113 / Labeling and Scanning for shared scan capture/resolution behavior;
-11. use `Gregovate/MSB-Server-Management` for current runtime/deployment authority; and
-12. update controlled docs and this README handoff whenever accepted behavior or the next resume point changes.
+2. read the current [2026-09-11 Production engineering handoff](Setup_Session_Production_Engineering_Handoff_2026-09-11.md);
+3. read this engineering portal;
+4. read the Stage/Scene material-resolution contract before changing material or Scene classification;
+5. review Issue #141 before designing task-specific material groups, components/KITs, or Pick List release timing;
+6. review Issue #145 before creating or simulating real 2026 annual state;
+7. preserve annual 2025 facts separately from reusable future knowledge;
+8. preserve the V0.3.7 dirty-edit/client-build protections and V0.3.8 visible client version marker;
+9. use the predecessor/readiness contract before rebuilding dependencies;
+10. use the Pick List contract before implementing logistics/pick behavior;
+11. use issue #130 / People and Identity for global capability/qualification work;
+12. use issue #113 / Labeling and Scanning for shared scan capture/resolution behavior;
+13. use `Gregovate/MSB-Server-Management` for current runtime/deployment authority; and
+14. update controlled docs, acceptance evidence, and this README handoff whenever accepted behavior or the next resume point changes.
 
 ## Related Systems
 

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Session_Production_Engineering_Handoff_2026-09-11.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Session_Production_Engineering_Handoff_2026-09-11.md
@@ -1,0 +1,306 @@
+# Setup Session Production Engineering Handoff — 2026-09-11
+
+| Document Control | Value |
+|---|---|
+| Document Type | Engineering Handoff |
+| System | Production Database — Setup Session |
+| Status | CURRENT HANDOFF — V0.3.8 accepted in Production; broader Setup development remains active |
+| Owner | MSB Production Database engineering |
+| Last Reviewed | 2026-09-11 |
+
+## Purpose
+
+Preserve the current accepted Setup Session Production state, recent runtime lineage, data/authorization boundaries, exact deployed source, fingerprint evidence, procedure-source behavior, open work, and engineering resume point so future work starts from repository evidence rather than reconstructing recent acceptance from chat or issue comments.
+
+This handoff supersedes the 2026-09-07 handoff as the **current** runtime/resume summary. The 2026-09-07 document remains historical foundation evidence for the original V0.3.4 Production promotion.
+
+## Current Production Runtime
+
+Protected application:
+
+```text
+https://my.sheboyganlights.org/setup/
+```
+
+Current accepted application version:
+
+```text
+V0.3.8-task-detail-compact
+```
+
+Exact deployed application source:
+
+```text
+/opt/msb-setup
+SHA = 2eee967b6c5359c0e2e2d876a2fe44af8359315c
+```
+
+Implementation lineage:
+
+```text
+Issue #153
+PR #160
+merge commit = d882bb33785321de9a6a880347521adf9518502e
+```
+
+The runtime intentionally remains pinned to the exact browser-accepted candidate rather than silently moving to the later repository merge/documentation commit.
+
+Current accepted service/runtime facts remain:
+
+```text
+msb-setup.service                   = active / enabled
+listener                            = 192.168.5.9:8794
+msb-setup-google-links.service      = active / enabled
+Display Folders mount               = /mnt/msb-display-folders (read-only)
+Google native link view             = /mnt/msb-setup-google-links
+protected route                     = https://my.sheboyganlights.org/setup/
+```
+
+Server/runtime authority remains `Gregovate/MSB-Server-Management`.
+
+## Current Annual / Catalog Boundary
+
+The current annual context remains:
+
+```text
+2025 Setup Session  = HISTORICAL_VERIFICATION
+2026 Setup Sessions = 0
+```
+
+Do not use older fixed reusable-task counts such as 57 or 185 as current authority. The reusable Catalog has legitimately changed during reconstruction and live review.
+
+The active reusable Catalog is the future-work baseline. A reusable task may legitimately exist without a 2025 annual row. New annual Session creation seeds every active reusable task, so Issue #145 remains the hard cleanup gate before creating 2026.
+
+Do not force newer reusable tasks into the 2025 historical Session merely to make the historical Plan appear complete.
+
+## Current V0.3.8 Task-Detail Presentation
+
+Accepted laptop/desktop task-detail layout:
+
+```text
+LEFT                               RIGHT
+Reusable Task Definition            Annual Historical Actual
+Material / Logistics                Captains / Knowledge Owners
+```
+
+The reusable definition itself uses a compact two-column desktop grid. Material / Logistics retains the four essential counts plus the existing full detail dialog. Prerequisites and Equipment / Resources remain below the rail block and are reachable with materially less scrolling.
+
+No schema, API, authorization, or Plan / Schedule behavior changed solely for V0.3.8.
+
+Physical mobile-device acceptance was not performed. Responsive stacking is contract-covered and was checked using a narrowed desktop browser only.
+
+Issue #159 separately owns cross-application palette and dark-mode white-logo consistency. The blue Setup logo in dark mode is a known current presentation inconsistency and is not an accepted V0.3.8 theme standard.
+
+## Recent Runtime / Safety Lineage
+
+### V0.3.5 — accepted Stage/Scene material baseline
+
+```text
+SHA     = 9791a6b5a9739c1107746ecbe3cf3ebb558f38bd
+version = V0.3.5-stage-scene-material-review
+```
+
+This release established the current Stage/real-Scene material-resolution and Stage-oriented presentation baseline and applied migration 025.
+
+### V0.3.6 — failed protected Production acceptance and rollback
+
+The first dirty-edit safety implementation reached Production as:
+
+```text
+SHA     = 89012d5e40a26323db78dce50d9e58dd27580169
+version = V0.3.6-catalog-dirty-edit-safety
+```
+
+Real protected-route validation reproduced the unsafe behavior: `Mark Verified` committed annual VERIFIED state while unsaved reusable crew/completion edits disappeared after reload.
+
+The source-only deployment was rolled back to the prior accepted V0.3.5 application. No database dump restore was used because the operator acceptance itself legitimately wrote annual-review state.
+
+This failure is durable evidence that disposable browser acceptance alone is not sufficient for this class of client/runtime interaction; real protected-route acceptance remains mandatory.
+
+### V0.3.7 — accepted dirty-edit / version safety
+
+Accepted exact candidate:
+
+```text
+SHA     = 9d0c31421ce7cbd1b1cbcf733b06198ace418e9d
+version = V0.3.7-catalog-dirty-edit-followup
+```
+
+Accepted protections include:
+
+- live-form vs selected-task dirty comparison;
+- reusable save before annual verification, with verification blocked if save fails;
+- Save / Discard / Stay protection for dirty navigation;
+- visible `Client V0.3.7` client-build badge;
+- governed-write client/server build-match validation;
+- `no-store` protection for Setup page/assets/health so a stale client bundle cannot quietly continue writing; and
+- independent Effort / Material / Resource / Captain save surfaces remain separately governed.
+
+V0.3.7 Production deployment evidence:
+
+```text
+focused live regression = 45 passed
+pre/post source-deployment fingerprint = 0298e2b1c3531e13b1a0a86d4e55509d
+protected health = V0.3.7-catalog-dirty-edit-followup
+```
+
+Real operator validation on reusable task 200 / annual task 81 confirmed crew min/max 4/6 and completion point survived `Mark Verified` without a separate manual reusable save, and annual state became VERIFIED.
+
+### V0.3.8 — current accepted runtime
+
+Accepted exact candidate:
+
+```text
+SHA     = 2eee967b6c5359c0e2e2d876a2fe44af8359315c
+version = V0.3.8-task-detail-compact
+```
+
+V0.3.8 preserves the V0.3.7 dirty-edit/build-match protections and changes the task-detail presentation only.
+
+Production source-only deployment evidence:
+
+```text
+exact detached preflight regression = 53 passed
+live focused regression              = 53 passed
+fingerprint before deployment        = 9510360aa7de2da59d1ed8a9ad9d69f7
+fingerprint after deployment         = 9510360aa7de2da59d1ed8a9ad9d69f7
+protected health                     = V0.3.8-task-detail-compact
+final protected browser acceptance   = PASS
+```
+
+Final browser acceptance required no special Production data write.
+
+See [`Setup_Task_Detail_Production_Acceptance_2026-09-11.md`](../../../../../Setup/Acceptance/Setup_Task_Detail_Production_Acceptance_2026-09-11.md).
+
+## Data / Authorization Boundary
+
+Cloudflare authentication, Setup capability, Person identity mapping, and PostgreSQL grants remain separate layers:
+
+```text
+Cloudflare Access authenticated email
+  -> Setup backend capability lookup
+  -> Directus / ref.person identity
+  -> narrow PostgreSQL SECURITY DEFINER command
+```
+
+Do not grant broad direct Setup table DML to solve operator identity or capability problems.
+
+The characteristic error:
+
+```text
+Authenticated Setup operator is not mapped to an MSB person
+```
+
+is an identity-link / Person mapping problem, not evidence that the browser needs broader database permissions.
+
+## Procedure / Editable Source Boundary
+
+Current published field instruction:
+
+```text
+<Stage/Sub-stage/Scene>\Procedures\Setup\<current>.pdf
+```
+
+Authoritative editable Google-native source after migration:
+
+```text
+<Stage/Sub-stage/Scene>\Procedures\Setup\SourceDocs\
+```
+
+Historical original / fallback source:
+
+```text
+<Stage/Sub-stage/Scene>\Procedures\Setup\Archive\
+```
+
+Manager editable-source resolution is:
+
+```text
+SourceDocs first
+-> Archive only when no editable SourceDocs .gdoc exists
+```
+
+The 2026 migration workflow is controlled in the Google Drive operator SOPs: open the archived `.gdoc` in Google Docs, use **File -> Make a copy**, save the new Google-native copy into `SourceDocs`, then edit only the SourceDocs copy. Copying the Windows `.gdoc` shortcut file is not the migration method.
+
+Issue #161 / PR #162 completed that documentation closeout.
+
+## Current Material / Planning Boundaries
+
+The accepted Stage/Scene material resolver remains context, not a complete task-specific release/pick model.
+
+```text
+material enabled + real Scene
+    -> exact current Scene Displays
+
+material enabled + Stage
+    -> current Stage-level Displays
+    -> true child Scenes excluded
+
+resolved Displays
+    -> current ref.display.container_id
+    -> deduplicated Containers
+```
+
+Issue #141 remains responsible for task-specific staged material subdivision and release timing.
+
+Setup planning remains a rolling operational model rather than a rigid season-long fixed calendar:
+
+```text
+preferred order / hard predecessors
+    + readiness
+    + volunteers/equipment
+    + weather/site conditions
+    + prior progress
+    -> candidate work
+    -> operator selects practical work
+    -> short-horizon schedule
+```
+
+## Current Open Work / Resume Point
+
+Completed and accepted in this recent line:
+
+```text
+#154 dirty-edit / Mark Verified safety  = CLOSED / ACCEPTED V0.3.7
+#153 compact task-detail layout         = CLOSED / ACCEPTED V0.3.8
+#161 SourceDocs migration documentation = CLOSED / COMPLETED
+```
+
+Real independent work remains, including:
+
+```text
+#145 reusable Catalog cleanup before 2026 Session creation
+#151 Shift+left-drag predecessor creation
+#152 resource catalog sort order / existing-resource editing
+#159 cross-app light/dark palette and dark-mode white-logo standardization
+#141 task-specific staged material / Pick List release timing
+#132 Captain work-report duration / multi-day effort capture
+#113 shared Scan readiness / identity capture integration
+```
+
+Do not create the 2026 Setup Session until #145 is complete and the cleaned active Catalog has passed the disposable 2026 seeding check.
+
+## Engineering Resume Sequence
+
+Before the next Setup change:
+
+1. refresh current remote `main` and read the Project Rules;
+2. read this handoff and [`README.md`](README.md);
+3. read the responsible contract for the work item being changed;
+4. preserve the V0.3.7 dirty-edit/client-server build protections;
+5. preserve the V0.3.8 visible client version marker;
+6. preserve current 2025 historical state and do not create 2026 without #145 acceptance;
+7. use `Gregovate/MSB-Server-Management` for runtime/deployment authority;
+8. perform disposable/current-Production-clone browser acceptance before Production deployment when browser behavior changes;
+9. perform real protected-route operator validation for behavior that depends on actual client/runtime interaction; and
+10. complete controlled engineering/operator documentation and issue closeout before leaving the work item.
+
+## Related Documents
+
+- [Setup engineering portal](README.md)
+- [V0.3.8 Production acceptance](../../../../../Setup/Acceptance/Setup_Task_Detail_Production_Acceptance_2026-09-11.md)
+- [Stage / Scene material resolution contract](Setup_Stage_Scene_Material_Resolution_Contract_2026-09-10.md)
+- [Data consumption and authorization contract](Setup_Data_Consumption_and_Authorization_Contract_2026-09-10.md)
+- [Predecessor and readiness contract](Setup_Predecessor_and_Readiness_Contract_2026-09-09.md)
+- [Original V0.3.4 foundation handoff — historical](Setup_Session_Production_Engineering_Handoff_2026-09-07.md)
+- [Manager Review Guide](../../../02_Operational_SOPs/Setup/Setup_Session_Manager_Review_Guide.md)

--- a/Setup/Acceptance/Setup_Task_Detail_Production_Acceptance_2026-09-11.md
+++ b/Setup/Acceptance/Setup_Task_Detail_Production_Acceptance_2026-09-11.md
@@ -1,0 +1,177 @@
+# Setup Task Detail Compact Layout — Production Acceptance — 2026-09-11
+
+| Document Control | Value |
+|---|---|
+| Document Type | Production Acceptance Record |
+| System | Production Database — Setup Session |
+| Status | ACCEPTED PRODUCTION |
+| Owner | MSB Production Database engineering |
+| Accepted application SHA | `2eee967b6c5359c0e2e2d876a2fe44af8359315c` |
+| Accepted version | `V0.3.8-task-detail-compact` |
+| Repository merge | PR #160 / merge commit `d882bb33785321de9a6a880347521adf9518502e` |
+| Prior accepted runtime | `9d0c31421ce7cbd1b1cbcf733b06198ace418e9d` / `V0.3.7-catalog-dirty-edit-followup` |
+
+## Purpose
+
+Preserve the accepted Production evidence for Issue #153 so the V0.3.8 task-detail layout, deployment facts, fingerprint baseline, and final operator acceptance do not depend on chat history or issue comments.
+
+This was a source-only Setup application deployment. It did not include a database migration, schema change, authorization change, Plan / Schedule behavior change, or Production data migration.
+
+## Accepted UI Behavior
+
+At normal laptop/desktop width the task-detail editor is organized as two independent vertical rails:
+
+```text
+LEFT                               RIGHT
+Reusable Task Definition            Annual Historical Actual
+Material / Logistics                Captains / Knowledge Owners
+```
+
+Accepted behavior:
+
+- the reusable task editor remains a compact two-column editor inside the left rail;
+- **Material / Logistics** follows immediately beneath the reusable definition instead of spanning the full page below both rails;
+- the four essential material counts remain visible in the compact summary;
+- **View Material Details** remains available for the full resolved Display / Container detail and reasons;
+- **Annual Historical Actual** remains in the right rail;
+- **Captains / Knowledge Owners** remains immediately below Annual Historical Actual;
+- Prerequisites and Equipment / Resources remain below the rail block and are reachable with materially less scrolling; and
+- the layout-only stylesheet does not introduce a new independent color palette.
+
+Cross-application palette and dark-mode logo standardization are deliberately separate work under Issue #159.
+
+## Disposable Browser Acceptance
+
+Final accepted browser/deployment candidate:
+
+```text
+2eee967b6c5359c0e2e2d876a2fe44af8359315c
+```
+
+Final laptop browser review confirmed:
+
+- visible `Client V0.3.8`;
+- compact reusable editor;
+- independent left/right rails;
+- Material / Logistics beneath Reusable Task Definition;
+- Annual Historical Actual plus Captains / Knowledge Owners in the right rail;
+- no large dead area beneath the reusable editor;
+- Material Details remained functional; and
+- light/dark readability was acceptable for Issue #153.
+
+Physical mobile-device acceptance was **not** performed. Responsive stacking is covered by the implementation/contract and a narrowed-desktop-browser proxy only. Do not claim physical mobile acceptance from this record.
+
+Two earlier preview attempts stopped before browser startup because of acceptance-contract false positives. Both teardown checks proved Production and the live Setup checkout remained unchanged. The final accepted candidate above contains the corrected contracts and refined rail layout.
+
+## Production Pre-Mutation Gate
+
+Immediately before source-only deployment:
+
+```text
+live Setup SHA                     = 9d0c31421ce7cbd1b1cbcf733b06198ace418e9d
+accepted target                    = 2eee967b6c5359c0e2e2d876a2fe44af8359315c
+forward ancestry                   = PASS
+live Setup worktree                = clean
+exact detached candidate regression = 53 passed in 0.24s
+REGRESSION_RC                      = 0
+PRE_MUTATION_GATE                  = PASS
+Production fingerprint             = 9510360aa7de2da59d1ed8a9ad9d69f7
+```
+
+No Production mutation had occurred at this gate.
+
+## Source-Only Production Deployment
+
+Only the detached Setup worktree advanced:
+
+```text
+OLD_HEAD   = 9d0c31421ce7cbd1b1cbcf733b06198ace418e9d
+TARGET_SHA = 2eee967b6c5359c0e2e2d876a2fe44af8359315c
+```
+
+Checkout verification passed with a clean worktree.
+
+Only:
+
+```text
+msb-setup.service
+```
+
+was restarted.
+
+No PostgreSQL migration was applied and no database dump restore was required.
+
+## Runtime / Regression Evidence
+
+Post-restart health:
+
+```json
+{"data_mode":"postgres","status":"ok","version":"V0.3.8-task-detail-compact"}
+```
+
+Focused live deployed regression:
+
+```text
+53 passed in 0.24s
+LIVE_REGRESSION_RC=0
+```
+
+Protected route health also returned `V0.3.8-task-detail-compact`.
+
+## Production Fingerprint Evidence
+
+The source-only deployment did not change the Setup Production data covered by the deployment fingerprint:
+
+```text
+PROD_BEFORE = 9510360aa7de2da59d1ed8a9ad9d69f7
+PROD_AFTER  = 9510360aa7de2da59d1ed8a9ad9d69f7
+DEPLOYMENT_FINGERPRINT = PASS
+```
+
+This fingerprint records equality across the source-only deployment. It is not a permanent promise that later legitimate Manager activity will never change Production data.
+
+## Final Protected Production Browser Acceptance
+
+The real protected Production application was opened after deployment:
+
+```text
+https://my.sheboyganlights.org/setup/
+```
+
+Final operator validation passed:
+
+- visible `Client V0.3.8`;
+- left rail = Reusable Task Definition -> Material / Logistics;
+- right rail = Annual Historical Actual -> Captains / Knowledge Owners;
+- Prerequisites / Resources remain below without the prior dead space; and
+- final laptop layout matched the accepted disposable-browser candidate.
+
+No special Production data write was required for final Issue #153 acceptance.
+
+## Recent Runtime Lineage
+
+The immediate prior accepted runtime was Issue #154 V0.3.7:
+
+```text
+9d0c31421ce7cbd1b1cbcf733b06198ace418e9d
+V0.3.7-catalog-dirty-edit-followup
+```
+
+That release fixed the unsafe reusable-edit / `Mark Verified` path after the earlier V0.3.6 candidate failed real Production acceptance and was rolled back. V0.3.8 preserves the accepted V0.3.7 dirty-edit and client/server build-match protections while changing task-detail presentation.
+
+## Deliberate Follow-Ups / Deferrals
+
+Issue #153 does not absorb unrelated work discovered during acceptance:
+
+- Issue #159 remains open for cross-application light/dark palette and dark-mode white-logo consistency.
+- Setup Google Doc migration from `Archive` to authoritative `SourceDocs` was documented separately in Issue #161 / PR #162 and is now closed completed.
+- physical mobile-device acceptance was not performed for V0.3.8.
+
+## Related Authority
+
+- `Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Session_Production_Engineering_Handoff_2026-09-11.md`
+- `Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/README.md`
+- Issue #153 — compact Setup task-detail / Material layout
+- Issue #154 — dirty-edit / Mark Verified safety
+- Issue #159 — cross-application theme/logo consistency
+- PR #160 — V0.3.8 implementation lineage

--- a/Setup/Application/README.md
+++ b/Setup/Application/README.md
@@ -1,8 +1,8 @@
 # Setup Session Application
 
-Status: **PRODUCTION RUNTIME OPERATIONAL — 2025 HISTORICAL REVIEW / TRAINING; UI/WORKFLOW IN LIVE EVALUATION**
+Status: **PRODUCTION RUNTIME OPERATIONAL — V0.3.8 ACCEPTED; 2025 HISTORICAL REVIEW / TRAINING CONTINUES**
 
-This folder contains the browser-native Setup Session application used for the Production-backed 2025 Historical Verification workflow.
+This folder contains the browser-native Setup Session application used for the Production-backed 2025 Historical Verification workflow and ongoing reusable Setup development.
 
 The application is live at:
 
@@ -19,7 +19,13 @@ Setup/Application/production_backend.py
 Current reported version:
 
 ```text
-V0.3.4-shared-season-guard-review
+V0.3.8-task-detail-compact
+```
+
+Current exact deployed source:
+
+```text
+2eee967b6c5359c0e2e2d876a2fe44af8359315c
 ```
 
 ## Current Production Meaning
@@ -31,12 +37,15 @@ Managers/reviewers use it to:
 - reconstruct and correct 2025 annual Setup information;
 - verify records where evidence exists;
 - add/correct reusable Setup tasks;
+- delete reconstruction-safe Catalog mistakes where the governed command permits it;
 - add/correct reusable resources and prerequisites;
 - improve task scope, order, crew/time/readiness information;
 - review current Setup Procedure context; and
 - identify UI/workflow/data-model problems before the 2026 Setup Session is created.
 
-Production deployment is accepted, but the Setup/UI subsystem is intentionally **not final**. PRs #123, #124, and #125 remain open while real-use findings are collected and resolved.
+The reusable Catalog and the 2025 annual Session are intentionally separate. A valid reusable task may exist without a 2025 annual row. Do not force newer reusable definitions into 2025 merely to make the historical Plan appear complete.
+
+The 2026 Setup Session must not be created until the active reusable Catalog cleanup gate in Issue #145 is complete and the intended seeded task set has been proven in disposable validation.
 
 ## Application Architecture
 
@@ -61,8 +70,9 @@ Key boundaries:
 - Setup capabilities are resolved server-side;
 - writes use narrow governed PostgreSQL command functions;
 - the browser does not receive broad table DML authority;
-- Stage/Sub-stage/Scene path resolution reuses the accepted shared resolver; and
-- Google Drive Procedure publishing remains separately controlled.
+- Stage/Sub-stage/Scene path resolution reuses the accepted shared resolver;
+- Google Drive Procedure publishing remains separately controlled; and
+- server/runtime deployment authority lives in `Gregovate/MSB-Server-Management`.
 
 ## Annual vs Reusable Data
 
@@ -90,6 +100,40 @@ The selected Setup Session owns the allowed operational year.
 
 The browser constrains date controls and the database independently enforces the same rule. Audit timestamps remain real current timestamps.
 
+## Dirty-Edit / Client Build Safety
+
+The accepted V0.3.7 safety behavior remains part of V0.3.8.
+
+The Setup header visibly shows the loaded client build, currently:
+
+```text
+Client V0.3.8
+```
+
+Governed writes verify that the client build matches `/api/health`. A stale/mismatched client fails closed instead of quietly writing against a different server build.
+
+Reusable edits are compared against the current selected server-backed task. State-changing actions such as `Mark Verified` cannot silently discard pending reusable edits. The application either safely saves the reusable changes before the annual action or stops the action when the reusable save cannot complete.
+
+Dirty navigation uses explicit save/discard/stay behavior. Independent save surfaces such as Physical Effort, Display/Container Material, Resources, and Captains remain separately governed.
+
+The first V0.3.6 dirty-edit candidate failed real Production protected-route acceptance and was rolled back. V0.3.7 corrected that failure and V0.3.8 preserves the accepted protection.
+
+## Current Task-Detail Layout
+
+At normal laptop/desktop width the accepted V0.3.8 layout is:
+
+```text
+LEFT                               RIGHT
+Reusable Task Definition            Annual Historical Actual
+Material / Logistics                Captains / Knowledge Owners
+```
+
+The reusable editor itself uses a compact two-column desktop grid. Material / Logistics keeps its four resolved counts and full `View Material Details` dialog. Prerequisites and Equipment / Resources remain below the rail block.
+
+Physical mobile-device acceptance was not performed for V0.3.8. Responsive stacking is contract-covered and was checked with a narrowed desktop browser only.
+
+Cross-application theme and dark-mode white-logo consistency are tracked separately in Issue #159.
+
 ## Current Manager / Reviewer Capabilities
 
 The live review workflow supports the current governed application behavior for:
@@ -98,9 +142,11 @@ The live review workflow supports the current governed application behavior for:
 - reviewing verification state;
 - correcting supported annual information;
 - creating/copying reusable tasks;
+- reconstruction-safe deletion/deactivation where governed rules allow;
 - maintaining task scope and order;
 - maintaining prerequisites;
 - maintaining structured equipment/resources;
+- maintaining supported reusable material applicability;
 - reviewing supported planning information; and
 - opening current Setup Procedure/document context.
 
@@ -124,7 +170,16 @@ Park-wide work with no appropriate LOR Stage/Scene uses:
 G:\Shared drives\Display Folders\41 Park Infrastructure-PI\Procedures\Setup
 ```
 
-The application may expose both the current published PDF and an editable Google-native source to authorized Managers. If the editable procedure is corrected, the current published PDF must also be updated before the instruction is treated as current.
+For authorized Managers, editable Google-native source resolution is:
+
+```text
+SourceDocs first
+-> Archive only when no editable SourceDocs .gdoc exists
+```
+
+During the 2026 migration, the archived `.gdoc` remains the historical original. To establish the current editable source, open the archived document in Google Docs, use **File -> Make a copy**, and save the new Google-native document in `Procedures\Setup\SourceDocs`. All later edits occur in the SourceDocs copy. Copying the Windows `.gdoc` shortcut file is not the migration method.
+
+The current published field PDF remains directly in `Procedures\Setup` and must be updated when the approved editable procedure changes.
 
 The runtime uses `/mnt/msb-setup-google-links` to expose link-form representations of native Google documents without converting normal Word documents.
 
@@ -139,7 +194,13 @@ Permanent source checkout:
 Current deployed source SHA:
 
 ```text
-c0639c5b04de667176a8d8eef14fce0409f03ec6
+2eee967b6c5359c0e2e2d876a2fe44af8359315c
+```
+
+Current health:
+
+```json
+{"data_mode":"postgres","status":"ok","version":"V0.3.8-task-detail-compact"}
 ```
 
 Service/runtime facts are owned by `Gregovate/MSB-Server-Management`.
@@ -153,36 +214,45 @@ listener                       = 192.168.5.9:8794
 public route                   = https://my.sheboyganlights.org/setup/
 ```
 
-## Prototype Lineage
+V0.3.8 was deployed source-only. Exact detached preflight regression and live focused regression both passed 53 tests. The Production source-deployment fingerprint remained unchanged:
+
+```text
+9510360aa7de2da59d1ed8a9ad9d69f7
+```
+
+before and after deployment.
+
+See `Setup/Acceptance/Setup_Task_Detail_Production_Acceptance_2026-09-11.md` for the full Production evidence.
+
+## Prototype / Historical Lineage
 
 Earlier files in this folder include prototype-era UI and local validation support. They remain useful lineage and test evidence, but they are not the Production entry point.
 
-Do not infer current Production behavior from old prototype comments or local-storage-only code paths. Current authority is the Production entry point, current tests, current database migrations, and the Setup engineering handoff.
+Do not infer current Production behavior from old prototype comments or local-storage-only code paths. Current authority is the Production entry point, current tests, current database migrations, current acceptance records, and the current Setup engineering handoff.
+
+Historical runtime milestones include:
+
+```text
+V0.3.5  Stage/Scene material + presentation baseline
+V0.3.6  dirty-edit candidate; failed real Production acceptance and rolled back
+V0.3.7  accepted dirty-edit / client-build safety
+V0.3.8  current accepted compact task-detail layout
+```
 
 ## Current Boundaries
 
 Still outside the accepted Production-ready workflow:
 
-- Pick List generation; and
-- Container/Display movement/scanning write commands.
-
-Do not infer movement history merely because identifiers are scanned or because a review action occurs.
+- Pick List generation;
+- task-specific staged material release timing;
+- Container/Display movement/scanning write commands; and
+- park-location execution evidence.
 
 The application also does not automatically publish revised PDFs back into Google Drive.
 
 ## Testing / Live Evaluation
 
-Automated contract tests remain useful for application changes, but final UI/workflow acceptance depends on real 2025 review use by Managers.
-
-During live evaluation, collect:
-
-- bugs;
-- confusing labels or fields;
-- missing information;
-- difficult task/resource/prerequisite workflows;
-- navigation/search/filter issues;
-- operational suggestions; and
-- places where the UI does not match how Setup work is actually planned or performed.
+Automated contract tests remain useful for application changes, but browser behavior that depends on real client/runtime interaction must also pass protected-route operator validation before being treated as accepted Production behavior.
 
 Do not create fake Production work days, movement events, or throwaway records merely to exercise controls.
 
@@ -192,14 +262,18 @@ Before changing the application:
 
 1. read `System_Documentation/Project_Rules/README.md`;
 2. read `Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/README.md`;
-3. read the current Production engineering handoff;
-4. review PRs #123, #124, and #125 together;
-5. review current manager/reviewer findings; and
-6. use `Gregovate/MSB-Server-Management` for live runtime facts and deployment runbooks.
+3. read the current `Setup_Session_Production_Engineering_Handoff_2026-09-11.md`;
+4. preserve V0.3.7 dirty-edit/client-server build protection and the visible client build marker;
+5. preserve the 2025 annual vs reusable Catalog boundary;
+6. review Issue #145 before any 2026 Session creation;
+7. review the active issue/contract for the feature being changed; and
+8. use `Gregovate/MSB-Server-Management` for live runtime facts and deployment runbooks.
 
 ## Related Documentation
 
 - `Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/README.md`
+- `Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/README.md`
+- `Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Session_Production_Engineering_Handoff_2026-09-11.md`
 - `Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/operatorSOP/Review_2025_Setup_History.md`
 - `Docs/02_Production_Database/02_Operational_SOPs/Setup/Setup_Session_Manager_Review_Guide.md`
-- `Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Session_Production_Engineering_Handoff_2026-09-07.md`
+- `Setup/Acceptance/Setup_Task_Detail_Production_Acceptance_2026-09-11.md`


### PR DESCRIPTION
Completes the controlled engineering-documentation closeout for Issue #153 under the repository Issue Management / Documentation Maintenance rules.

Production implementation and operator acceptance were already completed on exact deployed SHA `2eee967b6c5359c0e2e2d876a2fe44af8359315c` / `V0.3.8-task-detail-compact`. This PR does not change application code, schema, authorization, runtime, or Production data.

Documentation closeout includes:
- durable V0.3.8 Production acceptance record with exact target, 53-test preflight/live evidence, pre/post fingerprint `9510360aa7de2da59d1ed8a9ad9d69f7`, protected-route health, laptop browser acceptance, rollback boundary, and mobile-test limitation;
- new current `Setup_Session_Production_Engineering_Handoff_2026-09-11.md` with current SHA/version, V0.3.6 failed acceptance/rollback, V0.3.7 recovery, V0.3.8 current state, SourceDocs rule, open issues, and resume sequence;
- refreshed Setup engineering portal so normal repository navigation lands on V0.3.8 rather than stale V0.3.5 facts;
- refreshed `Setup/Application/README.md` with current runtime, dirty-edit/client-build safety, procedure-source contract, and current resume boundary.

Issue #159 remains a deliberate separate follow-up for cross-app theme/dark-mode logo consistency. Issue #161 / PR #162 already completed the Google Doc Archive -> SourceDocs operator documentation.

Counterpart runtime-owned closeout is being made in `Gregovate/MSB-Server-Management` from branch `docs/setup-v038-runtime-closeout`.

Refs #153.