### PR TITLE
Add Shift-drag predecessor creation to Setup Catalog

### DIFF
--- a/Setup/Acceptance/run_setup_predecessor_drag_browser_preview.ps1
+++ b/Setup/Acceptance/run_setup_predecessor_drag_browser_preview.ps1
@@ -1,0 +1,69 @@
+param(
+    [string]$Server = 'msbadmin@192.168.5.9',
+    [Parameter(Mandatory=$true)]
+    [int]$PreviewPort,
+    [string]$PreviewEmail = 'gliebig@sheboyganlights.org'
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Exact application/test candidate for Issue #151. Later commits may harden
+# acceptance tooling only; browser/deployment approval remains pinned here.
+$AcceptedCandidateSha = '4cada529a0cd714f5da2cb43f5dffb016e40b7ac'
+$AcceptedBranch = 'agent/setup-shift-drag-predecessor-151'
+$BaseWrapper = Join-Path $PSScriptRoot 'run_setup_source_only_browser_preview.ps1'
+
+if (-not (Test-Path -LiteralPath $BaseWrapper)) {
+    throw "Setup source-only preview base wrapper is missing: $BaseWrapper"
+}
+
+function Replace-Required {
+    param(
+        [Parameter(Mandatory=$true)][string]$Source,
+        [Parameter(Mandatory=$true)][string]$Needle,
+        [Parameter(Mandatory=$true)][string]$Replacement,
+        [Parameter(Mandatory=$true)][string]$Description
+    )
+    if (-not $Source.Contains($Needle)) {
+        throw "Setup predecessor-drag preview could not find expected $Description."
+    }
+    return $Source.Replace($Needle, $Replacement)
+}
+
+$text = [System.IO.File]::ReadAllText($BaseWrapper)
+$text = $text.Replace("`r`n", "`n").Replace("`r", "`n")
+
+$text = Replace-Required -Source $text -Needle "`$CandidateSha = '51c739bd85115c9f5d2853763e8e1450ac381407'" -Replacement "`$CandidateSha = '$AcceptedCandidateSha'" -Description 'source-only candidate SHA assignment'
+$text = Replace-Required -Source $text -Needle "`$ExpectedBranch = 'agent/setup-session-production-foundation'" -Replacement "`$ExpectedBranch = '$AcceptedBranch'" -Description 'source-only expected branch assignment'
+
+$scriptDirLiteral = $PSScriptRoot.Replace("'", "''")
+$text = Replace-Required -Source $text -Needle '$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path' -Replacement "`$ScriptDir = '$scriptDirLiteral'" -Description 'base wrapper ScriptDir initialization'
+
+$regressionNeedle = "        '      Setup/Application/test_setup_next_pass_contract.py'"
+$regressionReplacement = @(
+    "        '      Setup/Application/test_setup_next_pass_contract.py \',",
+    "        '      Setup/Application/test_setup_predecessor_drag_contract.py \',",
+    "        '      Setup/Application/test_setup_dirty_edit_guard_contract.py \',",
+    "        '      Setup/Application/test_setup_task_detail_compact_contract.py'"
+) -join "`n"
+$text = Replace-Required -Source $text -Needle $regressionNeedle -Replacement $regressionReplacement -Description 'focused regression tail'
+
+$text = $text.Replace('SETUP SOURCE-ONLY BROWSER PREVIEW', 'SETUP SHIFT-DRAG PREDECESSOR BROWSER PREVIEW')
+$text = $text.Replace('SETUP SOURCE-ONLY BROWSER REVIEW READY', 'SETUP SHIFT-DRAG PREDECESSOR BROWSER REVIEW READY')
+
+Write-Host 'Issue #151 Shift-drag predecessor browser acceptance checklist:'
+Write-Host '  0. Confirm the header still visibly shows Client V0.3.8 and the Catalog shows the Fast prerequisite entry hint.'
+Write-Host '  1. Choose two disposable-clone reusable tasks A and B and note both tasks'' current scope/order before testing.'
+Write-Host '  2. Hold Shift BEFORE starting the drag on dependent task A. A must visibly show Dependent.'
+Write-Host '  3. Drag A over prerequisite task B. B must visibly show Prerequisite target; release on B.'
+Write-Host '  4. Confirm explicit success feedback says A depends on B and neither task moved. A''s Requires line must show B.'
+Write-Host '  5. Repeat the same Shift-drag A -> B. Confirm it remains one dependency, not a duplicate.'
+Write-Host '  6. Try Shift-drag B -> A. Confirm the governed circular-dependency error is shown and neither task moves.'
+Write-Host '  7. Confirm A and B still have their original scope/order after all Shift-drag operations.'
+Write-Host '  8. Now perform one ordinary drag WITHOUT Shift. Confirm normal Catalog move/reorder behavior still works.'
+Write-Host '  9. Open task A and confirm the existing manual prerequisite editor still shows/removes B as a normal fallback.'
+Write-Host ' 10. Verify Shift-drag over empty Stage/Scene space does not move the task and reports that a task target is required.'
+Write-Host
+
+$script = [scriptblock]::Create($text)
+& $script -Server $Server -PreviewPort $PreviewPort -PreviewEmail $PreviewEmail

--- a/Setup/Acceptance/run_setup_predecessor_drag_browser_preview.ps1
+++ b/Setup/Acceptance/run_setup_predecessor_drag_browser_preview.ps1
@@ -12,9 +12,12 @@ $ErrorActionPreference = 'Stop'
 $AcceptedCandidateSha = '55478f98f760473b65b5d700a84c868285022ab7'
 $AcceptedBranch = 'agent/setup-shift-drag-predecessor-151'
 $BaseWrapper = Join-Path $PSScriptRoot 'run_setup_source_only_browser_preview.ps1'
+$CleanupScript = Join-Path $PSScriptRoot 'setup_session_browser_preview_cleanup_server.sh'
 
-if (-not (Test-Path -LiteralPath $BaseWrapper)) {
-    throw "Setup source-only preview base wrapper is missing: $BaseWrapper"
+foreach ($requiredPath in @($BaseWrapper, $CleanupScript)) {
+    if (-not (Test-Path -LiteralPath $requiredPath)) {
+        throw "Required Setup preview file is missing: $requiredPath"
+    }
 }
 
 function Replace-Required {
@@ -38,6 +41,44 @@ $text = Replace-Required -Source $text -Needle "`$ExpectedBranch = 'agent/setup-
 
 $scriptDirLiteral = $PSScriptRoot.Replace("'", "''")
 $text = Replace-Required -Source $text -Needle '$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path' -Replacement "`$ScriptDir = '$scriptDirLiteral'" -Description 'base wrapper ScriptDir initialization'
+
+# Recover a prior source-only preview only after the base wrapper has verified
+# the expected branch, clean worktree, and exact pinned candidate. The cleanup
+# script is LF-normalized before upload and refuses governed Production ports.
+$cleanupInjectionNeedle = '$stamp = Get-Date -Format ''yyyyMMdd-HHmmss'''
+$cleanupInjection = @'
+$cleanupScript = Join-Path $ScriptDir 'setup_session_browser_preview_cleanup_server.sh'
+if (-not (Test-Path -LiteralPath $cleanupScript)) {
+    throw "Setup preview stale-cleanup script is missing: $cleanupScript"
+}
+$cleanupStamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+$cleanupTemp = Join-Path ([System.IO.Path]::GetTempPath()) "msb-setup-source-preview-cleanup-$cleanupStamp.sh"
+$cleanupRemote = "/tmp/msb-setup-source-preview-cleanup-$cleanupStamp.sh"
+$cleanupUtf8 = New-Object System.Text.UTF8Encoding($false)
+try {
+    $cleanupText = [System.IO.File]::ReadAllText($cleanupScript)
+    $cleanupText = $cleanupText.Replace("`r`n", "`n").Replace("`r", "`n")
+    [System.IO.File]::WriteAllText($cleanupTemp, $cleanupText, $cleanupUtf8)
+
+    & scp $cleanupTemp "${Server}:$cleanupRemote"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Setup preview stale-cleanup upload failed with exit code $LASTEXITCODE"
+    }
+
+    $cleanupCommand = "chmod 700 '$cleanupRemote'; bash -n '$cleanupRemote'; rc=`$?; if [ `$rc -eq 0 ]; then bash '$cleanupRemote' '$PreviewPort'; rc=`$?; fi; rm -f '$cleanupRemote'; exit `$rc"
+    & ssh -tt $Server $cleanupCommand
+    if ($LASTEXITCODE -ne 0) {
+        throw "Setup preview stale-cleanup failed with exit code $LASTEXITCODE"
+    }
+}
+finally {
+    Remove-Item -LiteralPath $cleanupTemp -Force -ErrorAction SilentlyContinue
+}
+
+$stamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+'@
+$cleanupInjection = $cleanupInjection.Replace("`r`n", "`n").Replace("`r", "`n")
+$text = Replace-Required -Source $text -Needle $cleanupInjectionNeedle -Replacement $cleanupInjection -Description 'source-only stale-cleanup injection point'
 
 $regressionNeedle = "        '      Setup/Application/test_setup_next_pass_contract.py'"
 $regressionReplacement = @(
@@ -94,10 +135,20 @@ $serverInjection = @'
     }
     $serverText = $serverText.Replace($migrationNeedle, $migrationReplacement)
 
+    # A disconnected browser-review SSH session must be able to trigger the same
+    # instance-scoped cleanup path when the remote shell receives SIGHUP.
+    $serverText = $serverText.Replace('trap - EXIT INT TERM', 'trap - EXIT HUP INT TERM')
+    $serverText = $serverText.Replace('trap cleanup EXIT INT TERM', 'trap cleanup EXIT HUP INT TERM')
+
     # Fail locally before SCP if any CR characters were reintroduced by a later
 '@
 $serverInjection = $serverInjection.Replace("`r`n", "`n").Replace("`r", "`n")
 $text = Replace-Required -Source $text -Needle $serverInjectionNeedle -Replacement $serverInjection -Description 'disposable migration injection point'
+
+# Bound abandoned reviews and make dead SSH transports fail promptly instead of
+# silently leaving a detached source-only Flask listener behind indefinitely.
+$text = Replace-Required -Source $text -Needle "bash '`$remoteServer' '`$CandidateSha' '`$PreviewPort' '`$PreviewEmail' '`$ApprovedRef'" -Replacement "timeout --signal=TERM 28800s bash '`$remoteServer' '`$CandidateSha' '`$PreviewPort' '`$PreviewEmail' '`$ApprovedRef'" -Description 'remote source-only preview invocation'
+$text = Replace-Required -Source $text -Needle '& ssh -t -L "${PreviewPort}:127.0.0.1:${PreviewPort}" $Server $remoteCommand' -Replacement '& ssh -tt -o ServerAliveInterval=15 -o ServerAliveCountMax=3 -L "${PreviewPort}:127.0.0.1:${PreviewPort}" $Server $remoteCommand' -Description 'source-only SSH tunnel invocation'
 
 $text = $text.Replace('SETUP SOURCE-ONLY BROWSER PREVIEW', 'SETUP SHIFT-DRAG PREDECESSOR V0.3.9 BROWSER PREVIEW')
 $text = $text.Replace('SETUP SOURCE-ONLY BROWSER REVIEW READY', 'SETUP SHIFT-DRAG PREDECESSOR V0.3.9 BROWSER REVIEW READY')

--- a/Setup/Acceptance/run_setup_predecessor_drag_browser_preview.ps1
+++ b/Setup/Acceptance/run_setup_predecessor_drag_browser_preview.ps1
@@ -9,7 +9,7 @@ $ErrorActionPreference = 'Stop'
 
 # Exact V0.3.9 application/schema/test candidate for Issue #151. Later commits
 # may harden acceptance tooling only; browser/deployment approval remains pinned.
-$AcceptedCandidateSha = '280ec6bee5ec9847459f28de41140520e71b0910'
+$AcceptedCandidateSha = '66a70e3661d92482d9bfc629cd87e8f7026cf458'
 $AcceptedBranch = 'agent/setup-shift-drag-predecessor-151'
 $BaseWrapper = Join-Path $PSScriptRoot 'run_setup_source_only_browser_preview.ps1'
 

--- a/Setup/Acceptance/run_setup_predecessor_drag_browser_preview.ps1
+++ b/Setup/Acceptance/run_setup_predecessor_drag_browser_preview.ps1
@@ -9,7 +9,7 @@ $ErrorActionPreference = 'Stop'
 
 # Exact V0.3.9 application/schema/test candidate for Issue #151. Later commits
 # may harden acceptance tooling only; browser/deployment approval remains pinned.
-$AcceptedCandidateSha = '66a70e3661d92482d9bfc629cd87e8f7026cf458'
+$AcceptedCandidateSha = '55478f98f760473b65b5d700a84c868285022ab7'
 $AcceptedBranch = 'agent/setup-shift-drag-predecessor-151'
 $BaseWrapper = Join-Path $PSScriptRoot 'run_setup_source_only_browser_preview.ps1'
 

--- a/Setup/Acceptance/run_setup_predecessor_drag_browser_preview.ps1
+++ b/Setup/Acceptance/run_setup_predecessor_drag_browser_preview.ps1
@@ -9,7 +9,7 @@ $ErrorActionPreference = 'Stop'
 
 # Exact V0.3.9 application/test candidate for Issue #151. Later commits may
 # harden acceptance tooling only; browser/deployment approval remains pinned here.
-$AcceptedCandidateSha = 'b3b48d0f5b8b94519257c4a65166f317411265f4'
+$AcceptedCandidateSha = '9a27e91e3251019bf2920bc9410f0bdd7fc426c1'
 $AcceptedBranch = 'agent/setup-shift-drag-predecessor-151'
 $BaseWrapper = Join-Path $PSScriptRoot 'run_setup_source_only_browser_preview.ps1'
 

--- a/Setup/Acceptance/run_setup_predecessor_drag_browser_preview.ps1
+++ b/Setup/Acceptance/run_setup_predecessor_drag_browser_preview.ps1
@@ -145,9 +145,10 @@ $serverInjection = @'
 $serverInjection = $serverInjection.Replace("`r`n", "`n").Replace("`r", "`n")
 $text = Replace-Required -Source $text -Needle $serverInjectionNeedle -Replacement $serverInjection -Description 'disposable migration injection point'
 
-# Bound abandoned reviews and make dead SSH transports fail promptly instead of
-# silently leaving a detached source-only Flask listener behind indefinitely.
-$text = Replace-Required -Source $text -Needle "bash '`$remoteServer' '`$CandidateSha' '`$PreviewPort' '`$PreviewEmail' '`$ApprovedRef'" -Replacement "timeout --signal=TERM 28800s bash '`$remoteServer' '`$CandidateSha' '`$PreviewPort' '`$PreviewEmail' '`$ApprovedRef'" -Description 'remote source-only preview invocation'
+# Bound abandoned reviews without moving the interactive server script into a
+# background terminal process group. --foreground preserves sudo/read access to
+# the SSH PTY while still enforcing the eight-hour fail-safe.
+$text = Replace-Required -Source $text -Needle "bash '`$remoteServer' '`$CandidateSha' '`$PreviewPort' '`$PreviewEmail' '`$ApprovedRef'" -Replacement "timeout --foreground --signal=TERM 28800s bash '`$remoteServer' '`$CandidateSha' '`$PreviewPort' '`$PreviewEmail' '`$ApprovedRef'" -Description 'interactive remote source-only preview invocation'
 $text = Replace-Required -Source $text -Needle '& ssh -t -L "${PreviewPort}:127.0.0.1:${PreviewPort}" $Server $remoteCommand' -Replacement '& ssh -tt -o ServerAliveInterval=15 -o ServerAliveCountMax=3 -L "${PreviewPort}:127.0.0.1:${PreviewPort}" $Server $remoteCommand' -Description 'source-only SSH tunnel invocation'
 
 $text = $text.Replace('SETUP SOURCE-ONLY BROWSER PREVIEW', 'SETUP SHIFT-DRAG PREDECESSOR V0.3.9 BROWSER PREVIEW')

--- a/Setup/Acceptance/run_setup_predecessor_drag_browser_preview.ps1
+++ b/Setup/Acceptance/run_setup_predecessor_drag_browser_preview.ps1
@@ -9,7 +9,7 @@ $ErrorActionPreference = 'Stop'
 
 # Exact V0.3.9 application/test candidate for Issue #151. Later commits may
 # harden acceptance tooling only; browser/deployment approval remains pinned here.
-$AcceptedCandidateSha = '9a27e91e3251019bf2920bc9410f0bdd7fc426c1'
+$AcceptedCandidateSha = 'f23e305a25959297fbe83b68753a5be471871652'
 $AcceptedBranch = 'agent/setup-shift-drag-predecessor-151'
 $BaseWrapper = Join-Path $PSScriptRoot 'run_setup_source_only_browser_preview.ps1'
 
@@ -54,7 +54,7 @@ $text = $text.Replace('SETUP SOURCE-ONLY BROWSER REVIEW READY', 'SETUP SHIFT-DRA
 Write-Host 'Issue #151 Shift-drag predecessor V0.3.9 browser acceptance checklist:'
 Write-Host '  0. Confirm the header visibly shows Client V0.3.9 and the Catalog shows the Fast prerequisite entry hint.'
 Write-Host '  1. Choose two disposable-clone reusable tasks A and B and note both tasks'' current scope/order before testing.'
-Write-Host '  2. Hold Shift BEFORE starting the drag on dependent task A. A must visibly show Dependent.'
+Write-Host '  2. Hold Shift BEFORE pressing the left mouse button on dependent task A, then drag. A must visibly show Dependent.'
 Write-Host '  3. Drag A over prerequisite task B. B must visibly show Prerequisite target; release on B.'
 Write-Host '  4. Confirm explicit success feedback says A depends on B and neither task moved. A''s Requires line must show B.'
 Write-Host '  5. Repeat the same Shift-drag A -> B. Confirm it remains one dependency, not a duplicate.'

--- a/Setup/Acceptance/run_setup_predecessor_drag_browser_preview.ps1
+++ b/Setup/Acceptance/run_setup_predecessor_drag_browser_preview.ps1
@@ -9,7 +9,7 @@ $ErrorActionPreference = 'Stop'
 
 # Exact V0.3.9 application/test candidate for Issue #151. Later commits may
 # harden acceptance tooling only; browser/deployment approval remains pinned here.
-$AcceptedCandidateSha = '47845209a1eadb694a6ec75deba67ce241f37a5e'
+$AcceptedCandidateSha = 'b3b48d0f5b8b94519257c4a65166f317411265f4'
 $AcceptedBranch = 'agent/setup-shift-drag-predecessor-151'
 $BaseWrapper = Join-Path $PSScriptRoot 'run_setup_source_only_browser_preview.ps1'
 

--- a/Setup/Acceptance/run_setup_predecessor_drag_browser_preview.ps1
+++ b/Setup/Acceptance/run_setup_predecessor_drag_browser_preview.ps1
@@ -7,9 +7,9 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-# Exact application/test candidate for Issue #151. Later commits may harden
-# acceptance tooling only; browser/deployment approval remains pinned here.
-$AcceptedCandidateSha = '4cada529a0cd714f5da2cb43f5dffb016e40b7ac'
+# Exact V0.3.9 application/test candidate for Issue #151. Later commits may
+# harden acceptance tooling only; browser/deployment approval remains pinned here.
+$AcceptedCandidateSha = 'bd7457205b7f6596b9221348b6118ba9861abecc'
 $AcceptedBranch = 'agent/setup-shift-drag-predecessor-151'
 $BaseWrapper = Join-Path $PSScriptRoot 'run_setup_source_only_browser_preview.ps1'
 
@@ -48,11 +48,11 @@ $regressionReplacement = @(
 ) -join "`n"
 $text = Replace-Required -Source $text -Needle $regressionNeedle -Replacement $regressionReplacement -Description 'focused regression tail'
 
-$text = $text.Replace('SETUP SOURCE-ONLY BROWSER PREVIEW', 'SETUP SHIFT-DRAG PREDECESSOR BROWSER PREVIEW')
-$text = $text.Replace('SETUP SOURCE-ONLY BROWSER REVIEW READY', 'SETUP SHIFT-DRAG PREDECESSOR BROWSER REVIEW READY')
+$text = $text.Replace('SETUP SOURCE-ONLY BROWSER PREVIEW', 'SETUP SHIFT-DRAG PREDECESSOR V0.3.9 BROWSER PREVIEW')
+$text = $text.Replace('SETUP SOURCE-ONLY BROWSER REVIEW READY', 'SETUP SHIFT-DRAG PREDECESSOR V0.3.9 BROWSER REVIEW READY')
 
-Write-Host 'Issue #151 Shift-drag predecessor browser acceptance checklist:'
-Write-Host '  0. Confirm the header still visibly shows Client V0.3.8 and the Catalog shows the Fast prerequisite entry hint.'
+Write-Host 'Issue #151 Shift-drag predecessor V0.3.9 browser acceptance checklist:'
+Write-Host '  0. Confirm the header visibly shows Client V0.3.9 and the Catalog shows the Fast prerequisite entry hint.'
 Write-Host '  1. Choose two disposable-clone reusable tasks A and B and note both tasks'' current scope/order before testing.'
 Write-Host '  2. Hold Shift BEFORE starting the drag on dependent task A. A must visibly show Dependent.'
 Write-Host '  3. Drag A over prerequisite task B. B must visibly show Prerequisite target; release on B.'

--- a/Setup/Acceptance/run_setup_predecessor_drag_browser_preview.ps1
+++ b/Setup/Acceptance/run_setup_predecessor_drag_browser_preview.ps1
@@ -61,10 +61,10 @@ $serverInjection = @'
         'SQL',
         '',
         'echo',
-        'echo "--- Apply Issue #151 prerequisite-order migration to disposable clone only ---"',
-        'M026="$CANDIDATE_WORKTREE/Setup/Database/026_add_setup_dependency_order.sql"',
-        'if [[ ! -s "$M026" ]]; then echo "FAIL: Issue #151 migration missing: $M026"; exit 13; fi',
-        'psql_test < "$M026"',
+        'echo "--- Apply Issue #151 prerequisite-order migration to disposable clone only ---"'.Replace('\"','"'),
+        'M026="$CANDIDATE_WORKTREE/Setup/Database/026_add_setup_dependency_order.sql"'.Replace('\"','"'),
+        'if [[ ! -s "$M026" ]]; then echo "FAIL: Issue #151 migration missing: $M026"; exit 13; fi'.Replace('\"','"'),
+        'psql_test < "$M026"'.Replace('\"','"'),
         "psql_test <<'SQL151'",
         'DO $block$',
         'BEGIN',
@@ -85,7 +85,7 @@ $serverInjection = @'
         'END',
         '$block$;',
         'SQL151',
-        'echo "Issue #151 prerequisite-order migration on disposable clone: PASS"',
+        'echo "Issue #151 prerequisite-order migration on disposable clone: PASS"'.Replace('\"','"'),
         '',
         'TEST_IP='
     ) -join "`n"

--- a/Setup/Acceptance/run_setup_predecessor_drag_browser_preview.ps1
+++ b/Setup/Acceptance/run_setup_predecessor_drag_browser_preview.ps1
@@ -7,9 +7,9 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-# Exact V0.3.9 application/test candidate for Issue #151. Later commits may
-# harden acceptance tooling only; browser/deployment approval remains pinned here.
-$AcceptedCandidateSha = 'bfff954618f12a591af4900b71c4938ca5790382'
+# Exact V0.3.9 application/schema/test candidate for Issue #151. Later commits
+# may harden acceptance tooling only; browser/deployment approval remains pinned.
+$AcceptedCandidateSha = '280ec6bee5ec9847459f28de41140520e71b0910'
 $AcceptedBranch = 'agent/setup-shift-drag-predecessor-151'
 $BaseWrapper = Join-Path $PSScriptRoot 'run_setup_source_only_browser_preview.ps1'
 
@@ -43,26 +43,78 @@ $regressionNeedle = "        '      Setup/Application/test_setup_next_pass_contr
 $regressionReplacement = @(
     "        '      Setup/Application/test_setup_next_pass_contract.py \',",
     "        '      Setup/Application/test_setup_predecessor_drag_contract.py \',",
+    "        '      Setup/Application/test_setup_prerequisite_editor_contract.py \',",
     "        '      Setup/Application/test_setup_dirty_edit_guard_contract.py \',",
     "        '      Setup/Application/test_setup_task_detail_compact_contract.py'"
 ) -join "`n"
 $text = Replace-Required -Source $text -Needle $regressionNeedle -Replacement $regressionReplacement -Description 'focused regression tail'
 
+# Issue #151 now includes a narrow schema migration for persistent prerequisite
+# review order. Apply it only after the current Production dump has been restored
+# into the disposable clone and after fieldwiring_app has been recreated there.
+# The live Production database remains pg_dump + SELECT only during this preview.
+$serverInjectionNeedle = '    # Fail locally before SCP if any CR characters were reintroduced by a later'
+$serverInjection = @'
+    # Issue #151 prerequisite-order migration belongs only in the disposable clone.
+    $migrationNeedle = "SQL`n`nTEST_IP="
+    $migrationReplacement = @(
+        'SQL',
+        '',
+        'echo',
+        'echo "--- Apply Issue #151 prerequisite-order migration to disposable clone only ---"',
+        'M026="$CANDIDATE_WORKTREE/Setup/Database/026_add_setup_dependency_order.sql"',
+        'if [[ ! -s "$M026" ]]; then echo "FAIL: Issue #151 migration missing: $M026"; exit 13; fi',
+        'psql_test < "$M026"',
+        "psql_test <<'SQL151'",
+        'DO $block$',
+        'BEGIN',
+        "    IF NOT EXISTS (SELECT 1 FROM pg_attribute WHERE attrelid = 'ref.setup_task_dependency'::regclass AND attname = 'sort_order' AND attnotnull) THEN",
+        "        RAISE EXCEPTION 'Issue #151 sort_order column is missing or nullable';",
+        '    END IF;',
+        "    IF to_regprocedure('ref.reorder_setup_task_dependencies(text,bigint,bigint[])') IS NULL THEN",
+        "        RAISE EXCEPTION 'Issue #151 reorder command is missing';",
+        '    END IF;',
+        "    IF NOT has_function_privilege('fieldwiring_app', 'ref.reorder_setup_task_dependencies(text,bigint,bigint[])', 'EXECUTE') THEN",
+        "        RAISE EXCEPTION 'fieldwiring_app cannot execute Issue #151 reorder command';",
+        '    END IF;',
+        "    IF has_table_privilege('fieldwiring_app', 'ref.setup_task_dependency', 'UPDATE')",
+        "       OR has_table_privilege('fieldwiring_app', 'ref.setup_task_dependency', 'INSERT')",
+        "       OR has_table_privilege('fieldwiring_app', 'ref.setup_task_dependency', 'DELETE') THEN",
+        "        RAISE EXCEPTION 'fieldwiring_app unexpectedly has broad prerequisite table DML';",
+        '    END IF;',
+        'END',
+        '$block$;',
+        'SQL151',
+        'echo "Issue #151 prerequisite-order migration on disposable clone: PASS"',
+        '',
+        'TEST_IP='
+    ) -join "`n"
+    if (-not $serverText.Contains($migrationNeedle)) {
+        throw 'Issue #151 preview could not find the disposable clone role-grant boundary.'
+    }
+    $serverText = $serverText.Replace($migrationNeedle, $migrationReplacement)
+
+    # Fail locally before SCP if any CR characters were reintroduced by a later
+'@
+$serverInjection = $serverInjection.Replace("`r`n", "`n").Replace("`r", "`n")
+$text = Replace-Required -Source $text -Needle $serverInjectionNeedle -Replacement $serverInjection -Description 'disposable migration injection point'
+
 $text = $text.Replace('SETUP SOURCE-ONLY BROWSER PREVIEW', 'SETUP SHIFT-DRAG PREDECESSOR V0.3.9 BROWSER PREVIEW')
 $text = $text.Replace('SETUP SOURCE-ONLY BROWSER REVIEW READY', 'SETUP SHIFT-DRAG PREDECESSOR V0.3.9 BROWSER REVIEW READY')
 
 Write-Host 'Issue #151 Shift-drag predecessor V0.3.9 browser acceptance checklist:'
-Write-Host '  0. Confirm the header visibly shows Client V0.3.9 and the Catalog shows the Fast prerequisite entry hint.'
-Write-Host '  1. Choose two disposable-clone reusable tasks A and B and note both tasks'' current scope/order before testing.'
-Write-Host '  2. Hold Shift BEFORE pressing the left mouse button on dependent task A, then drag. A must visibly show Dependent.'
-Write-Host '  3. Drag A over prerequisite task B. B must visibly show Prerequisite target; release on B.'
-Write-Host '  4. Confirm explicit success feedback says A depends on B and neither task moved. A''s Requires line must show B.'
-Write-Host '  5. Repeat the same Shift-drag A -> B. Confirm it remains one dependency, not a duplicate.'
-Write-Host '  6. Try Shift-drag B -> A. Confirm the governed circular-dependency error is shown and neither task moves.'
-Write-Host '  7. Confirm A and B still have their original scope/order after all Shift-drag operations.'
-Write-Host '  8. Now perform one ordinary drag WITHOUT Shift. Confirm normal Catalog move/reorder behavior still works.'
-Write-Host '  9. Open task A and confirm the existing manual prerequisite editor still shows/removes B as a normal fallback.'
-Write-Host ' 10. Verify Shift-drag over empty Stage/Scene space does not move the task and reports that a task target is required.'
+Write-Host '  0. Confirm the header visibly shows Client V0.3.9 and the preview reports the Issue #151 migration PASS on the disposable clone.'
+Write-Host '  1. In the Catalog, hold Shift BEFORE pressing the left mouse button on dependent task A; drag onto prerequisite B. Confirm A depends on B and neither task moves.'
+Write-Host '  2. Add a second prerequisite C to A by Shift-drag. Confirm the Catalog Requires line lists both B and C.'
+Write-Host '  3. Repeat A -> B and confirm no duplicate relationship appears.'
+Write-Host '  4. Try a reverse relationship that would make a cycle. Confirm the governed circular-dependency error and no task movement.'
+Write-Host '  5. Open A. Confirm there is ONE prerequisite list only: each row appears once with position, Up, Down, and Remove controls; the separate Add prerequisite form is below it.'
+Write-Host '  6. Move C above B with Up/Down. Confirm the detail list AND Catalog Requires line immediately show the same new order. Close/reopen A and confirm order persists.'
+Write-Host '  7. Remove one prerequisite. Confirm it disappears immediately from the one detail list and the Catalog Requires line; close/reopen A and confirm it stays removed.'
+Write-Host '  8. Add one prerequisite using the manual Add form. Confirm the newly added task appends once, the dropdown no longer offers it as an available choice, and all views agree.'
+Write-Host '  9. Perform one ordinary drag WITHOUT Shift. Confirm normal Catalog move/reorder/scope behavior remains unchanged.'
+Write-Host ' 10. Shift-drag over empty Stage/Scene space and release. Confirm the gesture cancels without moving the task.'
+Write-Host ' 11. Remember: prerequisite Up/Down is review/display order only. It does not imply one prerequisite depends on another.'
 Write-Host
 
 $script = [scriptblock]::Create($text)

--- a/Setup/Acceptance/run_setup_predecessor_drag_browser_preview.ps1
+++ b/Setup/Acceptance/run_setup_predecessor_drag_browser_preview.ps1
@@ -9,7 +9,7 @@ $ErrorActionPreference = 'Stop'
 
 # Exact V0.3.9 application/test candidate for Issue #151. Later commits may
 # harden acceptance tooling only; browser/deployment approval remains pinned here.
-$AcceptedCandidateSha = 'f23e305a25959297fbe83b68753a5be471871652'
+$AcceptedCandidateSha = 'bfff954618f12a591af4900b71c4938ca5790382'
 $AcceptedBranch = 'agent/setup-shift-drag-predecessor-151'
 $BaseWrapper = Join-Path $PSScriptRoot 'run_setup_source_only_browser_preview.ps1'
 

--- a/Setup/Acceptance/run_setup_predecessor_drag_browser_preview.ps1
+++ b/Setup/Acceptance/run_setup_predecessor_drag_browser_preview.ps1
@@ -9,7 +9,7 @@ $ErrorActionPreference = 'Stop'
 
 # Exact V0.3.9 application/test candidate for Issue #151. Later commits may
 # harden acceptance tooling only; browser/deployment approval remains pinned here.
-$AcceptedCandidateSha = 'bd7457205b7f6596b9221348b6118ba9861abecc'
+$AcceptedCandidateSha = '47845209a1eadb694a6ec75deba67ce241f37a5e'
 $AcceptedBranch = 'agent/setup-shift-drag-predecessor-151'
 $BaseWrapper = Join-Path $PSScriptRoot 'run_setup_source_only_browser_preview.ps1'
 

--- a/Setup/Acceptance/setup_session_browser_preview_cleanup_server.sh
+++ b/Setup/Acceptance/setup_session_browser_preview_cleanup_server.sh
@@ -2,7 +2,16 @@
 set -euo pipefail
 
 FIELDWIRING_ROOT="/opt/fieldwiring"
-PREVIEW_PORT="${1:-8794}"
+PREVIEW_PORT="${1:?preview port required}"
+
+if [[ ! "$PREVIEW_PORT" =~ ^[0-9]+$ ]] || (( PREVIEW_PORT < 1024 || PREVIEW_PORT > 65535 )); then
+    echo "FAIL: preview port must be 1024-65535"
+    exit 2
+fi
+if [[ "$PREVIEW_PORT" == "8055" || "$PREVIEW_PORT" == "8790" || "$PREVIEW_PORT" == "8792" || "$PREVIEW_PORT" == "8794" ]]; then
+    echo "FAIL: port $PREVIEW_PORT is a governed Production listener and must never be cleaned as preview state"
+    exit 3
+fi
 
 sudo -v
 
@@ -10,6 +19,8 @@ echo "========== SETUP SESSION BROWSER PREVIEW STALE CLEANUP =========="
 echo "Preview port: $PREVIEW_PORT"
 echo
 
+# Legacy Setup browser-preview resources. Keep this path for older launchers that
+# use the msb-setup-browser-preview-* naming contract.
 mapfile -t preview_pids < <(
     ps -eo pid=,comm=,args= \
         | awk '
@@ -21,7 +32,7 @@ mapfile -t preview_pids < <(
 )
 for pid in "${preview_pids[@]}"; do
     [[ -n "$pid" ]] || continue
-    echo "Stopping stale Setup preview Python process: $pid"
+    echo "Stopping stale legacy Setup preview Python process: $pid"
     sudo kill "$pid" >/dev/null 2>&1 || true
 done
 if (( ${#preview_pids[@]} > 0 )); then
@@ -30,6 +41,136 @@ if (( ${#preview_pids[@]} > 0 )); then
         [[ -n "$pid" ]] || continue
         if sudo kill -0 "$pid" >/dev/null 2>&1; then
             sudo kill -KILL "$pid" >/dev/null 2>&1 || true
+        fi
+    done
+fi
+
+# Source-only previews intentionally run a detached fieldwiring-owned Flask
+# process from /tmp/setup_session_browser_preview_entry.py. Recover only the
+# process actually listening on the requested non-Production preview port.
+source_worktrees=()
+source_stamps=()
+source_containers=()
+mapfile -t source_listener_pids < <(
+    sudo ss -ltnp "sport = :$PREVIEW_PORT" 2>/dev/null \
+        | grep -oE 'pid=[0-9]+' \
+        | cut -d= -f2 \
+        | sort -u \
+        || true
+)
+
+for pid in "${source_listener_pids[@]}"; do
+    [[ -n "$pid" ]] || continue
+
+    cmdline="$(sudo tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null || true)"
+    owner="$(ps -o user= -p "$pid" 2>/dev/null | xargs || true)"
+    if [[ "$cmdline" != *"/tmp/setup_session_browser_preview_entry.py"* || "$owner" != "fieldwiring" ]]; then
+        echo "FAIL: preview port $PREVIEW_PORT is owned by an unexpected process; refusing to kill it"
+        ps -o pid,ppid,pgid,user,args -p "$pid" || true
+        exit 4
+    fi
+
+    app_dir="$(sudo tr '\0' '\n' < "/proc/$pid/environ" 2>/dev/null \
+        | sed -n 's/^MSB_SETUP_PREVIEW_APP_DIR=//p' \
+        | head -1)"
+    if [[ "$app_dir" == /tmp/msb-setup-source-preview-candidate-*/Setup/Application ]]; then
+        worktree="${app_dir%/Setup/Application}"
+        stamp="${worktree#/tmp/msb-setup-source-preview-candidate-}"
+        source_worktrees+=("$worktree")
+        source_stamps+=("$stamp")
+    fi
+
+    dsn="$(sudo tr '\0' '\n' < "/proc/$pid/environ" 2>/dev/null \
+        | sed -n 's/^SETUP_DATABASE_DSN=//p' \
+        | head -1)"
+    db_host="$(sed -n 's/.*\(^\|[[:space:]]\)host=\([^[:space:]]*\).*/\2/p' <<<"$dsn")"
+    if [[ -n "$db_host" ]]; then
+        while IFS= read -r name; do
+            [[ -n "$name" ]] || continue
+            ip="$(sudo docker inspect "$name" --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' 2>/dev/null || true)"
+            if [[ "$ip" == "$db_host" ]]; then
+                source_containers+=("$name")
+            fi
+        done < <(sudo docker ps -a --format '{{.Names}}' | grep '^msb-setup-source-preview-' || true)
+    fi
+
+    pgid="$(ps -o pgid= -p "$pid" 2>/dev/null | tr -d ' ')"
+    if [[ ! "$pgid" =~ ^[0-9]+$ ]]; then
+        echo "FAIL: could not determine process group for source-only preview PID $pid"
+        exit 5
+    fi
+
+    echo "Stopping stale source-only Setup preview process group: $pgid (PID $pid)"
+    sudo -u fieldwiring -H kill -- -"$pgid" >/dev/null 2>&1 || true
+done
+
+if (( ${#source_listener_pids[@]} > 0 )); then
+    sleep 1
+    for pid in "${source_listener_pids[@]}"; do
+        [[ -n "$pid" ]] || continue
+        if sudo kill -0 "$pid" >/dev/null 2>&1; then
+            pgid="$(ps -o pgid= -p "$pid" 2>/dev/null | tr -d ' ')"
+            if [[ "$pgid" =~ ^[0-9]+$ ]]; then
+                sudo -u fieldwiring -H kill -KILL -- -"$pgid" >/dev/null 2>&1 || true
+            fi
+        fi
+    done
+fi
+
+# The source-only server wrapper waits on the review TTY after launching Flask.
+# If the SSH/tunnel side disappears, that wrapper can survive even after Flask is
+# stopped. Kill only wrappers whose command line contains this exact preview port.
+mapfile -t source_wrapper_pids < <(
+    ps -eo pid=,comm=,args= \
+        | awk -v port="$PREVIEW_PORT" '
+            $2 == "bash" &&
+            $0 ~ /bash \/tmp\/msb-setup-source-preview-[0-9-]+\.sh/ &&
+            index($0, " " port " ") {
+                print $1
+            }
+        '
+)
+for pid in "${source_wrapper_pids[@]}"; do
+    [[ -n "$pid" ]] || continue
+    source_containers+=("msb-setup-source-preview-$pid")
+    echo "Stopping stale source-only Setup preview wrapper: $pid"
+    sudo kill -KILL "$pid" >/dev/null 2>&1 || true
+done
+
+# Remove only disposable containers discovered from the exact wrapper PID or the
+# exact database host used by the source-only Flask listener.
+if (( ${#source_containers[@]} > 0 )); then
+    mapfile -t unique_source_containers < <(printf '%s\n' "${source_containers[@]}" | awk 'NF && !seen[$0]++')
+    for name in "${unique_source_containers[@]}"; do
+        [[ -n "$name" ]] || continue
+        if sudo docker ps -a --format '{{.Names}}' | grep -Fxq "$name"; then
+            echo "Removing stale source-only Setup preview container: $name"
+            sudo docker rm -f "$name" >/dev/null
+        fi
+    done
+fi
+
+# Remove only worktrees identified from the exact listener environment. Reports
+# and Flask logs are retained as acceptance evidence.
+if (( ${#source_worktrees[@]} > 0 )); then
+    mapfile -t unique_source_worktrees < <(printf '%s\n' "${source_worktrees[@]}" | awk 'NF && !seen[$0]++')
+    for wt in "${unique_source_worktrees[@]}"; do
+        [[ -n "$wt" ]] || continue
+        if sudo git -C "$FIELDWIRING_ROOT" worktree list --porcelain 2>/dev/null | grep -Fq "worktree $wt"; then
+            echo "Removing stale source-only Setup preview worktree: $wt"
+            sudo git -C "$FIELDWIRING_ROOT" worktree remove --force "$wt" >/dev/null
+        fi
+    done
+fi
+
+if (( ${#source_stamps[@]} > 0 )); then
+    mapfile -t unique_source_stamps < <(printf '%s\n' "${source_stamps[@]}" | awk 'NF && !seen[$0]++')
+    for stamp in "${unique_source_stamps[@]}"; do
+        [[ "$stamp" =~ ^[0-9]{8}T[0-9]{6}$ ]] || continue
+        dump="/tmp/msb-setup-source-preview-$stamp.dump"
+        if [[ -f "$dump" ]]; then
+            echo "Removing stale source-only Setup preview dump: $dump"
+            rm -f -- "$dump"
         fi
     done
 fi
@@ -71,7 +212,7 @@ for link_root in /tmp/msb-setup-google-links-*; do
     fi
     if mountpoint -q "$link_root" 2>/dev/null; then
         echo "FAIL: stale Setup Google Doc link view is still mounted: $link_root"
-        exit 3
+        exit 6
     fi
     sudo rm -rf -- "$link_root"
 done
@@ -81,7 +222,7 @@ mapfile -t preview_containers < <(
 )
 for name in "${preview_containers[@]}"; do
     [[ -n "$name" ]] || continue
-    echo "Removing stale Setup preview container: $name"
+    echo "Removing stale legacy Setup preview container: $name"
     sudo docker rm -f "$name" >/dev/null
 done
 
@@ -92,20 +233,26 @@ mapfile -t preview_worktrees < <(
 )
 for wt in "${preview_worktrees[@]}"; do
     [[ -n "$wt" ]] || continue
-    echo "Removing stale Setup preview worktree: $wt"
+    echo "Removing stale legacy Setup preview worktree: $wt"
     sudo git -C "$FIELDWIRING_ROOT" worktree remove --force "$wt" >/dev/null 2>&1 || true
 done
 
 for path in /tmp/msb-setup-browser-preview-*; do
     [[ -e "$path" ]] || continue
-    echo "Removing stale Setup preview bundle/path: $path"
+    echo "Removing stale legacy Setup preview bundle/path: $path"
     rm -rf -- "$path"
 done
 
+# The common source-only entry path is safe to remove only after the requested
+# preview port is no longer owned by a source-only preview process.
+if ! ss -ltnH "sport = :$PREVIEW_PORT" | grep -q .; then
+    rm -f /tmp/setup_session_browser_preview_entry.py >/dev/null 2>&1 || true
+fi
+
 if ss -ltnH "sport = :$PREVIEW_PORT" | grep -q .; then
     echo "FAIL: TCP port $PREVIEW_PORT is still listening after Setup preview cleanup"
-    ss -ltnp "sport = :$PREVIEW_PORT" || true
-    exit 2
+    sudo ss -ltnp "sport = :$PREVIEW_PORT" || true
+    exit 7
 fi
 
 echo "PASS: preview port $PREVIEW_PORT is free"

--- a/Setup/Acceptance/setup_session_browser_preview_cleanup_server.sh
+++ b/Setup/Acceptance/setup_session_browser_preview_cleanup_server.sh
@@ -62,15 +62,17 @@ mapfile -t source_listener_pids < <(
 for pid in "${source_listener_pids[@]}"; do
     [[ -n "$pid" ]] || continue
 
-    cmdline="$(sudo tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null || true)"
-    owner="$(ps -o user= -p "$pid" 2>/dev/null | xargs || true)"
-    if [[ "$cmdline" != *"/tmp/setup_session_browser_preview_entry.py"* || "$owner" != "fieldwiring" ]]; then
+    cmdline="$(sudo cat "/proc/$pid/cmdline" 2>/dev/null | tr '\0' ' ' || true)"
+    owner_uid="$(ps -o uid= -p "$pid" 2>/dev/null | xargs || true)"
+    fieldwiring_uid="$(id -u fieldwiring)"
+    if [[ "$cmdline" != *"/tmp/setup_session_browser_preview_entry.py"* || "$owner_uid" != "$fieldwiring_uid" ]]; then
         echo "FAIL: preview port $PREVIEW_PORT is owned by an unexpected process; refusing to kill it"
         ps -o pid,ppid,pgid,user,args -p "$pid" || true
         exit 4
     fi
 
-    app_dir="$(sudo tr '\0' '\n' < "/proc/$pid/environ" 2>/dev/null \
+    app_dir="$(sudo cat "/proc/$pid/environ" 2>/dev/null \
+        | tr '\0' '\n' \
         | sed -n 's/^MSB_SETUP_PREVIEW_APP_DIR=//p' \
         | head -1)"
     if [[ "$app_dir" == /tmp/msb-setup-source-preview-candidate-*/Setup/Application ]]; then
@@ -80,7 +82,8 @@ for pid in "${source_listener_pids[@]}"; do
         source_stamps+=("$stamp")
     fi
 
-    dsn="$(sudo tr '\0' '\n' < "/proc/$pid/environ" 2>/dev/null \
+    dsn="$(sudo cat "/proc/$pid/environ" 2>/dev/null \
+        | tr '\0' '\n' \
         | sed -n 's/^SETUP_DATABASE_DSN=//p' \
         | head -1)"
     db_host="$(sed -n 's/.*\(^\|[[:space:]]\)host=\([^[:space:]]*\).*/\2/p' <<<"$dsn")"

--- a/Setup/Application/production.html
+++ b/Setup/Application/production.html
@@ -12,6 +12,7 @@
   <link rel="stylesheet" href="setup_review_usability.css?v=2026-09-07.2">
   <link rel="stylesheet" href="setup_next_pass.css?v=2026-09-07.4">
   <link rel="stylesheet" href="setup_predecessor_drag.css?v=2026-09-11.1">
+  <link rel="stylesheet" href="setup_prerequisite_editor.css?v=2026-09-11.1">
   <link rel="stylesheet" href="setup_stage_order.css?v=2026-09-10.1">
   <link rel="stylesheet" href="setup_acceptance_fixes.css?v=2026-09-07.1">
   <link rel="stylesheet" href="setup_session_year_guard.css?v=2026-09-07.1">
@@ -146,8 +147,8 @@
 
           <section class="detail-section">
             <h3>Prerequisites</h3>
+            <div class="hint">All listed prerequisites must be complete before this task can start. Circular dependencies are blocked by the database command layer.</div>
             <div id="detail-dependencies" class="chip-row"></div>
-            <div class="hint">Managers can maintain reusable prerequisites in this review candidate. Circular dependencies are blocked by the database command layer.</div>
           </section>
 
           <section class="detail-section">
@@ -240,6 +241,7 @@
 <script src="setup_training_review_refinement.js?v=2026-09-09.3"></script>
 <script src="setup_catalog_effort.js?v=2026-09-09.3"></script>
 <script src="setup_catalog_dirty_guard.js?v=2026-09-11.1"></script>
+<script src="setup_prerequisite_editor.js?v=2026-09-11.1"></script>
 <script src="setup_task_detail_compact.js?v=2026-09-11.1"></script>
 </body>
 </html>

--- a/Setup/Application/production.html
+++ b/Setup/Application/production.html
@@ -11,6 +11,7 @@
   <link rel="stylesheet" href="setup_resource_review.css?v=2026-09-08.1">
   <link rel="stylesheet" href="setup_review_usability.css?v=2026-09-07.2">
   <link rel="stylesheet" href="setup_next_pass.css?v=2026-09-07.4">
+  <link rel="stylesheet" href="setup_predecessor_drag.css?v=2026-09-11.1">
   <link rel="stylesheet" href="setup_stage_order.css?v=2026-09-10.1">
   <link rel="stylesheet" href="setup_acceptance_fixes.css?v=2026-09-07.1">
   <link rel="stylesheet" href="setup_session_year_guard.css?v=2026-09-07.1">
@@ -228,6 +229,7 @@
 <script src="setup_resource_review.js?v=2026-09-08.1"></script>
 <script src="setup_review_usability.js?v=2026-09-07.2"></script>
 <script src="setup_next_pass.js?v=2026-09-07.4"></script>
+<script src="setup_predecessor_drag.js?v=2026-09-11.1"></script>
 <script src="setup_stage_order.js?v=2026-09-10.1"></script>
 <script src="setup_acceptance_fixes.js?v=2026-09-07.1"></script>
 <script src="setup_session_year_guard.js?v=2026-09-07.1"></script>

--- a/Setup/Application/production_backend.py
+++ b/Setup/Application/production_backend.py
@@ -20,7 +20,7 @@ from setup_effort_api import setup_effort_api
 from setup_material_api import setup_material_api
 from setup_material_resolution import install_setup_material_resolution
 
-PRODUCTION_VERSION = "V0.3.8-task-detail-compact"
+PRODUCTION_VERSION = "V0.3.9-predecessor-drag"
 PRODUCTION_ASSETS = frozenset(
     {
         "setup.css",

--- a/Setup/Application/production_backend.py
+++ b/Setup/Application/production_backend.py
@@ -18,6 +18,7 @@ from setup_next_api import setup_next_api
 from setup_training_api import setup_training_api
 from setup_effort_api import setup_effort_api
 from setup_material_api import setup_material_api
+from setup_prerequisite_order_api import setup_prerequisite_order_api
 from setup_material_resolution import install_setup_material_resolution
 
 PRODUCTION_VERSION = "V0.3.9-predecessor-drag"
@@ -37,6 +38,8 @@ PRODUCTION_ASSETS = frozenset(
         "setup_next_pass.js",
         "setup_predecessor_drag.css",
         "setup_predecessor_drag.js",
+        "setup_prerequisite_editor.css",
+        "setup_prerequisite_editor.js",
         "setup_stage_order.css",
         "setup_stage_order.js",
         "setup_acceptance_fixes.css",
@@ -71,6 +74,7 @@ app.register_blueprint(setup_next_api)
 app.register_blueprint(setup_training_api)
 app.register_blueprint(setup_effort_api)
 app.register_blueprint(setup_material_api)
+app.register_blueprint(setup_prerequisite_order_api)
 
 
 def _no_store(response):

--- a/Setup/Application/production_backend.py
+++ b/Setup/Application/production_backend.py
@@ -35,6 +35,8 @@ PRODUCTION_ASSETS = frozenset(
         "setup_review_usability.js",
         "setup_next_pass.css",
         "setup_next_pass.js",
+        "setup_predecessor_drag.css",
+        "setup_predecessor_drag.js",
         "setup_stage_order.css",
         "setup_stage_order.js",
         "setup_acceptance_fixes.css",

--- a/Setup/Application/setup_catalog_dirty_guard.js
+++ b/Setup/Application/setup_catalog_dirty_guard.js
@@ -12,7 +12,7 @@
 (() => {
   'use strict';
 
-  const CLIENT_BUILD = 'V0.3.8-task-detail-compact';
+  const CLIENT_BUILD = 'V0.3.9-predecessor-drag';
   const reusableFieldIds = new Set([
     'edit-task-name',
     'edit-stage-id',
@@ -117,7 +117,6 @@
   function anyDirty() {
     return reusableDirty() || annualDirty();
   }
-
   function dirtyDescription() {
     const parts = [];
     if (reusableDirty()) parts.push('reusable task');
@@ -132,7 +131,7 @@
     const badge = document.createElement('span');
     badge.id = 'setup-client-build-badge';
     badge.className = 'pill';
-    badge.textContent = 'Client V0.3.8';
+    badge.textContent = 'Client V0.3.9';
     badge.title = CLIENT_BUILD;
     access.insertAdjacentElement('afterend', badge);
   }
@@ -140,7 +139,7 @@
   function setBuildBadgeState(serverVersion, ok) {
     const badge = document.getElementById('setup-client-build-badge');
     if (!badge) return;
-    badge.textContent = ok ? 'Client V0.3.8' : 'CLIENT / SERVER MISMATCH';
+    badge.textContent = ok ? 'Client V0.3.9' : 'CLIENT / SERVER MISMATCH';
     badge.title = `Client ${CLIENT_BUILD}; server ${serverVersion || 'unknown'}`;
     badge.dataset.state = ok ? 'ok' : 'error';
   }

--- a/Setup/Application/setup_predecessor_drag.css
+++ b/Setup/Application/setup_predecessor_drag.css
@@ -15,6 +15,10 @@
   font-weight: 700;
 }
 
+.next-task-row[draggable="true"] {
+  user-select: none;
+}
+
 .next-task-row.dependency-dragging,
 .next-task-row.dependency-drop-target {
   position: relative;

--- a/Setup/Application/setup_predecessor_drag.css
+++ b/Setup/Application/setup_predecessor_drag.css
@@ -1,0 +1,51 @@
+/* Shift-drag predecessor cues for Setup Issue #151. */
+
+.next-predecessor-drag-hint {
+  margin: 0.65rem 0 0.8rem;
+}
+
+.next-predecessor-drag-hint kbd {
+  display: inline-block;
+  padding: 0.05rem 0.35rem;
+  border: 1px solid var(--border);
+  border-radius: 0.3rem;
+  background: var(--panel);
+  color: var(--text);
+  font: inherit;
+  font-weight: 700;
+}
+
+.next-task-row.dependency-dragging,
+.next-task-row.dependency-drop-target {
+  position: relative;
+}
+
+.next-task-row.dependency-dragging {
+  opacity: 0.72;
+  outline: 2px dashed var(--accent);
+  outline-offset: -2px;
+}
+
+.next-task-row.dependency-drop-target {
+  background: var(--accent-soft);
+  outline: 3px solid var(--accent);
+  outline-offset: -3px;
+}
+
+.next-task-row.dependency-dragging::after,
+.next-task-row.dependency-drop-target::after {
+  content: attr(data-dependency-role);
+  position: absolute;
+  top: 0.2rem;
+  right: 0.35rem;
+  z-index: 2;
+  padding: 0.15rem 0.4rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--panel);
+  color: var(--text);
+  font-size: 0.72rem;
+  font-weight: 800;
+  line-height: 1.2;
+  pointer-events: none;
+}

--- a/Setup/Application/setup_predecessor_drag.css
+++ b/Setup/Application/setup_predecessor_drag.css
@@ -1,4 +1,4 @@
-/* Shift-drag predecessor cues for Setup Issue #151. */
+/* Shift-drag predecessor cues for Setup Issue 151. */
 
 .next-predecessor-drag-hint {
   margin: 0.65rem 0 0.8rem;

--- a/Setup/Application/setup_predecessor_drag.js
+++ b/Setup/Application/setup_predecessor_drag.js
@@ -1,0 +1,152 @@
+/* Fast governed predecessor entry for Setup Issue #151.
+ *
+ * Hold Shift before starting a Catalog task drag. The dragged task is the
+ * dependent task; the task it is dropped onto becomes the prerequisite.
+ * Ordinary drag is intentionally left to setup_next_pass.js unchanged.
+ */
+(() => {
+  'use strict';
+
+  const state = {
+    dependencyMode: false,
+    sourceTaskId: null,
+    targetTaskId: null
+  };
+
+  function taskName(taskId) {
+    const task = typeof taskById === 'function' ? taskById(Number(taskId)) : null;
+    return task?.task_name || `Task ${taskId}`;
+  }
+
+  function clearVisualState() {
+    document.querySelectorAll('.next-task-row').forEach((row) => {
+      row.classList.remove('dependency-dragging', 'dependency-drop-target');
+      row.removeAttribute('data-dependency-role');
+    });
+    state.targetTaskId = null;
+  }
+
+  function finishDependencyDrag() {
+    clearVisualState();
+    state.dependencyMode = false;
+    state.sourceTaskId = null;
+  }
+
+  function installCatalogHint() {
+    const list = document.getElementById('library-list');
+    if (!list || document.getElementById('next-predecessor-drag-hint')) return;
+    const hint = document.createElement('div');
+    hint.id = 'next-predecessor-drag-hint';
+    hint.className = 'hint next-predecessor-drag-hint manager-only';
+    hint.innerHTML = '<strong>Fast prerequisite entry:</strong> Hold <kbd>Shift</kbd> before dragging the later/dependent task onto the task that must happen first. Normal drag still moves/reorders tasks.';
+    list.insertAdjacentElement('beforebegin', hint);
+  }
+
+  async function createPredecessorDependency(dependentTaskId, prerequisiteTaskId) {
+    const dependentName = taskName(dependentTaskId);
+    const prerequisiteName = taskName(prerequisiteTaskId);
+    try {
+      setBusy(true);
+      await api(
+        `api/setup/tasks/${dependentTaskId}/dependencies/${prerequisiteTaskId}`,
+        commandOptions('PATCH', {
+          active: true,
+          dependency_note: null
+        })
+      );
+      await reloadTasks(null);
+      await loadNextOrganization(false);
+      renderLibrary();
+      setAlert(`Prerequisite saved: ${dependentName} depends on ${prerequisiteName}. Neither task moved.`, 'ok');
+    } catch (error) {
+      const message = error.message || error;
+      setAlert(message, 'error');
+      window.alert(message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  document.addEventListener('dragstart', (event) => {
+    const row = event.target instanceof Element ? event.target.closest('.next-task-row') : null;
+    if (!row || !event.shiftKey || !appState.access?.can_manage_setup) return;
+
+    const taskId = Number(row.dataset.taskId || 0);
+    if (!taskId) return;
+
+    state.dependencyMode = true;
+    state.sourceTaskId = taskId;
+    clearVisualState();
+    row.classList.add('dependency-dragging');
+    row.dataset.dependencyRole = 'Dependent';
+
+    if (event.dataTransfer) {
+      event.dataTransfer.effectAllowed = 'link';
+      event.dataTransfer.setData('application/x-msb-setup-dependent-task', String(taskId));
+      event.dataTransfer.setData('text/plain', String(taskId));
+    }
+
+    // Prevent the existing ordinary move/reorder dragstart handler from running.
+    event.stopImmediatePropagation();
+    setAlert(`Dependency mode: ${taskName(taskId)} is the dependent task. Drop it onto the task that must happen first.`, 'ok');
+  }, true);
+
+  document.addEventListener('dragover', (event) => {
+    if (!state.dependencyMode) return;
+
+    // Shift-drag must never fall through to the ordinary row/scope move handlers.
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    clearVisualState();
+
+    const row = event.target instanceof Element ? event.target.closest('.next-task-row') : null;
+    const targetTaskId = Number(row?.dataset.taskId || 0);
+    if (!row || !targetTaskId || targetTaskId === state.sourceTaskId) {
+      if (event.dataTransfer) event.dataTransfer.dropEffect = 'none';
+      const sourceRow = document.querySelector(`.next-task-row[data-task-id="${state.sourceTaskId}"]`);
+      sourceRow?.classList.add('dependency-dragging');
+      if (sourceRow) sourceRow.dataset.dependencyRole = 'Dependent';
+      return;
+    }
+
+    const sourceRow = document.querySelector(`.next-task-row[data-task-id="${state.sourceTaskId}"]`);
+    sourceRow?.classList.add('dependency-dragging');
+    if (sourceRow) sourceRow.dataset.dependencyRole = 'Dependent';
+
+    state.targetTaskId = targetTaskId;
+    row.classList.add('dependency-drop-target');
+    row.dataset.dependencyRole = 'Prerequisite target';
+    if (event.dataTransfer) event.dataTransfer.dropEffect = 'link';
+  }, true);
+
+  document.addEventListener('drop', (event) => {
+    if (!state.dependencyMode) return;
+
+    event.preventDefault();
+    event.stopImmediatePropagation();
+
+    const dependentTaskId = Number(state.sourceTaskId || 0);
+    const row = event.target instanceof Element ? event.target.closest('.next-task-row') : null;
+    const prerequisiteTaskId = Number(row?.dataset.taskId || 0);
+    finishDependencyDrag();
+
+    if (!dependentTaskId || !prerequisiteTaskId) {
+      setAlert('Dependency drag canceled. Drop the dependent task onto another Setup task.', 'error');
+      return;
+    }
+    if (dependentTaskId === prerequisiteTaskId) {
+      setAlert('A Setup task cannot depend on itself.', 'error');
+      return;
+    }
+
+    void createPredecessorDependency(dependentTaskId, prerequisiteTaskId);
+  }, true);
+
+  document.addEventListener('dragend', (event) => {
+    if (!state.dependencyMode) return;
+    event.stopImmediatePropagation();
+    finishDependencyDrag();
+  }, true);
+
+  installCatalogHint();
+})();

--- a/Setup/Application/setup_predecessor_drag.js
+++ b/Setup/Application/setup_predecessor_drag.js
@@ -1,18 +1,20 @@
 /* Fast governed predecessor entry for Setup Issue #151.
  *
- * Hold Shift before starting a Catalog task drag. The dragged task is the
- * dependent task; the task it is dropped onto becomes the prerequisite.
- * Ordinary drag is intentionally left to setup_next_pass.js unchanged.
+ * Hold Shift before pressing the left mouse button on a Catalog task. The
+ * dragged task is the dependent task; the task released over becomes the
+ * prerequisite. Shift mode uses pointer events instead of native HTML5 drag so
+ * Windows/browser modifier behavior cannot interfere with the gesture.
+ * Ordinary drag remains owned by setup_next_pass.js unchanged.
  */
 (() => {
   'use strict';
 
   const state = {
-    shiftArmed: false,
-    armedTaskId: null,
-    dependencyMode: false,
+    active: false,
+    pointerId: null,
     sourceTaskId: null,
-    targetTaskId: null
+    targetTaskId: null,
+    sourceRow: null
   };
 
   function taskName(taskId) {
@@ -28,16 +30,13 @@
     state.targetTaskId = null;
   }
 
-  function clearArmedState() {
-    state.shiftArmed = false;
-    state.armedTaskId = null;
-  }
-
-  function finishDependencyDrag() {
+  function resetState() {
     clearVisualState();
-    clearArmedState();
-    state.dependencyMode = false;
+    state.active = false;
+    state.pointerId = null;
     state.sourceTaskId = null;
+    state.sourceRow = null;
+    document.body.classList.remove('setup-dependency-pointer-drag');
   }
 
   function installCatalogHint() {
@@ -75,120 +74,98 @@
     }
   }
 
-  document.addEventListener('pointerdown', (event) => {
-    if (state.dependencyMode) return;
-    if (event.button !== 0) {
-      clearArmedState();
-      return;
-    }
+  function rowAtPoint(clientX, clientY) {
+    const hit = document.elementFromPoint(clientX, clientY);
+    return hit instanceof Element ? hit.closest('.next-task-row') : null;
+  }
 
-    const row = event.target instanceof Element ? event.target.closest('.next-task-row') : null;
-    if (!row || !event.shiftKey || !appState.access?.can_manage_setup) {
-      clearArmedState();
-      return;
-    }
+  function updatePointerTarget(clientX, clientY) {
+    if (!state.active) return;
 
-    const taskId = Number(row.dataset.taskId || 0);
-    if (!taskId) {
-      clearArmedState();
-      return;
-    }
-
-    state.shiftArmed = true;
-    state.armedTaskId = taskId;
-  }, true);
-
-  document.addEventListener('pointerup', () => {
-    if (!state.dependencyMode) clearArmedState();
-  }, true);
-
-  document.addEventListener('dragstart', (event) => {
-    const row = event.target instanceof Element ? event.target.closest('.next-task-row') : null;
-    if (!row || !appState.access?.can_manage_setup) return;
-
-    const taskId = Number(row.dataset.taskId || 0);
-    const armedForThisTask = state.shiftArmed && Number(state.armedTaskId) === taskId;
-    if (!taskId || (!armedForThisTask && !event.shiftKey)) return;
-
-    state.dependencyMode = true;
-    state.sourceTaskId = taskId;
     clearVisualState();
-    row.classList.add('dependency-dragging');
-    row.dataset.dependencyRole = 'Dependent';
-
-    if (event.dataTransfer) {
-      // Use a permissive native drag effect. On Windows, Shift influences the
-      // browser's requested effect; restricting effectAllowed to "link" can
-      // prevent the drag from starting. The application still consumes the
-      // drop and performs only the dependency command below.
-      event.dataTransfer.effectAllowed = 'all';
-      event.dataTransfer.setData('application/x-msb-setup-dependent-task', String(taskId));
-      event.dataTransfer.setData('text/plain', String(taskId));
+    if (state.sourceRow?.isConnected) {
+      state.sourceRow.classList.add('dependency-dragging');
+      state.sourceRow.dataset.dependencyRole = 'Dependent';
     }
 
-    // Prevent the existing ordinary move/reorder dragstart handler from running.
-    event.stopImmediatePropagation();
-    setAlert(`Dependency mode: ${taskName(taskId)} is the dependent task. Drop it onto the task that must happen first.`, 'ok');
-  }, true);
-
-  document.addEventListener('dragover', (event) => {
-    if (!state.dependencyMode) return;
-
-    // Shift-drag must never fall through to the ordinary row/scope move handlers.
-    event.preventDefault();
-    event.stopImmediatePropagation();
-    clearVisualState();
-
-    const row = event.target instanceof Element ? event.target.closest('.next-task-row') : null;
+    const row = rowAtPoint(clientX, clientY);
     const targetTaskId = Number(row?.dataset.taskId || 0);
-    if (!row || !targetTaskId || targetTaskId === state.sourceTaskId) {
-      if (event.dataTransfer) event.dataTransfer.dropEffect = 'none';
-      const sourceRow = document.querySelector(`.next-task-row[data-task-id="${state.sourceTaskId}"]`);
-      sourceRow?.classList.add('dependency-dragging');
-      if (sourceRow) sourceRow.dataset.dependencyRole = 'Dependent';
-      return;
-    }
-
-    const sourceRow = document.querySelector(`.next-task-row[data-task-id="${state.sourceTaskId}"]`);
-    sourceRow?.classList.add('dependency-dragging');
-    if (sourceRow) sourceRow.dataset.dependencyRole = 'Dependent';
+    if (!row || !targetTaskId || targetTaskId === state.sourceTaskId) return;
 
     state.targetTaskId = targetTaskId;
     row.classList.add('dependency-drop-target');
     row.dataset.dependencyRole = 'Prerequisite target';
-    if (event.dataTransfer) event.dataTransfer.dropEffect = 'move';
+  }
+
+  document.addEventListener('pointerdown', (event) => {
+    if (state.active || event.button !== 0 || !event.shiftKey || !appState.access?.can_manage_setup) return;
+
+    const target = event.target instanceof Element ? event.target : null;
+    if (!target || target.closest('button, input, select, textarea, a')) return;
+
+    const row = target.closest('.next-task-row');
+    const taskId = Number(row?.dataset.taskId || 0);
+    if (!row || !taskId) return;
+
+    state.active = true;
+    state.pointerId = event.pointerId;
+    state.sourceTaskId = taskId;
+    state.sourceRow = row;
+    document.body.classList.add('setup-dependency-pointer-drag');
+
+    row.classList.add('dependency-dragging');
+    row.dataset.dependencyRole = 'Dependent';
+
+    try {
+      row.setPointerCapture(event.pointerId);
+    } catch (_error) {
+      // Capture is helpful but the document-level listeners below remain authoritative.
+    }
+
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    setAlert(`Dependency mode: ${taskName(taskId)} is the dependent task. Release over the task that must happen first.`, 'ok');
   }, true);
 
-  document.addEventListener('drop', (event) => {
-    if (!state.dependencyMode) return;
+  document.addEventListener('pointermove', (event) => {
+    if (!state.active || event.pointerId !== state.pointerId) return;
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    updatePointerTarget(event.clientX, event.clientY);
+  }, true);
+
+  document.addEventListener('pointerup', (event) => {
+    if (!state.active || event.pointerId !== state.pointerId) return;
 
     event.preventDefault();
     event.stopImmediatePropagation();
 
+    updatePointerTarget(event.clientX, event.clientY);
     const dependentTaskId = Number(state.sourceTaskId || 0);
-    const row = event.target instanceof Element ? event.target.closest('.next-task-row') : null;
-    const prerequisiteTaskId = Number(row?.dataset.taskId || 0);
-    finishDependencyDrag();
+    const prerequisiteTaskId = Number(state.targetTaskId || 0);
+    resetState();
 
     if (!dependentTaskId || !prerequisiteTaskId) {
-      setAlert('Dependency drag canceled. Drop the dependent task onto another Setup task.', 'error');
-      return;
-    }
-    if (dependentTaskId === prerequisiteTaskId) {
-      setAlert('A Setup task cannot depend on itself.', 'error');
+      setAlert('Dependency drag canceled. Release the dependent task over another Setup task.', 'error');
       return;
     }
 
     void createPredecessorDependency(dependentTaskId, prerequisiteTaskId);
   }, true);
 
-  document.addEventListener('dragend', (event) => {
-    if (!state.dependencyMode) {
-      clearArmedState();
-      return;
-    }
+  document.addEventListener('pointercancel', (event) => {
+    if (!state.active || event.pointerId !== state.pointerId) return;
     event.stopImmediatePropagation();
-    finishDependencyDrag();
+    resetState();
+    setAlert('Dependency drag canceled.', 'error');
+  }, true);
+
+  // Native drag events must never start while custom Shift-pointer mode owns
+  // the gesture. Ordinary non-Shift native drag remains untouched.
+  document.addEventListener('dragstart', (event) => {
+    if (!state.active) return;
+    event.preventDefault();
+    event.stopImmediatePropagation();
   }, true);
 
   installCatalogHint();

--- a/Setup/Application/setup_predecessor_drag.js
+++ b/Setup/Application/setup_predecessor_drag.js
@@ -8,6 +8,8 @@
   'use strict';
 
   const state = {
+    shiftArmed: false,
+    armedTaskId: null,
     dependencyMode: false,
     sourceTaskId: null,
     targetTaskId: null
@@ -26,8 +28,14 @@
     state.targetTaskId = null;
   }
 
+  function clearArmedState() {
+    state.shiftArmed = false;
+    state.armedTaskId = null;
+  }
+
   function finishDependencyDrag() {
     clearVisualState();
+    clearArmedState();
     state.dependencyMode = false;
     state.sourceTaskId = null;
   }
@@ -38,7 +46,7 @@
     const hint = document.createElement('div');
     hint.id = 'next-predecessor-drag-hint';
     hint.className = 'hint next-predecessor-drag-hint manager-only';
-    hint.innerHTML = '<strong>Fast prerequisite entry:</strong> Hold <kbd>Shift</kbd> before dragging the later/dependent task onto the task that must happen first. Normal drag still moves/reorders tasks.';
+    hint.innerHTML = '<strong>Fast prerequisite entry:</strong> Hold <kbd>Shift</kbd> before pressing the left mouse button, then drag the later/dependent task onto the task that must happen first. Normal drag still moves/reorders tasks.';
     list.insertAdjacentElement('beforebegin', hint);
   }
 
@@ -67,12 +75,40 @@
     }
   }
 
-  document.addEventListener('dragstart', (event) => {
+  document.addEventListener('pointerdown', (event) => {
+    if (state.dependencyMode) return;
+    if (event.button !== 0) {
+      clearArmedState();
+      return;
+    }
+
     const row = event.target instanceof Element ? event.target.closest('.next-task-row') : null;
-    if (!row || !event.shiftKey || !appState.access?.can_manage_setup) return;
+    if (!row || !event.shiftKey || !appState.access?.can_manage_setup) {
+      clearArmedState();
+      return;
+    }
 
     const taskId = Number(row.dataset.taskId || 0);
-    if (!taskId) return;
+    if (!taskId) {
+      clearArmedState();
+      return;
+    }
+
+    state.shiftArmed = true;
+    state.armedTaskId = taskId;
+  }, true);
+
+  document.addEventListener('pointerup', () => {
+    if (!state.dependencyMode) clearArmedState();
+  }, true);
+
+  document.addEventListener('dragstart', (event) => {
+    const row = event.target instanceof Element ? event.target.closest('.next-task-row') : null;
+    if (!row || !appState.access?.can_manage_setup) return;
+
+    const taskId = Number(row.dataset.taskId || 0);
+    const armedForThisTask = state.shiftArmed && Number(state.armedTaskId) === taskId;
+    if (!taskId || (!armedForThisTask && !event.shiftKey)) return;
 
     state.dependencyMode = true;
     state.sourceTaskId = taskId;
@@ -81,7 +117,11 @@
     row.dataset.dependencyRole = 'Dependent';
 
     if (event.dataTransfer) {
-      event.dataTransfer.effectAllowed = 'link';
+      // Use a permissive native drag effect. On Windows, Shift influences the
+      // browser's requested effect; restricting effectAllowed to "link" can
+      // prevent the drag from starting. The application still consumes the
+      // drop and performs only the dependency command below.
+      event.dataTransfer.effectAllowed = 'all';
       event.dataTransfer.setData('application/x-msb-setup-dependent-task', String(taskId));
       event.dataTransfer.setData('text/plain', String(taskId));
     }
@@ -116,7 +156,7 @@
     state.targetTaskId = targetTaskId;
     row.classList.add('dependency-drop-target');
     row.dataset.dependencyRole = 'Prerequisite target';
-    if (event.dataTransfer) event.dataTransfer.dropEffect = 'link';
+    if (event.dataTransfer) event.dataTransfer.dropEffect = 'move';
   }, true);
 
   document.addEventListener('drop', (event) => {
@@ -143,7 +183,10 @@
   }, true);
 
   document.addEventListener('dragend', (event) => {
-    if (!state.dependencyMode) return;
+    if (!state.dependencyMode) {
+      clearArmedState();
+      return;
+    }
     event.stopImmediatePropagation();
     finishDependencyDrag();
   }, true);

--- a/Setup/Application/setup_prerequisite_editor.css
+++ b/Setup/Application/setup_prerequisite_editor.css
@@ -1,0 +1,68 @@
+/* Canonical prerequisite editor for Setup Issue 151. */
+
+#detail-dependencies.next-prerequisite-list {
+  display: grid;
+  gap: 0;
+  width: 100%;
+}
+
+.next-prerequisite-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.65rem 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.next-prerequisite-row:first-child {
+  border-top: 1px solid var(--border);
+}
+
+.next-prerequisite-main {
+  display: grid;
+  grid-template-columns: 2.1rem minmax(0, 1fr);
+  gap: 0.55rem;
+  align-items: start;
+  min-width: 0;
+}
+
+.next-prerequisite-position {
+  font-weight: 800;
+  color: var(--muted);
+  text-align: right;
+}
+
+.next-prerequisite-name {
+  font-weight: 700;
+}
+
+.next-prerequisite-note {
+  margin-top: 0.15rem;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.next-prerequisite-actions {
+  display: flex;
+  gap: 0.3rem;
+  align-items: center;
+}
+
+#next-dependency-editor {
+  margin-top: 0.9rem;
+}
+
+#next-dependency-editor .next-prerequisite-order-hint {
+  margin-top: 0.45rem;
+}
+
+@media (max-width: 800px) {
+  .next-prerequisite-row {
+    grid-template-columns: 1fr;
+  }
+
+  .next-prerequisite-actions {
+    justify-content: flex-end;
+  }
+}

--- a/Setup/Application/setup_prerequisite_editor.js
+++ b/Setup/Application/setup_prerequisite_editor.js
@@ -1,0 +1,243 @@
+/* Canonical ordered prerequisite editor for Setup Issue 151. */
+(() => {
+  'use strict';
+
+  let orderSyncInFlight = false;
+
+  function dependencyRowsForTask(taskId) {
+    return (taskById(taskId)?.dependencies || []).map((dep) => ({
+      setup_task_id: Number(dep.setup_task_id),
+      task_name: dep.task_name || `Task ${dep.setup_task_id}`,
+      dependency_note: dep.dependency_note || null,
+      sort_order: Number(dep.sort_order || 0)
+    }));
+  }
+
+  async function loadOrderedDependencies({ rerender = true } = {}) {
+    if (orderSyncInFlight) return;
+    orderSyncInFlight = true;
+    try {
+      const payload = await api('api/setup/dependencies/ordered');
+      const grouped = new Map();
+      for (const row of payload.dependencies || []) {
+        const taskId = Number(row.setup_task_id);
+        if (!grouped.has(taskId)) grouped.set(taskId, []);
+        grouped.get(taskId).push({
+          setup_task_id: Number(row.prerequisite_setup_task_id),
+          task_name: row.task_name,
+          dependency_note: row.dependency_note || null,
+          sort_order: Number(row.sort_order || 0)
+        });
+      }
+      for (const task of appState.tasks || []) {
+        task.dependencies = grouped.get(Number(task.setup_task_id)) || [];
+      }
+
+      if (rerender) {
+        if (typeof renderReviewList === 'function') renderReviewList();
+        if (typeof renderLibrary === 'function') renderLibrary();
+        const selected = taskById(appState.selectedTaskId);
+        if (selected) renderCanonicalPrerequisites(selected);
+      }
+    } finally {
+      orderSyncInFlight = false;
+    }
+  }
+
+  function installCanonicalDependencyEditor() {
+    const section = el('detail-dependencies')?.closest('.detail-section');
+    if (!section) return null;
+
+    let editor = el('next-dependency-editor');
+    if (!editor) {
+      editor = document.createElement('div');
+      editor.id = 'next-dependency-editor';
+      editor.className = 'next-dependency-editor manager-only';
+      section.appendChild(editor);
+    }
+
+    if (editor.dataset.canonicalPrerequisiteEditor !== '1') {
+      editor.dataset.canonicalPrerequisiteEditor = '1';
+      editor.innerHTML = `
+        <div class="eyebrow">Add prerequisite</div>
+        <div class="next-dependency-add">
+          <select id="next-dependency-select" aria-label="Prerequisite task"></select>
+          <input id="next-dependency-note" type="text" placeholder="Optional prerequisite note">
+          <button id="next-dependency-add-button" type="button">Add prerequisite</button>
+        </div>
+        <div class="hint next-prerequisite-order-hint">Use ↑ / ↓ to change review order only. Every listed prerequisite is still required. Shift-drag in the Catalog remains the fastest way to add several prerequisites.</div>
+      `;
+      el('next-dependency-add-button').addEventListener('click', addCanonicalDependency);
+    }
+    return editor;
+  }
+
+  function renderCanonicalPrerequisites(task) {
+    const target = el('detail-dependencies');
+    if (!target || !task) return;
+    const deps = dependencyRowsForTask(task.setup_task_id);
+    const canManage = Boolean(appState.access?.can_manage_setup);
+
+    target.classList.add('next-prerequisite-list');
+    target.innerHTML = deps.length ? deps.map((dep, index) => `
+      <div class="next-prerequisite-row" data-prereq-id="${dep.setup_task_id}">
+        <div class="next-prerequisite-main">
+          <span class="next-prerequisite-position">${index + 1}.</span>
+          <div>
+            <div class="next-prerequisite-name">${escapeHtml(dep.task_name)}</div>
+            ${dep.dependency_note ? `<div class="next-prerequisite-note">${escapeHtml(dep.dependency_note)}</div>` : ''}
+          </div>
+        </div>
+        ${canManage ? `<div class="next-prerequisite-actions">
+          <button type="button" class="small secondary next-dependency-up next-dependency-remove" data-prereq-id="${dep.setup_task_id}" ${index === 0 ? 'disabled' : ''} aria-label="Move prerequisite up">↑</button>
+          <button type="button" class="small secondary next-dependency-down next-dependency-remove" data-prereq-id="${dep.setup_task_id}" ${index === deps.length - 1 ? 'disabled' : ''} aria-label="Move prerequisite down">↓</button>
+          <button type="button" class="small secondary next-dependency-delete next-dependency-remove" data-prereq-id="${dep.setup_task_id}">Remove</button>
+        </div>` : ''}
+      </div>
+    `).join('') : '<div class="muted">No task prerequisite recorded.</div>';
+
+    target.querySelectorAll('.next-dependency-up').forEach((button) => {
+      button.addEventListener('click', () => reorderCanonicalDependency(task.setup_task_id, Number(button.dataset.prereqId), -1));
+    });
+    target.querySelectorAll('.next-dependency-down').forEach((button) => {
+      button.addEventListener('click', () => reorderCanonicalDependency(task.setup_task_id, Number(button.dataset.prereqId), 1));
+    });
+    target.querySelectorAll('.next-dependency-delete').forEach((button) => {
+      button.addEventListener('click', () => removeCanonicalDependency(task.setup_task_id, Number(button.dataset.prereqId)));
+    });
+  }
+
+  function renderCanonicalDependencyEditor(task) {
+    const editor = installCanonicalDependencyEditor();
+    if (!editor || !task) return;
+    editor.hidden = !appState.access?.can_manage_setup;
+
+    const currentIds = new Set((task.dependencies || []).map((dep) => Number(dep.setup_task_id)));
+    const options = sortedTasks().filter((candidate) => (
+      Number(candidate.setup_task_id) !== Number(task.setup_task_id)
+      && !currentIds.has(Number(candidate.setup_task_id))
+    ));
+    const select = el('next-dependency-select');
+    select.innerHTML = options.length
+      ? options.map((candidate) => `<option value="${candidate.setup_task_id}">${escapeHtml(nextTaskLabel(candidate))}</option>`).join('')
+      : '<option value="">All available tasks are already prerequisites</option>';
+    select.disabled = !options.length;
+    el('next-dependency-add-button').disabled = !options.length;
+
+    renderCanonicalPrerequisites(task);
+  }
+
+  async function refreshPrerequisiteState(taskId, message) {
+    await reloadTasks(null);
+    const fresh = taskById(taskId);
+    if (fresh) selectTask(taskId);
+    if (message) setAlert(message, 'ok');
+  }
+
+  async function addCanonicalDependency() {
+    const task = taskById(appState.selectedTaskId);
+    const prerequisiteId = Number(el('next-dependency-select')?.value || 0);
+    if (!task || !prerequisiteId) return;
+    try {
+      setBusy(true);
+      await api(
+        `api/setup/tasks/${task.setup_task_id}/dependencies/${prerequisiteId}`,
+        commandOptions('PATCH', {
+          active: true,
+          dependency_note: el('next-dependency-note').value.trim() || null
+        })
+      );
+      el('next-dependency-note').value = '';
+      await refreshPrerequisiteState(task.setup_task_id, 'Prerequisite added.');
+    } catch (error) {
+      setAlert(error.message || error, 'error');
+      window.alert(error.message || error);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function removeCanonicalDependency(taskId, prerequisiteId) {
+    if (!window.confirm('Remove this prerequisite?')) return;
+    try {
+      setBusy(true);
+      await api(
+        `api/setup/tasks/${taskId}/dependencies/${prerequisiteId}`,
+        commandOptions('PATCH', { active: false })
+      );
+      await refreshPrerequisiteState(taskId, 'Prerequisite removed.');
+    } catch (error) {
+      setAlert(error.message || error, 'error');
+      window.alert(error.message || error);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function reorderCanonicalDependency(taskId, prerequisiteId, direction) {
+    const deps = dependencyRowsForTask(taskId);
+    const index = deps.findIndex((dep) => Number(dep.setup_task_id) === Number(prerequisiteId));
+    const destination = index + direction;
+    if (index < 0 || destination < 0 || destination >= deps.length) return;
+
+    [deps[index], deps[destination]] = [deps[destination], deps[index]];
+    const orderedIds = deps.map((dep) => Number(dep.setup_task_id));
+    try {
+      setBusy(true);
+      await api(
+        `api/setup/tasks/${taskId}/dependencies/order`,
+        commandOptions('PATCH', { prerequisite_setup_task_ids: orderedIds })
+      );
+      await refreshPrerequisiteState(taskId, 'Prerequisite review order updated.');
+    } catch (error) {
+      setAlert(error.message || error, 'error');
+      window.alert(error.message || error);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (typeof installDependencyEditor === 'function') {
+    installDependencyEditor = installCanonicalDependencyEditor;
+  }
+  if (typeof renderDependencyEditor === 'function') {
+    renderDependencyEditor = renderCanonicalDependencyEditor;
+  }
+  if (typeof addNextDependency === 'function') {
+    addNextDependency = addCanonicalDependency;
+  }
+  if (typeof removeNextDependency === 'function') {
+    removeNextDependency = function removeNextDependencyCanonical(task, prereqId) {
+      return removeCanonicalDependency(task.setup_task_id, prereqId);
+    };
+  }
+
+  if (typeof reloadTasks === 'function') {
+    const priorReloadTasks = reloadTasks;
+    reloadTasks = async function reloadTasksWithOrderedPrerequisites(...args) {
+      const result = await priorReloadTasks(...args);
+      await loadOrderedDependencies({ rerender: false });
+      if (typeof renderReviewList === 'function') renderReviewList();
+      if (typeof renderLibrary === 'function') renderLibrary();
+      const selected = taskById(appState.selectedTaskId);
+      if (selected) renderCanonicalDependencyEditor(selected);
+      return result;
+    };
+  }
+
+  if (typeof selectTask === 'function') {
+    const priorSelectTask = selectTask;
+    selectTask = function selectTaskWithCanonicalPrerequisites(taskId) {
+      const result = priorSelectTask(taskId);
+      const task = taskById(taskId);
+      if (task) renderCanonicalDependencyEditor(task);
+      return result;
+    };
+  }
+
+  if (appState.tasks?.length) {
+    void loadOrderedDependencies().catch((error) => {
+      setAlert(error.message || error, 'error');
+    });
+  }
+})();

--- a/Setup/Application/setup_prerequisite_editor.js
+++ b/Setup/Application/setup_prerequisite_editor.js
@@ -2,7 +2,7 @@
 (() => {
   'use strict';
 
-  let orderSyncInFlight = false;
+  let orderSyncPromise = null;
 
   function dependencyRowsForTask(taskId) {
     return (taskById(taskId)?.dependencies || []).map((dep) => ({
@@ -13,10 +13,9 @@
     }));
   }
 
-  async function loadOrderedDependencies({ rerender = true } = {}) {
-    if (orderSyncInFlight) return;
-    orderSyncInFlight = true;
-    try {
+  function loadOrderedDependencies({ rerender = true } = {}) {
+    if (orderSyncPromise) return orderSyncPromise;
+    orderSyncPromise = (async () => {
       const payload = await api('api/setup/dependencies/ordered');
       const grouped = new Map();
       for (const row of payload.dependencies || []) {
@@ -39,9 +38,10 @@
         const selected = taskById(appState.selectedTaskId);
         if (selected) renderCanonicalPrerequisites(selected);
       }
-    } finally {
-      orderSyncInFlight = false;
-    }
+    })().finally(() => {
+      orderSyncPromise = null;
+    });
+    return orderSyncPromise;
   }
 
   function installCanonicalDependencyEditor() {

--- a/Setup/Application/setup_prerequisite_order_api.py
+++ b/Setup/Application/setup_prerequisite_order_api.py
@@ -1,9 +1,11 @@
 """Protected ordered reusable Setup prerequisite API for Issue #151."""
 from __future__ import annotations
 
+import psycopg2
 from flask import Blueprint, Response, jsonify
 
 from setup_api import (
+    SetupAuthenticationError,
     SetupCommandError,
     json_body,
     require_manager,
@@ -11,7 +13,10 @@ from setup_api import (
     require_setup_command,
     setup_database_dsn,
 )
-from setup_prerequisite_order_repository import SetupPrerequisiteOrderRepository
+from setup_prerequisite_order_repository import (
+    SetupPrerequisiteOrderRepository,
+    SetupPrerequisiteOrderRepositoryError,
+)
 
 setup_prerequisite_order_api = Blueprint("setup_prerequisite_order_api", __name__)
 
@@ -53,3 +58,41 @@ def api_setup_reorder_dependencies(setup_task_id: int) -> Response:
         prerequisite_ids=prerequisite_ids,
     )
     return jsonify(dependencies=result)
+
+
+@setup_prerequisite_order_api.errorhandler(SetupAuthenticationError)
+def prerequisite_authentication_error(exc: SetupAuthenticationError) -> tuple[Response, int]:
+    return jsonify(
+        error="Setup Session sign-in identity is unavailable",
+        engineering_error=str(exc),
+    ), 401
+
+
+@setup_prerequisite_order_api.errorhandler(SetupCommandError)
+def prerequisite_command_error(exc: SetupCommandError) -> tuple[Response, int]:
+    return jsonify(error=str(exc), engineering_error=str(exc)), 403
+
+
+@setup_prerequisite_order_api.errorhandler(SetupPrerequisiteOrderRepositoryError)
+def prerequisite_repository_error(exc: SetupPrerequisiteOrderRepositoryError) -> tuple[Response, int]:
+    return jsonify(
+        error="Setup prerequisite data is temporarily unavailable.",
+        engineering_error=str(exc),
+    ), 503
+
+
+@setup_prerequisite_order_api.errorhandler(psycopg2.Error)
+def prerequisite_database_error(exc: psycopg2.Error) -> tuple[Response, int]:
+    sqlstate = exc.pgcode or ""
+    if sqlstate == "42501":
+        status = 403
+    elif sqlstate == "23505":
+        status = 409
+    elif sqlstate in {"22023", "23503", "23514"}:
+        status = 400
+    elif sqlstate == "P0002":
+        status = 404
+    else:
+        status = 500
+    message = (exc.diag.message_primary or "Setup prerequisite database command failed").strip()
+    return jsonify(error=message, engineering_error=str(exc)), status

--- a/Setup/Application/setup_prerequisite_order_api.py
+++ b/Setup/Application/setup_prerequisite_order_api.py
@@ -1,0 +1,55 @@
+"""Protected ordered reusable Setup prerequisite API for Issue #151."""
+from __future__ import annotations
+
+from flask import Blueprint, Response, jsonify
+
+from setup_api import (
+    SetupCommandError,
+    json_body,
+    require_manager,
+    require_reader,
+    require_setup_command,
+    setup_database_dsn,
+)
+from setup_prerequisite_order_repository import SetupPrerequisiteOrderRepository
+
+setup_prerequisite_order_api = Blueprint("setup_prerequisite_order_api", __name__)
+
+
+def repo() -> SetupPrerequisiteOrderRepository:
+    return SetupPrerequisiteOrderRepository(setup_database_dsn())
+
+
+@setup_prerequisite_order_api.get("/api/setup/dependencies/ordered")
+def api_setup_ordered_dependencies() -> Response:
+    require_reader()
+    return jsonify(dependencies=repo().ordered_dependencies())
+
+
+@setup_prerequisite_order_api.patch("/api/setup/tasks/<int:setup_task_id>/dependencies/order")
+def api_setup_reorder_dependencies(setup_task_id: int) -> Response:
+    require_setup_command()
+    _base_repo, email, _access = require_manager()
+    payload = json_body()
+    raw = payload.get("prerequisite_setup_task_ids")
+    if not isinstance(raw, list):
+        raise SetupCommandError("prerequisite_setup_task_ids must be a list")
+
+    prerequisite_ids: list[int] = []
+    for value in raw:
+        if isinstance(value, bool):
+            raise SetupCommandError("prerequisite_setup_task_ids must contain integers")
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError) as exc:
+            raise SetupCommandError("prerequisite_setup_task_ids must contain integers") from exc
+        if parsed <= 0:
+            raise SetupCommandError("prerequisite_setup_task_ids must contain positive task IDs")
+        prerequisite_ids.append(parsed)
+
+    result = repo().reorder_dependencies(
+        email=email,
+        task_id=setup_task_id,
+        prerequisite_ids=prerequisite_ids,
+    )
+    return jsonify(dependencies=result)

--- a/Setup/Application/setup_prerequisite_order_repository.py
+++ b/Setup/Application/setup_prerequisite_order_repository.py
@@ -49,6 +49,7 @@ class SetupPrerequisiteOrderRepository:
                   ON pt.setup_task_id = d.prerequisite_setup_task_id
                 ORDER BY d.setup_task_id,
                          d.sort_order,
+                         pt.display_order,
                          d.prerequisite_setup_task_id
                 """
             )

--- a/Setup/Application/setup_prerequisite_order_repository.py
+++ b/Setup/Application/setup_prerequisite_order_repository.py
@@ -1,0 +1,74 @@
+"""Ordered reusable Setup prerequisite access for Issue #151."""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any, Iterator
+
+import psycopg2
+from psycopg2.extras import RealDictCursor
+
+
+class SetupPrerequisiteOrderRepositoryError(RuntimeError):
+    pass
+
+
+class SetupPrerequisiteOrderRepository:
+    def __init__(self, dsn: str):
+        self.dsn = (dsn or "").strip()
+        if not self.dsn:
+            raise SetupPrerequisiteOrderRepositoryError("Setup PostgreSQL DSN is required")
+
+    @contextmanager
+    def connect(self) -> Iterator[Any]:
+        conn = psycopg2.connect(self.dsn)
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    @contextmanager
+    def write_connect(self) -> Iterator[Any]:
+        conn = psycopg2.connect(self.dsn)
+        try:
+            conn.set_session(readonly=False, autocommit=False)
+            yield conn
+        finally:
+            conn.close()
+
+    def ordered_dependencies(self) -> list[dict[str, Any]]:
+        with self.connect() as conn, conn.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute(
+                """
+                SELECT d.setup_task_id,
+                       d.prerequisite_setup_task_id,
+                       pt.task_name,
+                       d.dependency_note,
+                       d.sort_order
+                FROM ref.setup_task_dependency d
+                JOIN ref.setup_task pt
+                  ON pt.setup_task_id = d.prerequisite_setup_task_id
+                ORDER BY d.setup_task_id,
+                         d.sort_order,
+                         d.prerequisite_setup_task_id
+                """
+            )
+            return [dict(row) for row in cur.fetchall()]
+
+    def reorder_dependencies(
+        self,
+        *,
+        email: str,
+        task_id: int,
+        prerequisite_ids: list[int],
+    ) -> list[dict[str, Any]]:
+        with self.write_connect() as conn, conn.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute(
+                """
+                SELECT *
+                FROM ref.reorder_setup_task_dependencies(%s,%s,%s::bigint[])
+                """,
+                (email, task_id, prerequisite_ids),
+            )
+            rows = [dict(row) for row in cur.fetchall()]
+            conn.commit()
+            return rows

--- a/Setup/Application/test_setup_dirty_edit_guard_contract.py
+++ b/Setup/Application/test_setup_dirty_edit_guard_contract.py
@@ -83,8 +83,8 @@ def test_reusable_save_preserves_pending_annual_fields_across_reload():
 
 def test_client_build_is_visible_and_write_paths_fail_closed_on_mismatch():
     js = guard_source()
-    assert "V0.3.8-task-detail-compact" in js
-    assert "Client V0.3.8" in js
+    assert "V0.3.9-predecessor-drag" in js
+    assert "Client V0.3.9" in js
     assert "setup-client-build-badge" in js
     assert "window.msbSetupClientBuild = CLIENT_BUILD" in js
     assert "async function ensureServerBuild()" in js

--- a/Setup/Application/test_setup_predecessor_drag_browser_preview_contract.py
+++ b/Setup/Application/test_setup_predecessor_drag_browser_preview_contract.py
@@ -52,7 +52,7 @@ def test_predecessor_drag_preview_recovers_stale_source_preview_safely() -> None
         "source-only stale-cleanup injection point",
         "ServerAliveInterval=15",
         "ServerAliveCountMax=3",
-        "timeout --signal=TERM 28800s",
+        "timeout --foreground --signal=TERM 28800s",
         "trap cleanup EXIT HUP INT TERM",
     ):
         assert required in launcher

--- a/Setup/Application/test_setup_predecessor_drag_browser_preview_contract.py
+++ b/Setup/Application/test_setup_predecessor_drag_browser_preview_contract.py
@@ -9,7 +9,7 @@ ACCEPTANCE_DIR = REPO_ROOT / "Setup" / "Acceptance"
 def test_predecessor_drag_preview_pins_exact_candidate_branch_and_migration() -> None:
     launcher = (ACCEPTANCE_DIR / "run_setup_predecessor_drag_browser_preview.ps1").read_text(encoding="utf-8")
 
-    assert "280ec6bee5ec9847459f28de41140520e71b0910" in launcher
+    assert "66a70e3661d92482d9bfc629cd87e8f7026cf458" in launcher
     assert "agent/setup-shift-drag-predecessor-151" in launcher
     assert "run_setup_source_only_browser_preview.ps1" in launcher
     assert "test_setup_predecessor_drag_contract.py" in launcher

--- a/Setup/Application/test_setup_predecessor_drag_browser_preview_contract.py
+++ b/Setup/Application/test_setup_predecessor_drag_browser_preview_contract.py
@@ -6,29 +6,38 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 ACCEPTANCE_DIR = REPO_ROOT / "Setup" / "Acceptance"
 
 
-def test_predecessor_drag_preview_pins_exact_candidate_and_branch() -> None:
+def test_predecessor_drag_preview_pins_exact_candidate_branch_and_migration() -> None:
     launcher = (ACCEPTANCE_DIR / "run_setup_predecessor_drag_browser_preview.ps1").read_text(encoding="utf-8")
 
-    assert "bfff954618f12a591af4900b71c4938ca5790382" in launcher
+    assert "280ec6bee5ec9847459f28de41140520e71b0910" in launcher
     assert "agent/setup-shift-drag-predecessor-151" in launcher
     assert "run_setup_source_only_browser_preview.ps1" in launcher
     assert "test_setup_predecessor_drag_contract.py" in launcher
+    assert "test_setup_prerequisite_editor_contract.py" in launcher
     assert "test_setup_dirty_edit_guard_contract.py" in launcher
+    assert "026_add_setup_dependency_order.sql" in launcher
+    assert "prerequisite-order migration on disposable clone: PASS" in launcher
+    assert "ref.reorder_setup_task_dependencies(text,bigint,bigint[])" in launcher
+    assert "broad prerequisite table DML" in launcher
     assert "Client V0.3.9" in launcher
 
 
-def test_predecessor_drag_preview_checklist_covers_direction_cycle_and_normal_drag() -> None:
+def test_predecessor_drag_preview_checklist_covers_full_prerequisite_workflow() -> None:
     launcher = (ACCEPTANCE_DIR / "run_setup_predecessor_drag_browser_preview.ps1").read_text(encoding="utf-8")
 
     for required in (
-        "Hold Shift BEFORE pressing the left mouse button",
-        "Dependent",
-        "Prerequisite target",
-        "A depends on B",
-        "not a duplicate",
+        "hold Shift BEFORE pressing the left mouse button",
+        "neither task moves",
+        "no duplicate relationship",
         "circular-dependency error",
+        "ONE prerequisite list only",
+        "Up, Down, and Remove",
+        "same new order",
+        "order persists",
+        "stays removed",
+        "manual Add form",
         "ordinary drag WITHOUT Shift",
-        "manual prerequisite editor",
         "empty Stage/Scene space",
+        "review/display order only",
     ):
         assert required in launcher

--- a/Setup/Application/test_setup_predecessor_drag_browser_preview_contract.py
+++ b/Setup/Application/test_setup_predecessor_drag_browser_preview_contract.py
@@ -9,7 +9,7 @@ ACCEPTANCE_DIR = REPO_ROOT / "Setup" / "Acceptance"
 def test_predecessor_drag_preview_pins_exact_candidate_and_branch() -> None:
     launcher = (ACCEPTANCE_DIR / "run_setup_predecessor_drag_browser_preview.ps1").read_text(encoding="utf-8")
 
-    assert "47845209a1eadb694a6ec75deba67ce241f37a5e" in launcher
+    assert "b3b48d0f5b8b94519257c4a65166f317411265f4" in launcher
     assert "agent/setup-shift-drag-predecessor-151" in launcher
     assert "run_setup_source_only_browser_preview.ps1" in launcher
     assert "test_setup_predecessor_drag_contract.py" in launcher

--- a/Setup/Application/test_setup_predecessor_drag_browser_preview_contract.py
+++ b/Setup/Application/test_setup_predecessor_drag_browser_preview_contract.py
@@ -9,11 +9,12 @@ ACCEPTANCE_DIR = REPO_ROOT / "Setup" / "Acceptance"
 def test_predecessor_drag_preview_pins_exact_candidate_and_branch() -> None:
     launcher = (ACCEPTANCE_DIR / "run_setup_predecessor_drag_browser_preview.ps1").read_text(encoding="utf-8")
 
-    assert "4cada529a0cd714f5da2cb43f5dffb016e40b7ac" in launcher
+    assert "bd7457205b7f6596b9221348b6118ba9861abecc" in launcher
     assert "agent/setup-shift-drag-predecessor-151" in launcher
     assert "run_setup_source_only_browser_preview.ps1" in launcher
     assert "test_setup_predecessor_drag_contract.py" in launcher
     assert "test_setup_dirty_edit_guard_contract.py" in launcher
+    assert "Client V0.3.9" in launcher
 
 
 def test_predecessor_drag_preview_checklist_covers_direction_cycle_and_normal_drag() -> None:

--- a/Setup/Application/test_setup_predecessor_drag_browser_preview_contract.py
+++ b/Setup/Application/test_setup_predecessor_drag_browser_preview_contract.py
@@ -9,7 +9,7 @@ ACCEPTANCE_DIR = REPO_ROOT / "Setup" / "Acceptance"
 def test_predecessor_drag_preview_pins_exact_candidate_and_branch() -> None:
     launcher = (ACCEPTANCE_DIR / "run_setup_predecessor_drag_browser_preview.ps1").read_text(encoding="utf-8")
 
-    assert "b3b48d0f5b8b94519257c4a65166f317411265f4" in launcher
+    assert "9a27e91e3251019bf2920bc9410f0bdd7fc426c1" in launcher
     assert "agent/setup-shift-drag-predecessor-151" in launcher
     assert "run_setup_source_only_browser_preview.ps1" in launcher
     assert "test_setup_predecessor_drag_contract.py" in launcher

--- a/Setup/Application/test_setup_predecessor_drag_browser_preview_contract.py
+++ b/Setup/Application/test_setup_predecessor_drag_browser_preview_contract.py
@@ -9,7 +9,7 @@ ACCEPTANCE_DIR = REPO_ROOT / "Setup" / "Acceptance"
 def test_predecessor_drag_preview_pins_exact_candidate_and_branch() -> None:
     launcher = (ACCEPTANCE_DIR / "run_setup_predecessor_drag_browser_preview.ps1").read_text(encoding="utf-8")
 
-    assert "bd7457205b7f6596b9221348b6118ba9861abecc" in launcher
+    assert "47845209a1eadb694a6ec75deba67ce241f37a5e" in launcher
     assert "agent/setup-shift-drag-predecessor-151" in launcher
     assert "run_setup_source_only_browser_preview.ps1" in launcher
     assert "test_setup_predecessor_drag_contract.py" in launcher

--- a/Setup/Application/test_setup_predecessor_drag_browser_preview_contract.py
+++ b/Setup/Application/test_setup_predecessor_drag_browser_preview_contract.py
@@ -9,7 +9,7 @@ ACCEPTANCE_DIR = REPO_ROOT / "Setup" / "Acceptance"
 def test_predecessor_drag_preview_pins_exact_candidate_branch_and_migration() -> None:
     launcher = (ACCEPTANCE_DIR / "run_setup_predecessor_drag_browser_preview.ps1").read_text(encoding="utf-8")
 
-    assert "66a70e3661d92482d9bfc629cd87e8f7026cf458" in launcher
+    assert "55478f98f760473b65b5d700a84c868285022ab7" in launcher
     assert "agent/setup-shift-drag-predecessor-151" in launcher
     assert "run_setup_source_only_browser_preview.ps1" in launcher
     assert "test_setup_predecessor_drag_contract.py" in launcher

--- a/Setup/Application/test_setup_predecessor_drag_browser_preview_contract.py
+++ b/Setup/Application/test_setup_predecessor_drag_browser_preview_contract.py
@@ -9,7 +9,7 @@ ACCEPTANCE_DIR = REPO_ROOT / "Setup" / "Acceptance"
 def test_predecessor_drag_preview_pins_exact_candidate_and_branch() -> None:
     launcher = (ACCEPTANCE_DIR / "run_setup_predecessor_drag_browser_preview.ps1").read_text(encoding="utf-8")
 
-    assert "9a27e91e3251019bf2920bc9410f0bdd7fc426c1" in launcher
+    assert "bfff954618f12a591af4900b71c4938ca5790382" in launcher
     assert "agent/setup-shift-drag-predecessor-151" in launcher
     assert "run_setup_source_only_browser_preview.ps1" in launcher
     assert "test_setup_predecessor_drag_contract.py" in launcher
@@ -21,7 +21,7 @@ def test_predecessor_drag_preview_checklist_covers_direction_cycle_and_normal_dr
     launcher = (ACCEPTANCE_DIR / "run_setup_predecessor_drag_browser_preview.ps1").read_text(encoding="utf-8")
 
     for required in (
-        "Hold Shift BEFORE starting the drag",
+        "Hold Shift BEFORE pressing the left mouse button",
         "Dependent",
         "Prerequisite target",
         "A depends on B",

--- a/Setup/Application/test_setup_predecessor_drag_browser_preview_contract.py
+++ b/Setup/Application/test_setup_predecessor_drag_browser_preview_contract.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ACCEPTANCE_DIR = REPO_ROOT / "Setup" / "Acceptance"
+
+
+def test_predecessor_drag_preview_pins_exact_candidate_and_branch() -> None:
+    launcher = (ACCEPTANCE_DIR / "run_setup_predecessor_drag_browser_preview.ps1").read_text(encoding="utf-8")
+
+    assert "4cada529a0cd714f5da2cb43f5dffb016e40b7ac" in launcher
+    assert "agent/setup-shift-drag-predecessor-151" in launcher
+    assert "run_setup_source_only_browser_preview.ps1" in launcher
+    assert "test_setup_predecessor_drag_contract.py" in launcher
+    assert "test_setup_dirty_edit_guard_contract.py" in launcher
+
+
+def test_predecessor_drag_preview_checklist_covers_direction_cycle_and_normal_drag() -> None:
+    launcher = (ACCEPTANCE_DIR / "run_setup_predecessor_drag_browser_preview.ps1").read_text(encoding="utf-8")
+
+    for required in (
+        "Hold Shift BEFORE starting the drag",
+        "Dependent",
+        "Prerequisite target",
+        "A depends on B",
+        "not a duplicate",
+        "circular-dependency error",
+        "ordinary drag WITHOUT Shift",
+        "manual prerequisite editor",
+        "empty Stage/Scene space",
+    ):
+        assert required in launcher

--- a/Setup/Application/test_setup_predecessor_drag_browser_preview_contract.py
+++ b/Setup/Application/test_setup_predecessor_drag_browser_preview_contract.py
@@ -41,3 +41,30 @@ def test_predecessor_drag_preview_checklist_covers_full_prerequisite_workflow() 
         "review/display order only",
     ):
         assert required in launcher
+
+
+def test_predecessor_drag_preview_recovers_stale_source_preview_safely() -> None:
+    launcher = (ACCEPTANCE_DIR / "run_setup_predecessor_drag_browser_preview.ps1").read_text(encoding="utf-8")
+    cleanup = (ACCEPTANCE_DIR / "setup_session_browser_preview_cleanup_server.sh").read_text(encoding="utf-8")
+
+    for required in (
+        "setup_session_browser_preview_cleanup_server.sh",
+        "source-only stale-cleanup injection point",
+        "ServerAliveInterval=15",
+        "ServerAliveCountMax=3",
+        "timeout --signal=TERM 28800s",
+        "trap cleanup EXIT HUP INT TERM",
+    ):
+        assert required in launcher
+
+    for required in (
+        "governed Production listener and must never be cleaned as preview state",
+        "/tmp/setup_session_browser_preview_entry.py",
+        "fieldwiring",
+        "msb-setup-source-preview-candidate-",
+        "msb-setup-source-preview-",
+        "unexpected process; refusing to kill it",
+        "Reports and Flask logs are retained as acceptance evidence",
+        "PASS: preview port $PREVIEW_PORT is free",
+    ):
+        assert required in cleanup

--- a/Setup/Application/test_setup_predecessor_drag_browser_preview_contract.py
+++ b/Setup/Application/test_setup_predecessor_drag_browser_preview_contract.py
@@ -64,7 +64,7 @@ def test_predecessor_drag_preview_recovers_stale_source_preview_safely() -> None
         "msb-setup-source-preview-candidate-",
         "msb-setup-source-preview-",
         "unexpected process; refusing to kill it",
-        "Reports and Flask logs are retained as acceptance evidence",
+        "Flask logs are retained as acceptance evidence",
         "PASS: preview port $PREVIEW_PORT is free",
     ):
         assert required in cleanup

--- a/Setup/Application/test_setup_predecessor_drag_contract.py
+++ b/Setup/Application/test_setup_predecessor_drag_contract.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+APP_DIR = Path(__file__).resolve().parent
+DB_DIR = APP_DIR.parent / "Database"
+
+
+def read(name: str) -> str:
+    return (APP_DIR / name).read_text(encoding="utf-8")
+
+
+def test_predecessor_drag_assets_are_production_loaded_after_normal_drag_engine() -> None:
+    html = read("production.html")
+    backend = read("production_backend.py")
+
+    for asset in ("setup_predecessor_drag.css", "setup_predecessor_drag.js"):
+        assert asset in html
+        assert asset in backend
+
+    assert html.index("setup_next_pass.js") < html.index("setup_predecessor_drag.js")
+
+
+def test_shift_drag_uses_existing_dependency_command_only() -> None:
+    js = read("setup_predecessor_drag.js")
+
+    assert "event.shiftKey" in js
+    assert "event.stopImmediatePropagation()" in js
+    assert "effectAllowed = 'link'" in js
+    assert "dropEffect = 'link'" in js
+    assert "api/setup/tasks/${dependentTaskId}/dependencies/${prerequisiteTaskId}" in js
+    assert "active: true" in js
+    assert "dependency_note: null" in js
+
+    # The modifier interaction must never invoke the normal scope/reorder path.
+    assert "/scope" not in js
+    assert "nextMoveTask" not in js
+    assert "nextPersistOrder" not in js
+    assert "display_order" not in js
+
+
+def test_normal_drag_and_manual_prerequisite_editor_remain_available() -> None:
+    normal = read("setup_next_pass.js")
+    shift = read("setup_predecessor_drag.js")
+
+    assert "api/setup/tasks/${taskId}/scope" in normal
+    assert "event.dataTransfer.dropEffect = 'move'" in normal
+    assert "nextMoveTask(sourceId, stageId, sceneId, taskId)" in normal
+    assert "Add prerequisite" in normal
+    assert "dependencies/${prereq}" in normal
+
+    # Capture listeners only take ownership when dependencyMode is active.
+    assert "if (!state.dependencyMode) return;" in shift
+    assert "if (!row || !event.shiftKey" in shift
+
+
+def test_dependency_direction_and_failure_feedback_are_explicit() -> None:
+    js = read("setup_predecessor_drag.js")
+
+    assert "is the dependent task" in js
+    assert "Prerequisite target" in js
+    assert "depends on" in js
+    assert "Neither task moved" in js
+    assert "setAlert(message, 'error')" in js
+    assert "window.alert(message)" in js
+
+
+def test_dependency_mode_has_distinct_visual_cues_without_new_palette() -> None:
+    css = read("setup_predecessor_drag.css")
+
+    for selector in ("dependency-dragging", "dependency-drop-target", "data-dependency-role"):
+        assert selector in css
+    for token in ("var(--accent)", "var(--accent-soft)", "var(--panel)", "var(--text)", "var(--border)"):
+        assert token in css
+
+    assert re.search(r"#[0-9a-fA-F]{3,8}\b", css) is None
+
+
+def test_database_dependency_command_remains_idempotent_and_cycle_protected() -> None:
+    sql = (DB_DIR / "018_fix_setup_dependency_cycle_reference.sql").read_text(encoding="utf-8")
+
+    assert "ref.set_setup_task_dependency" in sql
+    assert "A Setup task cannot depend on itself" in sql
+    assert "Prerequisite would create a circular Setup dependency" in sql
+    assert "ON CONFLICT ON CONSTRAINT pk_setup_task_dependency" in sql
+    assert "DO UPDATE SET dependency_note = EXCLUDED.dependency_note" in sql

--- a/Setup/Application/test_setup_predecessor_drag_contract.py
+++ b/Setup/Application/test_setup_predecessor_drag_contract.py
@@ -22,28 +22,34 @@ def test_predecessor_drag_assets_are_production_loaded_after_normal_drag_engine(
     assert html.index("setup_next_pass.js") < html.index("setup_predecessor_drag.js")
 
 
-def test_shift_drag_arms_before_native_dragstart_and_uses_existing_dependency_command_only() -> None:
+def test_shift_drag_uses_custom_pointer_gesture_and_existing_dependency_command_only() -> None:
     js = read("setup_predecessor_drag.js")
 
     assert "document.addEventListener('pointerdown'" in js
+    assert "document.addEventListener('pointermove'" in js
+    assert "document.addEventListener('pointerup'" in js
+    assert "document.addEventListener('pointercancel'" in js
     assert "event.button !== 0" in js
     assert "event.shiftKey" in js
-    assert "state.shiftArmed = true" in js
-    assert "state.armedTaskId = taskId" in js
-    assert "armedForThisTask" in js
+    assert "state.active = true" in js
+    assert "row.setPointerCapture(event.pointerId)" in js
+    assert "document.elementFromPoint(clientX, clientY)" in js
+    assert "event.preventDefault()" in js
     assert "event.stopImmediatePropagation()" in js
-    assert "effectAllowed = 'all'" in js
-    assert "dropEffect = 'move'" in js
     assert "api/setup/tasks/${dependentTaskId}/dependencies/${prerequisiteTaskId}" in js
     assert "active: true" in js
     assert "dependency_note: null" in js
 
-    # The modifier interaction has exactly one governed API write: dependency upsert.
+    # Shift mode owns the pointer gesture and never calls the normal scope/reorder path.
     assert js.count("await api(") == 1
     assert "api/setup/tasks/${dependentTaskId}/scope" not in js
     assert "api/setup/tasks/${prerequisiteTaskId}/scope" not in js
     assert "nextMoveTask(" not in js
     assert "nextPersistOrder(" not in js
+
+    # Native drag is suppressed only after custom Shift-pointer mode is active.
+    assert "document.addEventListener('dragstart'" in js
+    assert "if (!state.active) return;" in js
 
 
 def test_normal_drag_and_manual_prerequisite_editor_remain_available() -> None:
@@ -56,9 +62,9 @@ def test_normal_drag_and_manual_prerequisite_editor_remain_available() -> None:
     assert "Add prerequisite" in normal
     assert "dependencies/${prereq}" in normal
 
-    # Capture listeners only take ownership after the Shift gesture is armed.
-    assert "if (!state.dependencyMode) return;" in shift
-    assert "if (!taskId || (!armedForThisTask && !event.shiftKey)) return;" in shift
+    # Shift extension does not patch or replace the normal drag functions.
+    assert "nextMoveTask =" not in shift
+    assert "nextPersistOrder =" not in shift
 
 
 def test_dependency_direction_and_failure_feedback_are_explicit() -> None:
@@ -68,6 +74,7 @@ def test_dependency_direction_and_failure_feedback_are_explicit() -> None:
     assert "Prerequisite target" in js
     assert "depends on" in js
     assert "Neither task moved" in js
+    assert "Release the dependent task over another Setup task" in js
     assert "setAlert(message, 'error')" in js
     assert "window.alert(message)" in js
 

--- a/Setup/Application/test_setup_predecessor_drag_contract.py
+++ b/Setup/Application/test_setup_predecessor_drag_contract.py
@@ -34,10 +34,13 @@ def test_shift_drag_uses_existing_dependency_command_only() -> None:
     assert "dependency_note: null" in js
 
     # The modifier interaction must never invoke the normal scope/reorder path.
-    assert "/scope" not in js
-    assert "nextMoveTask" not in js
-    assert "nextPersistOrder" not in js
-    assert "display_order" not in js
+    # Strip block comments first so explanatory prose such as "row/scope" cannot
+    # create a false positive for an executable /scope API reference.
+    executable_js = re.sub(r"/\*.*?\*/", "", js, flags=re.S)
+    assert "/scope" not in executable_js
+    assert "nextMoveTask" not in executable_js
+    assert "nextPersistOrder" not in executable_js
+    assert "display_order" not in executable_js
 
 
 def test_normal_drag_and_manual_prerequisite_editor_remain_available() -> None:

--- a/Setup/Application/test_setup_predecessor_drag_contract.py
+++ b/Setup/Application/test_setup_predecessor_drag_contract.py
@@ -33,14 +33,14 @@ def test_shift_drag_uses_existing_dependency_command_only() -> None:
     assert "active: true" in js
     assert "dependency_note: null" in js
 
-    # The modifier interaction must never invoke the normal scope/reorder path.
-    # Strip block comments first so explanatory prose such as "row/scope" cannot
-    # create a false positive for an executable /scope API reference.
-    executable_js = re.sub(r"/\*.*?\*/", "", js, flags=re.S)
-    assert "/scope" not in executable_js
-    assert "nextMoveTask" not in executable_js
-    assert "nextPersistOrder" not in executable_js
-    assert "display_order" not in executable_js
+    # The modifier interaction has exactly one governed API write: dependency upsert.
+    # Test executable call names instead of prose substrings so comments such as
+    # "row/scope" cannot produce false positives.
+    assert js.count("await api(") == 1
+    assert "api/setup/tasks/${dependentTaskId}/scope" not in js
+    assert "api/setup/tasks/${prerequisiteTaskId}/scope" not in js
+    assert "nextMoveTask(" not in js
+    assert "nextPersistOrder(" not in js
 
 
 def test_normal_drag_and_manual_prerequisite_editor_remain_available() -> None:

--- a/Setup/Application/test_setup_predecessor_drag_contract.py
+++ b/Setup/Application/test_setup_predecessor_drag_contract.py
@@ -22,20 +22,23 @@ def test_predecessor_drag_assets_are_production_loaded_after_normal_drag_engine(
     assert html.index("setup_next_pass.js") < html.index("setup_predecessor_drag.js")
 
 
-def test_shift_drag_uses_existing_dependency_command_only() -> None:
+def test_shift_drag_arms_before_native_dragstart_and_uses_existing_dependency_command_only() -> None:
     js = read("setup_predecessor_drag.js")
 
+    assert "document.addEventListener('pointerdown'" in js
+    assert "event.button !== 0" in js
     assert "event.shiftKey" in js
+    assert "state.shiftArmed = true" in js
+    assert "state.armedTaskId = taskId" in js
+    assert "armedForThisTask" in js
     assert "event.stopImmediatePropagation()" in js
-    assert "effectAllowed = 'link'" in js
-    assert "dropEffect = 'link'" in js
+    assert "effectAllowed = 'all'" in js
+    assert "dropEffect = 'move'" in js
     assert "api/setup/tasks/${dependentTaskId}/dependencies/${prerequisiteTaskId}" in js
     assert "active: true" in js
     assert "dependency_note: null" in js
 
     # The modifier interaction has exactly one governed API write: dependency upsert.
-    # Test executable call names instead of prose substrings so comments such as
-    # "row/scope" cannot produce false positives.
     assert js.count("await api(") == 1
     assert "api/setup/tasks/${dependentTaskId}/scope" not in js
     assert "api/setup/tasks/${prerequisiteTaskId}/scope" not in js
@@ -53,9 +56,9 @@ def test_normal_drag_and_manual_prerequisite_editor_remain_available() -> None:
     assert "Add prerequisite" in normal
     assert "dependencies/${prereq}" in normal
 
-    # Capture listeners only take ownership when dependencyMode is active.
+    # Capture listeners only take ownership after the Shift gesture is armed.
     assert "if (!state.dependencyMode) return;" in shift
-    assert "if (!row || !event.shiftKey" in shift
+    assert "if (!taskId || (!armedForThisTask && !event.shiftKey)) return;" in shift
 
 
 def test_dependency_direction_and_failure_feedback_are_explicit() -> None:
@@ -77,6 +80,7 @@ def test_dependency_mode_has_distinct_visual_cues_without_new_palette() -> None:
     for token in ("var(--accent)", "var(--accent-soft)", "var(--panel)", "var(--text)", "var(--border)"):
         assert token in css
 
+    assert 'user-select: none' in css
     assert re.search(r"#[0-9a-fA-F]{3,8}\b", css) is None
 
 

--- a/Setup/Application/test_setup_prerequisite_editor_contract.py
+++ b/Setup/Application/test_setup_prerequisite_editor_contract.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+APP_DIR = Path(__file__).resolve().parent
+DB_DIR = APP_DIR.parent / "Database"
+
+
+def read_app(name: str) -> str:
+    return (APP_DIR / name).read_text(encoding="utf-8")
+
+
+def test_dependency_order_migration_adds_persistent_governed_order() -> None:
+    sql = (DB_DIR / "026_add_setup_dependency_order.sql").read_text(encoding="utf-8")
+
+    assert "ADD COLUMN IF NOT EXISTS sort_order integer" in sql
+    assert "row_number() OVER" in sql
+    assert "ORDER BY pt.display_order, pt.setup_task_id" in sql
+    assert "ck_setup_task_dependency_sort_order" in sql
+    assert "ix_setup_task_dependency_order" in sql
+    assert "CREATE OR REPLACE FUNCTION ref.set_setup_task_dependency(" in sql
+    assert "coalesce(max(d.sort_order), 0) + 10" in sql
+    assert "ON CONFLICT ON CONSTRAINT pk_setup_task_dependency" in sql
+    assert "DO UPDATE SET dependency_note = EXCLUDED.dependency_note" in sql
+    assert "CREATE OR REPLACE FUNCTION ref.reorder_setup_task_dependencies(" in sql
+    assert "Complete ordered prerequisite list is required" in sql
+    assert "Prerequisite order contains duplicate task IDs" in sql
+    assert "Prerequisite order must contain the complete current prerequisite set" in sql
+    assert "ordered.ordinality::integer * 10" in sql
+    assert "GRANT EXECUTE ON FUNCTION ref.reorder_setup_task_dependencies" in sql
+    assert "GRANT UPDATE ON ref.setup_task_dependency" not in sql
+    assert "GRANT INSERT ON ref.setup_task_dependency" not in sql
+
+
+def test_ordered_prerequisite_api_and_repository_use_governed_boundaries() -> None:
+    api = read_app("setup_prerequisite_order_api.py")
+    repo = read_app("setup_prerequisite_order_repository.py")
+
+    assert '@setup_prerequisite_order_api.get("/api/setup/dependencies/ordered")' in api
+    assert "require_reader()" in api
+    assert '@setup_prerequisite_order_api.patch("/api/setup/tasks/<int:setup_task_id>/dependencies/order")' in api
+    assert "require_setup_command()" in api
+    assert "require_manager()" in api
+    assert "prerequisite_setup_task_ids" in api
+    assert "ref.reorder_setup_task_dependencies(%s,%s,%s::bigint[])" in repo
+    assert "FROM ref.setup_task_dependency d" in repo
+    assert "ORDER BY d.setup_task_id" in repo
+    assert "d.sort_order" in repo
+    assert "INSERT INTO ref.setup_task_dependency" not in repo
+    assert "UPDATE ref.setup_task_dependency" not in repo
+    assert "DELETE FROM ref.setup_task_dependency" not in repo
+
+
+def test_canonical_editor_replaces_duplicate_presentations_and_refreshes_from_db() -> None:
+    js = read_app("setup_prerequisite_editor.js")
+    html = read_app("production.html")
+
+    assert "api/setup/dependencies/ordered" in js
+    assert "renderCanonicalPrerequisites" in js
+    assert "renderCanonicalDependencyEditor" in js
+    assert "next-prerequisite-row" in js
+    assert "next-dependency-up" in js
+    assert "next-dependency-down" in js
+    assert "next-dependency-delete" in js
+    assert "dependencies/order" in js
+    assert "prerequisite_setup_task_ids" in js
+    assert "await reloadTasks(null)" in js
+    assert "if (fresh) selectTask(taskId)" in js
+    assert "!currentIds.has" in js
+    assert "All available tasks are already prerequisites" in js
+    assert "next-dependency-current" not in js
+    assert "Manager prerequisite correction" not in js
+    assert "All listed prerequisites must be complete before this task can start" in html
+    assert "setup_prerequisite_editor.js" in html
+    assert "setup_prerequisite_editor.css" in html
+
+
+def test_prerequisite_order_is_explicitly_review_order_not_dependency_semantics() -> None:
+    js = read_app("setup_prerequisite_editor.js")
+    sql = (DB_DIR / "026_add_setup_dependency_order.sql").read_text(encoding="utf-8")
+
+    assert "Use ↑ / ↓ to change review order only" in js
+    assert "Every listed prerequisite is still required" in js
+    assert "presentation order only" in sql
+    assert "does not create precedence between prerequisite tasks" in sql
+
+
+def test_prerequisite_editor_preserves_dirty_edit_guard_selector() -> None:
+    js = read_app("setup_prerequisite_editor.js")
+    dirty = read_app("setup_catalog_dirty_guard.js")
+
+    assert ".next-dependency-remove" in dirty
+    assert "next-dependency-up next-dependency-remove" in js
+    assert "next-dependency-down next-dependency-remove" in js
+    assert "next-dependency-delete next-dependency-remove" in js
+
+
+def test_prerequisite_editor_css_uses_existing_palette_only() -> None:
+    css = read_app("setup_prerequisite_editor.css")
+    for token in ("var(--border)", "var(--muted)"):
+        assert token in css
+    assert re.search(r"#[0-9a-fA-F]{3,8}\b", css) is None
+
+
+def test_production_registers_prerequisite_order_api_and_assets() -> None:
+    backend = read_app("production_backend.py")
+    html = read_app("production.html")
+
+    assert "from setup_prerequisite_order_api import setup_prerequisite_order_api" in backend
+    assert "app.register_blueprint(setup_prerequisite_order_api)" in backend
+    for asset in ("setup_prerequisite_editor.css", "setup_prerequisite_editor.js"):
+        assert f'"{asset}"' in backend
+        assert asset in html

--- a/Setup/Application/test_setup_prerequisite_editor_contract.py
+++ b/Setup/Application/test_setup_prerequisite_editor_contract.py
@@ -82,11 +82,12 @@ def test_canonical_editor_replaces_duplicate_presentations_and_refreshes_from_db
 def test_prerequisite_order_is_explicitly_review_order_not_dependency_semantics() -> None:
     js = read_app("setup_prerequisite_editor.js")
     sql = (DB_DIR / "026_add_setup_dependency_order.sql").read_text(encoding="utf-8")
+    semantic_sql = " ".join(sql.split())
 
     assert "Use ↑ / ↓ to change review order only" in js
     assert "Every listed prerequisite is still required" in js
-    assert "presentation order only" in sql
-    assert "does not create precedence between prerequisite tasks" in sql
+    assert "sort_order is presentation order only" in semantic_sql
+    assert "does not create precedence between prerequisite tasks" in semantic_sql
 
 
 def test_prerequisite_editor_preserves_dirty_edit_guard_selector() -> None:

--- a/Setup/Application/test_setup_prerequisite_editor_contract.py
+++ b/Setup/Application/test_setup_prerequisite_editor_contract.py
@@ -11,12 +11,13 @@ def read_app(name: str) -> str:
     return (APP_DIR / name).read_text(encoding="utf-8")
 
 
-def test_dependency_order_migration_adds_persistent_governed_order() -> None:
+def test_dependency_order_migration_adds_persistent_governed_order_without_audit_backfill() -> None:
     sql = (DB_DIR / "026_add_setup_dependency_order.sql").read_text(encoding="utf-8")
 
-    assert "ADD COLUMN IF NOT EXISTS sort_order integer" in sql
-    assert "row_number() OVER" in sql
-    assert "ORDER BY pt.display_order, pt.setup_task_id" in sql
+    assert "ADD COLUMN IF NOT EXISTS sort_order integer NOT NULL DEFAULT 100" in sql
+    assert "Existing audit actor/timestamps must not be rewritten" in sql
+    assert "row_number() OVER" not in sql
+    assert "UPDATE ref.setup_task_dependency d\nSET sort_order" not in sql
     assert "ck_setup_task_dependency_sort_order" in sql
     assert "ix_setup_task_dependency_order" in sql
     assert "CREATE OR REPLACE FUNCTION ref.set_setup_task_dependency(" in sql
@@ -28,6 +29,7 @@ def test_dependency_order_migration_adds_persistent_governed_order() -> None:
     assert "Prerequisite order contains duplicate task IDs" in sql
     assert "Prerequisite order must contain the complete current prerequisite set" in sql
     assert "ordered.ordinality::integer * 10" in sql
+    assert "ORDER BY d.sort_order, pt.display_order, d.prerequisite_setup_task_id" in sql
     assert "GRANT EXECUTE ON FUNCTION ref.reorder_setup_task_dependencies" in sql
     assert "GRANT UPDATE ON ref.setup_task_dependency" not in sql
     assert "GRANT INSERT ON ref.setup_task_dependency" not in sql
@@ -47,6 +49,7 @@ def test_ordered_prerequisite_api_and_repository_use_governed_boundaries() -> No
     assert "FROM ref.setup_task_dependency d" in repo
     assert "ORDER BY d.setup_task_id" in repo
     assert "d.sort_order" in repo
+    assert "pt.display_order" in repo
     assert "INSERT INTO ref.setup_task_dependency" not in repo
     assert "UPDATE ref.setup_task_dependency" not in repo
     assert "DELETE FROM ref.setup_task_dependency" not in repo

--- a/Setup/Application/test_setup_production_contract.py
+++ b/Setup/Application/test_setup_production_contract.py
@@ -89,7 +89,7 @@ def test_production_entry_point_serves_shared_ui_and_blocks_prototype_routes() -
     assert health.status_code == 200
     payload = health.get_json()
     assert payload["status"] == "ok"
-    assert payload["version"] == "V0.3.8-task-detail-compact"
+    assert payload["version"] == "V0.3.9-predecessor-drag"
     assert health.headers["Cache-Control"] == "no-store, max-age=0"
 
     for asset in (

--- a/Setup/Application/test_setup_production_contract.py
+++ b/Setup/Application/test_setup_production_contract.py
@@ -22,6 +22,8 @@ def test_production_html_uses_database_client_only() -> None:
         "setup_next_pass.css",
         "setup_predecessor_drag.js",
         "setup_predecessor_drag.css",
+        "setup_prerequisite_editor.js",
+        "setup_prerequisite_editor.css",
         "setup_stage_order.js",
         "setup_stage_order.css",
         "setup_acceptance_fixes.js",
@@ -48,6 +50,7 @@ def test_production_client_has_no_browser_local_prototype_state() -> None:
             "setup_resource_review.js",
             "setup_next_pass.js",
             "setup_predecessor_drag.js",
+            "setup_prerequisite_editor.js",
             "setup_stage_order.js",
             "setup_acceptance_fixes.js",
             "setup_session_year_guard.js",
@@ -66,6 +69,8 @@ def test_production_client_has_no_browser_local_prototype_state() -> None:
     assert "api/setup/schedule" in texts[2]
     assert "api/setup/execution" in texts[2]
     assert "dependencies/${prerequisiteTaskId}" in texts[3]
+    assert "api/setup/dependencies/ordered" in texts[4]
+    assert "dependencies/order" in texts[4]
 
 
 def test_production_runtime_declares_gunicorn() -> None:
@@ -107,6 +112,8 @@ def test_production_entry_point_serves_shared_ui_and_blocks_prototype_routes() -
         "/setup_next_pass.js",
         "/setup_predecessor_drag.css",
         "/setup_predecessor_drag.js",
+        "/setup_prerequisite_editor.css",
+        "/setup_prerequisite_editor.js",
         "/setup_stage_order.css",
         "/setup_stage_order.js",
         "/setup_acceptance_fixes.css",
@@ -134,6 +141,8 @@ def test_production_entry_point_serves_shared_ui_and_blocks_prototype_routes() -
         "/setup_resource_repository.py",
         "/setup_next_api.py",
         "/setup_next_repository.py",
+        "/setup_prerequisite_order_api.py",
+        "/setup_prerequisite_order_repository.py",
         "/setup_operations_repository.py",
         "/requirements.txt",
     ):
@@ -143,6 +152,7 @@ def test_production_entry_point_serves_shared_ui_and_blocks_prototype_routes() -
     assert client.get("/api/setup/access").status_code == 401
     assert client.get("/api/setup/resources").status_code == 401
     assert client.get("/api/setup/organization").status_code == 401
+    assert client.get("/api/setup/dependencies/ordered").status_code == 401
 
 
 def test_production_entry_point_uses_distinct_flask_app() -> None:
@@ -167,6 +177,8 @@ def test_production_api_contains_protected_read_and_command_surfaces() -> None:
         "/api/setup/organization",
         "/api/setup/tasks/<int:setup_task_id>/scope",
         "/api/setup/tasks/<int:setup_task_id>/dependencies/<int:prerequisite_setup_task_id>",
+        "/api/setup/dependencies/ordered",
+        "/api/setup/tasks/<int:setup_task_id>/dependencies/order",
         "/api/setup/session-tasks/<int:setup_session_task_id>/planned-order",
         "/api/setup/planning/promote-baseline",
         "/api/setup/schedule",

--- a/Setup/Application/test_setup_production_contract.py
+++ b/Setup/Application/test_setup_production_contract.py
@@ -20,6 +20,8 @@ def test_production_html_uses_database_client_only() -> None:
         "setup_review_usability.js",
         "setup_next_pass.js",
         "setup_next_pass.css",
+        "setup_predecessor_drag.js",
+        "setup_predecessor_drag.css",
         "setup_stage_order.js",
         "setup_stage_order.css",
         "setup_acceptance_fixes.js",
@@ -45,6 +47,7 @@ def test_production_client_has_no_browser_local_prototype_state() -> None:
             "setup_production.js",
             "setup_resource_review.js",
             "setup_next_pass.js",
+            "setup_predecessor_drag.js",
             "setup_stage_order.js",
             "setup_acceptance_fixes.js",
             "setup_session_year_guard.js",
@@ -62,6 +65,7 @@ def test_production_client_has_no_browser_local_prototype_state() -> None:
     assert "api/setup/organization" in texts[2]
     assert "api/setup/schedule" in texts[2]
     assert "api/setup/execution" in texts[2]
+    assert "dependencies/${prerequisiteTaskId}" in texts[3]
 
 
 def test_production_runtime_declares_gunicorn() -> None:
@@ -101,6 +105,8 @@ def test_production_entry_point_serves_shared_ui_and_blocks_prototype_routes() -
         "/setup_review_usability.js",
         "/setup_next_pass.css",
         "/setup_next_pass.js",
+        "/setup_predecessor_drag.css",
+        "/setup_predecessor_drag.js",
         "/setup_stage_order.css",
         "/setup_stage_order.js",
         "/setup_acceptance_fixes.css",

--- a/Setup/Application/test_setup_stage_order_contract.py
+++ b/Setup/Application/test_setup_stage_order_contract.py
@@ -39,4 +39,4 @@ def test_production_loads_stage_order_assets() -> None:
     assert "setup_stage_order.js" in html
     assert "setup_stage_order.css" in backend
     assert "setup_stage_order.js" in backend
-    assert "V0.3.8-task-detail-compact" in backend
+    assert "V0.3.9-predecessor-drag" in backend

--- a/Setup/Database/026_add_setup_dependency_order.sql
+++ b/Setup/Database/026_add_setup_dependency_order.sql
@@ -1,0 +1,295 @@
+/* ============================================================================
+MSB Setup Session — persistent prerequisite review order
+Issue: #151
+Status: PRODUCTION CANDIDATE — REVIEW BEFORE APPLY
+Revision: 2026-09-11 V0.3.9
+
+Purpose:
+  Give each reusable Setup task dependency a persistent display/review order so
+  Managers can arrange multiple prerequisites without changing dependency
+  meaning. All listed prerequisites remain required; sort_order is presentation
+  order only and does not create precedence between prerequisite tasks.
+
+Behavior:
+  - existing dependencies are backfilled deterministically using the current
+    prerequisite task Catalog display order;
+  - new dependencies append to the dependent task's current prerequisite list;
+  - the existing governed dependency command keeps its signature and cycle
+    protection;
+  - a new governed reorder command atomically renumbers the complete prerequisite
+    set for one dependent task;
+  - no broad table DML is granted to fieldwiring_app.
+============================================================================ */
+
+BEGIN;
+
+DO $preflight$
+BEGIN
+    IF to_regclass('ref.setup_task_dependency') IS NULL THEN
+        RAISE EXCEPTION 'ref.setup_task_dependency is required before migration 026';
+    END IF;
+    IF to_regprocedure('ref.set_setup_task_dependency(text,bigint,bigint,text,boolean)') IS NULL THEN
+        RAISE EXCEPTION 'Setup prerequisite command is required before migration 026';
+    END IF;
+    IF to_regprocedure('ref.setup_management_actor(text,boolean)') IS NULL THEN
+        RAISE EXCEPTION 'Setup management authorization function is required before migration 026';
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'fieldwiring_app') THEN
+        RAISE EXCEPTION 'Required application role fieldwiring_app does not exist';
+    END IF;
+END
+$preflight$;
+
+ALTER TABLE ref.setup_task_dependency
+    ADD COLUMN IF NOT EXISTS sort_order integer;
+
+WITH ranked AS (
+    SELECT d.setup_task_id,
+           d.prerequisite_setup_task_id,
+           row_number() OVER (
+               PARTITION BY d.setup_task_id
+               ORDER BY pt.display_order, pt.setup_task_id
+           ) * 10 AS desired_order
+    FROM ref.setup_task_dependency d
+    JOIN ref.setup_task pt
+      ON pt.setup_task_id = d.prerequisite_setup_task_id
+)
+UPDATE ref.setup_task_dependency d
+SET sort_order = ranked.desired_order
+FROM ranked
+WHERE d.setup_task_id = ranked.setup_task_id
+  AND d.prerequisite_setup_task_id = ranked.prerequisite_setup_task_id
+  AND d.sort_order IS NULL;
+
+ALTER TABLE ref.setup_task_dependency
+    ALTER COLUMN sort_order SET DEFAULT 100,
+    ALTER COLUMN sort_order SET NOT NULL;
+
+DO $constraint$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'ck_setup_task_dependency_sort_order'
+          AND conrelid = 'ref.setup_task_dependency'::regclass
+    ) THEN
+        ALTER TABLE ref.setup_task_dependency
+            ADD CONSTRAINT ck_setup_task_dependency_sort_order
+            CHECK (sort_order >= 0);
+    END IF;
+END
+$constraint$;
+
+CREATE INDEX IF NOT EXISTS ix_setup_task_dependency_order
+    ON ref.setup_task_dependency(setup_task_id, sort_order, prerequisite_setup_task_id);
+
+CREATE OR REPLACE FUNCTION ref.set_setup_task_dependency(
+    p_email text,
+    p_setup_task_id bigint,
+    p_prerequisite_setup_task_id bigint,
+    p_dependency_note text,
+    p_active boolean DEFAULT true
+)
+RETURNS TABLE (
+    setup_task_id bigint,
+    prerequisite_setup_task_id bigint,
+    active boolean,
+    operator_display_name text
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, ref
+AS $function$
+DECLARE
+    v_directus_user_id uuid;
+    v_person_id integer;
+    v_display_name text;
+    v_next_sort_order integer;
+BEGIN
+    SELECT a.directus_user_id, a.person_id, a.display_name
+      INTO v_directus_user_id, v_person_id, v_display_name
+    FROM ref.setup_management_actor(p_email, false) AS a;
+
+    IF p_setup_task_id = p_prerequisite_setup_task_id THEN
+        RAISE EXCEPTION USING ERRCODE = '22023',
+            MESSAGE = 'A Setup task cannot depend on itself';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM ref.setup_task t WHERE t.setup_task_id = p_setup_task_id
+    ) OR NOT EXISTS (
+        SELECT 1 FROM ref.setup_task t WHERE t.setup_task_id = p_prerequisite_setup_task_id
+    ) THEN
+        RAISE EXCEPTION USING ERRCODE = 'P0002',
+            MESSAGE = 'Setup task or prerequisite was not found';
+    END IF;
+
+    IF coalesce(p_active, true) THEN
+        IF EXISTS (
+            WITH RECURSIVE prerequisite_chain(setup_task_id) AS (
+                SELECT d.prerequisite_setup_task_id
+                FROM ref.setup_task_dependency d
+                WHERE d.setup_task_id = p_prerequisite_setup_task_id
+                UNION
+                SELECT d.prerequisite_setup_task_id
+                FROM ref.setup_task_dependency d
+                JOIN prerequisite_chain c
+                  ON d.setup_task_id = c.setup_task_id
+            )
+            SELECT 1
+            FROM prerequisite_chain c
+            WHERE c.setup_task_id = p_setup_task_id
+        ) THEN
+            RAISE EXCEPTION USING ERRCODE = '23514',
+                MESSAGE = 'Prerequisite would create a circular Setup dependency';
+        END IF;
+    END IF;
+
+    PERFORM pg_catalog.set_config(
+        'app.directus_user_uuid',
+        v_directus_user_id::text,
+        true
+    );
+
+    IF coalesce(p_active, true) THEN
+        SELECT coalesce(max(d.sort_order), 0) + 10
+          INTO v_next_sort_order
+        FROM ref.setup_task_dependency d
+        WHERE d.setup_task_id = p_setup_task_id;
+
+        INSERT INTO ref.setup_task_dependency(
+            setup_task_id,
+            prerequisite_setup_task_id,
+            dependency_note,
+            sort_order
+        ) VALUES (
+            p_setup_task_id,
+            p_prerequisite_setup_task_id,
+            nullif(btrim(p_dependency_note), ''),
+            v_next_sort_order
+        )
+        ON CONFLICT ON CONSTRAINT pk_setup_task_dependency
+        DO UPDATE SET dependency_note = EXCLUDED.dependency_note;
+    ELSE
+        DELETE FROM ref.setup_task_dependency d
+        WHERE d.setup_task_id = p_setup_task_id
+          AND d.prerequisite_setup_task_id = p_prerequisite_setup_task_id;
+    END IF;
+
+    RETURN QUERY
+    SELECT p_setup_task_id,
+           p_prerequisite_setup_task_id,
+           coalesce(p_active, true),
+           v_display_name;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION ref.reorder_setup_task_dependencies(
+    p_email text,
+    p_setup_task_id bigint,
+    p_prerequisite_setup_task_ids bigint[]
+)
+RETURNS TABLE (
+    setup_task_id bigint,
+    prerequisite_setup_task_id bigint,
+    sort_order integer,
+    operator_display_name text
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, ref
+AS $function$
+DECLARE
+    v_directus_user_id uuid;
+    v_person_id integer;
+    v_display_name text;
+    v_existing_count integer;
+    v_requested_count integer;
+BEGIN
+    SELECT a.directus_user_id, a.person_id, a.display_name
+      INTO v_directus_user_id, v_person_id, v_display_name
+    FROM ref.setup_management_actor(p_email, false) AS a;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM ref.setup_task t WHERE t.setup_task_id = p_setup_task_id
+    ) THEN
+        RAISE EXCEPTION USING ERRCODE = 'P0002',
+            MESSAGE = 'Setup task was not found';
+    END IF;
+
+    IF p_prerequisite_setup_task_ids IS NULL THEN
+        RAISE EXCEPTION USING ERRCODE = '22023',
+            MESSAGE = 'Complete ordered prerequisite list is required';
+    END IF;
+
+    SELECT count(*) INTO v_existing_count
+    FROM ref.setup_task_dependency d
+    WHERE d.setup_task_id = p_setup_task_id;
+
+    v_requested_count := cardinality(p_prerequisite_setup_task_ids);
+
+    IF v_requested_count <> (
+        SELECT count(DISTINCT x.id)
+        FROM unnest(p_prerequisite_setup_task_ids) AS x(id)
+    ) THEN
+        RAISE EXCEPTION USING ERRCODE = '22023',
+            MESSAGE = 'Prerequisite order contains duplicate task IDs';
+    END IF;
+
+    IF v_existing_count <> v_requested_count
+       OR EXISTS (
+            SELECT d.prerequisite_setup_task_id
+            FROM ref.setup_task_dependency d
+            WHERE d.setup_task_id = p_setup_task_id
+            EXCEPT
+            SELECT x.id FROM unnest(p_prerequisite_setup_task_ids) AS x(id)
+       )
+       OR EXISTS (
+            SELECT x.id FROM unnest(p_prerequisite_setup_task_ids) AS x(id)
+            EXCEPT
+            SELECT d.prerequisite_setup_task_id
+            FROM ref.setup_task_dependency d
+            WHERE d.setup_task_id = p_setup_task_id
+       ) THEN
+        RAISE EXCEPTION USING ERRCODE = '22023',
+            MESSAGE = 'Prerequisite order must contain the complete current prerequisite set';
+    END IF;
+
+    PERFORM pg_catalog.set_config(
+        'app.directus_user_uuid',
+        v_directus_user_id::text,
+        true
+    );
+
+    UPDATE ref.setup_task_dependency d
+    SET sort_order = ordered.ordinality::integer * 10
+    FROM unnest(p_prerequisite_setup_task_ids) WITH ORDINALITY AS ordered(prerequisite_id, ordinality)
+    WHERE d.setup_task_id = p_setup_task_id
+      AND d.prerequisite_setup_task_id = ordered.prerequisite_id;
+
+    RETURN QUERY
+    SELECT d.setup_task_id,
+           d.prerequisite_setup_task_id,
+           d.sort_order,
+           v_display_name
+    FROM ref.setup_task_dependency d
+    WHERE d.setup_task_id = p_setup_task_id
+    ORDER BY d.sort_order, d.prerequisite_setup_task_id;
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION ref.set_setup_task_dependency(
+    text,bigint,bigint,text,boolean
+) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION ref.set_setup_task_dependency(
+    text,bigint,bigint,text,boolean
+) TO fieldwiring_app;
+
+REVOKE ALL ON FUNCTION ref.reorder_setup_task_dependencies(
+    text,bigint,bigint[]
+) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION ref.reorder_setup_task_dependencies(
+    text,bigint,bigint[]
+) TO fieldwiring_app;
+
+COMMIT;

--- a/Setup/Database/026_add_setup_dependency_order.sql
+++ b/Setup/Database/026_add_setup_dependency_order.sql
@@ -11,8 +11,10 @@ Purpose:
   order only and does not create precedence between prerequisite tasks.
 
 Behavior:
-  - existing dependencies are backfilled deterministically using the current
-    prerequisite task Catalog display order;
+  - existing dependencies receive the constant schema default without a mass
+    UPDATE, preserving their existing audit actor/timestamp evidence;
+  - while existing rows share that initial value, current prerequisite task
+    Catalog order remains the deterministic tie-break until a Manager reorders;
   - new dependencies append to the dependent task's current prerequisite list;
   - the existing governed dependency command keeps its signature and cycle
     protection;
@@ -40,30 +42,30 @@ BEGIN
 END
 $preflight$;
 
+/*
+Use a constant schema default so PostgreSQL establishes the initial value for
+existing rows without firing the standard Setup dependency actor/update trigger.
+Existing audit actor/timestamps must not be rewritten merely to introduce a
+presentation-order column.
+*/
 ALTER TABLE ref.setup_task_dependency
-    ADD COLUMN IF NOT EXISTS sort_order integer;
-
-WITH ranked AS (
-    SELECT d.setup_task_id,
-           d.prerequisite_setup_task_id,
-           row_number() OVER (
-               PARTITION BY d.setup_task_id
-               ORDER BY pt.display_order, pt.setup_task_id
-           ) * 10 AS desired_order
-    FROM ref.setup_task_dependency d
-    JOIN ref.setup_task pt
-      ON pt.setup_task_id = d.prerequisite_setup_task_id
-)
-UPDATE ref.setup_task_dependency d
-SET sort_order = ranked.desired_order
-FROM ranked
-WHERE d.setup_task_id = ranked.setup_task_id
-  AND d.prerequisite_setup_task_id = ranked.prerequisite_setup_task_id
-  AND d.sort_order IS NULL;
+    ADD COLUMN IF NOT EXISTS sort_order integer NOT NULL DEFAULT 100;
 
 ALTER TABLE ref.setup_task_dependency
     ALTER COLUMN sort_order SET DEFAULT 100,
     ALTER COLUMN sort_order SET NOT NULL;
+
+DO $column_guard$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM ref.setup_task_dependency d
+        WHERE d.sort_order IS NULL
+    ) THEN
+        RAISE EXCEPTION 'setup_task_dependency.sort_order contains NULL after schema add';
+    END IF;
+END
+$column_guard$;
 
 DO $constraint$
 BEGIN
@@ -273,8 +275,10 @@ BEGIN
            d.sort_order,
            v_display_name
     FROM ref.setup_task_dependency d
+    JOIN ref.setup_task pt
+      ON pt.setup_task_id = d.prerequisite_setup_task_id
     WHERE d.setup_task_id = p_setup_task_id
-    ORDER BY d.sort_order, d.prerequisite_setup_task_id;
+    ORDER BY d.sort_order, pt.display_order, d.prerequisite_setup_task_id;
 END;
 $function$;
 


### PR DESCRIPTION
Implements Issue #151 from refreshed current `main`.

Exact V0.3.9 application/schema/test candidate now pinned for disposable browser review: `55478f98f760473b65b5d700a84c868285022ab7` (`V0.3.9-predecessor-drag`). Application/schema behavior is unchanged from `66a70e...`; `55478f...` only hardens the prerequisite semantic contract by normalizing SQL whitespace before asserting that `sort_order` is presentation-only and does not create precedence. Later branch commits are acceptance-tooling only.

## Accepted core gesture direction

Browser review already confirmed the custom pointer-driven Shift gesture works on the actual Windows/browser combination:
- hold Shift before left-button-down on the later/dependent task;
- release over the prerequisite task;
- creates only `dependent -> prerequisite`;
- neither task moves;
- multiple prerequisites can be stacked;
- repeated identical dependency does not duplicate state;
- reverse/circular dependency is rejected by the governed database command;
- ordinary unmodified drag remains the existing Catalog move/reorder/scope behavior.

The native HTML5 modifier-drag attempt was rejected during browser review because Shift prevented native dragstart on the actual client. The current implementation does not depend on native drag modifier semantics.

## Browser finding addressed in this candidate

The first successful gesture review exposed a separate prerequisite-detail UX/data-contract problem:
- the detail page showed the same prerequisite set twice (top chips plus a second Manager correction/remove list);
- add/remove could leave Catalog and detail views showing different cached dependency sets;
- multiple prerequisites had no independent persistent review/display order.

Current candidate resolves that before #151 can be accepted:
- one canonical prerequisite list in task detail, with each prerequisite shown once;
- separate Add prerequisite form beneath that list;
- Up / Down / Remove controls on the canonical rows;
- explicit database refresh after add/remove/reorder so Catalog and selected detail redraw from the same authoritative relationship rows;
- manually adding an already-assigned prerequisite is no longer offered in the dropdown;
- Shift-drag remains the fast-add path.

## Narrow schema addition

`Setup/Database/026_add_setup_dependency_order.sql` adds `ref.setup_task_dependency.sort_order` and governed `ref.reorder_setup_task_dependencies(text,bigint,bigint[])`.

Ordering semantics are deliberately narrow: prerequisite Up/Down changes review/display order only. Every listed prerequisite is still independently required; reordering does not create dependency relationships among the prerequisites.

Migration safety:
- existing relationship audit actor/timestamps are preserved: existing rows receive a constant schema default without a mass UPDATE;
- current prerequisite task Catalog order is only the initial tie-break while existing rows share that default;
- the first intentional Manager reorder writes 10/20/30 through the governed command and therefore carries the real Manager actor;
- new dependencies append after the current list;
- existing self/cycle/idempotence protections remain in the existing governed dependency function signature;
- fieldwiring_app receives EXECUTE on the narrow reorder function only, with no broad prerequisite-table DML.

## Disposable acceptance boundary

The #151 preview launcher applies migration 026 only to the disposable current-Production clone after restore and after recreating the least-privilege application role. Production remains pg_dump + SELECT only during preview. The preview additionally verifies the new column/function/EXECUTE boundary and that fieldwiring_app still lacks broad prerequisite INSERT/UPDATE/DELETE.

Acceptance history now also includes a contract-only failure at `66a70e...`: the SQL correctly said `sort_order is presentation` followed by a newline and then `order only`, while the test looked for the literal contiguous string `presentation order only`. The corrected candidate `55478f...` normalizes whitespace before asserting the semantic wording. Production fingerprint and live Setup SHA remained unchanged during that failed preview.

The next browser pass must prove:
- one prerequisite presentation only;
- persistent Up/Down ordering reflected identically in detail and Catalog;
- add/remove immediately synchronize both views and remain correct after close/reopen;
- manual Add appends once and removes assigned tasks from available choices;
- previously accepted Shift-drag direction, stacking, duplicate rejection, cycle rejection, and ordinary drag behavior remain intact.

Production remains on accepted V0.3.8 exact runtime `2eee967b6c5359c0e2e2d876a2fe44af8359315c`. No Production migration or application deployment has occurred for #151.