### PR TITLE
Close out Setup #151 Production documentation

### DIFF
--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/README.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/README.md
@@ -8,7 +8,7 @@
 | Status | CURRENT — Production runtime operational; Setup UI/workflow in live evaluation |
 | Owner | MSB Production Database / Setup administrator |
 | Last Reviewed | 2026-09-11 |
-| Keywords | Setup, 2025 review, training, 2026 plan, Setup procedures, deployment |
+| Keywords | Setup, 2025 review, reusable tasks, prerequisites, Shift-drag, Setup procedures, deployment |
 
 Setup and Deployment covers the work of planning and carrying out the annual move from storage to the park, plus the information crews need while installing the show.
 
@@ -19,6 +19,12 @@ https://my.sheboyganlights.org/setup/
 ```
 
 The current working session is **2025 — Historical Verification**. It uses real Production data so managers can reconstruct what happened in 2025, improve reusable Setup knowledge, and identify UI/workflow problems before the 2026 Setup Session is created.
+
+Current Production client:
+
+```text
+Client V0.3.9
+```
 
 ## Start Here
 
@@ -34,13 +40,30 @@ During this review you may, where supported by evidence:
 - add, delete, deactivate, or correct reusable Setup tasks through the supported controls;
 - correct task Stage/Scene scope and normal order;
 - mark whether a reusable task **Uses Display / Container Material**;
-- add or correct prerequisites;
+- add, remove, and reorder real task prerequisites;
+- use **Shift + drag** in the Catalog for fast prerequisite entry;
 - add or correct equipment/resources;
 - improve normal crew/time/readiness information;
 - review current Setup procedures; and
 - record questions or suggestions for the Setup workflow.
 
 Do not change information merely to make a record look complete.
+
+### Prerequisite shortcuts
+
+A hard prerequisite is another reusable Setup task that really must finish first.
+
+To make task A depend on task B:
+
+```text
+hold Shift before left-button-down on task A
+    -> drag A onto task B
+    -> release
+```
+
+Neither task moves during Shift-drag. Ordinary drag without Shift continues to move/reorder tasks and can move a task to another valid Stage/Scene.
+
+Open task detail for the canonical prerequisite list, manual **Add prerequisite**, **Up**, **Down**, and **Remove** controls. Up/Down changes display/review order only; it does not create dependency relationships between prerequisites.
 
 ### Display / Container material
 
@@ -87,7 +110,7 @@ Reusable Task information
 
 A correction that only applies to 2025 belongs in the 2025 annual history. A correction to how MSB normally performs a task belongs in the reusable task definition.
 
-The **Uses Display / Container Material** setting is reusable task knowledge. It should describe whether that task normally requires the current Display/Container material, not something that happened only in 2025.
+The **Uses Display / Container Material** setting and reusable prerequisites are reusable task knowledge. They should describe normal Setup behavior, not something that happened only in 2025.
 
 The selected Setup Session controls the allowable operational year. The 2025 session accepts 2025 operational dates only. Audit timestamps still show when the change was actually recorded.
 
@@ -95,12 +118,13 @@ Only an Administrator may create a new annual Setup Session or promote an annual
 
 ## Current Evaluation Boundary
 
-Production deployment is accepted, but final UI/workflow acceptance remains open while managers use the 2025 session and clean the reusable Catalog.
+Production deployment is accepted, but broader Setup workflow development remains active while managers use the 2025 session and clean the reusable Catalog.
 
 Current known boundaries:
 
 - no 2026 Setup Session has been created;
 - active reusable Catalog cleanup is required before 2026 creation because all active reusable tasks are seeded into a new annual Session;
+- structured outside/site readiness remains separate from task prerequisites;
 - Pick List generation is not yet a live Production workflow; and
 - Container/Display movement and scanning write commands remain outside this review boundary.
 

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/README.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/README.md
@@ -5,7 +5,7 @@
 | Document Type | Engineering Handoff Portal |
 | System | Production Database — Setup and Deployment |
 | Audience | Greg, maintainers, database administrators, future engineering sessions |
-| Status | CURRENT HANDOFF — V0.3.8 accepted in Production; broader Setup work remains active |
+| Status | CURRENT HANDOFF — V0.3.9 accepted in Production; broader Setup work remains active |
 | Owner | MSB Production Database engineering |
 | Last Reviewed | 2026-09-11 |
 
@@ -24,21 +24,21 @@ https://my.sheboyganlights.org/setup/
 Current exact accepted/deployed application target:
 
 ```text
-2eee967b6c5359c0e2e2d876a2fe44af8359315c
+55478f98f760473b65b5d700a84c868285022ab7
 ```
 
 Implementation repository lineage:
 
 ```text
-Issue #153
-PR #160
-main merge commit = d882bb33785321de9a6a880347521adf9518502e
+Issue #151
+PR #164
+main merge commit = ebade21e15a9ac62728dca0655476a619b47516d
 ```
 
 Current Setup health:
 
 ```text
-V0.3.8-task-detail-compact
+V0.3.9-predecessor-drag
 ```
 
 Current annual context:
@@ -50,34 +50,36 @@ Current annual context:
 
 The current PostgreSQL reusable Catalog is the working task baseline. Do not use older fixed counts such as 57 or the earlier 185-task reconstruction snapshot as current authority; live Catalog cleanup and task development continued after those dated baselines.
 
-V0.3.8 source-only Production acceptance on 2026-09-11 proved:
+V0.3.9 Production acceptance on 2026-09-11 proved:
 
 ```text
-exact detached candidate regression          = 53 passed
-live deployed focused regression              = 53 passed
-Production fingerprint before deployment      = 9510360aa7de2da59d1ed8a9ad9d69f7
-Production fingerprint after deployment       = 9510360aa7de2da59d1ed8a9ad9d69f7
-business/source fingerprint changed by deploy = NO
-protected health                              = V0.3.8-task-detail-compact
-final protected laptop browser acceptance     = PASS
+focused exact-candidate regression            = 63 passed
+live deployed focused regression              = 63 passed
+Production fingerprint before migration       = 9510360aa7de2da59d1ed8a9ad9d69f7
+Production fingerprint after migration/deploy = 9510360aa7de2da59d1ed8a9ad9d69f7
+existing dependency rows                      = 17
+legacy dependency audit fingerprint before    = 26b170fba3500ea2647967e87aa02a1c
+legacy dependency audit fingerprint after     = 26b170fba3500ea2647967e87aa02a1c
+protected health                              = V0.3.9-predecessor-drag
+protected Production browser acceptance       = PASS
 ```
 
-V0.3.8 did not apply a database migration or change Setup authorization. The accepted Stage/Scene material database baseline from V0.3.5 remains in force.
+Migration 026 added persistent prerequisite review/display order without rewriting existing dependency audit evidence and without granting broad dependency-table DML to `fieldwiring_app`.
 
 The immediately prior accepted runtime was:
 
 ```text
-9d0c31421ce7cbd1b1cbcf733b06198ace418e9d
-V0.3.7-catalog-dirty-edit-followup
+2eee967b6c5359c0e2e2d876a2fe44af8359315c
+V0.3.8-task-detail-compact
 ```
 
-V0.3.7 fixed the dirty reusable-edit / `Mark Verified` data-loss path after the first V0.3.6 Production candidate failed real protected-route acceptance and was rolled back. V0.3.8 preserves those dirty-edit, client-build badge, cache, and client/server build-match protections.
+V0.3.9 preserves the accepted V0.3.7 dirty-edit/client-build safety and V0.3.8 compact task-detail layout while adding the accepted prerequisite interaction and canonical editor.
 
-See the current [Setup Session Production Engineering Handoff — 2026-09-11](Setup_Session_Production_Engineering_Handoff_2026-09-11.md) and [V0.3.8 Production Acceptance](../../../../../Setup/Acceptance/Setup_Task_Detail_Production_Acceptance_2026-09-11.md).
+See the current [Setup Session Production Engineering Handoff — 2026-09-11](Setup_Session_Production_Engineering_Handoff_2026-09-11.md) and [V0.3.9 Prerequisite Production Acceptance](../../../../../Setup/Acceptance/Setup_Predecessor_V039_Production_Acceptance_2026-09-11.md).
 
 ## Current Accepted Task-Detail Presentation
 
-At laptop/desktop width the accepted task-detail layout is:
+At laptop/desktop width the accepted task-detail layout remains:
 
 ```text
 LEFT                               RIGHT
@@ -90,6 +92,40 @@ The reusable definition itself uses a compact two-column desktop grid. Material 
 Physical mobile-device acceptance was not performed for V0.3.8; responsive stacking is contract-covered and was checked using a narrowed desktop browser proxy only.
 
 Cross-application palette and dark-mode white-logo consistency remain separate work in Issue #159.
+
+## Current Accepted Prerequisite Model
+
+Keep separate:
+
+```text
+HARD PREDECESSOR
+PREFERRED ORDER
+READINESS CONDITION
+```
+
+A hard predecessor is another reusable Setup task that must complete first. A preferred order is only the normal sequence. A readiness condition is an outside/site condition and must not be fabricated as a Setup task merely to create a blocker.
+
+Accepted V0.3.9 prerequisite behavior:
+
+```text
+Shift held before left-button-down on dependent A
+    -> drag A onto prerequisite B
+    -> release
+    -> create A depends on B
+    -> neither task moves
+```
+
+Ordinary drag without Shift preserves the existing reusable-task reorder and Stage/real-Scene movement behavior. Releasing a Shift-drag over empty Stage/Scene space cancels the prerequisite gesture without moving the task.
+
+Task detail has one canonical prerequisite list with **Up**, **Down**, and **Remove**, plus a separate manual **Add prerequisite** form. Assigned prerequisites disappear from the Add choices. Add/remove/reorder refresh authoritative dependency state so task detail and the Catalog `Requires` line stay synchronized.
+
+Migration 026 adds `ref.setup_task_dependency.sort_order` and `ref.reorder_setup_task_dependencies(text,bigint,bigint[])`.
+
+Prerequisite Up/Down order is presentation/review order only. It does not create dependency relationships between the prerequisite tasks. Circular-dependency protection remains authoritative in the governed database command.
+
+Structured readiness remains pending and is still separate from task prerequisites.
+
+See [Setup Predecessor and Readiness Contract — 2026-09-09](Setup_Predecessor_and_Readiness_Contract_2026-09-09.md).
 
 ## Current Accepted Material Model
 
@@ -191,12 +227,13 @@ This workflow is controlled in the Google Drive operator SOPs and was closed thr
 
 ## Start Here
 
-- [Setup Session Production Engineering Handoff — 2026-09-11](Setup_Session_Production_Engineering_Handoff_2026-09-11.md) — current deployed SHA/version, recent V0.3.6/V0.3.7/V0.3.8 lineage, fingerprint evidence, current boundaries, and resume point.
-- [Setup V0.3.8 Task Detail Production Acceptance — 2026-09-11](../../../../../Setup/Acceptance/Setup_Task_Detail_Production_Acceptance_2026-09-11.md) — exact source-only deployment, regression, fingerprint, protected-route, and browser evidence.
+- [Setup Session Production Engineering Handoff — 2026-09-11](Setup_Session_Production_Engineering_Handoff_2026-09-11.md) — current deployed SHA/version, recent runtime lineage, fingerprint evidence, migration 026, current boundaries, and resume point.
+- [Setup V0.3.9 Prerequisite Production Acceptance — 2026-09-11](../../../../../Setup/Acceptance/Setup_Predecessor_V039_Production_Acceptance_2026-09-11.md) — exact migration, source deployment, rollback archive, regression, fingerprint, browser, and preview-lifecycle evidence.
+- [Setup V0.3.8 Task Detail Production Acceptance — 2026-09-11](../../../../../Setup/Acceptance/Setup_Task_Detail_Production_Acceptance_2026-09-11.md) — prior compact task-detail acceptance.
 - [Setup Stage / Scene Material Resolution Contract — 2026-09-10](Setup_Stage_Scene_Material_Resolution_Contract_2026-09-10.md) — current accepted material/source-classification authority.
 - [Setup Stage / Scene Production Acceptance — 2026-09-11](../../../../../Setup/Acceptance/Setup_Stage_Scene_Production_Acceptance_2026-09-11.md) — V0.3.5 material/presentation database migration and acceptance history.
 - [Setup Data Consumption and Authorization Contract — 2026-09-10](Setup_Data_Consumption_and_Authorization_Contract_2026-09-10.md) — Setup capability, Person mapping, application-role, governed write, and grant boundaries.
-- [Setup Predecessor and Readiness Contract — 2026-09-09](Setup_Predecessor_and_Readiness_Contract_2026-09-09.md) — hard predecessor vs preferred order vs external/site readiness.
+- [Setup Predecessor and Readiness Contract — 2026-09-09](Setup_Predecessor_and_Readiness_Contract_2026-09-09.md) — accepted predecessor interaction/order plus hard predecessor vs preferred order vs external/site readiness.
 - [Setup Reconstruction Migration and Acceptance History — 2026-09-07 to 09](Setup_Reconstruction_Migration_and_Acceptance_History_2026-09-07_to_09.md) — historical migration/disposable/browser lessons and reconstruction findings.
 - [Setup Planning Operating Model — 2026-09-08](Setup_Planning_Operating_Model_2026-09-08.md) — rolling-horizon planning direction.
 - [Setup Planning Candidate Work View — 2026-09-09](Setup_Planning_Candidate_Work_View_2026-09-09.md) — cross-Stage candidate planning direction.
@@ -225,15 +262,16 @@ Setup/Acceptance/
 
 The Production Database repository owns Setup application/business/database behavior.
 
-`Gregovate/MSB-Server-Management` owns deployed service, listener, firewall, reverse-proxy, restart/recovery, host permissions, and Production deployment runbooks/runtime facts.
+`Gregovate/MSB-Server-Management` owns deployed service, listener, firewall, reverse-proxy, restart/recovery, host permissions, browser-review runbook, and Production deployment runbooks/runtime facts.
 
 ## Current Repository / Issue Structure
 
 Recent completed acceptance:
 
 ```text
-#154  dirty-edit / Mark Verified safety             CLOSED / V0.3.7 accepted
-#153  compact task-detail / Material layout         CLOSED / V0.3.8 accepted
+#154  dirty-edit / Mark Verified safety              CLOSED / V0.3.7 accepted
+#153  compact task-detail / Material layout          CLOSED / V0.3.8 accepted
+#151  Shift+left-drag predecessor creation           V0.3.9 accepted; closeout docs in progress
 #161  Archive -> SourceDocs Google Doc documentation CLOSED / completed
 ```
 
@@ -242,7 +280,6 @@ Primary active work remains issue-driven:
 ```text
 #122  Setup Session engineering / planning / Pick List / live reconstruction umbrella
 #145  reusable Catalog cleanup gate before creating the 2026 Setup Session
-#151  Shift+left-drag predecessor creation
 #152  resource catalog sort order / existing-resource editing
 #159  shared light/dark palette and dark-mode white-logo consistency
 #141  task-specific staged material subdivision and Pick List release timing
@@ -324,7 +361,7 @@ READINESS CONDITION
 
 A readiness condition can be an external/site condition such as mowing/mulching complete in a specific work area. Do not invent fake Setup tasks for outside work.
 
-Structured readiness remains pending; the current free-text readiness note is descriptive only.
+Structured readiness remains pending; the current free-text readiness note is descriptive only. Efficient task-predecessor entry is now Production-operational in V0.3.9.
 
 ## Pick List Current Boundary
 
@@ -357,7 +394,7 @@ Authenticated Setup operator is not mapped to an MSB person
 
 is a Person/Directus identity-link problem, not justification for broad Setup table DML.
 
-Migration 025 added only the `ref.display_status` SELECT needed by automatic material resolution plus governed material setter EXECUTE; broad `ref.setup_task` DML remains forbidden for `fieldwiring_app`.
+Migration 025 added only the `ref.display_status` SELECT needed by automatic material resolution plus governed material setter EXECUTE. Migration 026 adds only prerequisite presentation order plus narrow governed reorder EXECUTE. Broad direct Setup table DML remains forbidden for `fieldwiring_app`.
 
 See [Setup Data Consumption and Authorization Contract](Setup_Data_Consumption_and_Authorization_Contract_2026-09-10.md).
 
@@ -368,7 +405,8 @@ Current significant remaining work includes:
 - reusable Catalog cleanup before 2026 propagation;
 - continued correction of task boundaries exposed by live review;
 - task-specific staged material subdivision / release timing for multi-step Stage work (Issue #141);
-- structured readiness and efficient predecessor entry;
+- structured readiness;
+- resource catalog sort/existing-resource editing (Issue #152);
 - cross-Stage candidate planning surface / short-horizon scheduler workflow;
 - authoritative Controller context from FieldWiring / Controller Inventory;
 - Pick List generation and tablet workflow;
@@ -388,12 +426,12 @@ Before changing this subsystem:
 5. review Issue #141 before designing task-specific material groups, components/KITs, or Pick List release timing;
 6. review Issue #145 before creating or simulating real 2026 annual state;
 7. preserve annual 2025 facts separately from reusable future knowledge;
-8. preserve the V0.3.7 dirty-edit/client-build protections and V0.3.8 visible client version marker;
-9. use the predecessor/readiness contract before rebuilding dependencies;
+8. preserve the V0.3.7 dirty-edit/client-build protections, V0.3.8 compact layout, and V0.3.9 visible client/prerequisite behavior;
+9. use the predecessor/readiness contract before changing dependency or readiness semantics;
 10. use the Pick List contract before implementing logistics/pick behavior;
 11. use issue #130 / People and Identity for global capability/qualification work;
 12. use issue #113 / Labeling and Scanning for shared scan capture/resolution behavior;
-13. use `Gregovate/MSB-Server-Management` for current runtime/deployment authority; and
+13. use `Gregovate/MSB-Server-Management` for current runtime/deployment/browser-review authority; and
 14. update controlled docs, acceptance evidence, and this README handoff whenever accepted behavior or the next resume point changes.
 
 ## Related Systems

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Predecessor_and_Readiness_Contract_2026-09-09.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Predecessor_and_Readiness_Contract_2026-09-09.md
@@ -4,15 +4,17 @@
 |---|---|
 | Document Type | Engineering Contract / Live Review Finding |
 | System | Production Database — Setup and Deployment |
-| Status | CURRENT DESIGN AUTHORITY — structured readiness implementation pending |
+| Status | CURRENT DESIGN AUTHORITY — task predecessor interaction accepted in V0.3.9; structured readiness pending |
 | Owner | MSB Production Database engineering |
-| Related Work | Issue #122; Issue #145 |
+| Related Work | Issue #122; Issue #145; Issue #151 |
 
 ## Purpose
 
 Preserve the operator-confirmed distinction between reusable task predecessors, preferred order, and external/site readiness so future Setup work does not reconstruct these rules from chat or historical task order.
 
-The 2025 reconstruction intentionally reset reusable dependencies because the imported predecessor set was not trustworthy. The next dependency pass must rebuild only reviewed relationships.
+The 2025 reconstruction intentionally reset reusable dependencies because the imported predecessor set was not trustworthy. Dependency relationships must be rebuilt from reviewed operational knowledge.
+
+Issue #151 completed the Production interaction for efficient prerequisite entry and persistent prerequisite review/display order. Structured readiness remains separate future work.
 
 ## Three Different Concepts
 
@@ -118,26 +120,140 @@ Readiness does not imply predecessor completion, and predecessor completion does
 
 Weather can influence day-to-day planning separately; do not automatically turn every weather note into a durable readiness condition without an accepted rule.
 
-## Efficient Predecessor Editing
+## Accepted Efficient Predecessor Editing — V0.3.9
 
-The current prerequisite selector/button is too cumbersome for the large review pass.
+The prior prerequisite selector/button workflow was too cumbersome for the large review pass. Issue #151 established the accepted Production interaction.
 
-Operator-confirmed desired interaction:
+### Shift-drag direction
 
 ```text
-Shift-drag the later/dependent task onto its predecessor
-    -> create dependency: dragged task depends on target task
+hold Shift before left-button-down on the later/dependent task A
+    -> drag A onto prerequisite task B
+    -> release over B
+    -> create A depends on B
     -> neither task moves
 ```
 
-Requirements:
+The gesture is implemented with a custom pointer-driven interaction rather than relying on native HTML5 modifier-drag semantics. The native Shift+HTML5 drag attempt was rejected during browser review because Shift prevented the expected `dragstart` behavior on the actual Windows/browser client.
 
-- ordinary unmodified drag preserves existing reorder and Stage/Scene movement behavior;
-- Shift-drag is visually distinct from normal drag;
-- use the existing governed `ref.set_setup_task_dependency(...)` write path;
+Accepted requirements:
+
+- Shift must be held before left-button-down on the dependent task;
+- the target is visibly distinguished as the intended prerequisite;
+- neither task moves during the dependency gesture;
+- explicit success/failure feedback names the dependency direction;
+- multiple prerequisites may be stacked on one dependent task;
+- repeating an existing dependency remains idempotent and does not create duplicate state;
 - database circular-dependency protection remains authoritative;
-- show explicit success/failure feedback; and
+- releasing over empty Stage/Scene space cancels the dependency gesture without moving the task; and
 - modifier-drag applies only to task predecessors, not readiness conditions.
+
+### Ordinary drag remains movement/reorder/scope
+
+Unmodified left-drag preserves the existing reusable-task reorder and Stage/real-Scene movement behavior.
+
+The modifier is the switch:
+
+```text
+left-drag          -> normal move/reorder/scope behavior
+Shift + left-drag  -> create predecessor relationship; do not move either task
+```
+
+This distinction passed both disposable browser review and real protected Production browser acceptance.
+
+## Canonical Prerequisite Editor
+
+Task detail contains one canonical prerequisite list. Each current prerequisite appears once with:
+
+- position;
+- **Up**;
+- **Down**; and
+- **Remove**.
+
+A separate manual **Add prerequisite** form remains available as a fallback/precision entry method. Already-assigned prerequisites are excluded from the available Add choices for that task.
+
+After add/remove/reorder, the application reloads authoritative dependency state so task detail and the Catalog `Requires` line redraw from the same relationship rows.
+
+This avoids the earlier review defect where prerequisite state could be duplicated in the UI or become visually stale between detail and Catalog views.
+
+## Persistent Prerequisite Review Order
+
+Migration 026 is the accepted Production schema authority for prerequisite review/display order:
+
+```text
+Setup/Database/026_add_setup_dependency_order.sql
+```
+
+It adds:
+
+```text
+ref.setup_task_dependency.sort_order integer NOT NULL DEFAULT 100
+ref.reorder_setup_task_dependencies(text,bigint,bigint[])
+```
+
+Ordering semantics are deliberately narrow:
+
+```text
+prerequisite Up/Down = review/display order only
+```
+
+It does **not** mean:
+
+```text
+prerequisite 1 depends on prerequisite 2
+```
+
+Every listed prerequisite remains independently required by the dependent task.
+
+Existing dependency rows received the constant schema default without a mass UPDATE, preserving their existing note/audit actor/timestamp evidence. While existing rows share the initial default, prerequisite task Catalog order remains the deterministic tie-break until a Manager intentionally reorders the list.
+
+The first intentional Manager reorder writes 10/20/30/... through the governed command. New dependencies append after the current list.
+
+`fieldwiring_app` receives EXECUTE on the narrow governed reorder function and retains no broad INSERT/UPDATE/DELETE privilege on `ref.setup_task_dependency`.
+
+## Governed Write Boundary
+
+Task dependency creation/removal continues through:
+
+```text
+ref.set_setup_task_dependency(text,bigint,bigint,text,boolean)
+```
+
+Reordering uses:
+
+```text
+ref.reorder_setup_task_dependencies(text,bigint,bigint[])
+```
+
+Do not add direct browser/application table DML for prerequisite maintenance.
+
+Circular-dependency protection remains in the governed dependency command and is authoritative even if the browser also performs earlier UX validation.
+
+## Production Acceptance Evidence
+
+Issue #151 accepted runtime:
+
+```text
+SHA     = 55478f98f760473b65b5d700a84c868285022ab7
+version = V0.3.9-predecessor-drag
+PR      = #164
+merge   = ebade21e15a9ac62728dca0655476a619b47516d
+```
+
+Migration 026 Production validation proved:
+
+```text
+existing dependency rows              = 17
+initial sort_order range               = 100 / 100
+legacy dependency audit fingerprint    = 26b170fba3500ea2647967e87aa02a1c before/after
+governed Setup fingerprint             = 9510360aa7de2da59d1ed8a9ad9d69f7 before/after
+reorder EXECUTE for fieldwiring_app    = PASS
+broad dependency table DML             = NO
+```
+
+Focused exact-candidate and live deployed regressions both passed 63 tests. Final protected Production browser acceptance passed Shift-drag, canonical prerequisite presentation, manual Add behavior, and ordinary movement behavior.
+
+See `Setup/Acceptance/Setup_Predecessor_V039_Production_Acceptance_2026-09-11.md`.
 
 ## Reconstruction Rule
 
@@ -162,30 +278,35 @@ A task is normally done earlier for convenience but can safely move
     -> PREFERRED ORDER
 ```
 
+Use Shift-drag or the manual prerequisite editor only for the **HARD PREDECESSOR** case.
+
 ## 2026 Session Gate
 
 **Do not create the 2026 Setup Session until the reconstructed reusable Catalog and predecessor/readiness model are ready enough for planning.**
 
-This gate now also includes Issue #145: every active reusable task is seeded into a newly created annual Setup Session, so confirmed reconstruction duplicates must be removed or deactivated before 2026 creation.
+This gate includes Issue #145: every active reusable task is seeded into a newly created annual Setup Session, so confirmed reconstruction duplicates must be removed or deactivated before 2026 creation.
 
-## Implementation Gate
+Issue #151 completes efficient hard-predecessor editing; it does not complete structured readiness or the Catalog-cleanup gate.
 
-Before Production implementation of structured readiness or Shift-drag predecessor entry:
+## Remaining Implementation Gate — Structured Readiness
 
-1. preserve current normal drag/reorder/scope behavior;
-2. keep readiness conditions separate from reusable task dependencies;
-3. support one readiness condition gating multiple tasks;
-4. support independent readiness by work area;
-5. prove the Stage 00 HWY42 condition blocks affected work until READY;
-6. ensure readiness conditions do not appear as completed Setup work or crew/reporting tasks;
-7. prove Shift-drag creates only the intended directed task dependency and does not move either task;
-8. prove unmodified drag remains unchanged; and
-9. perform protected browser validation before Production acceptance.
+Before Production implementation of structured readiness:
+
+1. keep readiness conditions separate from reusable task dependencies;
+2. support one readiness condition gating multiple tasks;
+3. support independent readiness by work area;
+4. prove the Stage 00 HWY42 condition blocks affected work until READY;
+5. ensure readiness conditions do not appear as completed Setup work or crew/reporting tasks; and
+6. perform protected browser validation before Production acceptance.
+
+Do not reopen the accepted V0.3.9 predecessor interaction merely because structured readiness remains unfinished.
 
 ## Related Durable Sources
 
+- [Setup V0.3.9 Prerequisite Production Acceptance](../../../../../Setup/Acceptance/Setup_Predecessor_V039_Production_Acceptance_2026-09-11.md)
 - [Setup Planning Operating Model](Setup_Planning_Operating_Model_2026-09-08.md)
 - [Setup Stage / Scene Material Resolution Contract](Setup_Stage_Scene_Material_Resolution_Contract_2026-09-10.md)
 - [Setup engineering portal](README.md)
 - GitHub Issue #122
 - GitHub Issue #145
+- GitHub Issue #151

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Session_Production_Engineering_Handoff_2026-09-11.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Session_Production_Engineering_Handoff_2026-09-11.md
@@ -4,13 +4,13 @@
 |---|---|
 | Document Type | Engineering Handoff |
 | System | Production Database — Setup Session |
-| Status | CURRENT HANDOFF — V0.3.8 accepted in Production; broader Setup development remains active |
+| Status | CURRENT HANDOFF — V0.3.9 accepted in Production; broader Setup development remains active |
 | Owner | MSB Production Database engineering |
 | Last Reviewed | 2026-09-11 |
 
 ## Purpose
 
-Preserve the current accepted Setup Session Production state, recent runtime lineage, data/authorization boundaries, exact deployed source, fingerprint evidence, procedure-source behavior, open work, and engineering resume point so future work starts from repository evidence rather than reconstructing recent acceptance from chat or issue comments.
+Preserve the current accepted Setup Session Production state, recent runtime lineage, data/authorization boundaries, exact deployed source, fingerprint evidence, prerequisite behavior, procedure-source behavior, open work, and engineering resume point so future work starts from repository evidence rather than reconstructing recent acceptance from chat or issue comments.
 
 This handoff supersedes the 2026-09-07 handoff as the **current** runtime/resume summary. The 2026-09-07 document remains historical foundation evidence for the original V0.3.4 Production promotion.
 
@@ -25,25 +25,25 @@ https://my.sheboyganlights.org/setup/
 Current accepted application version:
 
 ```text
-V0.3.8-task-detail-compact
+V0.3.9-predecessor-drag
 ```
 
 Exact deployed application source:
 
 ```text
 /opt/msb-setup
-SHA = 2eee967b6c5359c0e2e2d876a2fe44af8359315c
+SHA = 55478f98f760473b65b5d700a84c868285022ab7
 ```
 
 Implementation lineage:
 
 ```text
-Issue #153
-PR #160
-merge commit = d882bb33785321de9a6a880347521adf9518502e
+Issue #151
+PR #164
+merge commit = ebade21e15a9ac62728dca0655476a619b47516d
 ```
 
-The runtime intentionally remains pinned to the exact browser-accepted candidate rather than silently moving to the later repository merge/documentation commit.
+The runtime intentionally remains pinned to the exact browser-accepted candidate rather than silently moving to the later merge/documentation commits.
 
 Current accepted service/runtime facts remain:
 
@@ -57,6 +57,47 @@ protected route                     = https://my.sheboyganlights.org/setup/
 ```
 
 Server/runtime authority remains `Gregovate/MSB-Server-Management`.
+
+## Current Database / Migration Baseline
+
+Current accepted Setup database additions include migration 025 for Stage/Scene material resolution and migration 026 for persistent prerequisite review/display order.
+
+Migration 026:
+
+```text
+Setup/Database/026_add_setup_dependency_order.sql
+blob = 759774d80eb51b706a0e7b71c5e834636b64a451
+```
+
+Accepted Production state:
+
+```text
+ref.setup_task_dependency.sort_order = integer NOT NULL DEFAULT 100
+ref.reorder_setup_task_dependencies(text,bigint,bigint[]) = installed
+fieldwiring_app reorder EXECUTE = YES
+fieldwiring_app broad dependency INSERT/UPDATE/DELETE = NO
+```
+
+The 17 dependency rows that existed before migration retained their legacy note/audit fingerprint:
+
+```text
+26b170fba3500ea2647967e87aa02a1c
+```
+
+before and after migration. The governed Setup fingerprint also remained:
+
+```text
+9510360aa7de2da59d1ed8a9ad9d69f7
+```
+
+Migration 026 did not rewrite existing dependency audit evidence merely to introduce display order.
+
+Validated rollback archive retained on the Production host:
+
+```text
+/home/msbadmin/backups/setup-151/msb-pre-setup-151-20260911T071801.dump
+SHA256 = 21e5b9b0fbd07dd01b7c9a86027615988bc33f950767839e4d74bb4a1f407029
+```
 
 ## Current Annual / Catalog Boundary
 
@@ -73,7 +114,46 @@ The active reusable Catalog is the future-work baseline. A reusable task may leg
 
 Do not force newer reusable tasks into the 2025 historical Session merely to make the historical Plan appear complete.
 
+## Current V0.3.9 Prerequisite Behavior
+
+The accepted fast-entry interaction is:
+
+```text
+hold Shift before left-button-down on dependent task A
+    -> drag A onto prerequisite task B
+    -> release
+    -> A depends on B
+    -> neither task moves
+```
+
+Accepted behavior includes:
+
+- multiple prerequisites on one task;
+- idempotent repeated dependency entry;
+- database-authoritative circular-dependency rejection;
+- Shift-release over empty Stage/Scene space cancels without moving the task;
+- ordinary drag without Shift keeps reusable reorder and Stage/real-Scene movement behavior; and
+- explicit success/failure feedback with the intended dependency direction.
+
+Task detail now uses one canonical prerequisite list. Each prerequisite appears once with position plus **Up**, **Down**, and **Remove**. A separate manual **Add prerequisite** form remains available, and already-assigned prerequisites are excluded from its choices.
+
+Add/remove/reorder reload authoritative dependency state so task detail and the Catalog `Requires` line remain synchronized.
+
+Prerequisite Up/Down changes review/display order only. It does not create dependency relationships among prerequisite tasks.
+
+Keep the domain distinction:
+
+```text
+HARD PREDECESSOR != PREFERRED ORDER != READINESS CONDITION
+```
+
+Structured outside/site readiness remains future work.
+
+See [`Setup_Predecessor_and_Readiness_Contract_2026-09-09.md`](Setup_Predecessor_and_Readiness_Contract_2026-09-09.md).
+
 ## Current V0.3.8 Task-Detail Presentation
+
+The V0.3.8 layout remains accepted and is preserved by V0.3.9.
 
 Accepted laptop/desktop task-detail layout:
 
@@ -85,11 +165,9 @@ Material / Logistics                Captains / Knowledge Owners
 
 The reusable definition itself uses a compact two-column desktop grid. Material / Logistics retains the four essential counts plus the existing full detail dialog. Prerequisites and Equipment / Resources remain below the rail block and are reachable with materially less scrolling.
 
-No schema, API, authorization, or Plan / Schedule behavior changed solely for V0.3.8.
-
 Physical mobile-device acceptance was not performed. Responsive stacking is contract-covered and was checked using a narrowed desktop browser only.
 
-Issue #159 separately owns cross-application palette and dark-mode white-logo consistency. The blue Setup logo in dark mode is a known current presentation inconsistency and is not an accepted V0.3.8 theme standard.
+Issue #159 separately owns cross-application palette and dark-mode white-logo consistency.
 
 ## Recent Runtime / Safety Lineage
 
@@ -131,22 +209,12 @@ Accepted protections include:
 - live-form vs selected-task dirty comparison;
 - reusable save before annual verification, with verification blocked if save fails;
 - Save / Discard / Stay protection for dirty navigation;
-- visible `Client V0.3.7` client-build badge;
+- visible client-build badge;
 - governed-write client/server build-match validation;
 - `no-store` protection for Setup page/assets/health so a stale client bundle cannot quietly continue writing; and
 - independent Effort / Material / Resource / Captain save surfaces remain separately governed.
 
-V0.3.7 Production deployment evidence:
-
-```text
-focused live regression = 45 passed
-pre/post source-deployment fingerprint = 0298e2b1c3531e13b1a0a86d4e55509d
-protected health = V0.3.7-catalog-dirty-edit-followup
-```
-
-Real operator validation on reusable task 200 / annual task 81 confirmed crew min/max 4/6 and completion point survived `Mark Verified` without a separate manual reusable save, and annual state became VERIFIED.
-
-### V0.3.8 — current accepted runtime
+### V0.3.8 — accepted compact task-detail layout
 
 Accepted exact candidate:
 
@@ -154,8 +222,6 @@ Accepted exact candidate:
 SHA     = 2eee967b6c5359c0e2e2d876a2fe44af8359315c
 version = V0.3.8-task-detail-compact
 ```
-
-V0.3.8 preserves the V0.3.7 dirty-edit/build-match protections and changes the task-detail presentation only.
 
 Production source-only deployment evidence:
 
@@ -168,9 +234,51 @@ protected health                     = V0.3.8-task-detail-compact
 final protected browser acceptance   = PASS
 ```
 
-Final browser acceptance required no special Production data write.
+### V0.3.9 — current accepted prerequisite workflow
 
-See [`Setup_Task_Detail_Production_Acceptance_2026-09-11.md`](../../../../../Setup/Acceptance/Setup_Task_Detail_Production_Acceptance_2026-09-11.md).
+Accepted exact candidate:
+
+```text
+SHA     = 55478f98f760473b65b5d700a84c868285022ab7
+version = V0.3.9-predecessor-drag
+```
+
+Production evidence:
+
+```text
+migration 026                         = PASS
+focused exact-candidate regression    = 63 passed
+live focused regression               = 63 passed
+pre/post governed fingerprint         = 9510360aa7de2da59d1ed8a9ad9d69f7
+pre/post legacy dependency fingerprint= 26b170fba3500ea2647967e87aa02a1c
+protected direct negative path        = HTTP 401 PASS
+protected health                      = V0.3.9-predecessor-drag
+final protected browser acceptance    = PASS
+```
+
+The broad `Setup/Application` suite reported 191 passed / 2 failed on the exact V0.3.9 candidate. The same two failing literal-string contracts were reproduced on the already accepted V0.3.8 checkout, proving they were inherited stale test debt rather than V0.3.9 regressions. Closeout updates those literals rather than falsely claiming the pre-deployment full suite was green.
+
+See [`Setup_Predecessor_V039_Production_Acceptance_2026-09-11.md`](../../../../../Setup/Acceptance/Setup_Predecessor_V039_Production_Acceptance_2026-09-11.md).
+
+## Browser Preview Lifecycle Finding
+
+The #151 disposable review exposed a browser-preview lifecycle failure that is now durable operational knowledge.
+
+A lost workstation SSH tunnel can leave the remote source-only preview wrapper blocked on its browser-review prompt while the Flask child survives in its own session/process group. In that state the browser reports `Failed to fetch`, but the application may still be healthy on the server.
+
+Diagnosis must distinguish:
+
+```text
+application crash
+vs.
+SSH/tunnel loss with surviving preview
+```
+
+The final #151 evidence showed the last dependency mutation and following refreshes returned HTTP 200, and a direct server health request still returned V0.3.9. The application had not crashed.
+
+Acceptance tooling was hardened to clean only recognized preview-owned resources, reject Production ports, preserve reports/logs, use SSH keepalives, include HUP handling, and use `timeout --foreground` for an interactive bounded remote review. A non-foreground `timeout` attempt stopped at `sudo -v` and was rejected before final acceptance.
+
+Server-side browser-review operational authority is `Gregovate/MSB-Server-Management/docs/server/Pre_Production_Browser_Review_Runbook.md`.
 
 ## Data / Authorization Boundary
 
@@ -192,6 +300,8 @@ Authenticated Setup operator is not mapped to an MSB person
 ```
 
 is an identity-link / Person mapping problem, not evidence that the browser needs broader database permissions.
+
+Migration 026 preserves the same boundary: `fieldwiring_app` receives narrow EXECUTE on prerequisite commands and no broad dependency-table DML.
 
 ## Procedure / Editable Source Boundary
 
@@ -263,6 +373,7 @@ Completed and accepted in this recent line:
 ```text
 #154 dirty-edit / Mark Verified safety  = CLOSED / ACCEPTED V0.3.7
 #153 compact task-detail layout         = CLOSED / ACCEPTED V0.3.8
+#151 Shift+left-drag predecessor entry  = ACCEPTED V0.3.9 / close after documentation merge
 #161 SourceDocs migration documentation = CLOSED / COMPLETED
 ```
 
@@ -270,13 +381,14 @@ Real independent work remains, including:
 
 ```text
 #145 reusable Catalog cleanup before 2026 Session creation
-#151 Shift+left-drag predecessor creation
 #152 resource catalog sort order / existing-resource editing
 #159 cross-app light/dark palette and dark-mode white-logo standardization
 #141 task-specific staged material / Pick List release timing
 #132 Captain work-report duration / multi-day effort capture
 #113 shared Scan readiness / identity capture integration
 ```
+
+Structured readiness remains open design/implementation work under the broader Setup planning stream and must remain separate from hard task prerequisites.
 
 Do not create the 2026 Setup Session until #145 is complete and the cleaned active Catalog has passed the disposable 2026 seeding check.
 
@@ -287,18 +399,20 @@ Before the next Setup change:
 1. refresh current remote `main` and read the Project Rules;
 2. read this handoff and [`README.md`](README.md);
 3. read the responsible contract for the work item being changed;
-4. preserve the V0.3.7 dirty-edit/client-server build protections;
-5. preserve the V0.3.8 visible client version marker;
-6. preserve current 2025 historical state and do not create 2026 without #145 acceptance;
-7. use `Gregovate/MSB-Server-Management` for runtime/deployment authority;
-8. perform disposable/current-Production-clone browser acceptance before Production deployment when browser behavior changes;
-9. perform real protected-route operator validation for behavior that depends on actual client/runtime interaction; and
-10. complete controlled engineering/operator documentation and issue closeout before leaving the work item.
+4. preserve V0.3.7 dirty-edit/client-server build protections;
+5. preserve V0.3.8 compact task-detail layout;
+6. preserve V0.3.9 client marker, Shift-drag prerequisite direction, canonical prerequisite editor, and display-order-only semantics;
+7. preserve current 2025 historical state and do not create 2026 without #145 acceptance;
+8. use `Gregovate/MSB-Server-Management` for runtime/deployment/browser-review authority;
+9. perform disposable/current-Production-clone browser acceptance before Production deployment when browser behavior changes;
+10. perform real protected-route operator validation for behavior that depends on actual client/runtime interaction; and
+11. complete controlled engineering/operator documentation and issue closeout before leaving the work item.
 
 ## Related Documents
 
 - [Setup engineering portal](README.md)
-- [V0.3.8 Production acceptance](../../../../../Setup/Acceptance/Setup_Task_Detail_Production_Acceptance_2026-09-11.md)
+- [V0.3.9 prerequisite Production acceptance](../../../../../Setup/Acceptance/Setup_Predecessor_V039_Production_Acceptance_2026-09-11.md)
+- [V0.3.8 task-detail Production acceptance](../../../../../Setup/Acceptance/Setup_Task_Detail_Production_Acceptance_2026-09-11.md)
 - [Stage / Scene material resolution contract](Setup_Stage_Scene_Material_Resolution_Contract_2026-09-10.md)
 - [Data consumption and authorization contract](Setup_Data_Consumption_and_Authorization_Contract_2026-09-10.md)
 - [Predecessor and readiness contract](Setup_Predecessor_and_Readiness_Contract_2026-09-09.md)

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/operatorSOP/README.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/operatorSOP/README.md
@@ -8,7 +8,7 @@
 | Status | CURRENT — Production runtime operational; UI/workflow in live evaluation |
 | Owner | MSB Production Database / Setup administrator |
 | Last Reviewed | 2026-09-11 |
-| Keywords | Setup, 2025, historical review, training, reusable tasks, resources, material, 2026 baseline |
+| Keywords | Setup, 2025, historical review, training, reusable tasks, resources, material, prerequisites, Shift-drag, 2026 baseline |
 
 Use this area for plain-English instructions for working in the Setup application. Engineering, database, service, permission, and deployment details belong in [`../engineering/`](../engineering/README.md).
 
@@ -28,15 +28,21 @@ The current shared working session is:
 
 The application uses real Production data. It is available for manager/reviewer use now, but the UI/workflow is still being evaluated through real 2025 review work.
 
+Current Production client:
+
+```text
+Client V0.3.9
+```
+
 ## What Do You Need To Do?
 
-- [Review and Correct the 2025 Setup History](Review_2025_Setup_History.md) — verify 2025 information, improve reusable Setup knowledge, add missing tasks/resources where appropriate, mark which tasks use Display/Container material, and record questions or suggestions.
+- [Review and Correct the 2025 Setup History](Review_2025_Setup_History.md) — verify 2025 information, improve reusable Setup knowledge, add missing tasks/resources where appropriate, mark which tasks use Display/Container material, add/correct prerequisites, and record questions or suggestions.
 
 Additional task procedures will be added only when the corresponding workflow is actually production-operational.
 
 ## Material Checkbox
 
-Reusable tasks now have:
+Reusable tasks have:
 
 ```text
 [ ] Uses Display / Container Material
@@ -71,6 +77,37 @@ This is a real reusable-scope change, not only a visual reorder. The application
 
 Use this when the task was organized under the wrong Stage-level/Scene location. Do not create a fake Scene or use a programming-only LOR group as a Setup Scene merely to obtain a different material result.
 
+## Adding and Reviewing Prerequisites
+
+A prerequisite is another reusable Setup task that truly must be complete before the dependent task can proceed.
+
+### Fast prerequisite entry
+
+To make task A depend on task B:
+
+```text
+hold Shift before left-button-down on task A
+    -> drag task A onto task B
+    -> release
+    -> task A depends on task B
+```
+
+Neither task moves during Shift-drag. Releasing over empty Stage/Scene space cancels the prerequisite gesture.
+
+### Normal movement
+
+Drag without Shift when you intend to reorder a task or move it to another valid Stage/Scene. Ordinary drag remains the normal movement interaction.
+
+### Task-detail prerequisite controls
+
+Open task detail to use the canonical prerequisite list. Each prerequisite appears once with **Up**, **Down**, and **Remove** controls. A separate **Add prerequisite** control remains available for manual entry.
+
+After a prerequisite is assigned, it is no longer offered in that task's Add list.
+
+**Up** and **Down** change review/display order only. They do not make one prerequisite depend on another. Every listed prerequisite remains independently required.
+
+Circular prerequisite relationships are rejected. Do not work around that warning by creating fake tasks or reversing the intended dependency.
+
 ## Important Boundaries
 
 - The 2025 review area uses real Production data.
@@ -79,6 +116,7 @@ Use this when the task was organized under the wrong Stage-level/Scene location.
 - The material checkbox is reusable task knowledge, not a one-year 2025 fact.
 - Operational dates entered for the selected Setup Session must be in that session's year.
 - Only an Administrator may create a new annual Setup Session or carry annual order forward as the future reusable baseline.
+- Hard predecessors are not the same as preferred order or outside/site readiness conditions.
 - Pick Lists and Container/Display movement/scanning writes are not part of the current live-review workflow.
 - Do not create fake records merely to test the UI. Use real review work and report workflow/UI findings instead.
 
@@ -91,7 +129,7 @@ Managers and reviewers are encouraged to:
 - mark **Uses Display / Container Material** only when that task really needs the current Display/Container material for its Stage/Scene work;
 - leave the material checkbox off for valid non-material tasks;
 - treat resolved material as context, not an automatic instruction to pick every item immediately;
-- add/correct resources and prerequisites;
+- add/correct resources and real prerequisites;
 - correct task scope, order, crew/time expectations, and notes where supported;
 - verify records only when they have actually been reviewed;
 - leave uncertain information UNVERIFIED or mark it NEEDS CORRECTION;
@@ -101,5 +139,6 @@ Managers and reviewers are encouraged to:
 ## Related Documents
 
 - [Setup and Deployment](../README.md)
+- [Review and Correct the 2025 Setup History](Review_2025_Setup_History.md)
 - [Engineering handoff](../engineering/README.md)
 - [Detailed Manager Review Guide](../../../02_Operational_SOPs/Setup/Setup_Session_Manager_Review_Guide.md)

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/operatorSOP/Review_2025_Setup_History.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/operatorSOP/Review_2025_Setup_History.md
@@ -9,7 +9,7 @@
 | Status | CURRENT — live 2025 review plus current reusable-task development |
 | Owner | MSB Setup administrator |
 | Last Reviewed | 2026-09-11 |
-| Keywords | Setup, 2025, historical review, reusable task, material, resources, verification |
+| Keywords | Setup, 2025, historical review, reusable task, material, resources, prerequisites, Shift-drag, verification |
 
 ## Purpose
 
@@ -97,7 +97,7 @@ Tasks such as locating, laying out an area, plugging power/network, greasing bea
 
 ## Use the Display / Container Material Checkbox
 
-Reusable task details now include:
+Reusable task details include:
 
 ```text
 [ ] Uses Display / Container Material
@@ -198,6 +198,51 @@ For reusable tasks, check whether practical requirements are represented correct
 Do not invent quantities or dependencies merely to fill fields.
 
 A predecessor is another Setup task that must be complete first. A readiness condition may instead be an external/site condition such as mowing/mulching being complete in the applicable work area. Do not create fake Setup tasks merely to represent outside conditions.
+
+## Add or Correct Prerequisites
+
+Use a prerequisite only when another reusable Setup task really must be completed first.
+
+### Fast entry with Shift-drag
+
+To make task A depend on task B:
+
+1. In the reusable Catalog, hold **Shift before pressing the left mouse button** on task A, the task that happens later.
+2. Drag task A onto task B, the task that must happen first.
+3. Release the mouse over task B.
+4. Confirm the success message shows the intended direction and the Catalog **Requires** line updates.
+
+Example:
+
+```text
+Install Panels depends on Set Posts
+
+hold Shift
++ drag Install Panels onto Set Posts
+```
+
+During Shift-drag, neither task moves. If you release over empty Stage/Scene space instead of another task, the prerequisite gesture cancels and the task stays where it was.
+
+### Normal drag still moves/reorders tasks
+
+Do **not** hold Shift when you intend to move or reorder a task. Ordinary drag keeps its existing behavior, including movement between valid Stage-level / General and real Scene locations.
+
+### Manual prerequisite editor
+
+Open the task detail when you want to review or maintain the prerequisite list directly.
+
+The **Prerequisites** area has one current list. Each prerequisite appears once with:
+
+- its position;
+- **Up**;
+- **Down**; and
+- **Remove**.
+
+Use the separate **Add prerequisite** control when manual entry is easier than Shift-drag. After a prerequisite is assigned, it is removed from the available Add choices for that task.
+
+**Up** and **Down** only change how the prerequisites are displayed/reviewed. They do not mean one prerequisite depends on another. Every prerequisite listed for the task remains independently required.
+
+If Setup rejects a circular dependency, leave the tasks as they are and correct the relationship rather than trying to work around the warning.
 
 ## Procedures and Instructions
 

--- a/Docs/02_Production_Database/02_Operational_SOPs/Setup/Setup_Session_Manager_Review_Guide.md
+++ b/Docs/02_Production_Database/02_Operational_SOPs/Setup/Setup_Session_Manager_Review_Guide.md
@@ -35,10 +35,10 @@ Only an Administrator may create a new annual Setup Session or promote annual or
 
 ## Confirm the Loaded Client
 
-The Setup header displays the currently loaded client version, for example:
+The Setup header displays the currently loaded client version. Current Production is:
 
 ```text
-Client V0.3.7
+Client V0.3.9
 ```
 
 After a deployment, after leaving Setup open for a long period, or whenever the displayed client version is unexpected, refresh or reopen the application before making a governed change.
@@ -156,7 +156,7 @@ real Scene task
 
 resolved Displays
     -> current Display-to-Container assignment
-    -> deduplicated current Containers
+    -> deduplicated Containers
 ```
 
 The Manager does **not** choose a separate LOR Preview, programming group, or manual ordinary Display list as the material source.
@@ -248,6 +248,47 @@ A readiness condition may instead be an outside/site condition such as mowing/mu
 
 Structured readiness remains future work; free-text readiness notes are descriptive, not a complete scheduling control.
 
+### Fast prerequisite entry with Shift-drag
+
+When one reusable task truly must finish before another, you can create the dependency directly in the Catalog.
+
+If task A depends on task B:
+
+1. Hold **Shift before pressing the left mouse button** on task A, the later/dependent task.
+2. Drag task A onto task B, the task that must happen first.
+3. Release over task B.
+4. Confirm the success feedback and the Catalog **Requires** line show the intended direction.
+
+Example:
+
+```text
+Install Panels depends on Set Posts
+
+hold Shift
++ drag Install Panels onto Set Posts
+```
+
+Neither task moves during Shift-drag. If you release over empty Stage/Scene space, the prerequisite gesture cancels without moving the task.
+
+### Normal drag remains normal movement
+
+Drag without Shift when you intend to reorder or move a task. Ordinary drag still supports legitimate movement between Stage-level / General and real Scene locations.
+
+### Canonical prerequisite list
+
+Open task detail to review the current prerequisites. The task shows one prerequisite list only. Each prerequisite appears once with:
+
+- position;
+- **Up**;
+- **Down**; and
+- **Remove**.
+
+Use the separate **Add prerequisite** control for manual entry when that is easier than Shift-drag. After a prerequisite is assigned, the Add list no longer offers it for the same task.
+
+**Up** and **Down** are review/display order only. They do not create dependencies between prerequisite tasks. Every listed prerequisite remains independently required.
+
+Circular dependencies are rejected by the system. Correct the relationship rather than trying to bypass the warning.
+
 ## Rolling-Horizon Planning
 
 Setup is not intended to be a rigid season-long Gantt schedule.
@@ -283,6 +324,8 @@ Production-operational now includes:
 - Stage-oriented Plan / Schedule and Perform Work presentation;
 - search across Catalog, Plan / Schedule, and Perform Work;
 - resource/effort/prerequisite maintenance;
+- Shift-drag prerequisite creation with circular-dependency protection;
+- one canonical prerequisite editor with manual Add, Up/Down display order, and Remove;
 - Procedure/document context; and
 - authenticated browser access.
 
@@ -291,11 +334,11 @@ Still incomplete/separate work includes:
 - final reusable Catalog cleanup before 2026 creation;
 - task-specific staged material subdivision / release timing (#141);
 - structured readiness gating;
-- improved predecessor-entry interaction;
 - Pick List generation/tablet workflow;
 - mixed-stage Container annual mobilization/unload-state workflow;
-- Container/Display movement/scanning writes; and
-- park-location execution evidence.
+- Container/Display movement/scanning writes;
+- park-location execution evidence; and
+- resource catalog sort/existing-resource editing work tracked separately.
 
 ## 2025 to 2026 Transition
 

--- a/Docs/02_Production_Database/02_Operational_SOPs/Setup/Setup_Session_Manager_Review_Guide.md
+++ b/Docs/02_Production_Database/02_Operational_SOPs/Setup/Setup_Session_Manager_Review_Guide.md
@@ -124,6 +124,16 @@ Task scope answers **where the work belongs**. Do not move a task to the wrong S
 
 Programming-only LOR groups are not separate Setup Scenes just because they exist in LOR.
 
+### Park Infrastructure is not a catch-all Stage
+
+Truly park-wide Setup work with no appropriate LOR Stage/Scene uses the controlled non-LOR root:
+
+```text
+41 Park Infrastructure-PI
+```
+
+Do not use Park Infrastructure merely because a Stage has no wired inventory. `40-CommandCenter`, for example, remains a legitimate Stage with its own Stage/Preview context; its Setup tasks and Procedures remain under Stage 40 when Command Center is the correct operational owner.
+
 ## Uses Display / Container Material
 
 Each reusable task has:
@@ -354,4 +364,4 @@ Issue #145 tracks the Catalog-cleanup gate before 2026 creation.
 
 - [Setup operator portal](../../01_System_Architecture/12_Setup_and_Deployment/README.md)
 - [2025 review procedure](../../01_System_Architecture/12_Setup_and_Deployment/operatorSOP/Review_2025_Setup_History.md)
-- [Setup engineering handoff](../../01_System_Architecture/12_Setup_and_Deployment/engineering/README.md)
+- [Setup engineering handoff](../../01_System_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/README.md)

--- a/Docs/02_Production_Database/02_Operational_SOPs/Setup/Setup_Session_Manager_Review_Guide.md
+++ b/Docs/02_Production_Database/02_Operational_SOPs/Setup/Setup_Session_Manager_Review_Guide.md
@@ -364,4 +364,4 @@ Issue #145 tracks the Catalog-cleanup gate before 2026 creation.
 
 - [Setup operator portal](../../01_System_Architecture/12_Setup_and_Deployment/README.md)
 - [2025 review procedure](../../01_System_Architecture/12_Setup_and_Deployment/operatorSOP/Review_2025_Setup_History.md)
-- [Setup engineering handoff](../../01_System_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/README.md)
+- [Setup engineering handoff](../../01_System_Architecture/12_Setup_and_Deployment/engineering/README.md)

--- a/Setup/Acceptance/Setup_Predecessor_V039_Production_Acceptance_2026-09-11.md
+++ b/Setup/Acceptance/Setup_Predecessor_V039_Production_Acceptance_2026-09-11.md
@@ -1,0 +1,332 @@
+# Setup Prerequisite Editing V0.3.9 — Production Acceptance — 2026-09-11
+
+| Document Control | Value |
+|---|---|
+| Document Type | Production Acceptance Record |
+| System | Production Database — Setup Session |
+| Status | ACCEPTED PRODUCTION |
+| Owner | MSB Production Database engineering |
+| Issue | #151 — Shift+left-drag predecessor creation |
+| Implementation PR | #164 |
+| PR merge commit | `ebade21e15a9ac62728dca0655476a619b47516d` |
+| Accepted application/schema/test candidate | `55478f98f760473b65b5d700a84c868285022ab7` |
+| Accepted version | `V0.3.9-predecessor-drag` |
+| Prior accepted runtime | `2eee967b6c5359c0e2e2d876a2fe44af8359315c` / `V0.3.8-task-detail-compact` |
+| Production migration | `Setup/Database/026_add_setup_dependency_order.sql` |
+
+## Purpose
+
+Preserve the final Production acceptance evidence for Issue #151 so the accepted prerequisite interaction, persistent review order, migration boundary, deployment evidence, rollback point, browser-review failure lesson, and final operator disposition do not depend on chat or issue comments.
+
+## Accepted Operator Behavior
+
+The reusable Setup task Catalog now supports two prerequisite-entry paths.
+
+### Shift-drag fast entry
+
+To make task A depend on task B:
+
+```text
+hold Shift before left-button-down on dependent task A
+    -> drag A onto prerequisite task B
+    -> release
+    -> A depends on B
+```
+
+Accepted behavior:
+
+- neither task moves during the Shift-drag gesture;
+- the target visibly indicates that it will become the prerequisite;
+- success feedback names the dependency direction;
+- multiple prerequisites can be added to one dependent task;
+- repeating an existing dependency remains idempotent and does not create duplicate state;
+- circular dependencies fail closed through the governed database command; and
+- releasing over empty Stage/Scene space cancels the prerequisite gesture without moving the task.
+
+Ordinary drag without Shift remains the normal reusable Catalog movement/reorder/scope interaction, including legitimate movement between Stage-level / General and real Scene locations.
+
+### Canonical prerequisite editor
+
+Task detail now contains one canonical prerequisite list. Each current prerequisite appears once with:
+
+- position;
+- **Up**;
+- **Down**; and
+- **Remove**.
+
+A separate **Add prerequisite** form remains available as the manual/fallback entry method.
+
+After add/remove/reorder, the application reloads authoritative dependency state so task detail and the Catalog **Requires** line agree immediately. A prerequisite already assigned to the task is no longer offered by the Add dropdown.
+
+Prerequisite Up/Down order is review/display order only. It does not create prerequisite-to-prerequisite dependency semantics. Every listed prerequisite remains independently required.
+
+## Database Migration 026
+
+Migration:
+
+```text
+Setup/Database/026_add_setup_dependency_order.sql
+```
+
+Accepted candidate blob:
+
+```text
+759774d80eb51b706a0e7b71c5e834636b64a451
+```
+
+The migration adds:
+
+- `ref.setup_task_dependency.sort_order integer NOT NULL DEFAULT 100`;
+- `ck_setup_task_dependency_sort_order`;
+- `ix_setup_task_dependency_order`;
+- updated governed `ref.set_setup_task_dependency(...)` append-order behavior; and
+- governed `ref.reorder_setup_task_dependencies(text,bigint,bigint[])`.
+
+`fieldwiring_app` receives EXECUTE on the narrow governed command and retains no broad `INSERT`, `UPDATE`, or `DELETE` privilege on `ref.setup_task_dependency`.
+
+Existing dependency rows received the constant schema default without a mass UPDATE. Their legacy audit fields were required to remain unchanged.
+
+## Disposable Browser Acceptance
+
+Exact accepted candidate:
+
+```text
+55478f98f760473b65b5d700a84c868285022ab7
+V0.3.9-predecessor-drag
+```
+
+Final disposable browser evidence:
+
+```text
+preview report = /tmp/MSB_Setup_Source_Only_Preview_20260911T065847.txt
+preview log    = /tmp/MSB_Setup_Source_Only_Preview_Flask_20260911T065847.log
+```
+
+Operator acceptance confirmed:
+
+- Shift-drag direction `dependent -> prerequisite`;
+- neither task moves;
+- multiple prerequisites stack correctly;
+- repeated dependency remains single/idempotent;
+- circular dependency is rejected;
+- one canonical prerequisite list only;
+- Up/Down persistent display ordering is reflected identically in detail and Catalog;
+- Remove synchronizes both views and persists after reopen;
+- manual Add appends once and removes the assigned task from the available dropdown;
+- Shift-release over empty Stage/Scene space cancels without moving the task; and
+- ordinary drag, including movement to another valid Stage/Scene, remains functional.
+
+Final preview cleanup proved Production remained unchanged:
+
+```text
+Production fingerprint before = 9510360aa7de2da59d1ed8a9ad9d69f7
+Production fingerprint after  = 9510360aa7de2da59d1ed8a9ad9d69f7
+live Setup before             = 2eee967b6c5359c0e2e2d876a2fe44af8359315c
+live Setup after              = 2eee967b6c5359c0e2e2d876a2fe44af8359315c
+```
+
+## Browser Preview Lifecycle Failure / Recovery Finding
+
+During the final review pass, the original workstation SSH tunnel disappeared while the remote source-only preview wrapper remained blocked on its browser-review prompt. The detached `fieldwiring` Flask process therefore survived and continued listening on preview port 8795.
+
+Evidence showed the application itself had not crashed at the last prerequisite mutation: the final dependency request logged HTTP 200 and the following refresh requests also logged 200. A direct server health request still returned:
+
+```json
+{"data_mode":"postgres","status":"ok","version":"V0.3.9-predecessor-drag"}
+```
+
+The failure was the preview/tunnel lifecycle, not the prerequisite Add operation.
+
+Acceptance tooling was hardened before final review to:
+
+- recognize the source-only preview resource naming/runtime boundary;
+- refuse governed Production ports;
+- clean only the identified stale preview resources;
+- preserve acceptance reports/logs;
+- use SSH keepalives;
+- include HUP in preview cleanup handling; and
+- use `timeout --foreground` when bounding the interactive remote preview so `sudo` and the final review prompt retain the controlling PTY.
+
+A first non-foreground `timeout` attempt was rejected after it stopped the remote shell at its terminal-sensitive `sudo -v` step. The corrected foreground-safe launcher then completed final browser acceptance normally.
+
+## Production Pre-Mutation Gate
+
+Immediately before mutation:
+
+```text
+live Setup SHA          = 2eee967b6c5359c0e2e2d876a2fe44af8359315c
+live health             = V0.3.8-task-detail-compact
+accepted target         = 55478f98f760473b65b5d700a84c868285022ab7
+forward ancestry        = PASS
+migration 026 blob      = 759774d80eb51b706a0e7b71c5e834636b64a451
+Production fingerprint  = 9510360aa7de2da59d1ed8a9ad9d69f7
+sort_order already live = NO
+reorder function live   = NO
+broad dependency DML    = NO
+fieldwiring_app read-only default = ON
+```
+
+The exact candidate full Setup application suite produced:
+
+```text
+191 passed
+2 failed
+```
+
+The same two failures were then reproduced against the already accepted V0.3.8 Production checkout:
+
+```text
+2 failed
+6 passed
+```
+
+The failures are inherited stale literal-string contracts, not V0.3.9 regressions:
+
+- `test_setup_internal_analytics_contract.py` expected `Updated 2026-09-10` while accepted source displays `Updated 2026-09-11`;
+- `test_setup_shared_review_contract.py` expected the literal phrase `must be in 2025` while the current operator authority says the 2025 session accepts 2025 operational dates only.
+
+The current focused V0.3.9 deployment suite passed:
+
+```text
+63 passed in 0.27s
+```
+
+Closeout corrects those stale test literals; this acceptance record does not falsely claim that the pre-deployment full suite was green.
+
+## Rollback Archive
+
+Before migration 026, a custom-format Production PostgreSQL archive was created and validated:
+
+```text
+/home/msbadmin/backups/setup-151/msb-pre-setup-151-20260911T071801.dump
+```
+
+SHA256:
+
+```text
+21e5b9b0fbd07dd01b7c9a86027615988bc33f950767839e4d74bb4a1f407029
+```
+
+The pre-migration dependency baseline was:
+
+```text
+dependency rows               = 17
+dependency legacy fingerprint = 26b170fba3500ea2647967e87aa02a1c
+```
+
+## Production Migration Acceptance
+
+Migration 026 applied successfully.
+
+Post-migration validation:
+
+```text
+sort_order NOT NULL/default   = PASS / 100
+reorder command present       = PASS
+reorder EXECUTE               = PASS
+dependency command EXECUTE    = PASS
+broad INSERT/UPDATE/DELETE    = f / f / f
+dependency rows               = 17
+min/max initial sort_order    = 100 / 100
+dependency legacy fingerprint = 26b170fba3500ea2647967e87aa02a1c
+Production governed fingerprint = 9510360aa7de2da59d1ed8a9ad9d69f7
+```
+
+The unchanged legacy dependency fingerprint proves migration 026 did not rewrite the existing dependency-note/audit evidence while adding presentation order.
+
+## Production Application Deployment
+
+The dedicated Setup Production checkout advanced from:
+
+```text
+2eee967b6c5359c0e2e2d876a2fe44af8359315c
+V0.3.8-task-detail-compact
+```
+
+to the exact browser-accepted candidate:
+
+```text
+55478f98f760473b65b5d700a84c868285022ab7
+V0.3.9-predecessor-drag
+```
+
+Only `msb-setup.service` was restarted for the application promotion.
+
+Post-restart evidence:
+
+```json
+{"data_mode":"postgres","status":"ok","version":"V0.3.9-predecessor-drag"}
+```
+
+Live focused regression:
+
+```text
+63 passed in 0.27s
+```
+
+Direct unauthenticated protected-path negative check:
+
+```text
+HTTP 401 = PASS
+```
+
+Final governed fingerprint before any operator acceptance write:
+
+```text
+9510360aa7de2da59d1ed8a9ad9d69f7
+```
+
+## Final Protected Production Browser Acceptance
+
+The real protected Production application was opened at:
+
+```text
+https://my.sheboyganlights.org/setup/
+```
+
+Final operator validation confirmed:
+
+- visible `Client V0.3.9`;
+- Shift-drag creates the intended real prerequisite and does not move either task;
+- Catalog **Requires** updates correctly;
+- task detail shows one canonical prerequisite list;
+- the dependency appears once;
+- Up/Down/Remove controls are present;
+- the already-assigned prerequisite is absent from the manual Add choices; and
+- ordinary non-Shift movement remains functional.
+
+Production browser acceptance: **PASS**.
+
+## Current Boundary / Known Limitations
+
+Issue #151 does not implement structured external/site readiness. The existing distinction remains:
+
+```text
+hard predecessor != preferred order != readiness condition
+```
+
+Prerequisite display order does not create additional dependency semantics.
+
+No 2026 Setup Session was created by this work. Issue #145 remains the cleanup gate before 2026 annual-session creation.
+
+Task-specific staged material / Pick List release timing remains separate work in Issue #141. Resource editing/sort work remains separate from #151.
+
+## Closeout State
+
+Issue #151 is eligible for completed closeout after:
+
+- operator instructions are updated;
+- current engineering portal/handoff/contract are updated;
+- Server Management runtime and preview-runbook authority are updated;
+- stale inherited test literals are corrected;
+- documentation PRs are merged; and
+- local feature/closeout branches are cleaned after verifying `main`.
+
+## Related Authority
+
+- `Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Predecessor_and_Readiness_Contract_2026-09-09.md`
+- `Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Session_Production_Engineering_Handoff_2026-09-11.md`
+- `Docs/02_Production_Database/02_Operational_SOPs/Setup/Setup_Session_Manager_Review_Guide.md`
+- `Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/operatorSOP/Review_2025_Setup_History.md`
+- `Gregovate/MSB-Server-Management/docs/server/Production_Database_Change_Deployment_Runbook.md`
+- `Gregovate/MSB-Server-Management/docs/server/Pre_Production_Browser_Review_Runbook.md`

--- a/Setup/Application/README.md
+++ b/Setup/Application/README.md
@@ -1,6 +1,6 @@
 # Setup Session Application
 
-Status: **PRODUCTION RUNTIME OPERATIONAL — V0.3.8 ACCEPTED; 2025 HISTORICAL REVIEW / TRAINING CONTINUES**
+Status: **PRODUCTION RUNTIME OPERATIONAL — V0.3.9 ACCEPTED; 2025 HISTORICAL REVIEW / REUSABLE CATALOG WORK CONTINUES**
 
 This folder contains the browser-native Setup Session application used for the Production-backed 2025 Historical Verification workflow and ongoing reusable Setup development.
 
@@ -19,13 +19,13 @@ Setup/Application/production_backend.py
 Current reported version:
 
 ```text
-V0.3.8-task-detail-compact
+V0.3.9-predecessor-drag
 ```
 
 Current exact deployed source:
 
 ```text
-2eee967b6c5359c0e2e2d876a2fe44af8359315c
+55478f98f760473b65b5d700a84c868285022ab7
 ```
 
 ## Current Production Meaning
@@ -39,6 +39,8 @@ Managers/reviewers use it to:
 - add/correct reusable Setup tasks;
 - delete reconstruction-safe Catalog mistakes where the governed command permits it;
 - add/correct reusable resources and prerequisites;
+- use Shift-drag for fast hard-predecessor entry;
+- maintain prerequisite review/display order in the canonical task-detail list;
 - improve task scope, order, crew/time/readiness information;
 - review current Setup Procedure context; and
 - identify UI/workflow/data-model problems before the 2026 Setup Session is created.
@@ -102,25 +104,23 @@ The browser constrains date controls and the database independently enforces the
 
 ## Dirty-Edit / Client Build Safety
 
-The accepted V0.3.7 safety behavior remains part of V0.3.8.
+The accepted V0.3.7 safety behavior remains part of V0.3.9.
 
 The Setup header visibly shows the loaded client build, currently:
 
 ```text
-Client V0.3.8
+Client V0.3.9
 ```
 
 Governed writes verify that the client build matches `/api/health`. A stale/mismatched client fails closed instead of quietly writing against a different server build.
 
 Reusable edits are compared against the current selected server-backed task. State-changing actions such as `Mark Verified` cannot silently discard pending reusable edits. The application either safely saves the reusable changes before the annual action or stops the action when the reusable save cannot complete.
 
-Dirty navigation uses explicit save/discard/stay behavior. Independent save surfaces such as Physical Effort, Display/Container Material, Resources, and Captains remain separately governed.
-
-The first V0.3.6 dirty-edit candidate failed real Production protected-route acceptance and was rolled back. V0.3.7 corrected that failure and V0.3.8 preserves the accepted protection.
+Dirty navigation uses explicit save/discard/stay behavior. Independent save surfaces such as Physical Effort, Display/Container Material, Resources, Captains, and prerequisite maintenance remain separately governed.
 
 ## Current Task-Detail Layout
 
-At normal laptop/desktop width the accepted V0.3.8 layout is:
+V0.3.9 preserves the accepted V0.3.8 laptop/desktop layout:
 
 ```text
 LEFT                               RIGHT
@@ -134,9 +134,45 @@ Physical mobile-device acceptance was not performed for V0.3.8. Responsive stack
 
 Cross-application theme and dark-mode white-logo consistency are tracked separately in Issue #159.
 
+## Current Prerequisite Interaction
+
+Issue #151 established the Production hard-predecessor workflow.
+
+Fast entry:
+
+```text
+hold Shift before left-button-down on dependent task A
+    -> drag A onto prerequisite task B
+    -> release
+    -> A depends on B
+    -> neither task moves
+```
+
+Ordinary drag without Shift keeps normal reusable task reorder/scope movement behavior. Shift-release over empty Stage/Scene space cancels the prerequisite gesture without moving the task.
+
+Task detail shows one canonical prerequisite list with position, **Up**, **Down**, and **Remove**, plus a separate manual **Add prerequisite** control. Already-assigned prerequisites are excluded from the Add choices.
+
+Prerequisite Up/Down is presentation/review order only. It does not create dependency relationships among prerequisite tasks.
+
+Creation/removal remains governed by:
+
+```text
+ref.set_setup_task_dependency(text,bigint,bigint,text,boolean)
+```
+
+Reordering uses:
+
+```text
+ref.reorder_setup_task_dependencies(text,bigint,bigint[])
+```
+
+Circular-dependency protection remains database-authoritative.
+
+Structured external/site readiness remains separate future work. Do not represent mowing, access, outside construction, or similar conditions as fake Setup tasks merely to create blockers.
+
 ## Current Manager / Reviewer Capabilities
 
-The live review workflow supports the current governed application behavior for:
+The live review workflow supports current governed behavior for:
 
 - reading the 2025 annual task list;
 - reviewing verification state;
@@ -144,7 +180,7 @@ The live review workflow supports the current governed application behavior for:
 - creating/copying reusable tasks;
 - reconstruction-safe deletion/deactivation where governed rules allow;
 - maintaining task scope and order;
-- maintaining prerequisites;
+- maintaining prerequisites through Shift-drag or the canonical prerequisite editor;
 - maintaining structured equipment/resources;
 - maintaining supported reusable material applicability;
 - reviewing supported planning information; and
@@ -194,13 +230,13 @@ Permanent source checkout:
 Current deployed source SHA:
 
 ```text
-2eee967b6c5359c0e2e2d876a2fe44af8359315c
+55478f98f760473b65b5d700a84c868285022ab7
 ```
 
 Current health:
 
 ```json
-{"data_mode":"postgres","status":"ok","version":"V0.3.8-task-detail-compact"}
+{"data_mode":"postgres","status":"ok","version":"V0.3.9-predecessor-drag"}
 ```
 
 Service/runtime facts are owned by `Gregovate/MSB-Server-Management`.
@@ -214,15 +250,19 @@ listener                       = 192.168.5.9:8794
 public route                   = https://my.sheboyganlights.org/setup/
 ```
 
-V0.3.8 was deployed source-only. Exact detached preflight regression and live focused regression both passed 53 tests. The Production source-deployment fingerprint remained unchanged:
+V0.3.9 applied database migration 026 and then advanced only the dedicated Setup application checkout. Live focused regression passed 63 tests. The Production governed fingerprint remained unchanged across migration/deployment:
 
 ```text
 9510360aa7de2da59d1ed8a9ad9d69f7
 ```
 
-before and after deployment.
+Existing dependency note/audit evidence also remained unchanged across migration:
 
-See `Setup/Acceptance/Setup_Task_Detail_Production_Acceptance_2026-09-11.md` for the full Production evidence.
+```text
+26b170fba3500ea2647967e87aa02a1c
+```
+
+See `Setup/Acceptance/Setup_Predecessor_V039_Production_Acceptance_2026-09-11.md` for the full Production evidence and rollback archive.
 
 ## Prototype / Historical Lineage
 
@@ -236,15 +276,18 @@ Historical runtime milestones include:
 V0.3.5  Stage/Scene material + presentation baseline
 V0.3.6  dirty-edit candidate; failed real Production acceptance and rolled back
 V0.3.7  accepted dirty-edit / client-build safety
-V0.3.8  current accepted compact task-detail layout
+V0.3.8  accepted compact task-detail layout
+V0.3.9  current accepted Shift-drag prerequisite + canonical prerequisite editor
 ```
 
 ## Current Boundaries
 
 Still outside the accepted Production-ready workflow:
 
+- structured external/site readiness;
 - Pick List generation;
 - task-specific staged material release timing;
+- resource catalog sort/existing-resource editing;
 - Container/Display movement/scanning write commands; and
 - park-location execution evidence.
 
@@ -254,7 +297,9 @@ The application also does not automatically publish revised PDFs back into Googl
 
 Automated contract tests remain useful for application changes, but browser behavior that depends on real client/runtime interaction must also pass protected-route operator validation before being treated as accepted Production behavior.
 
-Do not create fake Production work days, movement events, or throwaway records merely to exercise controls.
+Do not create fake Production work days, movement events, dependencies, or throwaway records merely to exercise controls.
+
+During the V0.3.9 deployment gate, the broad Setup suite exposed two inherited stale literal-string tests that also failed on the already accepted V0.3.8 checkout. The V0.3.9 focused current deployment suite passed 63 tests. Closeout corrects those stale assertions; do not describe the pre-deployment broad suite as fully green.
 
 ## Engineering Resume
 
@@ -263,17 +308,20 @@ Before changing the application:
 1. read `System_Documentation/Project_Rules/README.md`;
 2. read `Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/README.md`;
 3. read the current `Setup_Session_Production_Engineering_Handoff_2026-09-11.md`;
-4. preserve V0.3.7 dirty-edit/client-server build protection and the visible client build marker;
-5. preserve the 2025 annual vs reusable Catalog boundary;
-6. review Issue #145 before any 2026 Session creation;
-7. review the active issue/contract for the feature being changed; and
-8. use `Gregovate/MSB-Server-Management` for live runtime facts and deployment runbooks.
+4. preserve V0.3.7 dirty-edit/client-server build protection;
+5. preserve the V0.3.8 compact task-detail layout;
+6. preserve the V0.3.9 Shift-drag direction, canonical prerequisite editor, and presentation-order semantics;
+7. preserve the 2025 annual vs reusable Catalog boundary;
+8. review Issue #145 before any 2026 Session creation;
+9. review the active issue/contract for the feature being changed; and
+10. use `Gregovate/MSB-Server-Management` for live runtime facts, browser-review procedure, and deployment runbooks.
 
 ## Related Documentation
 
 - `Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/README.md`
 - `Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/README.md`
 - `Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Session_Production_Engineering_Handoff_2026-09-11.md`
+- `Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Predecessor_and_Readiness_Contract_2026-09-09.md`
 - `Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/operatorSOP/Review_2025_Setup_History.md`
 - `Docs/02_Production_Database/02_Operational_SOPs/Setup/Setup_Session_Manager_Review_Guide.md`
-- `Setup/Acceptance/Setup_Task_Detail_Production_Acceptance_2026-09-11.md`
+- `Setup/Acceptance/Setup_Predecessor_V039_Production_Acceptance_2026-09-11.md`

--- a/Setup/Application/test_setup_internal_analytics_contract.py
+++ b/Setup/Application/test_setup_internal_analytics_contract.py
@@ -4,7 +4,7 @@ from pathlib import Path
 BASE_DIR = Path(__file__).resolve().parent
 ANALYTICS_VERSION = "2026-09-07.1"
 MEASUREMENT_ID = "G-X08ZTSY0VV"
-VISIBLE_UPDATE = "Updated 2026-09-10"
+VISIBLE_UPDATE = "Updated 2026-09-11"
 
 
 def test_setup_page_loads_versioned_analytics_asset_and_visible_update() -> None:

--- a/Setup/Application/test_setup_shared_review_contract.py
+++ b/Setup/Application/test_setup_shared_review_contract.py
@@ -17,7 +17,7 @@ def test_shared_2025_review_is_explicitly_permanent_and_year_bounded() -> None:
     ).read_text(encoding="utf-8")
     assert "not disposable test data" in guide.lower()
     assert "2025 Historical Verification" in guide
-    assert "must be in 2025" in guide
+    assert "accepts 2025 operational dates only" in guide
     assert "Administrator" in guide
     assert "41 Park Infrastructure-PI" in guide
     assert "40-CommandCenter" in guide


### PR DESCRIPTION
## Purpose

Complete the required Issue #151 closeout after accepted Production deployment of Setup `V0.3.9-predecessor-drag`.

## Production state documented

- accepted/deployed runtime: `55478f98f760473b65b5d700a84c868285022ab7`
- implementation PR #164 / merge `ebade21e15a9ac62728dca0655476a619b47516d`
- migration 026: `Setup/Database/026_add_setup_dependency_order.sql`
- migration blob: `759774d80eb51b706a0e7b71c5e834636b64a451`
- validated rollback archive: `/home/msbadmin/backups/setup-151/msb-pre-setup-151-20260911T071801.dump`
- rollback SHA256: `21e5b9b0fbd07dd01b7c9a86027615988bc33f950767839e4d74bb4a1f407029`
- governed fingerprint before/after: `9510360aa7de2da59d1ed8a9ad9d69f7`
- existing dependency legacy fingerprint before/after: `26b170fba3500ea2647967e87aa02a1c`
- live focused regression: 63 passed
- protected Production browser acceptance: PASS

## Documentation

Updates current operator portal/procedures, detailed Manager guide, application README, engineering portal, current Production handoff, and predecessor/readiness contract. Adds a durable V0.3.9 Production acceptance record.

Operator guidance now documents:
- Shift held before left-button-down on dependent task, then drag onto prerequisite;
- neither task moves during Shift-drag;
- ordinary drag remains normal movement/reorder/scope behavior;
- one canonical prerequisite list with Add / Up / Down / Remove;
- Up/Down is presentation/review order only;
- circular dependencies remain fail-closed; and
- hard predecessor remains distinct from preferred order and readiness.

## Test-debt correction

The broad exact-candidate Setup suite exposed two stale literal assertions. The same two failures were reproduced on the already accepted V0.3.8 checkout, proving they were inherited test debt rather than #151 regressions. This closeout updates those literals to current accepted source/operator wording.

No Production mutation is performed by this closeout PR.

Closes the documentation/testing portion required before Issue #151 can be closed completed.