### PR TITLE
Close out Setup #152 V0.3.10 Production acceptance

### DIFF
--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/README.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/README.md
@@ -8,7 +8,7 @@
 | Status | CURRENT — Production runtime operational; Setup UI/workflow in live evaluation |
 | Owner | MSB Production Database / Setup administrator |
 | Last Reviewed | 2026-09-11 |
-| Keywords | Setup, 2025 review, reusable tasks, prerequisites, Shift-drag, Setup procedures, deployment |
+| Keywords | Setup, 2025 review, reusable tasks, resources, prerequisites, Shift-drag, Setup procedures, deployment |
 
 Setup and Deployment covers the work of planning and carrying out the annual move from storage to the park, plus the information crews need while installing the show.
 
@@ -23,7 +23,7 @@ The current working session is **2025 — Historical Verification**. It uses rea
 Current Production client:
 
 ```text
-Client V0.3.9
+Client V0.3.10
 ```
 
 ## Start Here
@@ -42,12 +42,21 @@ During this review you may, where supported by evidence:
 - mark whether a reusable task **Uses Display / Container Material**;
 - add, remove, and reorder real task prerequisites;
 - use **Shift + drag** in the Catalog for fast prerequisite entry;
-- add or correct equipment/resources;
+- search and assign existing equipment/resources;
+- use **Manage Resource Catalog** to rename/correct resource entries in place, review inactive entries, and maintain catalog notes/type/active state/optional display order;
 - improve normal crew/time/readiness information;
 - review current Setup procedures; and
 - record questions or suggestions for the Setup workflow.
 
 Do not change information merely to make a record look complete.
+
+### Resource catalog maintenance
+
+The normal task-resource picker is intentionally name-oriented. Search for the existing resource first, then set task-specific quantity, Required-vs-Preferred, and task notes.
+
+Use **Manage Resource Catalog** only when the reusable catalog entry itself needs correction. Renaming an existing catalog row preserves its `setup_resource_id` and existing task assignments. Exact normalized duplicate names are blocked, and likely matches are shown while entering a new resource name.
+
+The optional numeric catalog display order remains available for review/maintenance, but operators do not need to maintain numeric order merely to make the normal picker usable.
 
 ### Prerequisite shortcuts
 
@@ -110,7 +119,7 @@ Reusable Task information
 
 A correction that only applies to 2025 belongs in the 2025 annual history. A correction to how MSB normally performs a task belongs in the reusable task definition.
 
-The **Uses Display / Container Material** setting and reusable prerequisites are reusable task knowledge. They should describe normal Setup behavior, not something that happened only in 2025.
+The **Uses Display / Container Material** setting, reusable resource requirements, and reusable prerequisites are reusable task knowledge. They should describe normal Setup behavior, not something that happened only in 2025.
 
 The selected Setup Session controls the allowable operational year. The 2025 session accepts 2025 operational dates only. Audit timestamps still show when the change was actually recorded.
 
@@ -124,7 +133,10 @@ Current known boundaries:
 
 - no 2026 Setup Session has been created;
 - active reusable Catalog cleanup is required before 2026 creation because all active reusable tasks are seeded into a new annual Session;
+- Extra Materials / KIT assignments / material-source tracking remain separate work in Issue #167;
 - structured outside/site readiness remains separate from task prerequisites;
+- task-specific staged material/Pick List timing remains separate work in Issue #141;
+- keeping the active task name visible while scrolling long detail remains separate usability work in Issue #169;
 - Pick List generation is not yet a live Production workflow; and
 - Container/Display movement and scanning write commands remain outside this review boundary.
 

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/README.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/README.md
@@ -5,7 +5,7 @@
 | Document Type | Engineering Handoff Portal |
 | System | Production Database — Setup and Deployment |
 | Audience | Greg, maintainers, database administrators, future engineering sessions |
-| Status | CURRENT HANDOFF — V0.3.9 accepted in Production; broader Setup work remains active |
+| Status | CURRENT HANDOFF — V0.3.10 accepted in Production; broader Setup work remains active |
 | Owner | MSB Production Database engineering |
 | Last Reviewed | 2026-09-11 |
 
@@ -24,21 +24,21 @@ https://my.sheboyganlights.org/setup/
 Current exact accepted/deployed application target:
 
 ```text
-55478f98f760473b65b5d700a84c868285022ab7
-```
-
-Implementation repository lineage:
-
-```text
-Issue #151
-PR #164
-main merge commit = ebade21e15a9ac62728dca0655476a619b47516d
+c2a1820627f1a036d634241cc6aecd1a926a1479
 ```
 
 Current Setup health:
 
 ```text
-V0.3.9-predecessor-drag
+V0.3.10-resource-catalog
+```
+
+Implementation lineage:
+
+```text
+Issue #152
+PR #168
+main merge commit = cc4b5767605373504fd993698ce735514bec0d37
 ```
 
 Current annual context:
@@ -48,34 +48,35 @@ Current annual context:
 2026 Setup Sessions = 0
 ```
 
-The current PostgreSQL reusable Catalog is the working task baseline. Do not use older fixed counts such as 57 or the earlier 185-task reconstruction snapshot as current authority; live Catalog cleanup and task development continued after those dated baselines.
+The current PostgreSQL reusable Catalog is the working task baseline. Do not use older fixed task counts as current authority; live Catalog cleanup and task development continue.
 
-V0.3.9 Production acceptance on 2026-09-11 proved:
-
-```text
-focused exact-candidate regression            = 63 passed
-live deployed focused regression              = 63 passed
-Production fingerprint before migration       = 9510360aa7de2da59d1ed8a9ad9d69f7
-Production fingerprint after migration/deploy = 9510360aa7de2da59d1ed8a9ad9d69f7
-existing dependency rows                      = 17
-legacy dependency audit fingerprint before    = 26b170fba3500ea2647967e87aa02a1c
-legacy dependency audit fingerprint after     = 26b170fba3500ea2647967e87aa02a1c
-protected health                              = V0.3.9-predecessor-drag
-protected Production browser acceptance       = PASS
-```
-
-Migration 026 added persistent prerequisite review/display order without rewriting existing dependency audit evidence and without granting broad dependency-table DML to `fieldwiring_app`.
-
-The immediately prior accepted runtime was:
+V0.3.10 Production acceptance on 2026-09-11 proved:
 
 ```text
-2eee967b6c5359c0e2e2d876a2fe44af8359315c
-V0.3.8-task-detail-compact
+migration 027                               = PASS
+stable Production fingerprint               = 7c21041caecac6eb77660238ba3c8cf9
+resource rows at deployment                 = 12
+task-resource relationships at deployment  = 32
+normalized duplicate resource groups        = 0
+corrected test-only derivative              = 209 passed
+live focused regression                     = 29 passed / 1 known stale assertion deselected
+protected negative path                     = HTTP 401 PASS
+protected health                            = V0.3.10-resource-catalog
+protected Production browser acceptance     = PASS
+legitimate catalog correction               = PASS
+existing task-resource relationship intact  = PASS
 ```
 
-V0.3.9 preserves the accepted V0.3.7 dirty-edit/client-build safety and V0.3.8 compact task-detail layout while adding the accepted prerequisite interaction and canonical editor.
+Migration 027 added governed reusable resource-catalog management without granting broad resource/task-resource DML to `fieldwiring_app`.
 
-See the current [Setup Session Production Engineering Handoff — 2026-09-11](Setup_Session_Production_Engineering_Handoff_2026-09-11.md) and [V0.3.9 Prerequisite Production Acceptance](../../../../../Setup/Acceptance/Setup_Predecessor_V039_Production_Acceptance_2026-09-11.md).
+Validated rollback archive:
+
+```text
+/home/msbadmin/backups/setup-152/msb-pre-setup-152-20260911T170411.dump
+SHA256 = b60857bf12eae68922cc309b795e920b3b2aaccd5a928b775527057450a7aa15
+```
+
+See the current [Setup Session Production Engineering Handoff — 2026-09-11](Setup_Session_Production_Engineering_Handoff_2026-09-11.md) and [V0.3.10 Resource Catalog Production Acceptance](../../../../../Setup/Acceptance/Setup_Resource_Catalog_V0310_Production_Acceptance_2026-09-11.md).
 
 ## Current Accepted Task-Detail Presentation
 
@@ -87,11 +88,9 @@ Reusable Task Definition            Annual Historical Actual
 Material / Logistics                Captains / Knowledge Owners
 ```
 
-The reusable definition itself uses a compact two-column desktop grid. Material / Logistics retains all four essential counts and the existing full detail dialog. Prerequisites and Equipment / Resources remain below the rail block and are reachable with materially less scrolling.
+The reusable definition itself uses a compact two-column desktop grid. Material / Logistics retains all four essential counts and the existing full detail dialog. Prerequisites and Equipment / Resources remain below the rail block.
 
-Physical mobile-device acceptance was not performed for V0.3.8; responsive stacking is contract-covered and was checked using a narrowed desktop browser proxy only.
-
-Cross-application palette and dark-mode white-logo consistency remain separate work in Issue #159.
+Cross-application palette/dark-mode consistency remains separate work in Issue #159. Keeping the active task name visible while scrolling long task detail is tracked separately in Issue #169.
 
 ## Current Accepted Prerequisite Model
 
@@ -103,9 +102,7 @@ PREFERRED ORDER
 READINESS CONDITION
 ```
 
-A hard predecessor is another reusable Setup task that must complete first. A preferred order is only the normal sequence. A readiness condition is an outside/site condition and must not be fabricated as a Setup task merely to create a blocker.
-
-Accepted V0.3.9 prerequisite behavior:
+Accepted prerequisite behavior remains the V0.3.9 model:
 
 ```text
 Shift held before left-button-down on dependent A
@@ -115,17 +112,37 @@ Shift held before left-button-down on dependent A
     -> neither task moves
 ```
 
-Ordinary drag without Shift preserves the existing reusable-task reorder and Stage/real-Scene movement behavior. Releasing a Shift-drag over empty Stage/Scene space cancels the prerequisite gesture without moving the task.
+Ordinary drag without Shift preserves normal reusable-task reorder and Stage/real-Scene movement. Task detail has one canonical prerequisite list with **Up**, **Down**, and **Remove**, plus manual **Add prerequisite**. Up/Down is presentation order only.
 
-Task detail has one canonical prerequisite list with **Up**, **Down**, and **Remove**, plus a separate manual **Add prerequisite** form. Assigned prerequisites disappear from the Add choices. Add/remove/reorder refresh authoritative dependency state so task detail and the Catalog `Requires` line stay synchronized.
-
-Migration 026 adds `ref.setup_task_dependency.sort_order` and `ref.reorder_setup_task_dependencies(text,bigint,bigint[])`.
-
-Prerequisite Up/Down order is presentation/review order only. It does not create dependency relationships between the prerequisite tasks. Circular-dependency protection remains authoritative in the governed database command.
-
-Structured readiness remains pending and is still separate from task prerequisites.
+Circular-dependency protection remains database-authoritative. Structured outside/site readiness remains separate from hard task prerequisites.
 
 See [Setup Predecessor and Readiness Contract — 2026-09-09](Setup_Predecessor_and_Readiness_Contract_2026-09-09.md).
+
+## Current Accepted Resource Catalog Model
+
+The normal task-resource workflow is intentionally compact and name-oriented:
+
+```text
+search existing resource
+    -> choose resource
+    -> set quantity / Required-vs-Preferred / task notes
+    -> add or update task relationship
+```
+
+The normal picker sorts primarily by meaningful `resource_name`, then type/ID. This is the accepted refinement from the original #152 wording. `display_order` remains a governed optional catalog field but is not required for ordinary picker usability.
+
+**Manage Resource Catalog** is the reusable catalog-maintenance surface. It supports:
+
+- search across active and inactive entries;
+- in-place rename/correction while preserving `setup_resource_id`;
+- type, catalog notes, active state, and optional display-order editing;
+- default Name sort plus alternate review sorts;
+- normalized exact duplicate blocking; and
+- likely-match suggestions before new-resource creation.
+
+Task-specific quantity, Required-vs-Preferred, and task notes remain separate from catalog identity/type/notes/order.
+
+Inactive resources remain discoverable for review. New inactive assignments are blocked, while existing inactive relationships remain visible/removable.
 
 ## Current Accepted Material Model
 
@@ -150,10 +167,10 @@ material disabled
     -> no LOR-derived Display/Container material
 
 material enabled + real Scene
-    -> exact current ref.lor_scene_display membership
+    -> exact current Scene Display membership
 
 material enabled + Stage
-    -> current LOR groups classified as Stage-level
+    -> current Stage-level LOR Display groups
     -> true child Scenes excluded
 
 resolved Displays
@@ -161,82 +178,118 @@ resolved Displays
     -> deduplicated Containers
 ```
 
-There is no operator-facing LOR Preview/programming-group/material-source selector. Programming-only LOR groups remain valid LOR objects but do not automatically become Setup Scenes.
+The accepted resolver provides Stage/Scene material context, not task-specific staged release timing. Issue #141 remains responsible for task-specific material subdivision/Pick List timing.
 
-The UI color marker is presentation only. `requires_display_material` is authoritative.
-
-### Important boundary — not yet task-specific staged material
-
-The accepted resolver is intentionally a **Stage/real-Scene material-context resolver**, not a complete task-specific pick/release model.
-
-When one Stage has several separate physical Setup tasks, multiple material-enabled Stage-level tasks can resolve the same Stage-level Displays/Containers even if only part of that material should leave storage for the current step.
-
-Magic Igloo is the representative case:
-
-```text
-frame work
-    -> may need frame material first
-
-skin installation
-    -> skins/bungees may need to remain warm in the workshop until later
-
-lighting/camera/finish work
-    -> later material may not be needed at the first step
-```
-
-The current checkbox answers whether the task uses Stage/Scene Display material and exposes that current context. It does not subdivide the Stage material by physical task step or release time.
-
-Do not claim that resolved material means `pick this now`. Task-specific material subdivision, component/KIT representation, and staged Pick List timing remain open engineering work in Issue #141.
+Issue #167 separately owns Extra Materials, KIT assignments, and material-source tracking. Do not collapse those facts into LOR Display membership or assume every Extra Material lives in a KIT.
 
 See [Setup Stage / Scene Material Resolution Contract — 2026-09-10](Setup_Stage_Scene_Material_Resolution_Contract_2026-09-10.md).
 
-## Current Accepted Planning / Execution Presentation
+## Current Planning / Execution Direction
 
-**Plan / Schedule** and **Perform Work** support Stage-oriented presentation:
+Setup is not intended to be a rigid season-long calendar scheduler.
+
+Accepted operating direction:
 
 ```text
-Stage
-    Stage-level / General
-    Scene — <real Scene>
+preferred order / hard predecessors
+    + readiness
+    + volunteers/equipment
+    + weather/site conditions
+    + prior progress
+    -> candidate work
+    -> operator chooses next practical work
+    -> short-horizon schedule
+    -> Pick List demand
+    -> perform / record / replan
 ```
 
-Stage view is presentation only; it does not rewrite annual planned order.
+**Plan / Schedule** and **Perform Work** support Stage-oriented presentation, but Plan / Schedule has not yet had the same cleanup/review pass as the reusable Catalog.
 
-Switching to **Planned order** returns to the existing annual planning sequence/reorder behavior.
-
-The shared **Find task or Stage** search applies to:
-
-- Reusable Task Catalog;
-- Plan / Schedule; and
-- Perform Work.
+There is currently no accepted Production Pick List generator/tablet workflow.
 
 ## Current Editable Procedure Source Rule
 
-Authorized Manager editable-source resolution is:
+Authorized Manager editable-source resolution remains:
 
 ```text
 Procedures\Setup\SourceDocs first
 -> Procedures\Setup\Archive only if no editable SourceDocs .gdoc exists
 ```
 
-During the 2026 migration, the archived Google Doc remains the historical original. Open it in Google Docs, use **File -> Make a copy**, save the new Google-native working copy into `SourceDocs`, and edit only the SourceDocs copy going forward. Do not treat copying the Windows `.gdoc` shortcut file as document migration.
+During migration of legacy Google Docs, the archived document remains historical evidence. Use Google Docs **File -> Make a copy** to create the current editable copy in `SourceDocs`; do not copy the Windows `.gdoc` shortcut file.
 
 The approved field PDF remains directly in `Procedures\Setup`.
 
-This workflow is controlled in the Google Drive operator SOPs and was closed through Issue #161 / PR #162.
+## Data / Authorization Boundary
+
+Cloudflare authentication, Setup capability, Person identity mapping, and PostgreSQL grants are separate layers:
+
+```text
+Cloudflare Access authenticated email
+  -> Setup backend capability lookup
+  -> Directus / ref.person identity
+  -> narrow PostgreSQL SECURITY DEFINER command
+```
+
+Do not grant broad Setup table DML to solve identity/capability problems.
+
+Migration 027 preserves this boundary with narrow EXECUTE on governed resource commands and no broad `ref.setup_resource` UPDATE/DELETE or broad `ref.setup_task_resource` UPDATE.
+
+See [Setup Data Consumption and Authorization Contract](Setup_Data_Consumption_and_Authorization_Contract_2026-09-10.md).
+
+## Reusable Catalog / Annual Session Boundary
+
+A valid reusable task can exist without a 2025 annual row. Annual Session creation seeds **every active reusable task** into the new Session.
+
+Therefore:
+
+```text
+active reusable Catalog cleanup
+    -> prove intended task set
+    -> disposable 2026 creation check
+    -> only then authorize real 2026 Session creation
+```
+
+Issue #145 owns this gate. Do not create the real 2026 Setup Session before #145 acceptance.
+
+## Current Repository / Issue Structure
+
+Recent completed acceptance:
+
+```text
+#154  dirty-edit / Mark Verified safety              CLOSED / V0.3.7 accepted
+#153  compact task-detail / Material layout          CLOSED / V0.3.8 accepted
+#151  Shift+left-drag predecessor creation           CLOSED / V0.3.9 accepted
+#152  reusable resource catalog management           V0.3.10 accepted / close after docs merge
+#161  Archive -> SourceDocs Google Doc documentation CLOSED / completed
+```
+
+Primary remaining work includes:
+
+```text
+#122  Setup Session planning / Pick List / live reconstruction umbrella
+#145  reusable Catalog cleanup gate before real 2026 Session creation
+#167  Extra Materials / KIT assignments / material-source tracking
+#169  keep active task name visible while reviewing long task detail
+#166  one-sudo browser-preview harness hardening
+#141  task-specific staged material subdivision / Pick List release timing
+#159  shared light/dark palette and dark-mode white-logo consistency
+#132  Captain work-report duration / multi-day effort capture
+#113  shared Scan application readiness / identity capture integration
+```
+
+Issue #130 global People/Capability/Qualification foundation is completed; subsystem-specific consumption remains separate integration work.
 
 ## Start Here
 
-- [Setup Session Production Engineering Handoff — 2026-09-11](Setup_Session_Production_Engineering_Handoff_2026-09-11.md) — current deployed SHA/version, recent runtime lineage, fingerprint evidence, migration 026, current boundaries, and resume point.
-- [Setup V0.3.9 Prerequisite Production Acceptance — 2026-09-11](../../../../../Setup/Acceptance/Setup_Predecessor_V039_Production_Acceptance_2026-09-11.md) — exact migration, source deployment, rollback archive, regression, fingerprint, browser, and preview-lifecycle evidence.
-- [Setup V0.3.8 Task Detail Production Acceptance — 2026-09-11](../../../../../Setup/Acceptance/Setup_Task_Detail_Production_Acceptance_2026-09-11.md) — prior compact task-detail acceptance.
-- [Setup Stage / Scene Material Resolution Contract — 2026-09-10](Setup_Stage_Scene_Material_Resolution_Contract_2026-09-10.md) — current accepted material/source-classification authority.
-- [Setup Stage / Scene Production Acceptance — 2026-09-11](../../../../../Setup/Acceptance/Setup_Stage_Scene_Production_Acceptance_2026-09-11.md) — V0.3.5 material/presentation database migration and acceptance history.
-- [Setup Data Consumption and Authorization Contract — 2026-09-10](Setup_Data_Consumption_and_Authorization_Contract_2026-09-10.md) — Setup capability, Person mapping, application-role, governed write, and grant boundaries.
-- [Setup Predecessor and Readiness Contract — 2026-09-09](Setup_Predecessor_and_Readiness_Contract_2026-09-09.md) — accepted predecessor interaction/order plus hard predecessor vs preferred order vs external/site readiness.
-- [Setup Reconstruction Migration and Acceptance History — 2026-09-07 to 09](Setup_Reconstruction_Migration_and_Acceptance_History_2026-09-07_to_09.md) — historical migration/disposable/browser lessons and reconstruction findings.
+- [Setup Session Production Engineering Handoff — 2026-09-11](Setup_Session_Production_Engineering_Handoff_2026-09-11.md) — current deployed SHA/version, migration 027, runtime evidence, boundaries, and resume point.
+- [Setup V0.3.10 Resource Catalog Production Acceptance — 2026-09-11](../../../../../Setup/Acceptance/Setup_Resource_Catalog_V0310_Production_Acceptance_2026-09-11.md) — exact migration/source deployment, rollback archive, regression, fingerprint, authorization, and browser acceptance evidence.
+- [Setup V0.3.9 Prerequisite Production Acceptance — 2026-09-11](../../../../../Setup/Acceptance/Setup_Predecessor_V039_Production_Acceptance_2026-09-11.md) — predecessor workflow acceptance history.
+- [Setup V0.3.8 Task Detail Production Acceptance — 2026-09-11](../../../../../Setup/Acceptance/Setup_Task_Detail_Production_Acceptance_2026-09-11.md) — compact task-detail acceptance history.
+- [Setup Stage / Scene Material Resolution Contract — 2026-09-10](Setup_Stage_Scene_Material_Resolution_Contract_2026-09-10.md) — accepted material/source-classification authority.
+- [Setup Data Consumption and Authorization Contract — 2026-09-10](Setup_Data_Consumption_and_Authorization_Contract_2026-09-10.md) — capability, Person mapping, application-role, governed write, and grant boundaries.
+- [Setup Predecessor and Readiness Contract — 2026-09-09](Setup_Predecessor_and_Readiness_Contract_2026-09-09.md) — predecessor interaction/order and hard predecessor vs preferred order vs external/site readiness.
 - [Setup Planning Operating Model — 2026-09-08](Setup_Planning_Operating_Model_2026-09-08.md) — rolling-horizon planning direction.
-- [Setup Planning Candidate Work View — 2026-09-09](Setup_Planning_Candidate_Work_View_2026-09-09.md) — cross-Stage candidate planning direction.
 - [Setup Pick List Tablet Workflow — 2026-09-09](Setup_Pick_List_Tablet_Workflow_2026-09-09.md) — Pick List direction; not yet Production-operational.
 - [Setup Session Production Engineering Handoff — 2026-09-07](Setup_Session_Production_Engineering_Handoff_2026-09-07.md) — historical V0.3.4 foundation/runtime baseline; not current deployment authority.
 
@@ -264,175 +317,21 @@ The Production Database repository owns Setup application/business/database beha
 
 `Gregovate/MSB-Server-Management` owns deployed service, listener, firewall, reverse-proxy, restart/recovery, host permissions, browser-review runbook, and Production deployment runbooks/runtime facts.
 
-## Current Repository / Issue Structure
+## Resume Checklist
 
-Recent completed acceptance:
-
-```text
-#154  dirty-edit / Mark Verified safety              CLOSED / V0.3.7 accepted
-#153  compact task-detail / Material layout          CLOSED / V0.3.8 accepted
-#151  Shift+left-drag predecessor creation           V0.3.9 accepted; closeout docs in progress
-#161  Archive -> SourceDocs Google Doc documentation CLOSED / completed
-```
-
-Primary active work remains issue-driven:
-
-```text
-#122  Setup Session engineering / planning / Pick List / live reconstruction umbrella
-#145  reusable Catalog cleanup gate before creating the 2026 Setup Session
-#152  resource catalog sort order / existing-resource editing
-#159  shared light/dark palette and dark-mode white-logo consistency
-#141  task-specific staged material subdivision and Pick List release timing
-#130  global People / Capability / Qualification work consumed by Setup
-#132  Captain work-report duration / multi-day effort capture
-#113  shared Scan application readiness / identity capture integration
-```
-
-Earlier Setup PRs #123/#124/#125/#134/#136/#137/#138/#139 are historical/superseded lineages and are not the current development authority.
-
-## Reusable Catalog / Annual Session Boundary
-
-The reusable Catalog and the selected annual Session are different things.
-
-A valid reusable task can exist without a 2025 `ops.setup_session_task` row. That task will not appear in the 2025 Plan / Schedule view merely because it exists in the reusable Catalog.
-
-Annual Session creation seeds **every active reusable task** into the new annual Session.
-
-Therefore:
-
-```text
-active reusable Catalog cleanup
-    -> prove intended task set
-    -> disposable 2026 creation check
-    -> only then authorize real 2026 Session creation
-```
-
-Do not force newer reusable tasks into 2025 merely to make the historical Plan look complete.
-
-Issue #145 owns this gate.
-
-## Reconstruction Source Rules
-
-Historical spreadsheets, 2025 notes, and recovered schedules are evidence, not a parallel ongoing task master.
-
-Use current PostgreSQL first:
-
-```text
-current reusable Catalog
-    -> identify gap/correction
-    -> verify practical task boundary and scope
-    -> correct through governed Setup controls
-```
-
-Do not restart a bulk spreadsheet import merely because a task is missing or wrong.
-
-Reconstruction mistakes may legitimately have no annual row. The governed reconstruction-safe delete path supports Catalog-only mistakes while failing closed when protected history exists.
-
-## Current Planning Model
-
-Setup is **not** a rigid season-long calendar scheduler.
-
-Accepted operating direction:
-
-```text
-preferred order / hard predecessors
-    + readiness
-    + volunteers/equipment
-    + weather/site conditions
-    + prior progress
-    -> candidate work
-    -> operator chooses next practical work
-    -> short-horizon schedule
-    -> Pick List demand
-    -> perform / record / replan
-```
-
-Tasks can span multiple work periods. Stage organization is useful for presentation but is not a requirement to finish an entire Stage before another Stage can begin.
-
-## Predecessor / Readiness Boundary
-
-Keep separate:
-
-```text
-HARD PREDECESSOR
-PREFERRED ORDER
-READINESS CONDITION
-```
-
-A readiness condition can be an external/site condition such as mowing/mulching complete in a specific work area. Do not invent fake Setup tasks for outside work.
-
-Structured readiness remains pending; the current free-text readiness note is descriptive only. Efficient task-predecessor entry is now Production-operational in V0.3.9.
-
-## Pick List Current Boundary
-
-There is currently **no Production Pick List generator/report** and no accepted Setup tablet Pick List workflow.
-
-The intended direction remains:
-
-```text
-selected Setup work
-    -> required material at the correct task/release step
-    -> resolved Displays / other governed material units
-    -> current Containers/storage
-    -> deduplicate
-    -> explain why each item/Container is required
-```
-
-The existing Stage/Scene material resolver provides useful context but does not yet provide the task-specific release step in the first arrow above. Issue #141 owns that unresolved material-subdivision/timing problem.
-
-Do not infer task scope from Container storage. Shared/mixed-stage Containers are normal.
-
-## Data / Authorization Boundary
-
-Cloudflare authentication, Setup capability, Person identity mapping, and PostgreSQL grants are separate layers.
-
-Characteristic write failure:
-
-```text
-Authenticated Setup operator is not mapped to an MSB person
-```
-
-is a Person/Directus identity-link problem, not justification for broad Setup table DML.
-
-Migration 025 added only the `ref.display_status` SELECT needed by automatic material resolution plus governed material setter EXECUTE. Migration 026 adds only prerequisite presentation order plus narrow governed reorder EXECUTE. Broad direct Setup table DML remains forbidden for `fieldwiring_app`.
-
-See [Setup Data Consumption and Authorization Contract](Setup_Data_Consumption_and_Authorization_Contract_2026-09-10.md).
-
-## Known Limitations / Open Work
-
-Current significant remaining work includes:
-
-- reusable Catalog cleanup before 2026 propagation;
-- continued correction of task boundaries exposed by live review;
-- task-specific staged material subdivision / release timing for multi-step Stage work (Issue #141);
-- structured readiness;
-- resource catalog sort/existing-resource editing (Issue #152);
-- cross-Stage candidate planning surface / short-horizon scheduler workflow;
-- authoritative Controller context from FieldWiring / Controller Inventory;
-- Pick List generation and tablet workflow;
-- mixed-stage Container annual mobilization/unload-group state and ordered-access rules;
-- Container/Display movement/scanning writes;
-- park-location execution evidence; and
-- cross-app palette/dark-mode logo normalization (Issue #159).
-
-## Resume Development
-
-Before changing this subsystem:
+Before the next Setup change:
 
 1. read the Production Database Project Rules;
 2. read the current [2026-09-11 Production engineering handoff](Setup_Session_Production_Engineering_Handoff_2026-09-11.md);
 3. read this engineering portal;
-4. read the Stage/Scene material-resolution contract before changing material or Scene classification;
-5. review Issue #141 before designing task-specific material groups, components/KITs, or Pick List release timing;
-6. review Issue #145 before creating or simulating real 2026 annual state;
-7. preserve annual 2025 facts separately from reusable future knowledge;
-8. preserve the V0.3.7 dirty-edit/client-build protections, V0.3.8 compact layout, and V0.3.9 visible client/prerequisite behavior;
-9. use the predecessor/readiness contract before changing dependency or readiness semantics;
-10. use the Pick List contract before implementing logistics/pick behavior;
-11. use issue #130 / People and Identity for global capability/qualification work;
-12. use issue #113 / Labeling and Scanning for shared scan capture/resolution behavior;
-13. use `Gregovate/MSB-Server-Management` for current runtime/deployment/browser-review authority; and
-14. update controlled docs, acceptance evidence, and this README handoff whenever accepted behavior or the next resume point changes.
+4. preserve V0.3.7 dirty-edit/client-build protections, V0.3.8 compact layout, V0.3.9 prerequisite behavior, and V0.3.10 resource-catalog behavior;
+5. review Issue #141 before designing task-specific staged material/Pick List release timing;
+6. review Issue #167 before designing Extra Materials/KIT/source relationships;
+7. review Issue #145 before creating or simulating real 2026 annual state;
+8. preserve annual 2025 facts separately from reusable future knowledge;
+9. use issue #113 / Labeling and Scanning for shared scan capture/resolution behavior;
+10. use `Gregovate/MSB-Server-Management` for current runtime/deployment/browser-review authority; and
+11. update controlled docs, acceptance evidence, and this README whenever accepted behavior or the resume point changes.
 
 ## Related Systems
 

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Session_Production_Engineering_Handoff_2026-09-11.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Session_Production_Engineering_Handoff_2026-09-11.md
@@ -4,13 +4,13 @@
 |---|---|
 | Document Type | Engineering Handoff |
 | System | Production Database — Setup Session |
-| Status | CURRENT HANDOFF — V0.3.9 accepted in Production; broader Setup development remains active |
+| Status | CURRENT HANDOFF — V0.3.10 accepted in Production; broader Setup development remains active |
 | Owner | MSB Production Database engineering |
 | Last Reviewed | 2026-09-11 |
 
 ## Purpose
 
-Preserve the current accepted Setup Session Production state, recent runtime lineage, data/authorization boundaries, exact deployed source, fingerprint evidence, prerequisite behavior, procedure-source behavior, open work, and engineering resume point so future work starts from repository evidence rather than reconstructing recent acceptance from chat or issue comments.
+Preserve the current accepted Setup Session Production state, recent runtime lineage, data/authorization boundaries, exact deployed source, fingerprint evidence, prerequisite behavior, resource-catalog behavior, procedure-source behavior, open work, and engineering resume point so future work starts from repository evidence rather than reconstructing recent acceptance from chat or issue comments.
 
 This handoff supersedes the 2026-09-07 handoff as the **current** runtime/resume summary. The 2026-09-07 document remains historical foundation evidence for the original V0.3.4 Production promotion.
 
@@ -25,25 +25,25 @@ https://my.sheboyganlights.org/setup/
 Current accepted application version:
 
 ```text
-V0.3.9-predecessor-drag
+V0.3.10-resource-catalog
 ```
 
 Exact deployed application source:
 
 ```text
 /opt/msb-setup
-SHA = 55478f98f760473b65b5d700a84c868285022ab7
+SHA = c2a1820627f1a036d634241cc6aecd1a926a1479
 ```
 
 Implementation lineage:
 
 ```text
-Issue #151
-PR #164
-merge commit = ebade21e15a9ac62728dca0655476a619b47516d
+Issue #152
+PR #168
+merge commit = cc4b5767605373504fd993698ce735514bec0d37
 ```
 
-The runtime intentionally remains pinned to the exact browser-accepted candidate rather than silently moving to the later merge/documentation commits.
+The runtime intentionally remains pinned to the exact browser-accepted application candidate rather than silently moving to later test/documentation commits.
 
 Current accepted service/runtime facts remain:
 
@@ -60,43 +60,54 @@ Server/runtime authority remains `Gregovate/MSB-Server-Management`.
 
 ## Current Database / Migration Baseline
 
-Current accepted Setup database additions include migration 025 for Stage/Scene material resolution and migration 026 for persistent prerequisite review/display order.
+Current accepted Setup database additions include migration 025 for Stage/Scene material resolution, migration 026 for persistent prerequisite review/display order, and migration 027 for reusable resource-catalog management.
 
-Migration 026:
+Migration 026 remains accepted:
 
 ```text
 Setup/Database/026_add_setup_dependency_order.sql
 blob = 759774d80eb51b706a0e7b71c5e834636b64a451
 ```
 
-Accepted Production state:
+Migration 027:
 
 ```text
-ref.setup_task_dependency.sort_order = integer NOT NULL DEFAULT 100
-ref.reorder_setup_task_dependencies(text,bigint,bigint[]) = installed
-fieldwiring_app reorder EXECUTE = YES
-fieldwiring_app broad dependency INSERT/UPDATE/DELETE = NO
+Setup/Database/027_add_setup_resource_catalog_management.sql
+blob = 8d65593a3c083ea74b4a35a95bfd6aa8fd617252
 ```
 
-The 17 dependency rows that existed before migration retained their legacy note/audit fingerprint:
+Accepted migration 027 state includes:
 
 ```text
-26b170fba3500ea2647967e87aa02a1c
+ref.setup_resource.display_order = integer NOT NULL DEFAULT 100
+non-negative display_order constraint = installed
+catalog-order index = installed
+ref.update_setup_resource(text,integer,text,text,text,boolean,integer) = installed
+normalized exact-name duplicate protection = installed
+fieldwiring_app narrow resource-command EXECUTE = YES
+fieldwiring_app broad setup_resource UPDATE/DELETE = NO
+fieldwiring_app broad setup_task_resource UPDATE = NO
 ```
 
-before and after migration. The governed Setup fingerprint also remained:
+Production had 12 resource rows, 32 task-resource relationships, and zero normalized duplicate groups at deployment. Migration 027 did not silently merge or rewrite existing catalog rows.
+
+The stable governed Setup fingerprint before and after migration/deployment, before the legitimate protected-route operator acceptance write, was:
 
 ```text
-9510360aa7de2da59d1ed8a9ad9d69f7
+7c21041caecac6eb77660238ba3c8cf9
 ```
-
-Migration 026 did not rewrite existing dependency audit evidence merely to introduce display order.
 
 Validated rollback archive retained on the Production host:
 
 ```text
-/home/msbadmin/backups/setup-151/msb-pre-setup-151-20260911T071801.dump
-SHA256 = 21e5b9b0fbd07dd01b7c9a86027615988bc33f950767839e4d74bb4a1f407029
+/home/msbadmin/backups/setup-152/msb-pre-setup-152-20260911T170411.dump
+SHA256 = b60857bf12eae68922cc309b795e920b3b2aaccd5a928b775527057450a7aa15
+```
+
+The earlier V0.3.9 dependency migration evidence remains historically valid, including the 17-row legacy dependency fingerprint:
+
+```text
+26b170fba3500ea2647967e87aa02a1c
 ```
 
 ## Current Annual / Catalog Boundary
@@ -116,7 +127,7 @@ Do not force newer reusable tasks into the 2025 historical Session merely to mak
 
 ## Current V0.3.9 Prerequisite Behavior
 
-The accepted fast-entry interaction is:
+The accepted fast-entry interaction remains:
 
 ```text
 hold Shift before left-button-down on dependent task A
@@ -135,7 +146,7 @@ Accepted behavior includes:
 - ordinary drag without Shift keeps reusable reorder and Stage/real-Scene movement behavior; and
 - explicit success/failure feedback with the intended dependency direction.
 
-Task detail now uses one canonical prerequisite list. Each prerequisite appears once with position plus **Up**, **Down**, and **Remove**. A separate manual **Add prerequisite** form remains available, and already-assigned prerequisites are excluded from its choices.
+Task detail uses one canonical prerequisite list. Each prerequisite appears once with position plus **Up**, **Down**, and **Remove**. A separate manual **Add prerequisite** form remains available, and already-assigned prerequisites are excluded from its choices.
 
 Add/remove/reorder reload authoritative dependency state so task detail and the Catalog `Requires` line remain synchronized.
 
@@ -151,11 +162,9 @@ Structured outside/site readiness remains future work.
 
 See [`Setup_Predecessor_and_Readiness_Contract_2026-09-09.md`](Setup_Predecessor_and_Readiness_Contract_2026-09-09.md).
 
-## Current V0.3.8 Task-Detail Presentation
+## Current Task-Detail Presentation
 
-The V0.3.8 layout remains accepted and is preserved by V0.3.9.
-
-Accepted laptop/desktop task-detail layout:
+V0.3.10 preserves the accepted V0.3.8 laptop/desktop layout:
 
 ```text
 LEFT                               RIGHT
@@ -165,9 +174,37 @@ Material / Logistics                Captains / Knowledge Owners
 
 The reusable definition itself uses a compact two-column desktop grid. Material / Logistics retains the four essential counts plus the existing full detail dialog. Prerequisites and Equipment / Resources remain below the rail block and are reachable with materially less scrolling.
 
-Physical mobile-device acceptance was not performed. Responsive stacking is contract-covered and was checked using a narrowed desktop browser only.
+Physical mobile-device acceptance was not performed for V0.3.8. Responsive stacking is contract-covered and was checked using a narrowed desktop browser only.
 
-Issue #159 separately owns cross-application palette and dark-mode white-logo consistency.
+Issue #159 separately owns cross-application palette and dark-mode white-logo consistency. Issue #169 separately owns keeping the active task name visible while scrolling long task detail.
+
+## Current V0.3.10 Resource Catalog Behavior
+
+The accepted ordinary task-resource workflow is deliberately compact and name-oriented:
+
+```text
+search existing resource
+    -> choose resource
+    -> set task quantity / Required-vs-Preferred / task notes
+    -> add or update relationship
+```
+
+The ordinary picker sorts primarily by `resource_name`, then type/ID. This is an accepted refinement from the original #152 wording: numeric `display_order` remains modeled/editable, but meaningful names drive normal selection and the full Manager catalog defaults to Name sort.
+
+Use **Manage Resource Catalog** only for reusable catalog maintenance. It:
+
+- searches active and inactive catalog rows;
+- supports alternate sorts including optional display order;
+- renames/corrects an existing catalog row in place;
+- edits resource type, reusable catalog notes, active state, and display order;
+- preserves stable `setup_resource_id` identity and existing task relationships; and
+- returns to the compact task flow through **Close Resource Catalog**.
+
+Normalized exact duplicate names are blocked after case/trim/repeated-whitespace normalization. Likely existing matches are surfaced while entering a new name so near-duplicates can be reviewed before creation.
+
+Task-specific quantity, Required-vs-Preferred, and task notes remain separate from catalog-level resource identity and notes.
+
+Inactive resources remain discoverable in the Manager catalog and on existing relationships. New inactive assignments are blocked; existing inactive relationships can still be removed.
 
 ## Recent Runtime / Safety Lineage
 
@@ -234,7 +271,7 @@ protected health                     = V0.3.8-task-detail-compact
 final protected browser acceptance   = PASS
 ```
 
-### V0.3.9 — current accepted prerequisite workflow
+### V0.3.9 — accepted prerequisite workflow
 
 Accepted exact candidate:
 
@@ -256,13 +293,53 @@ protected health                      = V0.3.9-predecessor-drag
 final protected browser acceptance    = PASS
 ```
 
-The broad `Setup/Application` suite reported 191 passed / 2 failed on the exact V0.3.9 candidate. The same two failing literal-string contracts were reproduced on the already accepted V0.3.8 checkout, proving they were inherited stale test debt rather than V0.3.9 regressions. Closeout updates those literals rather than falsely claiming the pre-deployment full suite was green.
+The broad `Setup/Application` suite reported 191 passed / 2 failed on the exact V0.3.9 candidate. The same two failing literal-string contracts were reproduced on the already accepted V0.3.8 checkout, proving they were inherited stale test debt rather than V0.3.9 regressions.
 
 See [`Setup_Predecessor_V039_Production_Acceptance_2026-09-11.md`](../../../../../Setup/Acceptance/Setup_Predecessor_V039_Production_Acceptance_2026-09-11.md).
 
+### V0.3.10 — current accepted reusable resource catalog
+
+Accepted exact application candidate:
+
+```text
+SHA     = c2a1820627f1a036d634241cc6aecd1a926a1479
+version = V0.3.10-resource-catalog
+```
+
+Implementation merge:
+
+```text
+PR #168
+merge commit = cc4b5767605373504fd993698ce735514bec0d37
+```
+
+Regression evidence:
+
+```text
+exact runtime candidate        = 207 passed / 1 stale literal assertion
+corrected test-only derivative = 209 passed
+live focused regression        = 29 passed / 1 deselected stale assertion
+```
+
+The exact-runtime failure was only an outdated CSS cache-token assertion. The immediately following commit `be19b4f0e013b16f40673d14364113219d081f01` changed only the test file and passed 209 tests in the Production Python environment.
+
+Production evidence:
+
+```text
+migration 027                     = PASS
+stable pre/post fingerprint       = 7c21041caecac6eb77660238ba3c8cf9
+protected direct negative path    = HTTP 401 PASS
+protected health                  = V0.3.10-resource-catalog
+protected browser acceptance      = PASS
+legitimate catalog edit           = PASS
+existing task relationship intact = PASS
+```
+
+See [`Setup_Resource_Catalog_V0310_Production_Acceptance_2026-09-11.md`](../../../../../Setup/Acceptance/Setup_Resource_Catalog_V0310_Production_Acceptance_2026-09-11.md).
+
 ## Browser Preview Lifecycle Finding
 
-The #151 disposable review exposed a browser-preview lifecycle failure that is now durable operational knowledge.
+The #151 disposable review exposed a browser-preview lifecycle failure that remains durable operational knowledge.
 
 A lost workstation SSH tunnel can leave the remote source-only preview wrapper blocked on its browser-review prompt while the Flask child survives in its own session/process group. In that state the browser reports `Failed to fetch`, but the application may still be healthy on the server.
 
@@ -274,9 +351,9 @@ vs.
 SSH/tunnel loss with surviving preview
 ```
 
-The final #151 evidence showed the last dependency mutation and following refreshes returned HTTP 200, and a direct server health request still returned V0.3.9. The application had not crashed.
+Acceptance tooling was hardened to clean only recognized preview-owned resources, reject Production ports, preserve reports/logs, use SSH keepalives, include HUP handling, and use `timeout --foreground` for an interactive bounded remote review.
 
-Acceptance tooling was hardened to clean only recognized preview-owned resources, reject Production ports, preserve reports/logs, use SSH keepalives, include HUP handling, and use `timeout --foreground` for an interactive bounded remote review. A non-foreground `timeout` attempt stopped at `sudo -v` and was rejected before final acceptance.
+Issue #166 separately tracks the remaining duplicate-sudo-prompt problem: the current #152-style launcher opens separate SSH/PTTY sessions for cleanup and preview, which can require two sudo authentications. Do not weaken sudo policy to hide that issue.
 
 Server-side browser-review operational authority is `Gregovate/MSB-Server-Management/docs/server/Pre_Production_Browser_Review_Runbook.md`.
 
@@ -301,7 +378,7 @@ Authenticated Setup operator is not mapped to an MSB person
 
 is an identity-link / Person mapping problem, not evidence that the browser needs broader database permissions.
 
-Migration 026 preserves the same boundary: `fieldwiring_app` receives narrow EXECUTE on prerequisite commands and no broad dependency-table DML.
+Migration 027 preserves the same boundary: `fieldwiring_app` receives narrow EXECUTE on resource-management commands and no broad resource/task-resource DML.
 
 ## Procedure / Editable Source Boundary
 
@@ -353,6 +430,8 @@ resolved Displays
 
 Issue #141 remains responsible for task-specific staged material subdivision and release timing.
 
+Issue #167 now owns the separate reusable Extra Materials / KIT assignments / material-source foundation. Do not collapse Extra Material requirements into LOR Display membership or assume every Extra Material lives in a KIT.
+
 Setup planning remains a rolling operational model rather than a rigid season-long fixed calendar:
 
 ```text
@@ -373,7 +452,8 @@ Completed and accepted in this recent line:
 ```text
 #154 dirty-edit / Mark Verified safety  = CLOSED / ACCEPTED V0.3.7
 #153 compact task-detail layout         = CLOSED / ACCEPTED V0.3.8
-#151 Shift+left-drag predecessor entry  = ACCEPTED V0.3.9 / close after documentation merge
+#151 Shift+left-drag predecessor entry  = CLOSED / ACCEPTED V0.3.9
+#152 reusable resource catalog workflow = ACCEPTED V0.3.10 / close after documentation merge
 #161 SourceDocs migration documentation = CLOSED / COMPLETED
 ```
 
@@ -381,7 +461,9 @@ Real independent work remains, including:
 
 ```text
 #145 reusable Catalog cleanup before 2026 Session creation
-#152 resource catalog sort order / existing-resource editing
+#167 Extra Materials / KIT assignments / material-source tracking
+#169 persistent active-task name/context while scrolling long task detail
+#166 one-sudo browser-preview harness hardening
 #159 cross-app light/dark palette and dark-mode white-logo standardization
 #141 task-specific staged material / Pick List release timing
 #132 Captain work-report duration / multi-day effort capture
@@ -401,16 +483,18 @@ Before the next Setup change:
 3. read the responsible contract for the work item being changed;
 4. preserve V0.3.7 dirty-edit/client-server build protections;
 5. preserve V0.3.8 compact task-detail layout;
-6. preserve V0.3.9 client marker, Shift-drag prerequisite direction, canonical prerequisite editor, and display-order-only semantics;
-7. preserve current 2025 historical state and do not create 2026 without #145 acceptance;
-8. use `Gregovate/MSB-Server-Management` for runtime/deployment/browser-review authority;
-9. perform disposable/current-Production-clone browser acceptance before Production deployment when browser behavior changes;
-10. perform real protected-route operator validation for behavior that depends on actual client/runtime interaction; and
-11. complete controlled engineering/operator documentation and issue closeout before leaving the work item.
+6. preserve V0.3.9 Shift-drag prerequisite direction, canonical prerequisite editor, and display-order-only semantics;
+7. preserve V0.3.10 name-oriented resource assignment, stable in-place resource editing, duplicate protection, inactive-resource rules, and narrow authorization boundary;
+8. preserve current 2025 historical state and do not create 2026 without #145 acceptance;
+9. use `Gregovate/MSB-Server-Management` for runtime/deployment/browser-review authority;
+10. perform disposable/current-Production-clone browser acceptance before Production deployment when browser behavior changes;
+11. perform real protected-route operator validation for behavior that depends on actual client/runtime interaction; and
+12. complete controlled engineering/operator documentation and issue closeout before leaving the work item.
 
 ## Related Documents
 
 - [Setup engineering portal](README.md)
+- [V0.3.10 resource-catalog Production acceptance](../../../../../Setup/Acceptance/Setup_Resource_Catalog_V0310_Production_Acceptance_2026-09-11.md)
 - [V0.3.9 prerequisite Production acceptance](../../../../../Setup/Acceptance/Setup_Predecessor_V039_Production_Acceptance_2026-09-11.md)
 - [V0.3.8 task-detail Production acceptance](../../../../../Setup/Acceptance/Setup_Task_Detail_Production_Acceptance_2026-09-11.md)
 - [Stage / Scene material resolution contract](Setup_Stage_Scene_Material_Resolution_Contract_2026-09-10.md)

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/operatorSOP/README.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/operatorSOP/README.md
@@ -31,7 +31,7 @@ The application uses real Production data. It is available for manager/reviewer 
 Current Production client:
 
 ```text
-Client V0.3.9
+Client V0.3.10
 ```
 
 ## What Do You Need To Do?
@@ -39,6 +39,25 @@ Client V0.3.9
 - [Review and Correct the 2025 Setup History](Review_2025_Setup_History.md) — verify 2025 information, improve reusable Setup knowledge, add missing tasks/resources where appropriate, mark which tasks use Display/Container material, add/correct prerequisites, and record questions or suggestions.
 
 Additional task procedures will be added only when the corresponding workflow is actually production-operational.
+
+## Equipment / Resource Workflow
+
+Use the compact resource picker for ordinary task work:
+
+```text
+search existing resource
+    -> select resource
+    -> enter task quantity / Required-vs-Preferred / task notes
+    -> add or update requirement
+```
+
+The normal picker is intentionally name-oriented. Search for an existing entry before creating anything new.
+
+Use **Manage Resource Catalog** when the reusable catalog itself needs maintenance. Managers can search active and inactive entries and correct an existing resource in place, including name, type, catalog notes, active state, and optional display order.
+
+Renaming an existing resource preserves its `setup_resource_id` and current task assignments. Exact normalized duplicate names are blocked, and likely matches are shown while entering a new resource name.
+
+Task-specific quantity / Required-vs-Preferred / task notes remain separate from catalog-level identity and catalog notes.
 
 ## Material Checkbox
 
@@ -114,9 +133,11 @@ Circular prerequisite relationships are rejected. Do not work around that warnin
 - Annual 2025 corrections stay with the 2025 Setup Session.
 - Reusable Task changes are permanent Setup knowledge and may affect future seasons.
 - The material checkbox is reusable task knowledge, not a one-year 2025 fact.
+- Resource-catalog identity/type/notes/active/order are reusable catalog facts; task quantity/requirement/notes remain task-specific.
 - Operational dates entered for the selected Setup Session must be in that session's year.
 - Only an Administrator may create a new annual Setup Session or carry annual order forward as the future reusable baseline.
 - Hard predecessors are not the same as preferred order or outside/site readiness conditions.
+- Extra Materials / KIT assignments / material-source tracking remain separate work in Issue #167.
 - Pick Lists and Container/Display movement/scanning writes are not part of the current live-review workflow.
 - Do not create fake records merely to test the UI. Use real review work and report workflow/UI findings instead.
 
@@ -126,6 +147,8 @@ Managers and reviewers are encouraged to:
 
 - open tasks and compare annual 2025 information with reusable task information;
 - add genuinely missing reusable tasks;
+- search for existing resource catalog entries before creating new ones;
+- correct poor resource names in place through **Manage Resource Catalog** instead of creating replacements;
 - mark **Uses Display / Container Material** only when that task really needs the current Display/Container material for its Stage/Scene work;
 - leave the material checkbox off for valid non-material tasks;
 - treat resolved material as context, not an automatic instruction to pick every item immediately;
@@ -135,6 +158,8 @@ Managers and reviewers are encouraged to:
 - leave uncertain information UNVERIFIED or mark it NEEDS CORRECTION;
 - ask questions and make suggestions about confusing, missing, or inefficient workflow; and
 - report UI problems instead of working around them silently.
+
+The known long-page task-context usability improvement identified during V0.3.10 acceptance is tracked separately in Issue #169.
 
 ## Related Documents
 

--- a/Docs/02_Production_Database/02_Operational_SOPs/Setup/Setup_Session_Manager_Review_Guide.md
+++ b/Docs/02_Production_Database/02_Operational_SOPs/Setup/Setup_Session_Manager_Review_Guide.md
@@ -38,7 +38,7 @@ Only an Administrator may create a new annual Setup Session or promote annual or
 The Setup header displays the currently loaded client version. Current Production is:
 
 ```text
-Client V0.3.9
+Client V0.3.10
 ```
 
 After a deployment, after leaving Setup open for a long period, or whenever the displayed client version is unexpected, refresh or reopen the application before making a governed change.
@@ -242,6 +242,47 @@ Review:
 
 Do not invent quantities or effort values merely to fill fields.
 
+### Assign an existing resource
+
+The normal resource workflow is compact and task-focused:
+
+1. Use the resource search field.
+2. Select the existing resource by its meaningful name.
+3. Enter task-specific quantity, Required vs Preferred, and task notes.
+4. Add or update the task requirement.
+
+The ordinary picker is intentionally name-oriented. Meaningful resource names are the primary way operators find related items. The optional numeric catalog display order is not required for ordinary selection.
+
+### Maintain the reusable resource catalog
+
+Use **Manage Resource Catalog** when the reusable catalog itself needs correction.
+
+The Manager catalog includes active and inactive rows and can be searched by name, type, or catalog notes. Name sort is the normal default; alternate review sorts, including optional display order, remain available.
+
+Use catalog maintenance to:
+
+- rename a poorly named resource in place;
+- correct resource type;
+- correct reusable catalog notes;
+- activate or deactivate a resource where appropriate; and
+- adjust optional catalog display order when there is a real reason to do so.
+
+Prefer correcting the existing catalog entry over creating a replacement. Renaming/editing preserves the same `setup_resource_id`, so existing task relationships stay attached.
+
+The application blocks normalized exact duplicates after ignoring case, outer whitespace, and repeated internal whitespace. While entering a new resource name, review the suggested likely matches before creating a new entry.
+
+Inactive resources remain visible in the Manager catalog. Existing task relationships to an inactive resource remain reviewable/removable, but a new inactive resource cannot be assigned to a task.
+
+Keep these facts separate:
+
+```text
+catalog-level resource identity/type/notes/active/order
+vs.
+task-specific quantity / Required-vs-Preferred / task notes
+```
+
+Do not put task-specific quantity or requirement notes into the reusable catalog entry merely because the same resource is used by several tasks.
+
 ## Review Prerequisites and Readiness
 
 Do not treat these as the same thing:
@@ -334,6 +375,9 @@ Production-operational now includes:
 - Stage-oriented Plan / Schedule and Perform Work presentation;
 - search across Catalog, Plan / Schedule, and Perform Work;
 - resource/effort/prerequisite maintenance;
+- searchable existing-resource assignment;
+- full reusable resource-catalog search/edit/activate/deactivate maintenance;
+- normalized duplicate resource blocking and stable in-place resource rename/correction;
 - Shift-drag prerequisite creation with circular-dependency protection;
 - one canonical prerequisite editor with manual Add, Up/Down display order, and Remove;
 - Procedure/document context; and
@@ -342,13 +386,15 @@ Production-operational now includes:
 Still incomplete/separate work includes:
 
 - final reusable Catalog cleanup before 2026 creation;
+- Extra Materials / KIT assignments / material-source tracking (#167);
 - task-specific staged material subdivision / release timing (#141);
 - structured readiness gating;
 - Pick List generation/tablet workflow;
 - mixed-stage Container annual mobilization/unload-state workflow;
 - Container/Display movement/scanning writes;
-- park-location execution evidence; and
-- resource catalog sort/existing-resource editing work tracked separately.
+- park-location execution evidence;
+- one-session browser-preview sudo hardening (#166); and
+- persistent active-task context while scrolling long task detail (#169).
 
 ## 2025 to 2026 Transition
 
@@ -365,3 +411,4 @@ Issue #145 tracks the Catalog-cleanup gate before 2026 creation.
 - [Setup operator portal](../../01_System_Architecture/12_Setup_and_Deployment/README.md)
 - [2025 review procedure](../../01_System_Architecture/12_Setup_and_Deployment/operatorSOP/Review_2025_Setup_History.md)
 - [Setup engineering handoff](../../01_System_Architecture/12_Setup_and_Deployment/engineering/README.md)
+- `Setup/Acceptance/Setup_Resource_Catalog_V0310_Production_Acceptance_2026-09-11.md`

--- a/Setup/Acceptance/Setup_Resource_Catalog_V0310_Production_Acceptance_2026-09-11.md
+++ b/Setup/Acceptance/Setup_Resource_Catalog_V0310_Production_Acceptance_2026-09-11.md
@@ -1,0 +1,249 @@
+# Setup Resource Catalog V0.3.10 Production Acceptance — 2026-09-11
+
+| Document control | Value |
+|---|---|
+| Status | ACCEPTED PRODUCTION |
+| Application | Setup Session |
+| Issue | #152 — Add Setup resource catalog sort order and existing-resource editing |
+| Implementation PR | #168 |
+| Merge commit | `cc4b5767605373504fd993698ce735514bec0d37` |
+| Exact deployed runtime | `c2a1820627f1a036d634241cc6aecd1a926a1479` |
+| Version | `V0.3.10-resource-catalog` |
+| Production migration | `Setup/Database/027_add_setup_resource_catalog_management.sql` |
+| Migration blob | `8d65593a3c083ea74b4a35a95bfd6aa8fd617252` |
+
+## Purpose
+
+Record the accepted Production result for Setup reusable resource-catalog management: searchable task assignment, Manager catalog review/editing, normalized duplicate protection, stable resource identity, inactive-resource handling, optional catalog display order, authorization boundaries, deployment evidence, rollback evidence, and protected-route operator acceptance.
+
+## Accepted Operator Behavior
+
+The normal task workflow is intentionally name-oriented:
+
+```text
+search existing resource
+    -> choose resource
+    -> enter task quantity / Required-vs-Preferred / task notes
+    -> add or update task requirement
+```
+
+The full catalog manager opens only on demand through **Manage Resource Catalog**. It supports searching all catalog rows, including inactive rows, and editing:
+
+- resource name;
+- resource type;
+- catalog notes;
+- active/inactive state; and
+- optional numeric `display_order`.
+
+The accepted refinement from the original issue wording is important:
+
+- `display_order` remains a governed catalog field and can be edited;
+- the ordinary assignment picker is sorted primarily by meaningful `resource_name`, then type/ID;
+- the full Manager catalog defaults to Name sort;
+- numeric display order is an advanced/optional review tool, not the normal picker order.
+
+This was accepted because names such as `Ladder-10 Feet`, `Ladder 5 Feet`, `Stake Pounder Short`, and `Stake Pounder Tall` naturally group for operators and proved easier to use than requiring numeric sort maintenance for ordinary selection.
+
+Task-specific quantity, Required-vs-Preferred, and task notes remain separate from catalog-level resource maintenance.
+
+## Database Contract
+
+Migration 027 added:
+
+```text
+ref.setup_resource.display_order integer NOT NULL DEFAULT 100
+```
+
+with a non-negative constraint and catalog-order index.
+
+It also installs/refreshes narrow governed commands including:
+
+```text
+ref.update_setup_resource(text,integer,text,text,text,boolean,integer)
+ref.create_setup_resource(text,text,text,text)
+ref.set_setup_task_resource(text,bigint,integer,integer,text,text,boolean)
+```
+
+Normalized exact duplicate resource names are rejected after trim/case/repeated-whitespace normalization. Existing historical normalized duplicates are reported rather than silently merged. Production had zero normalized duplicate groups at deployment.
+
+An existing inactive resource may be removed from a task relationship, while a new inactive resource assignment remains blocked.
+
+`setup_resource_id` remains stable when a resource is renamed or corrected. Existing task relationships therefore stay attached to the same catalog identity.
+
+## Production Preflight
+
+Immediately before deployment:
+
+```text
+live Setup SHA              = 55478f98f760473b65b5d700a84c868285022ab7
+live version                = V0.3.9-predecessor-drag
+msb-setup.service           = active
+resource rows               = 12
+task-resource rows          = 32
+normalized duplicate groups = 0
+display_order column        = absent
+update resource command     = absent
+broad setup_resource UPDATE = false
+broad setup_resource DELETE = false
+broad task-resource UPDATE  = false
+stable Setup fingerprint    = 7c21041caecac6eb77660238ba3c8cf9
+```
+
+The accepted target was fetched explicitly from GitHub. The server checkout's configured `origin/main` tracking ref was stale because that checkout follows a different branch refspec; `FETCH_HEAD` and `ls-remote origin main` both confirmed current GitHub `main` at:
+
+```text
+cc4b5767605373504fd993698ce735514bec0d37
+```
+
+The exact deployed runtime `c2a182...` existed and was a forward descendant of the live V0.3.9 runtime.
+
+## Regression Gate
+
+The exact runtime candidate `c2a182...` produced:
+
+```text
+207 passed
+1 failed
+```
+
+The single failure was a stale test literal in `test_setup_resource_picker_compact_contract.py` expecting the prior CSS cache token `.1` while the accepted runtime correctly loads `.2`.
+
+The immediately following commit:
+
+```text
+be19b4f0e013b16f40673d14364113219d081f01
+```
+
+changed only that test file and corrected the assertion to `.2`; there were no runtime/application changes between `c2a182...` and `be19b4f...`.
+
+Production-runtime regression on that test-only derivative passed:
+
+```text
+209 passed in 0.48s
+```
+
+This establishes the exact V0.3.10 runtime behavior as green while preserving truthful evidence that the exact runtime commit itself still contained one stale literal assertion.
+
+## Rollback Archive
+
+Before migration 027, a custom-format PostgreSQL archive was created and validated:
+
+```text
+/home/msbadmin/backups/setup-152/msb-pre-setup-152-20260911T170411.dump
+```
+
+Archive size:
+
+```text
+15,806,697 bytes
+```
+
+SHA256:
+
+```text
+b60857bf12eae68922cc309b795e920b3b2aaccd5a928b775527057450a7aa15
+```
+
+`pg_restore --list` validation passed using direct stdin redirection.
+
+## Migration 027 Acceptance
+
+Only migration 027 was applied.
+
+Post-migration validation passed for:
+
+- `display_order` present, `NOT NULL`, defaulted to 100 for current rows;
+- non-negative constraint present;
+- catalog-order index present;
+- `ref.update_setup_resource(...)` installed as a governed command;
+- `fieldwiring_app` EXECUTE on the narrow resource commands;
+- no broad `UPDATE` or `DELETE` on `ref.setup_resource`;
+- no broad `UPDATE` on `ref.setup_task_resource`;
+- 12 resource rows preserved;
+- 32 task-resource relationships preserved;
+- zero normalized duplicate groups; and
+- stable Setup fingerprint unchanged at `7c21041caecac6eb77660238ba3c8cf9`.
+
+The migration did not rewrite existing governed Setup data merely to introduce catalog management metadata.
+
+## Application Promotion and Runtime Acceptance
+
+The permanent detached Setup checkout was advanced from V0.3.9 to the exact accepted runtime:
+
+```text
+/opt/msb-setup
+SHA = c2a1820627f1a036d634241cc6aecd1a926a1479
+```
+
+Only `msb-setup.service` was restarted for application activation.
+
+Post-restart health:
+
+```json
+{"data_mode":"postgres","status":"ok","version":"V0.3.10-resource-catalog"}
+```
+
+Focused live regression:
+
+```text
+29 passed, 1 deselected in 0.20s
+```
+
+The one deselected test was the already-proven stale cache-token assertion documented above.
+
+Direct resource-catalog request without protected identity returned:
+
+```text
+HTTP 401 = PASS
+```
+
+Final governed fingerprint before any legitimate operator write remained:
+
+```text
+7c21041caecac6eb77660238ba3c8cf9
+```
+
+## Protected Production Browser Acceptance
+
+The real protected Production route was reviewed after deployment:
+
+```text
+https://my.sheboyganlights.org/setup/
+```
+
+Operator confirmed all nine requested acceptance checks were working, including:
+
+- expected V0.3.10 client/runtime;
+- compact searchable resource picker;
+- Manage Resource Catalog open/close behavior;
+- searchable full catalog;
+- legitimate in-place catalog correction;
+- save behavior;
+- stable existing task-resource relationship after the catalog correction;
+- corrected resource name visible in normal selection/search; and
+- surrounding Setup workflow remaining operational.
+
+Protected Production browser disposition:
+
+```text
+PASS
+```
+
+A separate usability improvement was identified during this acceptance: keep the active task name visible while scrolling long task detail. That work is independently tracked in Issue #169 and is not required for #152 acceptance.
+
+## Deferred Independent Work
+
+Issue #152 does not absorb unrelated remaining work:
+
+- #145 — reusable Catalog cleanup before real 2026 Session creation;
+- #166 — browser-preview harness should require only one sudo authentication;
+- #167 — Extra Materials, KIT assignments, and material-source tracking;
+- #169 — keep the active task name visible while reviewing long task detail;
+- #141 — task-specific staged material / Pick List release timing; and
+- #159 — cross-application palette/theme consistency.
+
+## Current Accepted Boundary
+
+Issue #152 is complete when this acceptance record and current Setup engineering/operator documentation are merged.
+
+The Production runtime remains intentionally pinned to the exact accepted application SHA `c2a182...`; documentation-only closeout commits do not require moving the live application checkout.

--- a/Setup/Application/README.md
+++ b/Setup/Application/README.md
@@ -1,6 +1,6 @@
 # Setup Session Application
 
-Status: **PRODUCTION RUNTIME OPERATIONAL — V0.3.9 ACCEPTED; 2025 HISTORICAL REVIEW / REUSABLE CATALOG WORK CONTINUES**
+Status: **PRODUCTION RUNTIME OPERATIONAL — V0.3.10 ACCEPTED; 2025 HISTORICAL REVIEW / REUSABLE CATALOG WORK CONTINUES**
 
 This folder contains the browser-native Setup Session application used for the Production-backed 2025 Historical Verification workflow and ongoing reusable Setup development.
 
@@ -19,13 +19,13 @@ Setup/Application/production_backend.py
 Current reported version:
 
 ```text
-V0.3.9-predecessor-drag
+V0.3.10-resource-catalog
 ```
 
 Current exact deployed source:
 
 ```text
-55478f98f760473b65b5d700a84c868285022ab7
+c2a1820627f1a036d634241cc6aecd1a926a1479
 ```
 
 ## Current Production Meaning
@@ -38,7 +38,9 @@ Managers/reviewers use it to:
 - verify records where evidence exists;
 - add/correct reusable Setup tasks;
 - delete reconstruction-safe Catalog mistakes where the governed command permits it;
-- add/correct reusable resources and prerequisites;
+- search, assign, rename, correct, activate/deactivate, and review reusable resource catalog entries;
+- maintain task-specific resource quantity / Required-vs-Preferred / notes separately from catalog identity;
+- add/correct prerequisites;
 - use Shift-drag for fast hard-predecessor entry;
 - maintain prerequisite review/display order in the canonical task-detail list;
 - improve task scope, order, crew/time/readiness information;
@@ -104,12 +106,12 @@ The browser constrains date controls and the database independently enforces the
 
 ## Dirty-Edit / Client Build Safety
 
-The accepted V0.3.7 safety behavior remains part of V0.3.9.
+The accepted V0.3.7 safety behavior remains part of V0.3.10.
 
 The Setup header visibly shows the loaded client build, currently:
 
 ```text
-Client V0.3.9
+Client V0.3.10
 ```
 
 Governed writes verify that the client build matches `/api/health`. A stale/mismatched client fails closed instead of quietly writing against a different server build.
@@ -120,7 +122,7 @@ Dirty navigation uses explicit save/discard/stay behavior. Independent save surf
 
 ## Current Task-Detail Layout
 
-V0.3.9 preserves the accepted V0.3.8 laptop/desktop layout:
+V0.3.10 preserves the accepted V0.3.8 laptop/desktop layout:
 
 ```text
 LEFT                               RIGHT
@@ -132,7 +134,7 @@ The reusable editor itself uses a compact two-column desktop grid. Material / Lo
 
 Physical mobile-device acceptance was not performed for V0.3.8. Responsive stacking is contract-covered and was checked with a narrowed desktop browser only.
 
-Cross-application theme and dark-mode white-logo consistency are tracked separately in Issue #159.
+Cross-application theme and dark-mode white-logo consistency are tracked separately in Issue #159. Keeping the active task name visible while scrolling long task detail is tracked separately in Issue #169.
 
 ## Current Prerequisite Interaction
 
@@ -170,6 +172,36 @@ Circular-dependency protection remains database-authoritative.
 
 Structured external/site readiness remains separate future work. Do not represent mowing, access, outside construction, or similar conditions as fake Setup tasks merely to create blockers.
 
+## Current Resource Catalog Interaction
+
+Issue #152 established the Production reusable resource-catalog workflow.
+
+Normal task assignment is intentionally compact and name-oriented:
+
+```text
+search existing resource
+    -> choose resource
+    -> set task quantity / Required-vs-Preferred / task notes
+    -> add or update the task requirement
+```
+
+The ordinary picker sorts primarily by meaningful `resource_name`, then type/ID. `display_order` remains a governed optional catalog field, but operators do not need to maintain numeric order merely to make the normal picker usable.
+
+Use **Manage Resource Catalog** only when catalog maintenance is needed. The Manager catalog:
+
+- searches active and inactive entries;
+- defaults to Name sort;
+- supports alternate sort/review choices, including optional display order;
+- edits poor names in place rather than requiring replacement rows;
+- edits type, catalog notes, active state, and display order; and
+- preserves the same `setup_resource_id` so existing task assignments remain attached after rename/correction.
+
+Normalized exact duplicate names are blocked after trim/case/repeated-whitespace normalization. While entering a new name, likely existing matches are shown so near-duplicates can be reviewed before creation.
+
+Task-specific quantity, Required-vs-Preferred, and task notes remain separate from catalog-level identity and catalog notes.
+
+Inactive catalog rows remain visible to Managers and remain visible on existing relationships. New inactive assignments are blocked, but an existing inactive relationship can still be removed.
+
 ## Current Manager / Reviewer Capabilities
 
 The live review workflow supports current governed behavior for:
@@ -181,7 +213,8 @@ The live review workflow supports current governed behavior for:
 - reconstruction-safe deletion/deactivation where governed rules allow;
 - maintaining task scope and order;
 - maintaining prerequisites through Shift-drag or the canonical prerequisite editor;
-- maintaining structured equipment/resources;
+- searchable structured equipment/resource assignment;
+- full reusable resource-catalog search/edit/activate/deactivate maintenance;
 - maintaining supported reusable material applicability;
 - reviewing supported planning information; and
 - opening current Setup Procedure/document context.
@@ -230,13 +263,13 @@ Permanent source checkout:
 Current deployed source SHA:
 
 ```text
-55478f98f760473b65b5d700a84c868285022ab7
+c2a1820627f1a036d634241cc6aecd1a926a1479
 ```
 
 Current health:
 
 ```json
-{"data_mode":"postgres","status":"ok","version":"V0.3.9-predecessor-drag"}
+{"data_mode":"postgres","status":"ok","version":"V0.3.10-resource-catalog"}
 ```
 
 Service/runtime facts are owned by `Gregovate/MSB-Server-Management`.
@@ -250,19 +283,30 @@ listener                       = 192.168.5.9:8794
 public route                   = https://my.sheboyganlights.org/setup/
 ```
 
-V0.3.9 applied database migration 026 and then advanced only the dedicated Setup application checkout. Live focused regression passed 63 tests. The Production governed fingerprint remained unchanged across migration/deployment:
+V0.3.10 applied database migration 027 and then advanced only the dedicated Setup application checkout. Migration validation preserved the stable governed Setup fingerprint:
 
 ```text
-9510360aa7de2da59d1ed8a9ad9d69f7
+7c21041caecac6eb77660238ba3c8cf9
 ```
 
-Existing dependency note/audit evidence also remained unchanged across migration:
+Production regression evidence includes:
 
 ```text
-26b170fba3500ea2647967e87aa02a1c
+exact runtime candidate         = 207 passed / 1 proven stale literal assertion
+corrected test-only derivative  = 209 passed
+live focused regression         = 29 passed / 1 deselected stale assertion
+protected negative path         = HTTP 401 PASS
+protected Production browser    = PASS
 ```
 
-See `Setup/Acceptance/Setup_Predecessor_V039_Production_Acceptance_2026-09-11.md` for the full Production evidence and rollback archive.
+Validated rollback archive:
+
+```text
+/home/msbadmin/backups/setup-152/msb-pre-setup-152-20260911T170411.dump
+SHA256 = b60857bf12eae68922cc309b795e920b3b2aaccd5a928b775527057450a7aa15
+```
+
+See `Setup/Acceptance/Setup_Resource_Catalog_V0310_Production_Acceptance_2026-09-11.md` for the full Production evidence.
 
 ## Prototype / Historical Lineage
 
@@ -277,7 +321,8 @@ V0.3.5  Stage/Scene material + presentation baseline
 V0.3.6  dirty-edit candidate; failed real Production acceptance and rolled back
 V0.3.7  accepted dirty-edit / client-build safety
 V0.3.8  accepted compact task-detail layout
-V0.3.9  current accepted Shift-drag prerequisite + canonical prerequisite editor
+V0.3.9  accepted Shift-drag prerequisite + canonical prerequisite editor
+V0.3.10 current accepted reusable resource-catalog management
 ```
 
 ## Current Boundaries
@@ -287,7 +332,8 @@ Still outside the accepted Production-ready workflow:
 - structured external/site readiness;
 - Pick List generation;
 - task-specific staged material release timing;
-- resource catalog sort/existing-resource editing;
+- Extra Materials / KIT assignments / material-source tracking (#167);
+- persistent active-task context while scrolling long detail (#169);
 - Container/Display movement/scanning write commands; and
 - park-location execution evidence.
 
@@ -297,9 +343,9 @@ The application also does not automatically publish revised PDFs back into Googl
 
 Automated contract tests remain useful for application changes, but browser behavior that depends on real client/runtime interaction must also pass protected-route operator validation before being treated as accepted Production behavior.
 
-Do not create fake Production work days, movement events, dependencies, or throwaway records merely to exercise controls.
+Do not create fake Production work days, movement events, dependencies, resources, or throwaway records merely to exercise controls.
 
-During the V0.3.9 deployment gate, the broad Setup suite exposed two inherited stale literal-string tests that also failed on the already accepted V0.3.8 checkout. The V0.3.9 focused current deployment suite passed 63 tests. Closeout corrects those stale assertions; do not describe the pre-deployment broad suite as fully green.
+For V0.3.10, the exact deployed runtime contained one stale CSS cache-token test literal. The immediately following test-only commit corrected that assertion without changing runtime/application files and passed 209 tests in the Production Python environment. Closeout records both facts rather than falsely claiming the exact runtime commit's broad suite was fully green.
 
 ## Engineering Resume
 
@@ -311,10 +357,11 @@ Before changing the application:
 4. preserve V0.3.7 dirty-edit/client-server build protection;
 5. preserve the V0.3.8 compact task-detail layout;
 6. preserve the V0.3.9 Shift-drag direction, canonical prerequisite editor, and presentation-order semantics;
-7. preserve the 2025 annual vs reusable Catalog boundary;
-8. review Issue #145 before any 2026 Session creation;
-9. review the active issue/contract for the feature being changed; and
-10. use `Gregovate/MSB-Server-Management` for live runtime facts, browser-review procedure, and deployment runbooks.
+7. preserve the V0.3.10 name-oriented compact resource picker, stable in-place catalog editing, duplicate protection, and narrow authorization boundary;
+8. preserve the 2025 annual vs reusable Catalog boundary;
+9. review Issue #145 before any 2026 Session creation;
+10. review the active issue/contract for the feature being changed; and
+11. use `Gregovate/MSB-Server-Management` for live runtime facts, browser-review procedure, and deployment runbooks.
 
 ## Related Documentation
 
@@ -325,3 +372,4 @@ Before changing the application:
 - `Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/operatorSOP/Review_2025_Setup_History.md`
 - `Docs/02_Production_Database/02_Operational_SOPs/Setup/Setup_Session_Manager_Review_Guide.md`
 - `Setup/Acceptance/Setup_Predecessor_V039_Production_Acceptance_2026-09-11.md`
+- `Setup/Acceptance/Setup_Resource_Catalog_V0310_Production_Acceptance_2026-09-11.md`


### PR DESCRIPTION
## Summary

Close out the accepted Production deployment for Issue #152 / Setup V0.3.10 resource-catalog management.

This documentation-only PR records the already-completed Production deployment and protected-route acceptance. It does **not** change the live Setup application or database.

## Accepted Production state

- deployed runtime: `c2a1820627f1a036d634241cc6aecd1a926a1479`
- version: `V0.3.10-resource-catalog`
- implementation PR: #168
- implementation merge: `cc4b5767605373504fd993698ce735514bec0d37`
- migration 027 blob: `8d65593a3c083ea74b4a35a95bfd6aa8fd617252`
- stable pre/post deployment fingerprint: `7c21041caecac6eb77660238ba3c8cf9`
- rollback archive: `/home/msbadmin/backups/setup-152/msb-pre-setup-152-20260911T170411.dump`
- rollback SHA256: `b60857bf12eae68922cc309b795e920b3b2aaccd5a928b775527057450a7aa15`
- test-only corrected derivative: 209 passed
- live focused regression: 29 passed / one known stale literal assertion deselected
- unauthenticated resource API: HTTP 401 PASS
- protected Production browser acceptance: PASS
- legitimate in-place catalog correction preserved the existing task-resource relationship

## Documentation updates

- add the durable V0.3.10 Production acceptance record;
- refresh the current Setup engineering handoff and engineering portal;
- refresh the Setup application README/runtime facts;
- update the operator portal and Manager Review Guide with the accepted compact/name-oriented resource workflow;
- record the accepted refinement that numeric `display_order` remains optional/advanced while normal selection is name-oriented;
- record independent follow-up work under #166, #167, #169, #145, #141, and #159.

No application/runtime/schema files are changed by this closeout PR.

Issue #152 should close only after this documentation PR and the corresponding Server Management runtime closeout are merged.