### PR TITLE
Clarify issue capture vs new issue creation

### DIFF
--- a/System_Documentation/Project_Rules/Issue_Management_and_Closeout_Rule.md
+++ b/System_Documentation/Project_Rules/Issue_Management_and_Closeout_Rule.md
@@ -6,7 +6,7 @@
 | Repository | MSB Production Database Project |
 | Status | CURRENT |
 | Owner | Production project owner / administrator |
-| Last Reviewed | 2026-08-24 |
+| Last Reviewed | 2026-09-12 |
 
 ## Purpose
 
@@ -14,11 +14,32 @@ This rule defines how GitHub issues are used and closed in the MSB Production Da
 
 Issues are durable work items. They are not a substitute for controlled repository documentation.
 
-## When to Create an Issue
+## Primary Operator Intent — Preserve Findings Without Fragmenting Work
 
-Create a separate issue when the work can reasonably be scheduled, implemented, accepted, deferred, or closed independently from the current work item.
+A common reason Greg asks to "put that in the issue", "add that to the issue", or "make sure there is an issue for that" during an engineering conversation is to make sure an important finding does **not get lost in chat history**.
 
-Examples include:
+Unless Greg explicitly asks for a **new/separate issue**, the default interpretation is:
+
+1. identify the existing active issue that already owns the workstream/problem;
+2. record the finding, correction, decision, edge case, requirement, or follow-up on that issue as a comment or scope/checklist update;
+3. update the responsible controlled documentation when the finding establishes durable project knowledge; and
+4. create a new issue only when the new work passes the independent-work test below.
+
+Do **not** interpret the importance of a finding as a reason to create another issue. An important finding may still belong entirely inside an existing issue.
+
+If the owning issue is not obvious, search the current issue set before creating anything new. Prefer attaching the finding to the issue that owns the underlying problem over creating a convenience issue whose only purpose is to preserve the conversation.
+
+## Independent-Work Test for a New Issue
+
+Create a separate issue only when the work can reasonably be **scheduled, implemented, accepted, deferred, and closed independently** from the current owning issue.
+
+A useful test is:
+
+> Could this work be completed and closed on its own without falsely implying that the parent/owning problem is solved, and does it need its own acceptance/closeout evidence?
+
+If the answer is **no**, keep the finding inside the existing owning issue.
+
+Examples of genuinely independent work include:
 
 - a separate application retirement;
 - a database compatibility migration;
@@ -26,7 +47,29 @@ Examples include:
 - a production defect requiring its own validation and acceptance; or
 - future engineering work that should remain visible after the current project closes.
 
-Do not create a new issue merely because a useful thought, discovery, or small follow-up occurred during a conversation. When the item belongs to an existing active issue, add it to that issue's scope, checklist, or comments as appropriate.
+Do not create a new issue merely because a useful thought, discovery, correction, requirement, edge case, or small follow-up occurred during a conversation. When the item belongs to an existing active issue, add it to that issue's scope, checklist, or comments as appropriate.
+
+## Findings, Issues, Pull Requests, and Documentation Are Different Things
+
+Use these project artifacts for different purposes:
+
+```text
+conversation finding / correction / decision
+    -> existing owning issue comment or scope update
+
+independently schedulable workstream/problem
+    -> GitHub issue
+
+implementation slice that can be reviewed/tested/merged
+    -> pull request
+
+accepted durable architecture / operating rule / system fact
+    -> controlled repository documentation
+```
+
+One issue may legitimately be implemented through several pull requests. Do not create child issues merely to make each implementation slice smaller. Use separate PRs under the same issue when the work is independently reviewable/testable but still belongs to the same durable problem/workstream.
+
+Likewise, several related findings may accumulate under one issue without requiring additional issues. The issue is the durable container for the workstream; comments preserve the discoveries that refine it.
 
 ## Issues Do Not Replace Documentation
 
@@ -44,6 +87,8 @@ Use an umbrella issue when a larger project contains several independently compl
 
 Do not split one normal engineering task into many small issues solely to record every finding.
 
+When a finding materially affects more than one existing issue, choose the **primary owning issue** for the full finding and cross-reference the other issue only when that issue's scope/acceptance is genuinely affected. Avoid duplicating the same long discussion into several issues.
+
 ## Closeout Is Part of the Work
 
 An issue is not finished merely because the code, documentation, or deployment change was made.
@@ -52,7 +97,7 @@ Before leaving a completed work item:
 
 1. review the issue's acceptance criteria and current comments;
 2. confirm the responsible controlled documentation has been updated for durable discoveries or decisions;
-3. identify the pull request, merge commit, deployment acceptance, or other evidence that completed the work;
+3. identify the pull request(s), merge commit(s), deployment acceptance, or other evidence that completed the work;
 4. record any deliberately deferred item and create a separate issue only when it is truly independent future work;
 5. close duplicate, superseded, completed, or no-longer-planned issues using the appropriate GitHub close reason; and
 6. leave an issue open only when real work remains, with a clear next step or unresolved acceptance item.
@@ -77,7 +122,8 @@ Issue closeout and documentation closeout are separate requirements that support
 
 ```text
 engineering discovery / decision
-    -> update responsible controlled documentation
+    -> preserve on the owning issue while work is active
+    -> update responsible controlled documentation when it becomes durable project knowledge
 
 work item completed
     -> record acceptance/evidence

--- a/System_Documentation/Project_Rules/README.md
+++ b/System_Documentation/Project_Rules/README.md
@@ -4,6 +4,8 @@ This folder contains documentation and governance rules that are specific to the
 
 When Greg says **read the project instructions**, read this README and every linked rule relevant to the requested work before proposing changes.
 
+When Greg says **put/add this in the issue**, **make sure this is in an issue**, or similar language during an engineering discussion, do **not** assume that means creating a new GitHub issue. Follow the [Issue Management and Closeout Rule](Issue_Management_and_Closeout_Rule.md): find the existing owning issue first and preserve the finding there unless Greg explicitly asks for a new/separate issue or the work is genuinely independently schedulable/acceptable/closable.
+
 ## Mandatory Production Gate
 
 **Production mutation commands are forbidden until the governing runbook has been retrieved from the responsible repository and read in the current workstream.**
@@ -16,7 +18,7 @@ Reusable rules that should apply across multiple repositories belong under [`../
 
 - [Runbook-First Production Rule](Runbook_First_Production_Rule.md) — requires retrieving and reading the governing repository-owned runbook before any Production mutation command, stating the authority/procedure/current step, stopping after failures, and declaring `RUNBOOK GAP FOUND` rather than improvising when documentation is incomplete.
 - [Repository Change Workflow](Repository_Change_Workflow.md) — requires refreshing current remote `main`, reviewing the latest affected files, and resolving stale-branch/concurrent-work issues before changing code, schema, configuration, or controlled documentation.
-- [Issue Management and Closeout Rule](Issue_Management_and_Closeout_Rule.md) — defines when a separate GitHub issue is warranted, requires durable discoveries to be promoted into controlled documentation rather than left only in issues/chat, and makes issue review/closure part of project and sub-project closeout.
+- [Issue Management and Closeout Rule](Issue_Management_and_Closeout_Rule.md) — defines the conversation-finding -> owning-issue default, when a separate GitHub issue is actually warranted, how multiple PRs may implement one issue, requires durable discoveries to be promoted into controlled documentation rather than left only in issues/chat, and makes issue review/closure part of project and sub-project closeout.
 - [Internal Web Analytics Rule](Internal_Web_Analytics_Rule.md) — requires GA4 usage analytics for `my.sheboyganlights.org` applications, defines the shared Measurement ID and privacy boundary, preserves per-project ownership, and makes analytics verification part of production acceptance.
 - [Production Operational Documentation Rule](Operational_Documentation_Rule.md) — defines Production-specific SOP ownership, `my.sheboyganlights.org` discovery, Display Folder procedure boundaries, and the rule that the existing central SOP tree is not the mandatory home for every operator procedure.
 - [Stage Setup Documentation Standard](Stage_Setup_Documentation_Standard.md) — governs how Stage/Scene setup instructions relate to the established Google Shared Drive structure, controlled templates, Production Database identity, QR resolution, and the `my.sheboyganlights.org` presentation layer.


### PR DESCRIPTION
## Purpose

Clarify the project governance for findings discovered during engineering conversations so important information is preserved without fragmenting one workstream into many GitHub issues.

## Changes

- makes the existing-owning-issue behavior explicit when Greg says to put/add/make sure a finding is in an issue;
- adds an independent-work test before creating a new issue;
- distinguishes conversation findings, issues, PRs, and controlled documentation;
- explicitly allows several implementation PRs under one issue instead of creating child issues for each slice;
- requires searching the current issue set before creating a convenience issue whose only purpose is to preserve chat findings;
- surfaces the rule prominently in the Project Rules README.

## Why

The existing rule already said not to create a new issue for every useful discovery, but the conversational intent was not explicit enough and was applied inconsistently during current Setup work. This change makes the operator intent unambiguous.

Documentation only. No Production mutation.