### PR TITLE
Correct Setup launch sequencing after #169

### DIFF
--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/README.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/README.md
@@ -48,15 +48,11 @@ V0.3.11 persistent active-task context is accepted in Production. V0.3.10 Resour
 
 The launch target is **real 2026 Setup Session creation and scheduling by September 30, 2026 under Issue #122**.
 
-Issue #169 is complete and no longer a remaining launch gate. Its accepted V0.3.11 header context is now part of the Production safety baseline used during Catalog cleanup.
+Issue #169 is complete and no longer a remaining launch gate. Its accepted V0.3.11 header context is now part of the Production safety baseline used during Catalog work.
 
 The remaining pre-launch dependency order is:
 
 ```text
-#145  Reusable Catalog cleanup / correct schedulable work packages
-   -> remove reconstruction mistakes and bad task boundaries
-   -> hard gate before real 2026 Session creation
-
 #141  Task-specific Display ownership/material subdivision
    -> preserve the accepted Stage/Scene resolver
    -> each resolved Display has exactly one effective Setup-task owner
@@ -67,13 +63,23 @@ The remaining pre-launch dependency order is:
    -> normalized Extra Material catalog and task requirements
    -> existing ref.container KIT/support relationships
    -> expected sources/contents without requiring full 2027 KIT inventory
+   -> may legitimately cause reusable-task additions/splits/corrections
+
+#145  FINAL REUSABLE-CATALOG ACCEPTANCE
+   -> review the resulting active reusable task set after #141/#167
+   -> remove any remaining reconstruction mistakes / low-value annual tasks
+   -> confirm intended schedulable work packages
+   -> run disposable 2026 Session creation
+   -> prove the seeded annual task set matches the accepted active Catalog
 
 #122  SEPTEMBER 30 SCHEDULING LAUNCH GATE
-   -> disposable proof first
-   -> then create real 2026 Setup Session
+   -> only after #145 final acceptance
+   -> create real 2026 Setup Session
    -> schedule 2026 work
    -> explain what Displays, Containers/KITs, Extra Materials, and constrained Resources need to be brought to the park and when
 ```
+
+**#145 is not unfinished Catalog-management software and does not block #141/#167.** Production already supports creating, deleting, moving/reordering reusable tasks, resolving Stage/Scene Display material, assigning task resources, and managing the reusable Resource Catalog. #145 remains open only as the final reusable-Catalog content/seed acceptance checkpoint immediately before the real 2026 Session is created.
 
 Before physical Setup work begins, the field-execution gate also requires the necessary portions of:
 
@@ -239,7 +245,7 @@ preferred order / hard predecessors
 
 Every reusable/annual task creates human completion/reporting burden. The reusable Catalog should therefore track meaningful operational control points, not every instruction step.
 
-There is currently no accepted Production Pick List generator/tablet workflow. That is part of the #122 September 30 launch gate after #145/#141/#167 establish trustworthy demand.
+There is currently no accepted Production Pick List generator/tablet workflow. That is part of the #122 September 30 launch gate after #141/#167 establish the task/material structure and #145 performs the final Catalog/disposable-seed acceptance.
 
 ## Extra Materials / KIT / Source Direction
 
@@ -359,15 +365,16 @@ Issue #175 owns the offline/unregistered-worker fallback: a self-contained print
 
 A valid reusable task can exist without a 2025 annual row. Annual Session creation seeds every active reusable task into the new Session.
 
-Therefore, after accepted #169 task-context safety:
+After accepted #169 task-context safety, continue engineering first and accept the final Catalog last:
 
 ```text
-#145 active reusable Catalog cleanup
-    -> #141 Display-to-task ownership
+#141 Display-to-task ownership
     -> #167 Extra Materials / KIT / source foundation
-    -> disposable 2026 creation/scheduling proof
+    -> #145 FINAL reusable-Catalog acceptance + disposable 2026 seed proof
     -> #122 real 2026 Session creation by September 30
 ```
+
+#141/#167 may legitimately add, split, merge, or otherwise correct reusable tasks. Do not freeze the final 2026 Catalog before that work is established. #145 remains open only to review the resulting active task set and prove that disposable annual-session seeding matches the accepted Catalog.
 
 Do not force new reusable tasks into 2025 merely to make the 2025 Plan appear complete.
 
@@ -387,9 +394,9 @@ Recent accepted Production work:
 ### Remaining pre-September-30 launch path
 
 ```text
-#145  reusable Catalog cleanup
 #141  one-Display-to-one-Setup-task ownership / staged subdivision
 #167  Extra Materials / KIT / material-source foundation
+#145  final reusable-Catalog acceptance + disposable 2026 seed proof
 #122  real 2026 Session + scheduling / Pick List launch gate
 ```
 
@@ -414,7 +421,7 @@ Recent accepted Production work:
 
 ## Start Here
 
-- [Setup Session Production Engineering Handoff — 2026-09-11](Setup_Session_Production_Engineering_Handoff_2026-09-11.md) — broader runtime/data boundary; use the V0.3.11 acceptance record below for the current deployed SHA/version.
+- [Setup Session Production Engineering Handoff — 2026-09-11](Setup_Session_Production_Engineering_Handoff_2026-09-11.md) — broader runtime/data boundary; where its older sequencing language conflicts with this README or the Supporting Information Contract, the current launch sequence here controls.
 - [Setup Active Task Context V0.3.11 Production Acceptance — 2026-09-12](../../../../../Setup/Acceptance/Setup_Active_Task_Context_V0311_Production_Acceptance_2026-09-12.md) — current exact deployed source, source-only deployment evidence, fingerprint, live regression, and protected browser acceptance.
 - [Setup Task Supporting Information Contract — 2026-09-11](Setup_Task_Supporting_Information_Contract_2026-09-11.md) — current launch sequence, task ownership, Extra Materials/KIT/source rules, Production Crew boundary, Work Order correction path, and field-start gates.
 - [Setup V0.3.10 Resource Catalog Production Acceptance — 2026-09-11](../../../../../Setup/Acceptance/Setup_Resource_Catalog_V0310_Production_Acceptance_2026-09-11.md) — accepted resource-catalog deployment and rollback evidence.
@@ -460,7 +467,7 @@ Before the next Setup change:
 4. read the [Setup Task Supporting Information Contract](Setup_Task_Supporting_Information_Contract_2026-09-11.md);
 5. preserve accepted V0.3.7 through V0.3.11 behavior;
 6. use 2025 as the sandbox/historical proving ground until the remaining pre-launch gates pass;
-7. work the remaining pre-launch sequence #145 -> #141 -> #167 -> #122 rather than creating the real 2026 Session early;
+7. work the remaining pre-launch sequence #141 -> #167 -> #145 final acceptance/disposable seed proof -> #122 rather than creating the real 2026 Session early;
 8. use issue #113 / Labeling and Scanning for shared scan capture/resolution behavior;
 9. use `Gregovate/MSB-Server-Management` for current runtime/deployment/browser-review authority; and
 10. update controlled docs, acceptance evidence, and this README whenever accepted behavior or the resume point changes.

--- a/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Task_Supporting_Information_Contract_2026-09-11.md
+++ b/Docs/02_Production_Database/01_System_Architecture/12_Setup_and_Deployment/engineering/Setup_Task_Supporting_Information_Contract_2026-09-11.md
@@ -21,18 +21,11 @@ The 2025 Setup Session is intentionally the **sandbox / proving ground** while r
 
 The operational launch point is **Issue #122 / creation and scheduling of the real 2026 Setup Session by September 30, 2026**.
 
-The accepted pre-launch dependency order is:
+Issue #169 is complete in Production as V0.3.11 and is now part of the accepted edit-safety baseline rather than a remaining launch gate.
+
+The remaining pre-launch dependency order is:
 
 ```text
-#169  Persistent active-task identity while editing
-   -> error-prevention control while Catalog work is underway
-   -> selected task name must remain visible while long task detail scrolls
-
-#145  Reusable Catalog cleanup / correct schedulable work packages
-   -> remove reconstruction mistakes and incorrect task boundaries
-   -> preserve meaningful reusable work packages
-   -> hard gate before real 2026 Session creation
-
 #141  Task-specific Display ownership/material subdivision
    -> preserve the accepted Stage/Scene resolver as the source set
    -> each resolved Display has exactly one effective Setup-task owner
@@ -44,12 +37,22 @@ The accepted pre-launch dependency order is:
    -> normalized Extra Material identities and task requirements
    -> existing ref.container KIT/support relationships
    -> expected sources/contents without requiring full 2027 KIT inventory
+   -> may legitimately cause reusable-task additions/splits/corrections
+
+#145  FINAL REUSABLE-CATALOG ACCEPTANCE
+   -> review the resulting active reusable task set after #141/#167
+   -> remove any remaining reconstruction mistakes / low-value annual tasks
+   -> confirm intended schedulable work packages
+   -> run disposable 2026 Session creation
+   -> prove the seeded annual task set matches the accepted active Catalog
 
 #122  SEPTEMBER 30 SCHEDULING LAUNCH GATE
-   -> create the real 2026 Setup Session only after the reusable/task/material foundation is accepted
+   -> create the real 2026 Setup Session only after #145 final acceptance
    -> support 2026 scheduling
    -> explain what Displays, Containers/KITs, Extra Materials, and constrained Resources need to be brought to the park and when
 ```
+
+**#145 is not unfinished Catalog-management software and does not block #141/#167.** Current Production already supports creating, deleting, moving/reordering reusable tasks, resolving Stage/Scene Display material, assigning task resources, and managing the Resource Catalog. #145 remains open only as the final reusable-Catalog content/seed acceptance gate immediately before real 2026 Session creation.
 
 After the September 30 scheduling launch, a second **field-start gate** applies before crews rely on the system for physical Setup:
 
@@ -70,6 +73,7 @@ Current accepted Production behavior wins over stale issue prose or older design
 - V0.3.8 compact task-detail behavior;
 - V0.3.9 prerequisite behavior;
 - V0.3.10 Resource Catalog behavior;
+- V0.3.11 persistent active-task context;
 - the working Stage/Scene Display resolver;
 - 2025 historical/sandbox boundaries;
 - current Display/Container authority; and
@@ -111,7 +115,7 @@ PROCEDURE
     -> detailed how-to steps that do not need separate annual completion
 ```
 
-Issue #169 is part of this cleanup safety boundary. While Managers are reviewing/creating reusable tasks, the active task identity must remain visible so scrolling a long detail screen does not cause an edit to be made against the wrong task.
+Issue #169 established the accepted V0.3.11 cleanup safety boundary. While Managers are reviewing/creating reusable tasks, the active task identity remains visible so scrolling a long detail screen does not cause an edit to be made against the wrong task.
 
 ## Authority Hierarchy
 
@@ -571,7 +575,7 @@ Use the best available procedures, Production data, derived rules, KIT/source in
 
 Do not block useful 2026 operation on the future 2027 detailed KIT inventory.
 
-Do not create the real 2026 Setup Session until the #169/#145/#141/#167 pre-launch foundation is accepted and the #122 disposable creation/scheduling proof passes.
+Do not create the real 2026 Setup Session until #141/#167 establish the task/material foundation, #145 final reusable-Catalog acceptance and disposable 2026 seed proof pass, and #122 is ready for the real scheduling launch.
 
 ## Resume Development
 
@@ -579,9 +583,9 @@ Before implementing this contract:
 
 1. read the Production Database Project Rules;
 2. refresh current `main` and read the current Setup engineering handoff/README;
-3. preserve accepted V0.3.7 through V0.3.10 behavior;
+3. preserve accepted V0.3.7 through V0.3.11 behavior;
 4. treat 2025 as the sandbox/historical proving ground until the pre-launch gates pass;
-5. read Issues #169, #145, #141, #167, and #122 before changing the reusable Catalog/task/material/scheduling path;
+5. work the current pre-launch sequence **#141 -> #167 -> #145 final acceptance/disposable seed proof -> #122**; #169 is already accepted Production baseline;
 6. read Issues #132, #113/#88, #171, and #175 before field-start execution work;
 7. read the current Production schema/migrations before asking the operator to rediscover schema facts;
 8. use governed `SECURITY DEFINER` application commands and actor attribution rather than broad table DML; and
@@ -599,9 +603,9 @@ Before implementing this contract:
 - GitHub #122 — Setup Session umbrella / September 30 scheduling launch gate
 - GitHub #132 — Production Crew work reporting / duration / execution authorization
 - GitHub #141 — Display-to-task ownership / staged material release
-- GitHub #145 — Catalog cleanup gate before 2026 Session creation
+- GitHub #145 — final Catalog content/seed acceptance gate before 2026 Session creation
 - GitHub #167 — Extra Materials / KIT / material source foundation
-- GitHub #169 — persistent active-task identity while editing
+- GitHub #169 — persistent active-task identity while editing — completed V0.3.11
 - GitHub #171 — GIS/layout/targeted locate integration
 - GitHub #172 — broader field observation / continuous-improvement triage
 - GitHub #175 — offline/print Setup field packet + Work Order correction handoff


### PR DESCRIPTION
## Purpose

Correct the controlled Setup launch sequence after Issue #169/V0.3.11 acceptance so future engineering does not incorrectly treat Issue #145 as a blocker to #141/#167.

## Correct sequence

```text
#141  Display-to-task ownership/subdivision
   ->
#167  Extra Materials / KIT / source foundation
   ->
#145  FINAL reusable-Catalog acceptance + disposable 2026 seed proof
   ->
#122  real 2026 Session / scheduling / Pick List launch
```

Issue #145 remains open only as the final Catalog content/seed acceptance checkpoint. Current Production already has the reusable task management capabilities required to proceed with #141/#167.

## Changes

- corrects the Setup engineering README launch sequence and resume instructions;
- corrects the Setup Task Supporting Information Contract launch sequence;
- records #169 as completed V0.3.11 baseline;
- explicitly states that #141/#167 may legitimately refine reusable tasks before #145 final acceptance;
- preserves the September 30 #122 scheduling launch target and the field-start gate.

Documentation only. No Production mutation.